### PR TITLE
Begin adding capability to read from C++ ITensor files

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -190,7 +190,9 @@ function Base.read(io::IO,::Type{Index}; kwargs...)
     tags = read(io,TagSet;kwargs...)
     id = read(io,IDType)
     dim = convert(Int64,read(io,Int32))
-    dir = read(io,Arrow)
+    dir_int = read(io,Int32)
+    dir = dir_int < 0 ? In : Out
+    read(io,8) # Read default IQIndexDat size, 8 bytes
     i = Index(id,dim,dir,tags)
   else
     throw(ArgumentError("read Index: format=$format not supported"))

--- a/src/index.jl
+++ b/src/index.jl
@@ -182,3 +182,18 @@ prime(iv::IndexVal,inc::Integer=1) = IndexVal(prime(ind(iv),inc),val(iv))
 adjoint(iv::IndexVal) = IndexVal(adjoint(ind(iv)),val(iv))
 
 show(io::IO,iv::IndexVal) = print(io,ind(iv),"=$(val(iv))")
+
+function Base.read(io::IO,::Type{Index}; kwargs...)
+  format = get(kwargs,:format,"hdf5")
+  i = Index()
+  if format=="cpp"
+    tags = read(io,TagSet;kwargs...)
+    id = read(io,IDType)
+    dim = convert(Int64,read(io,Int32))
+    dir = read(io,Arrow)
+    i = Index(id,dim,dir,tags)
+  else
+    throw(ArgumentError("read Index: format=$format not supported"))
+  end
+  return i
+end

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -19,8 +19,8 @@ export IndexSet,
        maxDim
 
 struct IndexSet
-    inds::Vector{Index}
-    IndexSet(inds::Vector{Index}) = new(inds)
+  inds::Vector{Index}
+  IndexSet(inds::Vector{Index}) = new(inds)
 end
 
 inds(is::IndexSet) = is.inds
@@ -518,3 +518,19 @@ function compute_strides(inds::IndexSet)
   return stride
 end
 
+function Base.read(io::IO,::Type{IndexSet};kwargs...)
+  format = get(kwargs,:format,"hdf5")
+  is = IndexSet()
+  if format=="cpp"
+    size = read(io,Int)
+    resize!(is.inds,size)
+    for n=1:size
+      i = read(io,Index;kwargs...)
+      stride = read(io,UInt64)
+      is.inds[n] = i
+    end
+  else
+    throw(ArgumentError("read IndexSet: format=$format not supported"))
+  end
+  return is
+end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -596,3 +596,39 @@ function multSiteOps(A::ITensor,
   return mapprime(R,2,1)
 end
 
+function readCpp!(T::ITensor;kwargs...)
+  T.inds = read(io,IndexSet;kwargs...)
+  read(io,12) # ignore scale factor
+  storage_type = read(io,Int32) # see StorageType enum above
+  if storage_type==0 # Null
+    T.store = Dense{Nothing}()
+  elseif storage_type==1  # DenseReal
+    T.store = read(io,Dense{Float64};kwargs...)
+  elseif storage_type==2  # DenseCplx
+    T.store = read(io,Dense{ComplexF64};kwargs...)
+  elseif storage_type==3  # Combiner
+    T.store = CombinerStorage(T.inds[1])
+  #elseif storage_type==4  # DiagReal
+  #elseif storage_type==5  # DiagCplx
+  #elseif storage_type==6  # QDenseReal
+  #elseif storage_type==7  # QDenseCplx
+  #elseif storage_type==8  # QCombiner
+  #elseif storage_type==9  # QDiagReal
+  #elseif storage_type==10 # QDiagCplx
+  #elseif storage_type==11 # ScalarReal
+  #elseif storage_type==12 # ScalarCplx
+  else
+    throw(ErrorException("C++ ITensor storage type $storage_type not yet supported"))
+  end
+end
+
+function Base.read(io::IO,::Type{ITensor};kwargs...)
+  format = get(kwargs,:format,"hdf5")
+  T = ITensor()
+  if format=="cpp"
+    readCpp!(T;kwargs...)
+  else
+    throw(ArgumentError("read ITensor: format=$format not supported"))
+  end
+  return T
+end

--- a/src/smallstring.jl
+++ b/src/smallstring.jl
@@ -1,6 +1,6 @@
 export convert,
-       #push,
-       setindex
+       setindex,
+       read
 
 const IntChar = UInt8
 const IntSmallString = UInt64
@@ -131,4 +131,18 @@ function Base.show(io::IO, s::SmallString)
     print(io,Char(s[n]))
     n += 1
   end
+end
+
+function Base.read(io::IO,::Type{SmallString}; kwargs...)
+  format = get(kwargs,:format,"hdf5")
+  s = SmallString()
+  if format=="cpp"
+    for n=1:7
+      c = read(io,Char)
+      s = setindex(s,c,n)
+    end
+  else
+    throw(ArgumentError("read SmallString: format=$format not supported"))
+  end
+  return s
 end

--- a/src/storage/combiner.jl
+++ b/src/storage/combiner.jl
@@ -1,4 +1,3 @@
-export Combiner
 
 struct CombinerStorage <: TensorStorage
   ci::Index

--- a/src/storage/dense.jl
+++ b/src/storage/dense.jl
@@ -362,3 +362,15 @@ function storage_exp(As::Dense{T}, Lis,Ris; hermitian=false) where {T}
                            exp(reshape(data(As),dim(Lis),dim(Ris))) )
   return Dense{T}(vec(expAdata))
 end
+
+function Base.read(io::IO,::Type{Dense{T}};kwargs...) where {T}
+  format = get(kwargs,:format,"hdf5")
+  if format=="cpp"
+    size = read(io,UInt64)
+    D = Dense{T}(size)
+    read!(io,D.data)
+  else
+    throw(ArgumentError("read ITensor: format=$format not supported"))
+  end
+  return D
+end

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -285,3 +285,22 @@ function show(io::IO, T::TagSet)
   print(io,primestring(T))
 end
 
+function Base.read(io::IO,::Type{TagSet}; kwargs...)
+  format = get(kwargs,:format,"hdf5")
+  ts = TagSet()
+  if format=="cpp"
+    mstore = MTagSetStorage(ntuple(_ -> IntTag(0),Val(maxTags)))
+    ntags = 0
+    for n=1:4
+      t = read(io,Tag;kwargs...)
+      if t != Tag()
+        ntags = _addtag_ordered!(mstore,ntags,IntSmallString(t))
+      end
+    end
+    plev = convert(Int,read(io,Int32))
+    ts = TagSet(TagSetStorage(mstore),plev,ntags)
+  else
+    throw(ArgumentError("read TagSet: format=$format not supported"))
+  end
+  return ts
+end


### PR DESCRIPTION
This pull adds the ability to read dense and combiner ITensors, as well as Tag, TagSet, Index, and IndexSet from binary files written by the C++ read/write system.

We ought to think of a way to unit test this. One way could be to include a sample C++ code that generates output files and a Makefile, and some companion Julia unit test code, but just not include it in runtests.jl. Instead we could run it manually once in a while.