### PR TITLE
Implement swapprime for IndexSet, test it for IndexSet and ITensor

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -279,6 +279,16 @@ setprime(is::IndexSet, vargs...) = setprime!(copy(is), vargs...)
 noprime!(is::IndexSet, match = nothing) = setprime!(is, 0, match)
 noprime(is::IndexSet, vargs...) = noprime!(copy(is), vargs...)
 
+function swapprime!(is::IndexSet, vargs...) 
+  pos = indexpositions(is,vargs)
+  plevs = reverse(plev.(is))
+  for n in pos
+    is[n] = setprime(is[n],plevs[n])
+  end
+  return is
+end
+swapprime(is::IndexSet, vargs...) = swapprime!(copy(is), vargs...)
+
 function mapprime!(is::IndexSet,
                    plold::Integer,
                    plnew::Integer,

--- a/test/test_indexset.jl
+++ b/test/test_indexset.jl
@@ -83,4 +83,21 @@ using ITensors,
     I = IndexSet(i, j)
     @test ITensors.compute_strides(I) == [1, idim]
   end
+  @testset "setprime" begin
+    I = IndexSet(i, j)
+    J = setprime(I, 2, i)
+    @test i'' ∈ J
+  end
+  @testset "prime" begin
+    I = IndexSet(i, j)
+    J = prime(I, j)
+    @test i ∈ J
+    @test j' ∈ J
+  end
+  @testset "noprime" begin
+    I = IndexSet(i'', j')
+    J = noprime(I)
+    @test i ∈ J
+    @test j ∈ J
+  end
 end

--- a/test/test_itensor.jl
+++ b/test/test_itensor.jl
@@ -271,6 +271,13 @@ end
     @test hasinds(mapprime(A2,1,7),s2,l^7,l'')
     @test hasinds(mapprime(A2,0,1),s2',l',l'')
   end
+  @testset "setprime" begin
+    @test hasinds(setprime(A2,2,s2),s2'',l',l'')
+    @test hasinds(setprime(A2,0,l''),s2,l',l)
+  end
+  @testset "swapprime" begin
+    @test hasinds(swapprime(A2,l'',s2),s2'',l',l)
+  end
 end
 
 @testset "ITensor, Dense{$SType} storage" for SType ∈ (Float64,ComplexF64)


### PR DESCRIPTION
I didn't want to change the function signature for `ITensor` but I think this should probably take two `IndexSet`s or `Index`s specifically, rather than varargs.