### PR TITLE
dmrg observer & fix for replaceBond!

### DIFF
--- a/examples/dmrg/dmrg_with_observer.jl
+++ b/examples/dmrg/dmrg_with_observer.jl
@@ -1,0 +1,43 @@
+# In this example we show how to pass a DMRGObserver to
+# the dmrg function which allows tracking energy convergence and
+# convergence of local operators.
+using ITensors
+
+
+"""
+get MPO of transverse field Ising model Hamiltonian with field strength h
+"""
+function tfimMPO(h,sites)
+    # Input operator terms which define a Hamiltonian
+    ampo = AutoMPO(sites)
+    for j=1:length(sites)-1
+        add!(ampo,"Sz",j,"Sz",j+1)
+        add!(ampo,h,"Sx",j)
+    end
+    add!(ampo,h,"Sx",length(sites))
+    # Convert these terms to an MPO tensor network
+    return toMPO(ampo)
+end
+
+N = 20
+sites = spinHalfSites(N)
+psi0 = randomMPS(sites)
+sweeps = Sweeps(5)
+maxdim!(sweeps, 10,20,100,100,200)
+cutoff!(sweeps, 1E-10)
+
+#=
+create observer which will measure Sᶻ at each
+site during the dmrg sweeps and track energies after each sweep.
+in addition it will stop the computation if energy converges within
+1e-8 tolerance
+=#
+observer= DMRGObserver(["Sz"],sites,1e-4)
+
+# Run the DMRG algorithm, returning energy and optimized MPS
+energy, psi = dmrg(tfimMPO(0.1,sites),psi0, sweeps,observer=observer)
+# @printf("Final energy = %.12f\n",energy)
+
+for Szs in measurements(observer)["Sz"]
+    println(Szs)
+end

--- a/examples/dmrg/dmrg_with_observer.jl
+++ b/examples/dmrg/dmrg_with_observer.jl
@@ -32,7 +32,7 @@ cutoff!(sweeps, 1E-10)
 create observer which will measure Sᶻ at each
 site during the dmrg sweeps and track energies after each sweep.
 in addition it will stop the computation if energy converges within
-1e-8 tolerance
+1e-6 tolerance
 =#
 observer= DMRGObserver(["Sz"],sites,1e-6)
 

--- a/examples/dmrg/dmrg_with_observer.jl
+++ b/examples/dmrg/dmrg_with_observer.jl
@@ -11,7 +11,7 @@ function tfimMPO(h,sites)
     # Input operator terms which define a Hamiltonian
     ampo = AutoMPO(sites)
     for j=1:length(sites)-1
-        add!(ampo,"Sz",j,"Sz",j+1)
+        add!(ampo,-1.,"Sz",j,"Sz",j+1)
         add!(ampo,h,"Sx",j)
     end
     add!(ampo,h,"Sx",length(sites))
@@ -19,9 +19,11 @@ function tfimMPO(h,sites)
     return toMPO(ampo)
 end
 
-N = 20
+N = 100
 sites = spinHalfSites(N)
 psi0 = randomMPS(sites)
+
+# define parameters for DMRG sweeps
 sweeps = Sweeps(5)
 maxdim!(sweeps, 10,20,100,100,200)
 cutoff!(sweeps, 1E-10)
@@ -32,12 +34,35 @@ site during the dmrg sweeps and track energies after each sweep.
 in addition it will stop the computation if energy converges within
 1e-8 tolerance
 =#
-observer= DMRGObserver(["Sz"],sites,1e-4)
+observer= DMRGObserver(["Sz"],sites,1e-6)
 
-# Run the DMRG algorithm, returning energy and optimized MPS
+# we will now run DMRG calculation for different values
+# of the transverse field and check how local observables
+# converge to their ground state values
+
+println("Running DMRG for TFIM with h=0.1")
+println("================================")
 energy, psi = dmrg(tfimMPO(0.1,sites),psi0, sweeps,observer=observer)
-# @printf("Final energy = %.12f\n",energy)
 
-for Szs in measurements(observer)["Sz"]
-    println(Szs)
+for (i,Szs) in enumerate(measurements(observer)["Sz"])
+    println("magnetization after sweep $i = ", sum(Szs)/N)
+end
+
+
+println("\nRunning DMRG for TFIM with h=1")
+println("================================")
+observer= DMRGObserver(["Sz"],sites,1e-6)
+energy, psi = dmrg(tfimMPO(1.,sites),psi0, sweeps,observer=observer)
+
+for (i,Szs) in enumerate(measurements(observer)["Sz"])
+    println("magnetization after sweep $i = ", sum(Szs)/N)
+end
+
+println("\nRunning DMRG for TFIM with h=5.")
+println("================================")
+observer= DMRGObserver(["Sz","Sx"],sites,1e-6)
+energy, psi = dmrg(tfimMPO(5.,sites),psi0, sweeps,observer=observer)
+
+for (i,Sxs) in enumerate(measurements(observer)["Sx"])
+    println("<Sˣ> after sweep $i = ", sum(Sxs)/N)
 end

