### PR TITLE
Reduce dependencies

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,12 +3,6 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[Combinatorics]]
-deps = ["LinearAlgebra", "Polynomials", "Test"]
-git-tree-sha1 = "50b3ae4d643dc27eaff69fb6be06ee094d5500c9"
-uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
-version = "0.7.0"
-
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
 git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
@@ -22,12 +16,6 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
-[[KrylovKit]]
-deps = ["LinearAlgebra", "Printf", "Random", "Test"]
-git-tree-sha1 = "b20b380cc5e28f079ba5212450d7d42a10a85194"
-uuid = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
-version = "0.3.4"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -48,18 +36,6 @@ deps = ["Random", "Serialization", "Test"]
 git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.1.0"
-
-[[Permutations]]
-deps = ["Combinatorics", "LinearAlgebra", "Random", "Test"]
-git-tree-sha1 = "6b51b8689ed5bf3b99643bd8eadb962ace80ea86"
-uuid = "2ae35dd2-176d-5d53-8349-f30d82d94d4f"
-version = "0.3.2"
-
-[[Polynomials]]
-deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "62142bd65d3f8aeb2226ec64dd8493349147df94"
-uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
-version = "0.5.2"
 
 [[Printf]]
 deps = ["Unicode"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,18 @@ authors = ["mfishman <mfishman@caltech.edu>"]
 version = "0.1.0"
 
 [deps]
-Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
-KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Permutations = "2ae35dd2-176d-5d53-8349-f30d82d94d4f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+julia = "1"
+
+[extras]
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Combinatorics", "Test"]

--- a/test/test_contract.jl
+++ b/test/test_contract.jl
@@ -1,7 +1,7 @@
 using ITensors,
       LinearAlgebra, # For tr()
-      Combinatorics, # For permutations()
       Test
+using Combinatorics: permutations
 
 digits(::Type{T},i,j,k) where {T} = T(i*10^2+j*10+k)
 

--- a/test/test_itensor.jl
+++ b/test/test_itensor.jl
@@ -1,6 +1,5 @@
 using ITensors,
       LinearAlgebra, # For tr()
-      Combinatorics, # For permutations()
       Random,        # To set a seed
       Test
 


### PR DESCRIPTION
AFAICT `KrylovKit` and `Permutations` are not used right now, and `Combinatorics` is just needed for tests so can be test-only dependency