### PR TITLE
isless for complex coefficient in autompo, with test

### DIFF
--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -58,7 +58,10 @@ end
 
 function Base.isless(t1::MPOTerm,t2::MPOTerm)::Bool
   if !isapprox(coef(t1),coef(t2))
-    return coef(t1) < coef(t2)
+    ct1 = coef(t1)
+    ct2 = coef(t2)
+    #"lexicographic" ordering on  complex numbers
+    return real(ct1) < real(ct2) || (real(ct1) == real(ct2) && imag(ct1) < imag(ct2))
   end
   return ops(t1) < ops(t2)
 end

--- a/test/test_autompo.jl
+++ b/test/test_autompo.jl
@@ -332,6 +332,17 @@ end
     T = setElt(l[1])*H[1]
     O = op(sites[1],"Sx")+op(sites[1],"Sy")
     @test norm(T-0.5*O) < 1E-8
+
+      
+    sites = spinOneSites(4)
+    ampo = AutoMPO()
+    add!(ampo, 0.5im, "Sx",1)
+    add!(ampo, 0.5, "Sy",1)
+    H = toMPO(ampo, sites)
+    l = commonindex(H[1],H[2])
+    T = setElt(l[1])*H[1]
+    O = im*op(sites[1],"Sx")+op(sites[1],"Sy")
+    @test norm(T-0.5*O) < 1E-8
   end
 
 end


### PR DESCRIPTION
The coef of each MPOterm is complex, but before this commit, line 61 was
    coef(t1) < coef(t2)
So if execution ever reached this line (which it did not in any of the tests, AFAICT), this line would fail: there is no method `isless` for those `Complex{Float64}` variables.

This commit replaces that line with a check for a "lexicographic ordering", and adds a test that should trigger the bug in the old code.

Incidentally, none of this code will check for or gracefully handle terms with coef NaN.