### PR TITLE
Use concrete storage in ITensor, MPS, MPO

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -208,15 +208,19 @@ end
 /(A::ITensor,x::Number) = A*(1.0/x)
 
 -(A::ITensor) = -one(eltype(A))*A
-function +(A::ITensor,B::ITensor)
-  C = copy(A)
-  add!(C,B)
-  return C
-end
-function -(A::ITensor,B::ITensor)
-  C = copy(A)
-  add!(C,-1,B)
-  return C
+
+
++(A::ITensor,B::ITensor) = add!(copy_promote(A, B),B)
+-(A::ITensor,B::ITensor) = add!(copy_promote(A, B),-1,B)
+
+function copy_promote(A::ITensor,B::ITensor)
+  if eltype(A) == eltype(B)
+    C = copy(A)
+  else
+    CT = promote_type(eltype(A),eltype(B))
+    C = ITensor(inds(A), convert(Dense{CT}, store(A))) # TODO promote_type on storage?
+  end
+  C
 end
 
 #TODO: Add special case of A==B
@@ -264,7 +268,8 @@ Add ITensors B and A and store the result in B.
 B .+= A
 """
 function add!(B::ITensor,A::ITensor)
-  B.store = storage_add!(store(B),inds(B),store(A),inds(A))
+    B.store = storage_add!(store(B),inds(B),store(A),inds(A))
+    B
 end
 
 """

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -14,12 +14,11 @@ export ITensor,
        scalar,
        store
 
-mutable struct ITensor
+mutable struct ITensor{T <: TensorStorage}
   inds::IndexSet
-  store::TensorStorage
+  store::T
   #TODO: check that the storage is consistent with the
   #total dimension of the indices (possibly only in debug mode);
-  ITensor(is::IndexSet,st::T) where T = new(is,st)
 end
 
 ITensor() = ITensor(IndexSet(),Dense{Nothing}())

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -15,10 +15,12 @@ export ITensor,
        store
 
 mutable struct ITensor{T <: TensorStorage}
-  inds::IndexSet
-  store::T
-  #TODO: check that the storage is consistent with the
-  #total dimension of the indices (possibly only in debug mode);
+    inds::IndexSet
+    store::T
+    #TODO: check that the storage is consistent with the
+    #total dimension of the indices (possibly only in debug mode);
+    ITensor{T}(inds, store) = new{T}(inds, store)
+    ITensor(inds, store)    = new{TensorStorage}(inds, store)
 end
 
 ITensor() = ITensor(IndexSet(),Dense{Nothing}())
@@ -48,6 +50,8 @@ function ITensor(A::Array{S},inds::IndexSet) where {S<:Number}
   return ITensor(inds,Dense{float(S)}(float(vec(A))))
 end
 ITensor(A::Array{S},inds::Index...) where {S<:Number} = ITensor(A,IndexSet(inds...))
+
+
 
 # Convert to complex
 complex(T::ITensor) = ITensor(inds(T),storage_complex(store(T)))

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -1,14 +1,14 @@
 export MPO,
        randomMPO
 
-struct MPO
+struct MPO{T}
   N_::Int
-  A_::Vector{ITensor}
+  A_::Vector{ITensor{T}}
 
-  MPO() = new(0,Vector{ITensor}())
+  MPO() = new{Dense{Nothing}}(0,Vector{ITensor{Dense{Nothing}}}())
 
-  function MPO(N::Int, A::Vector{ITensor})
-    new(N,A)
+  function MPO(N::Int, A::Vector{ITensor{T}})
+    new{T}(N,A)
   end
 
   function MPO(sites)
@@ -26,7 +26,7 @@ struct MPO
         v[ii] = ITensor(l[ii-1], s, sp, l[ii])
       end
     end
-    new(N,v)
+    new{store(v[1])}(N,v)
   end
  
   function MPO(sites::SiteSet, 
@@ -51,12 +51,12 @@ struct MPO
         end
         its[ii] = this_it
     end
-    new(N,its)
+    new{store(its)}(N,its)
   end
 
   function MPO(sites::SiteSet, 
                ops::String)
-    return MPO(sites, fill(ops, length(sites)))
+      MPO(sites, fill(ops, length(sites)))
   end
 
 end

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -7,7 +7,7 @@ struct MPO{T}
 
   MPO() = new{Dense{Nothing}}(0,Vector{ITensor{Dense{Nothing}}}())
 
-  function MPO(N::Int, A::Vector{ITensor{T}})
+  function MPO(N::Int, A::Vector{ITensor{T}}) where {T}
     new{T}(N,A)
   end
 

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -10,19 +10,19 @@ export MPS,
        siteindex,
        siteinds
 
-mutable struct MPS
+mutable struct MPS{T}
   N_::Int
-  A_::Vector{ITensor}
+  A_::Vector{ITensor{T}}
   llim_::Int
   rlim_::Int
 
-  MPS() = new(0,Vector{ITensor}(),0,0)
+  MPS() = new{Dense{Nothing}}(0,Vector{ITensorDense{Nothing}}(),0,0)
 
   function MPS(N::Int, 
-               A::Vector{ITensor}, 
+               A::Vector{ITensor{T}}, 
                llim::Int=0, 
-               rlim::Int=N+1)
-    new(N,A,llim,rlim)
+               rlim::Int=N+1) where {T}
+    new{T}(N,A,llim,rlim)
   end
   
   function MPS(sites::SiteSet)
@@ -39,7 +39,7 @@ mutable struct MPS
         v[ii] = ITensor(l[ii-1], l[ii], s)
       end
     end
-    new(N,v)
+    new{typeof(v[1].store)}(N,v)
   end
 
   function MPS(is::InitState)
@@ -61,7 +61,7 @@ mutable struct MPS
       end
       As[n] = A
     end
-    new(N,As,0,2)
+    new{typeof(As[1].store)}(N,As,0,2)
   end
 end
 MPS(N::Int, d::Int, opcode::String) = MPS(InitState(Sites(N,d), opcode))


### PR DESCRIPTION
Currently, MPS, MPO and ITensor are not fully type inferrable because `ITensor` stores the abstract type `TensorStorage`. This PR is a first step towards making everything parametric on the storage type. There's a lot to fix still and the tests fail currently but this is really important to the performance of the package. 