### PR TITLE
Fix many MPS/MPO bugs, more tests

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -74,6 +74,8 @@ function randomMPS(sites)
     randn!(M[i])
     normalize!(M[i])
   end
+  M.llim_ = 1
+  M.rlim_ = length(M)
   return M
 end
 
@@ -106,7 +108,7 @@ end
 function show(io::IO, M::MPS)
   print(io,"MPS")
   (length(M) > 0) && print(io,"\n")
-  @inbounds for (i, m) ∈ eachindex(M)
+  @inbounds for (i, m) ∈ enumerate(inds.(M.A_))
     println(io,"$i  $m")
   end
 end
@@ -154,7 +156,6 @@ end
 function position!(M::MPS,
                    j::Integer)
   N = length(M)
-
   while leftLim(M) < (j-1)
     ll = leftLim(M)+1
     s = findindex(M[ll],"Site")
@@ -195,7 +196,7 @@ Compute <ψ|ϕ>
 function inner(M1::MPS, M2::MPS)::Number
   N = length(M1)
   if length(M2) != N
-    error("inner: mismatched lengths $N and $(length(M2))")
+      throw(DimensionMismatch("inner: mismatched lengths $N and $(length(M2))"))
   end
   M1dag = dag(M1)
   simlinks!(M1dag)

--- a/test/test_mpo.jl
+++ b/test/test_mpo.jl
@@ -5,8 +5,13 @@ using ITensors,
 
   N = 10
   sites = SiteSet(N,2)
+  @test length(MPO()) == 0
   O = MPO(sites)
   @test length(O) == N
+
+  str = split(sprint(show, O), '\n')
+  @test str[1] == "MPO"
+  @test length(str) == length(O) + 2
 
   O[1] = ITensor(sites[1], prime(sites[1]))
   @test hasindex(O[1],sites[1])
@@ -19,6 +24,7 @@ using ITensors,
   @testset "inner" begin
     phi = randomMPS(sites)
     K = randomMPO(sites)
+    @test maxDim(K) == 1
     psi = randomMPS(sites)
     phidag = dag(phi)
     prime!(phidag)
@@ -27,6 +33,15 @@ using ITensors,
       phiKpsi *= phidag[j]*K[j]*psi[j]
     end
     @test phiKpsi[] ≈ inner(phi,K,psi)
-  end
 
+    badsites = SiteSet(N+1,2)
+    badpsi = randomMPS(badsites)
+    @test_throws DimensionMismatch inner(phi,K,badpsi)
+  end
+  
+  sites = spinHalfSites(N)
+  O = MPO(sites,"Sz")
+  @test length(O) == N # just make sure this works
+ 
+  @test_throws ErrorException randomMPO(sites, 2)
 end

--- a/test/test_mps.jl
+++ b/test/test_mps.jl
@@ -7,6 +7,11 @@ using ITensors,
   sites = SiteSet(N,2)
   psi = MPS(sites)
   @test length(psi) == N
+  @test length(MPS()) == 0
+
+  str = split(sprint(show, psi), '\n')
+  @test str[1] == "MPS"
+  @test length(str) == length(psi) + 2
 
   @test siteindex(psi,2) == sites[2]
   @test hasindex(psi[3],linkindex(psi,2))
@@ -31,6 +36,10 @@ using ITensors,
       phipsi *= dag(phi[j])*psi[j]
     end
     @test phipsi[] ≈ inner(phi,psi)
+ 
+    badsites = SiteSet(N+1,2)
+    badpsi = randomMPS(badsites)
+    @test_throws DimensionMismatch inner(phi,badpsi)
   end
 
   @testset "inner same MPS" begin
@@ -44,4 +53,13 @@ using ITensors,
     @test psipsi[] ≈ inner(psi,psi)
   end
 
+  sites = spinHalfSites(N)
+  psi = MPS(sites)
+  @test length(psi) == N # just make sure this works
+  @test length(siteinds(psi)) == N
+
+  psi = randomMPS(sites)
+  position!(psi, N-1)
+  @test ITensors.leftLim(psi) == N-2
+  @test ITensors.rightLim(psi) == N
 end


### PR DESCRIPTION
I decided to have `show` just print the indices of the MPS/MPO. I think we can define another function (like a `MIME` one) if you want to see all the elements.