### PR TITLE
import Base.iterate to define SweepNext iterator

### DIFF
--- a/src/mps/sweeps.jl
+++ b/src/mps/sweeps.jl
@@ -66,6 +66,8 @@ end
 
 sweepnext(N::Int)::SweepNext = SweepNext(N)
 
+import Base.iterate
+
 function iterate(sn::SweepNext,state=(0,1))
   b,ha = state
   if ha==1


### PR DESCRIPTION
Hi,
This is a super small fix to allow using `sweepnext(N)` iterator outside of ITensors.
I just added `import Base.iterate` so it will overload `iterate` properly.