### PR TITLE
Overload `show` for IndexSet

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -38,6 +38,12 @@ IndexSet(inds::NTuple{2,IndexSet}) = IndexSet(inds...)
 # Convert to an Index if there is only one
 Index(is::IndexSet) = length(is)==1 ? is[1] : error("Number of Index in IndexSet ≠ 1")
 
+function Base.show(io::IO, indset::IndexSet)
+  print(io, "IndexSet(")
+  join(io, (sprint(show, ind) for ind in indset.inds), ", ")
+  print(io, ')')
+end
+
 getindex(is::IndexSet,n::Integer) = getindex(is.inds,n)
 setindex!(is::IndexSet,i::Index,n::Integer) = setindex!(is.inds,i,n)
 length(is::IndexSet) = length(is.inds)

--- a/test/test_indexset.jl
+++ b/test/test_indexset.jl
@@ -10,6 +10,12 @@ using ITensors,
   j = Index(jdim,"j")
   k = Index(kdim,"k")
   l = Index(ldim,"l")
+  @testset "show" begin
+      indices = (i, j, k, l)
+      indset = IndexSet(indices)
+      inner = sprint.(show, indices)
+      @test sprint(show, indset) == string("IndexSet(", join(inner, ", "), ")")
+  end
   @testset "Index dimensions" begin
     I = IndexSet(i,j,k)
     @test dim(I) == idim*jdim*kdim


### PR DESCRIPTION
Let me know if this should print differently from this :) Should be easy to update 

Before:
```julia
julia> k = Index(4,"k");

julia> l = Index(4,"l");

julia> T = randomITensor(k,l);

julia> inds(T)
IndexSet(Index[(4|id=429|k), (4|id=0|l)])
```

After:
```julia
julia> k = Index(4,"k");

julia> l = Index(4,"l");

julia> T = randomITensor(k,l);

julia> inds(T)
IndexSet((4|id=589|k), (4|id=986|l))
```