--- a/examples/dmrg/dmrg_with_observer.jl
+++ b/examples/dmrg/dmrg_with_observer.jl
@@ -5,18 +5,18 @@ using ITensors
 
 
 """
-get MPO of transverse field Ising model Hamiltonian with field strength h
-"""
+  get MPO of transverse field Ising model Hamiltonian with field strength h
+  """
 function tfimMPO(h,sites)
-    # Input operator terms which define a Hamiltonian
-    ampo = AutoMPO(sites)
-    for j=1:length(sites)-1
-        add!(ampo,-1.,"Sz",j,"Sz",j+1)
-        add!(ampo,h,"Sx",j)
-    end
-    add!(ampo,h,"Sx",length(sites))
-    # Convert these terms to an MPO tensor network
-    return toMPO(ampo)
+  # Input operator terms which define a Hamiltonian
+  ampo = AutoMPO(sites)
+  for j=1:length(sites)-1
+    add!(ampo,-1.,"Sz",j,"Sz",j+1)
+    add!(ampo,h,"Sx",j)
+  end
+  add!(ampo,h,"Sx",length(sites))
+  # Convert these terms to an MPO tensor network
+  return toMPO(ampo)
 end
 
 N = 100
@@ -45,7 +45,7 @@ println("================================")
 energy, psi = dmrg(tfimMPO(0.1,sites),psi0, sweeps,observer=observer)
 
 for (i,Szs) in enumerate(measurements(observer)["Sz"])
-    println("magnetization after sweep $i = ", sum(Szs)/N)
+  println("magnetization after sweep $i = ", sum(Szs)/N)
 end
 
 
@@ -55,7 +55,7 @@ observer= DMRGObserver(["Sz"],sites,1e-6)
 energy, psi = dmrg(tfimMPO(1.,sites),psi0, sweeps,observer=observer)
 
 for (i,Szs) in enumerate(measurements(observer)["Sz"])
-    println("magnetization after sweep $i = ", sum(Szs)/N)
+  println("magnetization after sweep $i = ", sum(Szs)/N)
 end
 
 println("\nRunning DMRG for TFIM with h=5.")
@@ -64,5 +64,5 @@ observer= DMRGObserver(["Sz","Sx"],sites,1e-6)
 energy, psi = dmrg(tfimMPO(5.,sites),psi0, sweeps,observer=observer)
 
 for (i,Sxs) in enumerate(measurements(observer)["Sx"])
-    println("<Sˣ> after sweep $i = ", sum(Sxs)/N)
+  println("<Sˣ> after sweep $i = ", sum(Sxs)/N)
 end

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -76,6 +76,7 @@ include("mps/mps.jl")
 include("mps/mpo.jl")
 include("mps/sweeps.jl")
 include("mps/projmpo.jl")
+include("mps/observer.jl")
 include("mps/dmrg.jl")
 include("mps/autompo.jl")
 

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -1,11 +1,13 @@
 export dmrg
 
+
 function dmrg(H::MPO,
               psi0::MPS,
               sweeps::Sweeps;
               kwargs...)::Tuple{Float64,MPS}
 
   which_factorization::String = get(kwargs,:which_factorization,"automatic")
+  obs = get(kwargs, :observer, NoObserver() )
 
   psi = copy(psi0)
   N = length(psi)
@@ -37,16 +39,19 @@ function dmrg(H::MPO,
                    cutoff=cutoff(sweeps,sw),
                    dir=dir,
                    which_factorization=which_factorization)
+      measure!(obs,psi,DMRGStepInfo(ha==2,b,sw,energy))
     end
     end
     if !quiet
       @printf("After sweep %d energy=%.12f maxLinkDim=%d time=%.3f\n",sw,energy,maxLinkDim(psi),sw_time)
     end
+    @debug printTimes(timer)
+    checkdone(obs,quiet=quiet) && break
   end
   return (energy,psi)
 end
 
-@doc """ 
+@doc """
 dmrg(H::MPO,psi0::MPS,sweeps::Sweeps;kwargs...)::Tuple{Float64,MPS}
 
 Optimize a matrix product state (MPS) to be the eigenvector

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -182,6 +182,15 @@ function replaceBond!(M::MPS,
                         tags=tags(linkindex(M,b)), kwargs...)
   M[b]   = FU
   M[b+1] = FV
+
+  dir = get(kwargs,:dir,"center")
+  if dir=="fromright"
+    M.llim_ ==b && (M.llim_ -= 1)
+    M.rlim_ == b+2 && (M.rlim_ -= 1)
+  elseif dir=="fromleft"
+    M.llim_ == b-1 && (M.llim_ += 1)
+    M.rlim_ == b+1 && (M.rlim_ += 1)
+  end
 end
 
 

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -1,24 +1,24 @@
 export DMRGObserver, measurements, energies
 
 """
