### PR TITLE
WIP: New syntax for specifying tags and a prime level

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -57,21 +57,21 @@ struct Index
   tags::TagSet
 end
 
-Index() = Index(IDType(0),1,Neither,TagSet("0"))
+Index() = Index(IDType(0),1,Neither,TagSet(("",0)))
 
 """
-    Index(dim::Integer, tags="0")
+  Index(dim::Integer, tags=("",0))
 Create an `Index` with a unique `id` and a tagset given by `tags`.
 
 Example: create a two dimensional index with tag `l`:
     Index(2, "l")
 """
-function Index(dim::Integer,tags="0")
+function Index(dim::Integer,tags=("",0))
   ts = TagSet(tags)
   # By default, an Index has a prime level of 0
   # A prime level less than 0 is interpreted as the
   # prime level not being set
-  plev(ts) < 0 && (ts = setprime(ts,0))
+  !hasplev(ts) && (ts = setprime(ts,0))
   Index(rand(IDType),dim,Out,ts)
 end
 
@@ -121,7 +121,7 @@ hastags(i::Index, ts) = hastags(tags(i),ts)
 function settags(i::Index, strts)
   ts = TagSet(strts)
   # By default, an Index has a prime level of 0
-  plev(ts) < 0 && (ts = setprime(ts,0))
+  !hasplev(ts) && (ts = setprime(ts,0))
   Index(id(i),dim(i),dir(i),ts)
 end
 

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -290,7 +290,9 @@ indexpositions(inds) = collect(1:length(inds))
 indexpositions(inds, match::Nothing) = collect(1:length(inds))
 #indexpositions(inds, match::Tuple{}) = collect(1:length(inds))
 # Version for matching a tag set
-function indexpositions(inds, match::T) where {T<:Union{AbstractString,TagSet}}
+function indexpositions(inds, match::T) where {T<:Union{AbstractString,
+                                                        Tuple{<:AbstractString,<:Integer},
+                                                        TagSet}}
   is = IndexSet(inds)
   tsmatch = TagSet(match)
   pos = Int[]

