### PR TITLE
Modify position to use SVD sometimes

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -52,8 +52,20 @@ tensors(m::MPS) = m.A_
 leftLim(m::MPS) = m.llim_
 rightLim(m::MPS) = m.rlim_
 
-getindex(m::MPS, n::Integer) = getindex(tensors(m),n)
-setindex!(m::MPS,T::ITensor,n::Integer) = setindex!(tensors(m),T,n)
+function setLeftLim!(m::MPS,new_ll::Int) 
+  m.llim_ = new_ll
+end
+
+function setRightLim!(m::MPS,new_rl::Int) 
+  m.rlim_ = new_rl
+end
+
+getindex(M::MPS, n::Integer) = getindex(tensors(M),n)
+function setindex!(M::MPS,T::ITensor,n::Integer) 
+  (n <= leftLim(M)) && setLeftLim!(M,n-1)
+  (n >= rightLim(M)) && setRightLim!(M,n+1)
+  setindex!(tensors(M),T,n)
+end
 
 copy(m::MPS) = MPS(m.N_,copy(tensors(m)),m.llim_,m.rlim_)
 similar(m::MPS) = MPS(m.N_, similar(tensors(m)), 0, m.N_)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -146,17 +146,26 @@ function replacesites!(M::MPS,sites)
   return M
 end
 
-function position!(M::MPS,
-                   j::Integer)
+function position!(M::MPS, j::Integer; kwargs...)
+  default_method = (rightLim(M) - leftLim(M) > 2) ? "qr" : "svd"
+  method = get(kwargs, :which_factorization, default_method)
   N = length(M)
   while leftLim(M) < (j-1)
     ll = leftLim(M)+1
     s = findindex(M[ll],"Site")
     if ll == 1
-      (Q,R) = qr(M[ll],s)
+      if method == "svd"
+          (Q,R,ci) = factorize(M[ll],s; which_factorization="svd", dir="fromleft", kwargs...)
+      else
+          Q, R = qr(M[ll], s; kwargs...)
+      end
     else
       li = linkindex(M,ll-1)
-      (Q,R) = qr(M[ll],s,li)
+      if method == "svd"
+          (Q,R,ci) = factorize(M[ll],s,li; which_factorization="svd", dir="fromleft", kwargs...)
+      else
+          Q, R = qr(M[ll], s, li; kwargs...)
+      end
     end
     M[ll] = Q
     M[ll+1] *= R
@@ -167,10 +176,18 @@ function position!(M::MPS,
     rl = rightLim(M)-1
     s = findindex(M[rl],"Site")
     if rl == N
-      (Q,R) = qr(M[rl],s)
+      if method == "svd"
+          (Q,R,ci) = factorize(M[rl],s; which_factorization="svd", dir="fromright", kwargs...)
+      else
+          Q, R = qr(M[rl], s; kwargs...)
+      end
     else
       ri = linkindex(M,rl)
-      (Q,R) = qr(M[rl],s,ri)
+      if method == "svd"
+          (Q,R,ci) = factorize(M[rl],s,ri; which_factorization="svd", dir="fromright", kwargs...)
+      else
+          Q, R = qr(M[rl], s, ri; kwargs...)
+      end
     end
     M[rl] = Q
     M[rl-1] *= R

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -159,38 +159,6 @@ function replacesites!(M::MPS,sites)
   return M
 end
 
-function position!(M::Union{MPS,MPO}, 
-                   j::Int)
-
-  while leftLim(M) < (j-1)
-    (leftLim(M) < 0) && setLeftLim!(M,0)
-    b = leftLim(M)+1
-    linds = uniqueinds(M[b],M[b+1])
-    Q,R = qr(M[b], linds)
-    M[b] = Q
-    M[b+1] *= R
-    setLeftLim!(M,b)
-    if rightLim(M) < leftLim(M)+2
-      setRightLim!(M,leftLim(M)+2)
-    end
-  end
-
-  N = length(M)
-
-  while rightLim(M) > (j+1)
-    (rightLim(M) > (N+1)) && setRightLim!(M,N+1)
-    b = rightLim(M)-2
-    rinds = uniqueinds(M[b+1],M[b])
-    Q,R = qr(M[b+1], rinds)
-    M[b+1] = Q
-    M[b] *= R
-    setRightLim!(M,b+1)
-    if leftLim(M) > rightLim(M)-2
-      setLeftLim!(M,rightLim(M)-2)
-    end
-  end
-
-end
 
 function inner(M1::MPS, M2::MPS)::Number
   N = length(M1)
@@ -224,13 +192,3 @@ Compute <psi|phi>
 """ inner
 
 
-@doc """
-position!(M::MPS, j::Int)
-
-Move the gauge position, or orthogonality center, 
-to site j of the MPS. No observable property of 
-the MPS will be changed, and no truncation of the 
-bond indices is performed. Afterward, tensors 
-1,2,...,j-1 will be left-orthogonal and tensors 
-j+1,j+2,...,N will be right-orthogonal.
-""" position!

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -61,6 +61,7 @@ function setRightLim!(m::MPS,new_rl::Int)
 end
 
 getindex(M::MPS, n::Integer) = getindex(tensors(M),n)
+
 function setindex!(M::MPS,T::ITensor,n::Integer) 
   (n <= leftLim(M)) && setLeftLim!(M,n-1)
   (n >= rightLim(M)) && setRightLim!(M,n+1)
@@ -158,7 +159,7 @@ function replacesites!(M::MPS,sites)
   return M
 end
 
-function position!(M::MPS, 
+function position!(M::Union{MPS,MPO}, 
                    j::Int)
 
   while leftLim(M) < (j-1)


### PR DESCRIPTION
The way we have this now, you can't truncate when you call position and so the bond dimension can grow pretty badly in `sum`, `applyMPO`, and friends.