### PR TITLE
fix storage_eigen such that it uses tags keyword

### DIFF
--- a/src/storage/dense.jl
+++ b/src/storage/dense.jl
@@ -288,7 +288,7 @@ function storage_eigen(Astore::Dense{T},
   cutoff::Float64 = get(kwargs,:cutoff,0.0)
   absoluteCutoff::Bool = get(kwargs,:absoluteCutoff,false)
   doRelCutoff::Bool = get(kwargs,:doRelCutoff,true)
-  tags = TagSet(get(kwargs,:lefttags,"Link,u"))
+  tags = TagSet(get(kwargs,:tags,"Link,u"))
   lefttags = TagSet(get(kwargs,:lefttags,tags))
   righttags = TagSet(get(kwargs,:righttags,prime(lefttags)))
 

--- a/test/test_mps.jl
+++ b/test/test_mps.jl
@@ -116,8 +116,11 @@ using ITensors,
     psi = randomMPS(sites)
     phi = psi[1]*psi[2]
     bondindtags = tags(linkindex(psi,1))
-    replaceBond!(psi,1,phi)
-    @test tags(linkindex(psi,1)) == bondindtags
+
+    for which in ["svd","eigen"], dir in ["center","fromleft","fromright"]
+      replaceBond!(psi,1,phi, which_factorization=which, dir=dir)
+      @test tags(linkindex(psi,1)) == bondindtags
+    end
 
     # check that replaceBond! updates llim_ and rlim_ properly
     orthogonalize!(psi,5)


### PR DESCRIPTION
This is a small fix for https://github.com/ITensor/ITensors.jl/issues/82. 
Also added some tests to make sure `replaceBond!` preserves bond indices for all possible options of `which_factorization` and `dir`. 