-    DMRGStepInfo
-Container for passing information about
-DMRG step to an observer object.
+      DMRGStepInfo
+  Container for passing information about
+  DMRG step to an observer object.
 
-# Fields:
-- dir::Bool - `false` if sweeping is currently towards the right (forward part of sweep)
-               and `true` otherwise
-- sweepnum::Int - current sweep number
-- energy::Float64 - current variational energy
-- bond::Int - last bond on which DMRG update was performed
-"""
+  # Fields:
+  - dir::Bool - `false` if sweeping is currently towards the right (forward part of sweep)
+                 and `true` otherwise
+  - sweepnum::Int - current sweep number
+  - energy::Float64 - current variational energy
+  - bond::Int - last bond on which DMRG update was performed
+  """
 struct DMRGStepInfo
-    dir::Bool
-    bond::Int64
-    sweepnum::Int64
-    energy::Float64
-    # TODO: also need to pass here truncerr and singular values
-    # once those are returned from replaceBond!
+  dir::Bool
+  bond::Int64
+  sweepnum::Int64
+  energy::Float64
+  # TODO: also need to pass here truncerr and singular values
+  # once those are returned from replaceBond!
 end
 
 
@@ -36,22 +36,22 @@ struct NoObserver <: AbstractObserver
 end
 
 struct DMRGObserver <: AbstractObserver
-    ops_::Vector{String}
-    sites_::SiteSet
-    measurements::Dict{String, Vector{Vector{Float64}} }
-    energies::Vector{Float64}
-    etol::Float64
-    minsweeps::Int64
+  ops_::Vector{String}
+  sites_::SiteSet
+  measurements::Dict{String, Vector{Vector{Float64}} }
+  energies::Vector{Float64}
+  etol::Float64
+  minsweeps::Int64
 
-    DMRGObserver(etol::Real=0, minsweeps::Int=2) = new([],SiteSet(),
-                                                       Dict{String,Vector{Vector{Float64}}}(),
-                                                       [],etol,minsweeps)
+  DMRGObserver(etol::Real=0, minsweeps::Int=2) = new([],SiteSet(),
+                                                     Dict{String,Vector{Vector{Float64}}}(),
+                                                     [],etol,minsweeps)
 
-    function DMRGObserver(ops::Vector{String}, sites::SiteSet,etol::Real=0,
-                          minsweeps::Int=2)
-        measurements = Dict(o => Vector{Float64}[] for o in ops)
-        return new(ops,sites,measurements,[],etol,minsweeps)
-    end
+  function DMRGObserver(ops::Vector{String}, sites::SiteSet,etol::Real=0,
+                        minsweeps::Int=2)
+    measurements = Dict(o => Vector{Float64}[] for o in ops)
+    return new(ops,sites,measurements,[],etol,minsweeps)
+  end
 end
 
 measurements(o::DMRGObserver) = o.measurements
@@ -61,41 +61,41 @@ energies(o::DMRGObserver) = o.energies
 op(obs::DMRGObserver,O,i) = op(obs.sites_,O,i)
 
 function _measure_local_ops!(obs::DMRGObserver,psi::MPS,i)
-    for o in obs.ops_
-        m = dot(prime(psi[ i ],"Site"), op(obs, o, i)*psi[i])
-        imag(m)>1e-8 && (@warn "encountered finite imaginary part when measuring $o")
-        obs.measurements[o][end][i]=real(m)
-    end
+  for o in obs.ops_
+    m = dot(prime(psi[ i ],"Site"), op(obs, o, i)*psi[i])
+    imag(m)>1e-8 && (@warn "encountered finite imaginary part when measuring $o")
+    obs.measurements[o][end][i]=real(m)
+  end
 end
 
 function measure!(obs::DMRGObserver, psi::MPS, si::DMRGStepInfo)
