### PR TITLE
Add tests for similar, get function signatures to work

### DIFF
--- a/src/tensor/diag.jl
+++ b/src/tensor/diag.jl
@@ -31,13 +31,13 @@ Base.eltype(::Type{<:Diag{T}}) where {T} = eltype(T)
 # Deal with uniform Diag conversion
 Base.convert(::Type{<:Diag{T}},D::Diag) where {T} = Diag{T}(data(D))
 
-Base.similar(D::Diag{T}) where {T} = Diag{T}(similar(data(D)))
+Base.similar(D::Diag{T}, ::Type{T}) where {T} = Diag{T}(similar(data(D)))
 
 # TODO: write in terms of ::Int, not inds
-Base.similar(D::Diag{T},inds) where {T} = Diag{T}(similar(data(D),minimum(dims(inds))))
-Base.similar(D::Type{<:NonuniformDiag{T}},inds) where {T} = Diag{T}(similar(T,length(inds)==0 ? 1 : minimum(dims(inds))))
+Base.similar(D::Diag{T},inds::IndexSet) where {T} = Diag{T}(similar(data(D),minimum(dims(inds))))
+Base.similar(D::Type{<:NonuniformDiag{T}},inds::IndexSet) where {T} = Diag{T}(similar(T,length(inds)==0 ? 1 : minimum(dims(inds))))
 
-Base.similar(D::UniformDiag{T}) where {T<:Number} = Diag{T}(zero(T))
+Base.similar(D::UniformDiag{T}, ::Type{T}) where {T<:Number} = Diag{T}(zero(T))
 Base.similar(::Type{<:UniformDiag{T}},inds) where {T<:Number} = Diag{T}(zero(T))
 
 # TODO: make this work for other storage besides Vector

--- a/src/tensor/diag.jl
+++ b/src/tensor/diag.jl
@@ -31,11 +31,12 @@ Base.eltype(::Type{<:Diag{T}}) where {T} = eltype(T)
 # Deal with uniform Diag conversion
 Base.convert(::Type{<:Diag{T}},D::Diag) where {T} = Diag{T}(data(D))
 
+Base.similar(D::Diag{T}) where {T} = Diag{T}(similar(data(D)))
 Base.similar(D::Diag{T}, ::Type{T}) where {T} = Diag{T}(similar(data(D)))
 
 # TODO: write in terms of ::Int, not inds
-Base.similar(D::Diag{T},inds::IndexSet) where {T} = Diag{T}(similar(data(D),minimum(dims(inds))))
-Base.similar(D::Type{<:NonuniformDiag{T}},inds::IndexSet) where {T} = Diag{T}(similar(T,length(inds)==0 ? 1 : minimum(dims(inds))))
+Base.similar(D::Diag{T},inds) where {T} = Diag{T}(similar(data(D),minimum(dims(inds))))
+Base.similar(D::Type{<:NonuniformDiag{T}},inds) where {T} = Diag{T}(similar(T,length(inds)==0 ? 1 : minimum(dims(inds))))
 
 Base.similar(D::UniformDiag{T}, ::Type{T}) where {T<:Number} = Diag{T}(zero(T))
 Base.similar(::Type{<:UniformDiag{T}},inds) where {T<:Number} = Diag{T}(zero(T))

--- a/test/test_itensor_diag.jl
+++ b/test/test_itensor_diag.jl
@@ -297,6 +297,22 @@ using ITensors,
         end
       end
     end
+    
+    @testset "similar/complex/basic stuff (order 2)" begin
+      D = δ(i,j)
+      cD = complex(D)
+      @test eltype(cD) == ComplexF64
+      for ii = 1:d, jj = 1:d
+        if ii == jj
+          @test cD[i(ii),j(jj)] == complex(1.0)
+        else
+          @test cD[i(ii),j(jj)] == complex(0.0)
+        end
+      end
+      sD = similar(D)
+      @test eltype(sD) == Float64
+      @test size(sD) == size(D)
+    end
 
     @testset "delta constructor (order 3)" begin
       D = δ(i,j,k)
@@ -322,6 +338,8 @@ using ITensors,
       @test_throws ErrorException D[i(1),j(1),k(1)] = 2.0
       @test_throws ErrorException D[i(2),j(1),k(1)] = 4.3
       @test_throws ErrorException D[i(1),j(2),k(1)] = 2
+      # setindex for the storage
+      @test_throws ErrorException setindex!(store(D), 2.0, 1)
     end
 
     @testset "Convert diag uniform to dense" begin


### PR DESCRIPTION
The old signatures would cause errors if you tried `similar(delta(...))`.