--- a/src/storage/dense.jl
+++ b/src/storage/dense.jl
@@ -244,8 +244,8 @@ function storage_svd(Astore::Dense{T},
   cutoff::Float64 = get(kwargs,:cutoff,0.0)
   absoluteCutoff::Bool = get(kwargs,:absoluteCutoff,false)
   doRelCutoff::Bool = get(kwargs,:doRelCutoff,true)
-  utags::String = get(kwargs,:utags,"Link,u")
-  vtags::String = get(kwargs,:vtags,"Link,v")
+  utags = TagSet(get(kwargs,:utags,"Link,u"))
+  vtags = TagSet(get(kwargs,:vtags,"Link,v"))
   fastSVD::Bool = get(kwargs,:fastSVD,false)
 
   if fastSVD
@@ -288,9 +288,9 @@ function storage_eigen(Astore::Dense{T},
   cutoff::Float64 = get(kwargs,:cutoff,0.0)
   absoluteCutoff::Bool = get(kwargs,:absoluteCutoff,false)
   doRelCutoff::Bool = get(kwargs,:doRelCutoff,true)
-  tags::TagSet = get(kwargs,:lefttags,"Link,u")
-  lefttags::TagSet = get(kwargs,:lefttags,tags)
-  righttags::TagSet = get(kwargs,:righttags,prime(lefttags))
+  tags = TagSet(get(kwargs,:lefttags,"Link,u"))
+  lefttags = TagSet(get(kwargs,:lefttags,tags))
+  righttags = TagSet(get(kwargs,:righttags,prime(lefttags)))
 
   dim_left = dim(Lis)
   dim_right = dim(Ris)
@@ -331,7 +331,7 @@ function storage_qr(Astore::Dense{T},
                     Lis::IndexSet,
                     Ris::IndexSet;
                     kwargs...) where {T}
-  tags::TagSet = get(kwargs,:tags,"Link,u")
+  tags = TagSet(get(kwargs,:tags,"Link,u"))
   dim_left = dim(Lis)
   dim_right = dim(Ris)
   MQ,MP = qr(reshape(data(Astore),dim_left,dim_right))

--- a/test/2d_classical_ising.jl
+++ b/test/2d_classical_ising.jl
@@ -37,7 +37,7 @@ function ising_mpo(sh::Tuple{Index,Index},sv::Tuple{Index,Index},
     Xh2 = ITensor(vec(√Q),sh[2],sh[2]')
     Xv1 = ITensor(vec(√Q),sv[1],sv[1]')
     Xv2 = ITensor(vec(√Q),sv[2],sv[2]')
-    T = replacetags(T*Xh1*Xh2*Xv1*Xv2,"1","0")
+    T = noprime(T*Xh1*Xh2*Xv1*Xv2)
   else
     sig(s) = 1.0-2.0*(s-1)
     E0 = -4.0

--- a/test/test_ctmrg.jl
+++ b/test/test_ctmrg.jl
@@ -30,7 +30,8 @@ function ctmrg(T::ITensor,
     Clu = Clu/norm(Clu)
 
     ## Calculate the renormalized half row transfer matrix (HRTM)
-    Al = Al*replacetags(Ud,"down","up")*T*Ud
+    Uu = replacetags(Ud,"down","up")
+    Al = Al*Uu*T*Ud
     Al = replacetags(replacetags(Al,"renorm","orig"),"right","left","site")
     Al = Al/norm(Al)
   end
@@ -69,24 +70,24 @@ end
   Clu,Al = ctmrg(T,Clu,Al;χmax=30,nsteps=2000)
 
   # Normalize corner matrix
-  trC⁴ = Clu*replacetags(Clu,"0","1","up")*
-         replacetags(Clu,"0","1")*replacetags(Clu,"0","1","left")
+  trC⁴ = Clu*mapprime(Clu,0,1,"up")*
+         mapprime(Clu,0,1)*mapprime(Clu,0,1,"left")
   Clu = Clu/scalar(trC⁴)^(1/4)
 
   # Normalize MPS tensor
-  trA² = Clu*replacetags(Clu,"0","1","up")*Al*
-         replacetags(Al,"0","1","link")*
-         replacetags(replacetags(Clu,"up,0","down,1"),"0","1","left")*
-         replacetags(replacetags(Clu,"0","1","left"),"up","down")
+  trA² = Clu*mapprime(Clu,0,1,"up")*Al*
+         mapprime(Al,0,1,"link")*
+         mapprime(replacetags(Clu,("up",0),("down",1)),0,1,"left")*
+         replacetags(mapprime(Clu,0,1,"left"),"up","down")
   Al = Al/sqrt(scalar(trA²))
 
   ## Get environment tensors for a single site measurement
-  Ar = replacetags(replacetags(Al,"left","right","site"),"0","1","link")
+  Ar = mapprime(replacetags(Al,"left","right","site"),0,1,"link")
   Au = replacetags(replacetags(replacetags(Al,"left","up","site"),"down","left","link"),"up","right","link")
-  Ad = replacetags(replacetags(Au,"up","down","site"),"0","1","link")
-  Cld = replacetags(replacetags(Clu,"up","down"),"0","1","left")
-  Cru = replacetags(replacetags(Clu,"left","right"),"0","1","up")
-  Crd = replacetags(replacetags(Cru,"0","1","right"),"up","down")
+  Ad  = mapprime(replacetags(Au,"up","down","site"),0,1,"link")
+  Cld = mapprime(replacetags(Clu,"up","down"),0,1,"left")
+  Cru = mapprime(replacetags(Clu,"left","right"),0,1,"up")
+  Crd = replacetags(mapprime(Cru,0,1,"right"),"up","down")
 
   ## Calculate partition function per site
   κ = scalar(Clu*Al*Cld*Au*T*Ad*Cru*Ar*Crd)

--- a/test/test_index.jl
+++ b/test/test_index.jl
@@ -11,7 +11,7 @@ import ITensors: In,Out,Neither
     @test dir(i) == Neither
     @test -dir(i) == Neither
     @test plev(i) == 0
-    @test tags(i) == TagSet("0")
+    @test tags(i) == TagSet(("",0))
   end
   @testset "Index with dim" begin
     i = Index(2)
@@ -19,21 +19,21 @@ import ITensors: In,Out,Neither
     @test dim(i) == 2
     @test dir(i) == Out
     @test plev(i) == 0
-    @test tags(i) == TagSet("0")
+    @test tags(i) == TagSet(("",0))
   end
   @testset "Index with all args" begin
-    i = Index(UInt64(1), 2, In, TagSet("Link,1"))
+    i = Index(UInt64(1), 2, In, TagSet(("Link",1)))
     @test id(i) == 1
     @test dim(i) == 2
     @test dir(i) == In
     @test plev(i) == 1 
-    @test tags(i) == TagSet("Link,1")
+    @test tags(i) == TagSet(("Link",1))
     j = copy(i)
     @test id(j) == 1
     @test dim(j) == 2
     @test dir(j) == In
     @test plev(j) == 1 
-    @test tags(j) == TagSet("Link,1")
+    @test tags(j) == TagSet(("Link",1))
     @test j == i
   end
   @testset "prime" begin

--- a/test/test_itensor.jl
+++ b/test/test_itensor.jl
@@ -246,20 +246,20 @@ end
     @test s1==findindex(A1,"Site")
     @test s1==findindex(A1,"s=1")
     @test s1==findindex(A1,"s=1,Site")
-    @test l==findindex(A1,"Link,0")
-    @test l'==findindex(A1,"1")
-    @test l'==findindex(A1,"Link,1")
+    @test l==findindex(A1,("Link",0))
+    @test l'==findindex(A1,("",1))
+    @test l'==findindex(A1,("Link",1))
     @test s2==findindex(A2,"Site")
     @test s2==findindex(A2,"s=2")
     @test s2==findindex(A2,"Site")
-    @test s2==findindex(A2,"0")
-    @test s2==findindex(A2,"s=2,0")
-    @test s2==findindex(A2,"Site,0")
-    @test s2==findindex(A2,"s=2,Site,0")
-    @test l'==findindex(A2,"1")
-    @test l'==findindex(A2,"Link,1")
-    @test l''==findindex(A2,"2")
-    @test l''==findindex(A2,"Link,2")
+    @test s2==findindex(A2,("",0))
+    @test s2==findindex(A2,("s=2",0))
+    @test s2==findindex(A2,("Site",0))
+    @test s2==findindex(A2,("s=2,Site",0))
+    @test l'==findindex(A2,("",1))
+    @test l'==findindex(A2,("Link",1))
+    @test l''==findindex(A2,("",2))
+    @test l''==findindex(A2,("Link",2))
   end
   @testset "addtags(::ITensor,::String,::String)" begin
     s1u = addtags(s1,"u")
@@ -271,20 +271,20 @@ end
     A1u = addtags(A1,"u","Link")
     @test hasinds(A1u,s1,lu,lu')
 
-    A1u = addtags(A1,"u","0")
+    A1u = addtags(A1,"u",("",0))
     @test hasinds(A1u,s1u,lu,l')
 
-    A1u = addtags(A1,"u","Link,0")
+    A1u = addtags(A1,"u",("Link",0))
     @test hasinds(A1u,s1,lu,l')
 
-    A1u = addtags(A1,"u","Link,1")
+    A1u = addtags(A1,"u",("Link",1))
     @test hasinds(A1u,s1,l,lu')
   end
   @testset "removetags(::ITensor,::String,::String)" begin
     A2r = removetags(A2,"Site")
     @test hasinds(A2r,removetags(s2,"Site"),l',l'')
 
-    A2r = removetags(A2,"Link","1")
+    A2r = removetags(A2,"Link",("",1))
     @test hasinds(A2r,s2,removetags(l,"Link")',l'')
   end
   @testset "replacetags(::ITensor,::String,::String)" begin
@@ -297,18 +297,18 @@ end
     A2r = replacetags(A2,"Link","Temp")
     @test hasinds(A2r,s2,ltmp',ltmp'')
 
-    A2r = replacetags(A2,"Link","Temp","1")
+    A2r = replacetags(A2,"Link","Temp",("",1))
     @test hasinds(A2r,s2,ltmp',l'')
 
-    A2r = replacetags(A2,"Link,2","Temp,3")
+    A2r = replacetags(A2,("Link",2),("Temp",3))
     @test hasinds(A2r,s2,l',ltmp''')
 
-    A2r = replacetags(A2,"1","5")
+    A2r = replacetags(A2,("",1),("",5))
     @test hasinds(A2r,s2,prime(l,5),l'')
 
     #In-place version
     cA2 = copy(A2)
-    replacetags!(cA2,"1","5")
+    replacetags!(cA2,("",1),("",5))
     @test hasinds(cA2,s2,prime(l,5),l'')
   end
   @testset "prime(::ITensor,::String)" begin


### PR DESCRIPTION
This implements the idea of using the syntax ("x",2) instead of "x,2" to specify tags along with a prime level. This can be used throughout the library, when tags are being specified to create a new index or for pattern matching.