### PR TITLE
Small fix to SVD of matrix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ let
   i = Index(10)           # index of dimension 10
   j = Index(20)           # index of dimension 20
   M = randomITensor(i,j)  # random matrix, indices i,j
-  U,S,V = svd(M)          # compute SVD
+  U,S,V = svd(M,i)          # compute SVD
   @show norm(M - U*S*V)   # ≈ 0.0
 end
 ```


### PR DESCRIPTION
In the matrix SVD example, no indices were input so it was taking the SVD of the ITensor treated as a vector.