### PR TITLE
Added errMPOProd

### DIFF
--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -2,7 +2,7 @@ export MPO,
        randomMPO,
        applyMPO,
        nmultMPO,
-       errMPOProd,
+       errorMPOProd,
        maxLinkDim,
        orthogonalize!,
        truncate!
@@ -36,8 +36,8 @@ mutable struct MPO
     end
     new(N,v,0,N+1)
   end
- 
-  function MPO(sites::SiteSet, 
+
+  function MPO(sites::SiteSet,
                ops::Vector{String})
     N = length(sites)
     its = Vector{ITensor}(undef, N)
@@ -81,17 +81,17 @@ tensors(m::MPO) = m.A_
 leftLim(m::MPO) = m.llim_
 rightLim(m::MPO) = m.rlim_
 
-function setLeftLim!(m::MPO,new_ll::Int) 
+function setLeftLim!(m::MPO,new_ll::Int)
   m.llim_ = new_ll
 end
 
-function setRightLim!(m::MPO,new_rl::Int) 
+function setRightLim!(m::MPO,new_rl::Int)
   m.rlim_ = new_rl
 end
 
 getindex(m::MPO, n::Integer) = getindex(tensors(m), n)
 
-function setindex!(M::MPO,T::ITensor,n::Integer) 
+function setindex!(M::MPO,T::ITensor,n::Integer)
   (n <= leftLim(M)) && setLeftLim!(M,n-1)
   (n >= rightLim(M)) && setRightLim!(M,n+1)
   setindex!(tensors(M),T,n)
@@ -181,7 +181,7 @@ Get the maximum link dimension of the MPS or MPO.
 """
 function maxLinkDim(M::T) where {T <: Union{MPS,MPO}}
   md = 0
-  for b ∈ eachindex(M)[1:end-1] 
+  for b ∈ eachindex(M)[1:end-1]
     md = max(md,dim(linkindex(M,b)))
   end
   md
@@ -195,7 +195,7 @@ function show(io::IO, W::MPO)
   end
 end
 
-function linkindex(M::MPO,j::Integer) 
+function linkindex(M::MPO,j::Integer)
   N = length(M)
   j ≥ length(M) && error("No link index to the right of site $j (length of MPO is $N)")
   li = commonindex(M[j],M[j+1])
@@ -261,16 +261,17 @@ end
 
 
 """
-errMPOProd(y::MPS, A::MPO, x::MPS)
+errorMPOProd(y::MPS, A::MPO, x::MPS)
 
-Compute the distance || |y> - A|x> ||^2.
+Compute the distance between A|x> and an approximation MPS y:
+| |y> - A|x> |/| A|x> | = √(1 + (<y|y> - 2*real(<y|A|x>))/<Ax|A|x>)
 """
-function errMPOProd(y::MPS, A::MPO, x::MPS)
+function errorMPOProd(y::MPS, A::MPO, x::MPS)
   N = length(A)
   if length(y) != N || length(x) != N
       throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y))"))
   end
-  return real(inner(y,y) - 2*inner(y,A,x) + inner(A,x,A,x))
+  return sqrt(abs(1. + (inner(y,y) - 2*real(inner(y,A,x)))/inner(A,x,A,x)))
 end
 
 function plussers(left_ind::Index, right_ind::Index, sum_ind::Index)
@@ -293,7 +294,7 @@ function plussers(left_ind::Index, right_ind::Index, sum_ind::Index)
 end
 
 function sum(A::T, B::T; kwargs...) where {T <: Union{MPS, MPO}}
-    n = A.N_ 
+    n = A.N_
     length(B) =! n && throw(DimensionMismatch("lengths of MPOs A ($n) and B ($(length(B))) do not match"))
     orthogonalize!(A, 1; kwargs...)
     orthogonalize!(B, 1; kwargs...)
@@ -337,7 +338,7 @@ function densityMatrixApplyMPO(A::MPO, psi::MPS; kwargs...)::MPS
     cutoff::Float64 = get(kwargs, :cutoff, 1e-13)
     maxdim::Int = get(kwargs,:maxdim,maxLinkDim(psi))
     mindim::Int = max(get(kwargs,:mindim,1), 1)
-    normalize::Bool = get(kwargs, :normalize, false) 
+    normalize::Bool = get(kwargs, :normalize, false)
 
     all(x->x!=Index(), [siteindex(A, psi, j) for j in 1:n]) || throw(ErrorException("MPS and MPO have different site indices in applyMPO method 'DensityMatrix'"))
     rand_plev = 14741
@@ -368,7 +369,7 @@ function densityMatrixApplyMPO(A::MPO, psi::MPS; kwargs...)::MPS
         dO  = prime(dag(O), rand_plev)
         ρ   = E[j-1] * O * dO
         ts  = tags(commonindex(psi[j], psi[j-1]))
-        Lis = IndexSet(commonindex(ρ, A[j]), commonindex(ρ, psi_out[j+1])) 
+        Lis = IndexSet(commonindex(ρ, A[j]), commonindex(ρ, psi_out[j+1]))
         Ris = uniqueinds(ρ, Lis)
         FU, D = eigen(ρ, Lis, Ris; tags=ts, kwargs...)
         psi_out[j] = dag(FU)
@@ -386,7 +387,7 @@ end
 
 function nmultMPO(A::MPO, B::MPO; kwargs...)::MPO
     cutoff::Float64 = get(kwargs, :cutoff, 1e-14)
-    resp_degen::Bool = get(kwargs, :respect_degenerate, true) 
+    resp_degen::Bool = get(kwargs, :respect_degenerate, true)
     maxdim::Int = get(kwargs,:maxdim,maxLinkDim(A)*maxLinkDim(B))
     mindim::Int = max(get(kwargs,:mindim,1), 1)
     N = length(A)
@@ -444,8 +445,8 @@ function nmultMPO(A::MPO, B::MPO; kwargs...)::MPO
     return res
 end
 
-function orthogonalize!(M::Union{MPS,MPO}, 
-                        j::Int; 
+function orthogonalize!(M::Union{MPS,MPO},
+                        j::Int;
                         kwargs...)
   while leftLim(M) < (j-1)
     (leftLim(M) < 0) && setLeftLim!(M,0)
@@ -500,9 +501,9 @@ orthogonalize!(M::MPS, j::Int; kwargs...)
 
 Move the orthogonality center of the MPS
 to site j. No observable property of the
-MPS will be changed, and no truncation of the 
-bond indices is performed. Afterward, tensors 
-1,2,...,j-1 will be left-orthogonal and tensors 
+MPS will be changed, and no truncation of the
+bond indices is performed. Afterward, tensors
+1,2,...,j-1 will be left-orthogonal and tensors
 j+1,j+2,...,N will be right-orthogonal.
 
 orthogonalize!(W::MPO, j::Int; kwargs...)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -2,6 +2,7 @@ export MPO,
        randomMPO,
        applyMPO,
        nmultMPO,
+       errMPOProd,
        maxLinkDim,
        orthogonalize!,
        truncate!
@@ -256,6 +257,20 @@ function inner(B::MPO,
     O = O*ydag[j]*Bdag[j]*A[j]*x[j]
   end
   return O[]
+end
+
+
+"""
+errMPOProd(y::MPS, A::MPO, x::MPS)
+
+Compute the distance || |y> - A|x> ||^2.
+"""
+function errMPOProd(y::MPS, A::MPO, x::MPS)
+  N = length(A)
+  if length(y) != N || length(x) != N
+      throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y))"))
+  end
+  return real(inner(y,y) - 2*inner(y,A,x) + inner(A,x,A,x))
 end
 
 function plussers(left_ind::Index, right_ind::Index, sum_ind::Index)

--- a/test/test_mpo.jl
+++ b/test/test_mpo.jl
@@ -106,6 +106,10 @@ using ITensors,
                         /inner(K,psi,K,psi)))
     @test dist ≈ errorMPOProd(phi,K,psi)
 
+    # Apply K to phi and check that errorMPOProd is close to 0.
+    Kphi = applyMPO(K, phi, maxdim=1)
+    @test errorMPOProd(Kphi, K, phi) ≈ 0. atol=1e-6
+
     badsites = SiteSet(N+1,2)
     badpsi = randomMPS(badsites)
     @test_throws DimensionMismatch errorMPOProd(phi,K,badpsi)

--- a/test/test_mpo.jl
+++ b/test/test_mpo.jl
@@ -25,7 +25,7 @@ using ITensors,
     K = randomMPO(sites)
     orthogonalize!(phi, 1)
     orthogonalize!(K, 1)
-    orig_inner = inner(phi, K, phi) 
+    orig_inner = inner(phi, K, phi)
     orthogonalize!(phi, div(N, 2))
     orthogonalize!(K, div(N, 2))
     @test inner(phi, K, phi) ≈ orig_inner
@@ -76,17 +76,18 @@ using ITensors,
     @test_throws DimensionMismatch inner(J,phi,K,badpsi)
   end
 
-  @testset "errMPOProd" begin
+  @testset "errorMPOProd" begin
     phi = randomMPS(sites)
     K = randomMPO(sites)
     @test maxLinkDim(K) == 1
     psi = randomMPS(sites)
-    dist = real(inner(phi,phi) - 2*inner(phi,K,psi) + inner(K,psi,K,psi))
-    @test dist ≈ errMPOProd(phi,K,psi)
+    dist = sqrt(abs(1 + (inner(phi,phi) - 2*real(inner(phi,K,psi)))
+                        /inner(K,psi,K,psi)))
+    @test dist ≈ errorMPOProd(phi,K,psi)
 
     badsites = SiteSet(N+1,2)
     badpsi = randomMPS(badsites)
-    @test_throws DimensionMismatch errMPOProd(phi,K,badpsi)
+    @test_throws DimensionMismatch errorMPOProd(phi,K,badpsi)
   end
 
   @testset "applyMPO" begin

--- a/test/test_mpo.jl
+++ b/test/test_mpo.jl
@@ -76,6 +76,19 @@ using ITensors,
     @test_throws DimensionMismatch inner(J,phi,K,badpsi)
   end
 
+  @testset "errMPOProd" begin
+    phi = randomMPS(sites)
+    K = randomMPO(sites)
+    @test maxLinkDim(K) == 1
+    psi = randomMPS(sites)
+    dist = real(inner(phi,phi) - 2*inner(phi,K,psi) + inner(K,psi,K,psi))
+    @test dist ≈ errMPOProd(phi,K,psi)
+
+    badsites = SiteSet(N+1,2)
+    badpsi = randomMPS(badsites)
+    @test_throws DimensionMismatch errMPOProd(phi,K,badpsi)
+  end
+
   @testset "applyMPO" begin
     phi = randomMPS(sites)
     K = randomMPO(sites)

--- a/test/test_mpo.jl
+++ b/test/test_mpo.jl
@@ -44,6 +44,16 @@ using ITensors,
     end
     @test phiKpsi[] ≈ inner(phi,K,psi)
 
+    # Do contraction manually.
+    O = 1.
+    for j ∈ eachindex(phi)
+        psij = reshape(Array(psi[j]),2)
+        phij = reshape(Array(phi[j]),2)
+        Kj = reshape(Array(K[j]),2,2)
+        O *= (phij'*transpose(Kj)*psij)[]
+    end
+    @test O ≈ inner(phi,K,psi)
+
     badsites = SiteSet(N+1,2)
     badpsi = randomMPS(badsites)
     @test_throws DimensionMismatch inner(phi,K,badpsi)
@@ -70,6 +80,17 @@ using ITensors,
       phiJdagKpsi = phiJdagKpsi*phidag[j]*Jdag[j]*K[j]*psi[j]
     end
     @test phiJdagKpsi[] ≈ inner(J,phi,K,psi)
+
+    # Do contraction manually.
+    O = 1.
+    for j ∈ eachindex(phi)
+        psij = reshape(Array(psi[j]),2)
+        phij = reshape(Array(phi[j]),2)
+        Kj = reshape(Array(K[j]),2,2)
+        Jj = reshape(Array(J[j]),2,2)
+        O *= ((transpose(Jj)*phij)'*transpose(Kj)*psij)[]
+    end
+    @test O ≈ inner(J,phi,K,psi)
 
     badsites = SiteSet(N+1,2)
     badpsi = randomMPS(badsites)


### PR DESCRIPTION
Hi,
This addresses issues #60 and #45.

I first added a new inner method `inner(B::MPO, y::MPS, A::MPO, x::MPS)` to compute `<By|A|x>`. Then I used that method to define the distance in `errMPOProd(y::MPS, A::MPO, x::MPS)` as `real(inner(y, y) - 2*inner(y, A, x) + inner(A, x, A, x))`.

You may find in `inner` that my way of swapping the prime levels is not very elegant (I use a temporal 3 level prime). If you find a better approach I'll be happy to change it.