-    if sweepdir(si)=="left"
-        if bond(si)==length(psi)-1
-            for o in obs.ops_
-                push!(obs.measurements[o],zeros(length(psi)))
-            end
-        end
-        # when sweeping left the orthogonality center is located at site n= bond(si) after the bond update.
-        # We want to measure at n=bond(si)+1 because there the tensor has been
-        # already fully updated (by the right and left pass of the sweep).
-        position!(psi,bond(si)+1)
-        _measure_local_ops!(obs,psi,bond(si)+1)
-        position!(psi,bond(si))
-
-        if bond(si)==1
-            push!(obs.energies, getenergy(si))
-            _measure_local_ops!(obs,psi,bond(si))
-        end
+  if sweepdir(si)=="left"
+    if bond(si)==length(psi)-1
+      for o in obs.ops_
+        push!(obs.measurements[o],zeros(length(psi)))
+      end
     end
+    # when sweeping left the orthogonality center is located at site n= bond(si) after the bond update.
+    # We want to measure at n=bond(si)+1 because there the tensor has been
+    # already fully updated (by the right and left pass of the sweep).
+    position!(psi,bond(si)+1)
+    _measure_local_ops!(obs,psi,bond(si)+1)
+    position!(psi,bond(si))
+
+    if bond(si)==1
+      push!(obs.energies, getenergy(si))
+      _measure_local_ops!(obs,psi,bond(si))
+    end
+  end
 end
 
 function checkdone(o::DMRGObserver ; quiet=false)
-    if (length(energies(o))>o.minsweeps &&
-        abs(energies(o)[end] - energies(o)[end-1]) < o.etol)
-        !quiet && println("Energy difference less than $(o.etol), stopping DMRG")
-        return true
-    else
-        return false
-    end
+  if (length(energies(o))>o.minsweeps &&
+      abs(energies(o)[end] - energies(o)[end-1]) < o.etol)
+    !quiet && println("Energy difference less than $(o.etol), stopping DMRG")
+    return true
+  else
+    return false
+  end
 end
 

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -78,9 +78,9 @@ function measure!(obs::DMRGObserver, psi::MPS, si::DMRGStepInfo)
     # when sweeping left the orthogonality center is located at site n= bond(si) after the bond update.
     # We want to measure at n=bond(si)+1 because there the tensor has been
     # already fully updated (by the right and left pass of the sweep).
-    position!(psi,bond(si)+1)
+    orthogonalize!(psi,bond(si)+1)
     _measure_local_ops!(obs,psi,bond(si)+1)
-    position!(psi,bond(si))
+    orthogonalize!(psi,bond(si))
 
     if bond(si)==1
       push!(obs.energies, getenergy(si))

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -1,0 +1,101 @@
+export DMRGObserver, measurements, energies
+
+"""
+    DMRGStepInfo
+Container for passing information about
+DMRG step to an observer object.
+
+# Fields:
+- dir::Bool - `false` if sweeping is currently towards the right (forward part of sweep)
+               and `true` otherwise
+- sweepnum::Int - current sweep number
+- energy::Float64 - current variational energy
+- bond::Int - last bond on which DMRG update was performed
+"""
+struct DMRGStepInfo
+    dir::Bool
+    bond::Int64
+    sweepnum::Int64
+    energy::Float64
+    # TODO: also need to pass here truncerr and singular values
+    # once those are returned from replaceBond!
+end
+
+
+sweepdir(si::DMRGStepInfo) = (si.dir ? "left" : "right")
+sweepnum(si::DMRGStepInfo) = si.sweepnum
+getenergy(si::DMRGStepInfo) = si.energy
+bond(si::DMRGStepInfo) = si.bond
+
+abstract type AbstractObserver end
+
+measure!(o::AbstractObserver, args...) = nothing
+checkdone(o::AbstractObserver, args...; kwargs...) = false
+
+struct NoObserver <: AbstractObserver
+end
+
+struct DMRGObserver <: AbstractObserver
+    ops_::Vector{String}
+    sites_::SiteSet
+    measurements::Dict{String, Vector{Vector{Float64}} }
+    energies::Vector{Float64}
+    etol::Float64
+    minsweeps::Int64
+
+    DMRGObserver(etol::Real=0, minsweeps::Int=2) = new([],SiteSet(),
+                                                       Dict{String,Vector{Vector{Float64}}}(),
+                                                       [],etol,minsweeps)
+
+    function DMRGObserver(ops::Vector{String}, sites::SiteSet,etol::Real=0,
+                          minsweeps::Int=2)
+        measurements = Dict(o => Vector{Float64}[] for o in ops)
+        return new(ops,sites,measurements,[],etol,minsweeps)
+    end
+end
+
+measurements(o::DMRGObserver) = o.measurements
+
+energies(o::DMRGObserver) = o.energies
+
+op(obs::DMRGObserver,O,i) = op(obs.sites_,O,i)
+
+function _measure_local_ops!(obs::DMRGObserver,psi::MPS,i)
+    for o in obs.ops_
+        m = dot(prime(psi[ i ],"Site"), op(obs, o, i)*psi[i])
+        imag(m)>1e-8 && (@warn "encountered finite imaginary part when measuring $o")
+        obs.measurements[o][end][i]=real(m)
+    end
+end
+
+function measure!(obs::DMRGObserver, psi::MPS, si::DMRGStepInfo)
+    if sweepdir(si)=="left"
+        if bond(si)==length(psi)-1
+            for o in obs.ops_
+                push!(obs.measurements[o],zeros(length(psi)))
+            end
+        end
+        # when sweeping left the orthogonality center is located at site n= bond(si) after the bond update.
+        # We want to measure at n=bond(si)+1 because there the tensor has been
+        # already fully updated (by the right and left pass of the sweep).
+        position!(psi,bond(si)+1)
+        _measure_local_ops!(obs,psi,bond(si)+1)
+        position!(psi,bond(si))
+
+        if bond(si)==1
+            push!(obs.energies, getenergy(si))
+            _measure_local_ops!(obs,psi,bond(si))
+        end
+    end
+end
+
+function checkdone(o::DMRGObserver ; quiet=false)
+    if (length(energies(o))>o.minsweeps &&
+        abs(energies(o)[end] - energies(o)[end-1]) < o.etol)
+        !quiet && println("Energy difference less than $(o.etol), stopping DMRG")
+        return true
+    else
+        return false
+    end
+end
+

