### PR TITLE
preserve bond index tags in replaceBond!

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -301,6 +301,8 @@ removetags(A::ITensor,vargs...) = ITensor(removetags(inds(A),vargs...),store(A))
 
 replacetags(A::ITensor,vargs...) = ITensor(replacetags(inds(A),vargs...),store(A))
 
+replacetags!(A::ITensor,vargs...) = replacetags!(A.inds,vargs...)
+
 settags(A::ITensor,vargs...) = ITensor(settags(inds(A),vargs...),store(A))
 
 swaptags(A::ITensor,vargs...) = ITensor(swaptags(inds(A),vargs...),store(A))

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -203,10 +203,11 @@ function replaceBond!(M::MPS,
                       b::Int,
                       phi::ITensor;
                       kwargs...)
-  FU,FV,u = factorize(phi,inds(M[b]); which_factorization="automatic", kwargs...)
-  replacetags!(FU,tags(u),tags(linkindex(M,b)), u)
-  replacetags!(FV,tags(u),tags(linkindex(M,b)), u)
+  FU,FV = factorize(phi,inds(M[b]); which_factorization="automatic",
+                        tags=tags(linkindex(M,b)), kwargs...)
   M[b]   = FU
   M[b+1] = FV
 end
+
+
 

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -203,7 +203,9 @@ function replaceBond!(M::MPS,
                       b::Int,
                       phi::ITensor;
                       kwargs...)
-  FU,FV = factorize(phi,inds(M[b]); which_factorization="automatic", kwargs...)
+  FU,FV,u = factorize(phi,inds(M[b]); which_factorization="automatic", kwargs...)
+  replacetags!(FU,tags(u),tags(linkindex(M,b)), u)
+  replacetags!(FV,tags(u),tags(linkindex(M,b)), u)
   M[b]   = FU
   M[b+1] = FV
 end

--- a/test/test_mps.jl
+++ b/test/test_mps.jl
@@ -110,4 +110,10 @@ using ITensors,
   @test ITensors.rightLim(psi) == div(N, 2) + 1
 
   @test_throws ErrorException linkindex(MPS(N, fill(ITensor(), N), 0, N + 1), 1)
+
+  # make sure factorization preserves the bond index tags
+  phi = psi[1]*psi[2]
+  bondindtags = tags(linkindex(psi,1))
+  replaceBond!(psi,1,phi)
+  @test tags(linkindex(psi,1)) == bondindtags
 end


### PR DESCRIPTION
this PR fixes a bug where the tags of the bond index of an MPS were not preserved by `replaceBond!`.

