### PR TITLE
replace call to maxDim with maxLinkDim

### DIFF
--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -39,7 +39,7 @@ function dmrg(H::MPO,
                    which_factorization=which_factorization)
     end
     end
-    !quiet && @printf "After sweep %d energy=%.12f maxDim=%d time=%.3f\n" sw energy maxDim(psi) sw_time
+    !quiet && @printf "After sweep %d energy=%.12f maxDim=%d time=%.3f\n" sw energy maxLinkDim(psi) sw_time
     @debug printTimes(timer)
   end
   return (energy,psi)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -158,8 +158,8 @@ function simlinks!(M::T) where {T <: Union{MPS,MPO}}
 end
 
 """
-maxDim(M::MPS)
-maxDim(M::MPO)
+maxLinkDim(M::MPS)
+maxLinkDim(M::MPO)
 
 Get the maximum link dimension of the MPS or MPO.
 """

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -6,7 +6,7 @@ export MPS,
        inner,
        productMPS,
        randomMPS,
-       maxDim,
+       maxLinkDim,
        linkindex,
        siteindex,
        siteinds

--- a/test/test_autompo.jl
+++ b/test/test_autompo.jl
@@ -300,7 +300,7 @@ end
     Oa = inner(psi,Ha,psi)
     Oe = inner(psi,He,psi)
     @test Oa ≈ Oe
-    #@test maxDim(Ha) == 8
+    #@test maxLinkDim(Ha) == 8
   end
 
 end


### PR DESCRIPTION
`maxDim(::MPS)` was renamed to `maxLinkDim`. updated `dmrg` to call the right function.
this fixes https://github.com/ITensor/ITensors.jl/issues/75 . 

