### PR TITLE
Wrap test files in a testset

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,20 @@
-using ITensors,
-      Test
+using ITensors, Test
 
-include("test_tagset.jl")
-include("test_index.jl")
-include("test_indexset.jl")
-include("test_itensor.jl")
-include("test_contract.jl")
-include("test_trg.jl")
-include("test_ctmrg.jl")
-include("test_siteset.jl")
-include("test_mps.jl")
-include("test_mpo.jl")
-include("test_autompo.jl")
-include("test_svd.jl")
+@testset "Itensors.jl" begin
+    @testset "$filename" for filename in (
+        "test_tagset.jl",
+        "test_index.jl",
+        "test_indexset.jl",
+        "test_itensor.jl",
+        "test_contract.jl",
+        "test_trg.jl",
+        "test_ctmrg.jl",
+        "test_siteset.jl",
+        "test_mps.jl",
+        "test_mpo.jl",
+        "test_autompo.jl",
+        "test_svd.jl",
+    )
+        include(filename)
+    end
+end


### PR DESCRIPTION
This just wraps all tests in a testset, to make sure they all runs even if one fails, and for prettier output

Example where a test fails:

Before:
```julia
(ITensors) pkg> test
   Testing ITensors
 Resolving package versions...
Test Summary: | Pass  Total
TagSet        |   17     17
Test Summary: | Pass  Total
Index         |   36     36
Test Summary: | Pass  Total
IndexSet      |   24     24
Test Summary:        | Pass  Total
ITensor constructors |    7      7
Test Summary:      | Pass  Total
Convert to complex |    1      1
Test Summary:              | Pass  Total
Test isapprox for ITensors |    4      4
Test Summary:               | Pass  Total
ITensor tagging and priming |   35     35
Test Summary:                   | Pass  Total
ITensor, Dense{Float64} storage |  111    111
Test Summary:                            | Pass  Total
ITensor, Dense{Complex{Float64}} storage |  111    111
Test Summary:                       | Pass  Total
Converting Real and Complex Storage |   10     10
Example failure: Test Failed at /Users/nick/juliacon/ITensors.jl/test/test_contract.jl:7
  Expression: 2 == 1
   Evaluated: 2 == 1
Stacktrace:
 [1] top-level scope at /Users/nick/juliacon/ITensors.jl/test/test_contract.jl:7
 [2] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/Test/src/Test.jl:1083
 [3] top-level scope at /Users/nick/juliacon/ITensors.jl/test/test_contract.jl:7
Test Summary:   | Fail  Total
Example failure |    1      1
ERROR: LoadError: LoadError: Some tests did not pass: 0 passed, 1 failed, 0 errored, 0 broken.
in expression starting at /Users/nick/juliacon/ITensors.jl/test/test_contract.jl:6
in expression starting at /Users/nick/juliacon/ITensors.jl/test/runtests.jl:8
ERROR: Package ITensors errored during testing
```

After:
```julia
(ITensors) pkg> test
   Testing ITensors
 Resolving package versions...
Example failure: Test Failed at /Users/nick/juliacon/ITensors.jl/test/test_contract.jl:7
  Expression: 2 == 1
   Evaluated: 2 == 1
Stacktrace:
 [1] top-level scope at /Users/nick/juliacon/ITensors.jl/test/test_contract.jl:7
 [2] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/Test/src/Test.jl:1083
 [3] top-level scope at /Users/nick/juliacon/ITensors.jl/test/test_contract.jl:7
Test Summary:                             | Pass  Fail  Total
Itensors.jl                               | 1340     1   1341
  test_tagset.jl                          |   17           17
  test_index.jl                           |   36           36
  test_indexset.jl                        |   24           24
  test_itensor.jl                         |  279          279
  test_contract.jl                        |  948     1    949
    Example failure                       |          1      1
    ITensor Float64 Contractions          |  471          471
    ITensor Complex{Float64} Contractions |  471          471
    Contraction conversions               |    6            6
  test_trg.jl                             |    1            1
  test_ctmrg.jl                           |    2            2
  test_siteset.jl                         |    1            1
  test_mps.jl                             |   11           11
  test_mpo.jl                             |    6            6
  test_autompo.jl                         |    8            8
  test_svd.jl                             |    7            7
ERROR: LoadError: Some tests did not pass: 1340 passed, 1 failed, 0 errored, 0 broken.
in expression starting at /Users/nick/juliacon/ITensors.jl/test/runtests.jl:3
ERROR: Package ITensors errored during testing
```
