### PR TITLE
replace digit parsing with subtraction

### DIFF
--- a/src/smallstring.jl
+++ b/src/smallstring.jl
@@ -71,7 +71,7 @@ function Base.parse(::Type{Int}, s::SmallString)
   n = length(s)
   int = 0
   for j = 1:n
-    int = int*10 + parse(Int,Char(s[j]))
+    int = int*10 + (s[j] - 0x30)  # 0x30 === UInt8('0'), '9'-'0' == 9
   end
   return int
 end

--- a/test/test_smallstring.jl
+++ b/test/test_smallstring.jl
@@ -33,7 +33,16 @@ import ITensors.SmallString, ITensors.IntChar, ITensors.push
       t = push(s, IntChar(2))
       @test u < t
   end
-
+      
+  @testset "convert to integer" begin
+      s = SmallString()
+      s = push(s, '2')
+      s = push(s, '6')
+      s = push(s, '7')
+      i = parse(Int, s)
+      @test i == 267
+  end
+      
   @testset "Convert to String" begin
     s = SmallString()
     s = push(s, 'a')


### PR DESCRIPTION
You can avoid the parse machinery here because the function is examining one decimal digit at a time. Conveniently, subtracting the character code for '0' from the character code for another digit gives the value of that digit as an integer.