### PR TITLE
Add basic DMRG test AND a test for tagset

### DIFF
--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -14,6 +14,7 @@ function dmrg(H::MPO,
   position!(PH,psi0,1)
   energy = 0.0
 
+  quiet::Bool = get(kwargs,:quiet,false)
   for sw=1:nsweep(sweeps)
     sw_time = @elapsed begin
 
@@ -38,7 +39,7 @@ function dmrg(H::MPO,
                    which_factorization=which_factorization)
     end
     end
-    @printf "After sweep %d energy=%.12f maxDim=%d time=%.3f\n" sw energy maxDim(psi) sw_time
+    !quiet && @printf "After sweep %d energy=%.12f maxDim=%d time=%.3f\n" sw energy maxDim(psi) sw_time
     @debug printTimes(timer)
   end
   return (energy,psi)

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -65,7 +65,7 @@ function _addtag!(ts::MTagSetStorage, plev::Int, ntags::Int, tag::IntTag)
   return plnew, ntags
 end
 
-isnull(v::MTagStorage) = v[0] == IntChar(0)
+isNull(v::MTagStorage) = v[0] == IntChar(0)
 
 function reset!(v::MTagStorage, nchar::Int)
   for i = 1:nchar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using ITensors, Test
         "test_contract.jl",
         "test_trg.jl",
         "test_ctmrg.jl",
+        "test_dmrg.jl",
         "test_siteset.jl",
         "test_mps.jl",
         "test_mpo.jl",

--- a/test/test_dmrg.jl
+++ b/test/test_dmrg.jl
@@ -1,0 +1,22 @@
+using ITensors, Test
+
+@testset "basic DMRG" begin
+  N = 100
+  sites = spinOneSites(N)
+
+  ampo = AutoMPO(sites)
+  for j=1:N-1
+    add!(ampo,"Sz",j,"Sz",j+1)
+    add!(ampo,0.5,"S+",j,"S-",j+1)
+    add!(ampo,0.5,"S-",j,"S+",j+1)
+  end
+  H = toMPO(ampo)
+
+  psi = randomMPS(sites)
+
+  sweeps = Sweeps(5)
+  maxdim!(sweeps,10,20,100,100,200)
+  cutoff!(sweeps,1E-11)
+  energy,psi = dmrg(H,psi,sweeps,maxiter=2,quiet=true)
+  @test energy ≈ -138.94 rtol=1e-3
+end

--- a/test/test_tagset.jl
+++ b/test/test_tagset.jl
@@ -10,6 +10,7 @@ using ITensors,
   @test hastags(ts,"t3")
   @test hastags(ts,"t3,t1")
   @test !hastags(ts,"t4")
+  @test TagSet(ts) === ts
 
   t1 = TagSet("t1")
   t2 = TagSet("t2")


### PR DESCRIPTION
Just make Miles review infinite PRs...

I also added a kwarg to make DMRG quieter. `isNull` should match between `TagSet` storage and `ITensor` imo. I changed `setindex` -> `setindex!` because I'm pretty sure code earlier in the file calls `setindex!` and not the immutable version.