### PR TITLE
fix bug in mul!

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -617,9 +617,9 @@ rmul!(T::ITensor,fac::Number) = scale!(T,fac)
     mul!(A::ITensor,x::Number,B::ITensor)
 
 Scalar multiplication of ITensor B with x, and store the result in A.
-Like `A .= x .* B`, and equivalent to `add!(A, 0, x, B)`.
+Like `A .= x .* B`.
 """
-mul!(R::ITensor,α::Number,T::ITensor) = add!(R,0,α,T)
+mul!(R::ITensor,α::Number,T::ITensor) = apply!(R,T,(r,t)->α*t )
 mul!(R::ITensor,T::ITensor,α::Number) = mul!(R,α,T)
 
 function summary(io::IO,

--- a/test/test_itensor_dense.jl
+++ b/test/test_itensor_dense.jl
@@ -233,6 +233,10 @@ end
   B = ITensor(b,i)
   @test mul!(A2, A, 2.0) == B == ITensors.add!(A2, 0, 2, A)
   @test rmul!(A, 2.0) == B == ITensors.scale!(A3, 2)
+  #make sure mul! works also when A2 has NaNs in it
+  A = ITensor([1.0; 2.0],i)
+  A2 = ITensor([NaN; 1.],i)
+  @test mul!(A2, A, 2.0) == B
 
   i = Index(2,"i")
   j = Index(2,"j")


### PR DESCRIPTION
This small PR fixes https://github.com/ITensor/ITensors.jl/issues/124 by defining `mul!` directly in terms of `apply!` instead of relying on `add!`.

I also added a test to verify that `mul!(w,a,v)` works when `w` contains NaNs. 