--- a/test/test_mps.jl
+++ b/test/test_mps.jl
@@ -120,7 +120,7 @@ using ITensors,
     @test tags(linkindex(psi,1)) == bondindtags
 
     # check that replaceBond! updates llim_ and rlim_ properly
-    position!(psi,5)
+    orthogonalize!(psi,5)
     phi = psi[5]*psi[6]
     replaceBond!(psi,5,phi, dir="fromleft")
     @test ITensors.leftLim(psi)==5

--- a/test/test_mps.jl
+++ b/test/test_mps.jl
@@ -111,11 +111,34 @@ using ITensors,
 
   @test_throws ErrorException linkindex(MPS(N, fill(ITensor(), N), 0, N + 1), 1)
 
+  @testset "replaceBond!" begin
   # make sure factorization preserves the bond index tags
-  phi = psi[1]*psi[2]
-  bondindtags = tags(linkindex(psi,1))
-  replaceBond!(psi,1,phi)
-  @test tags(linkindex(psi,1)) == bondindtags
+    psi = randomMPS(sites)
+    phi = psi[1]*psi[2]
+    bondindtags = tags(linkindex(psi,1))
+    replaceBond!(psi,1,phi)
+    @test tags(linkindex(psi,1)) == bondindtags
+
+    # check that replaceBond! updates llim_ and rlim_ properly
+    position!(psi,5)
+    phi = psi[5]*psi[6]
+    replaceBond!(psi,5,phi, dir="fromleft")
+    @test ITensors.leftLim(psi)==5
+    @test ITensors.rightLim(psi)==7
+
+    phi = psi[5]*psi[6]
+    replaceBond!(psi,5,phi,dir="fromright")
+    @test ITensors.leftLim(psi)==4
+    @test ITensors.rightLim(psi)==6
+
+    psi.llim_ = 3
+    psi.rlim_ = 7
+    phi = psi[5]*psi[6]
+    replaceBond!(psi,5,phi,dir="fromleft")
+    @test ITensors.leftLim(psi)==3
+    @test ITensors.rightLim(psi)==7
+  end
+
 end
 
 # Helper function for making MPS


### PR DESCRIPTION
Hi,

This PR includes two things (I could split to 2 different PRs if you prefer):
1. perform update of `llim_, rlim_`  in `replaceBond!` (as far as I understood from discussion in https://github.com/ITensor/ITensors.jl/issues/86 , `replaceBond!` should do that). 
2. my suggestion for a dmrg observer implementation (https://github.com/ITensor/ITensors.jl/issues/32) .

I implemented a basic `DMRGObserver` object which allows user to specify local operators to measure during the sweep, tracks energy and can stop it if some convergence criterion is reached. I also added an example showing the observer usage. 

Currently the option for tracking entropy and truncation error is missing because the factorization functions do not return the singular values and the error.

Note that (1) is necessary for (2) to work, as I'm calling `position!` inside the observer `measure!` function and it is causing an error in `dmrg` without the fix.

let me know what you think.