### PR TITLE
Fix combiner and add tests

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -58,11 +58,6 @@ IndexSet(inds::IndexSet,i::Index) = IndexSet(inds...,i)
 IndexSet(i::Index,inds::IndexSet) = IndexSet(i,inds...)
 IndexSet(is1::IndexSet,is2::IndexSet) = IndexSet(is1...,is2...)
 
-function IndexSet(inds::Vector{Index})
-  N = length(inds)
-  return IndexSet{N}(ntuple(i->inds[i],N))
-end
-
 # This is used in type promotion in the Tensor contraction code
 Base.promote_rule(::Type{<:IndexSet},::Type{Val{N}}) where {N} = IndexSet{N}
 

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -58,6 +58,11 @@ IndexSet(inds::IndexSet,i::Index) = IndexSet(inds...,i)
 IndexSet(i::Index,inds::IndexSet) = IndexSet(i,inds...)
 IndexSet(is1::IndexSet,is2::IndexSet) = IndexSet(is1...,is2...)
 
+function IndexSet(inds::Vector{Index})
+  N = length(inds)
+  return IndexSet{N}(ntuple(i->inds[i],N))
+end
+
 # This is used in type promotion in the Tensor contraction code
 Base.promote_rule(::Type{<:IndexSet},::Type{Val{N}}) where {N} = IndexSet{N}
 

--- a/src/tensor/combiner.jl
+++ b/src/tensor/combiner.jl
@@ -49,16 +49,15 @@ function contract!!(R::Tensor{<:Number,NR},
     # TODO: handle the case where inds(R) and inds(T1)
     # are not ordered the same?
     # Could just use a permutedims...
-    Alabels,Blabels = compute_contraction_labels(inds(T2),inds(T1))
-    final_labels    = contract_labels(Blabels, Alabels)
-    final_labels_n  = contract_labels(labelsT1,labelsT2)
-    indsR = inds(R)
-    if final_labels != final_labels_n
-        perm  = getperm(final_labels_n, final_labels)
-        indsR = permute(inds(R), perm) 
+    T2data      = data(store(T2))
+    cpos1,cpos2 = intersect_positions(labelsT1,labelsT2)
+    inds1       = [inds(T1)...]
+    inds2       = [inds(T2)...]
+    for (ii, ind) in enumerate(inds1[cpos1+1:end])
+        insert!(inds2, cpos2+ii, ind)
     end
-    # need to permute storeT2
-    return Tensor(store(T2),indsR)
+    deleteat!(inds2, cpos2)
+    return Tensor(Dense(vec(T2data)), IndexSet(inds2...))
   elseif is_combiner(labelsT1,labelsT2)
     # This is the case of combining
     Alabels,Blabels = compute_contraction_labels(inds(T2),inds(T1))

--- a/src/tensor/combiner.jl
+++ b/src/tensor/combiner.jl
@@ -43,7 +43,14 @@ function contract!!(R::Tensor{<:Number,NR},
     return R
   elseif N1 + N2 == NR
     error("Cannot perform outer product involving a combiner")
-  elseif count_common(labelsT1,labelsT2) == 1
+  elseif count_common(labelsT1,labelsT2) == 1 && length(inds(T1)) == 2
+    ci = commonindex(inds(T1), inds(T2))
+    ui = uniqueindex(inds(T1), inds(T2))
+    inds2        = [inds(T2)...]
+    cpos1,cpos2  = intersect_positions(labelsT1,labelsT2)
+    inds2[cpos2] = ui 
+    return Tensor(copy(store(T2)), IndexSet(inds2...))
+  elseif count_common(labelsT1,labelsT2) == 1 && length(inds(T1)) != 2
     # This is the case of Index replacement or
     # uncombining
     # TODO: handle the case where inds(R) and inds(T1)
@@ -57,7 +64,7 @@ function contract!!(R::Tensor{<:Number,NR},
         insert!(inds2, cpos2+ii, ind)
     end
     deleteat!(inds2, cpos2)
-    return Tensor(Dense(vec(T2data)), IndexSet(inds2...))
+    return Tensor(Dense(copy(T2data)), IndexSet(inds2...))
   elseif is_combiner(labelsT1,labelsT2)
     # This is the case of combining
     Alabels,Blabels = compute_contraction_labels(inds(T2),inds(T1))

--- a/src/tensor/combiner.jl
+++ b/src/tensor/combiner.jl
@@ -83,16 +83,15 @@ function contract!!(R::Tensor{<:Number,NR},
     final_labels_n  = contract_labels(labelsT1,labelsT2)
     indsR = inds(R)
     if final_labels != final_labels_n
-        perm  = getperm(final_labels_n, final_labels)
-        indsR = permute(inds(R), perm)
-        labelsR = permute(labelsR, perm)
+      perm  = getperm(final_labels_n, final_labels)
+      indsR = permute(inds(R), perm)
+      labelsR = permute(labelsR, perm)
     end
     cpos1,cposR = intersect_positions(labelsT1,labelsR)
     labels_comb = deleteat(labelsT1,cpos1)
     vlR = [labelsR...]
-    vlc = [labels_comb...]
-    for (ii, li) in enumerate(vlc)
-        insert!(vlR, cposR+ii, li)
+    for (ii, li) in enumerate(labels_comb)
+      insert!(vlR, cposR+ii, li)
     end
     deleteat!(vlR, cposR)
     labels_perm = tuple(vlR...) 

--- a/src/tensor/combiner.jl
+++ b/src/tensor/combiner.jl
@@ -39,7 +39,7 @@ function contract!!(R::Tensor{<:Number,NR},
                     T2::Tensor{<:Number,N2},
                     labelsT2::NTuple{N2}) where {NR,N1,N2}
   if N1 ≤ 1
-    println("identity")
+    #println("identity")
     return R
   elseif N1 + N2 == NR
     error("Cannot perform outer product involving a combiner")

--- a/src/tensor/combiner.jl
+++ b/src/tensor/combiner.jl
@@ -56,9 +56,9 @@ function contract!!(R::Tensor{<:Number,NR},
     cpos1,cpos2 = intersect_positions(labelsT1,labelsT2)
     indsC = inds(T1)
     indsT = inds(T2)
-    num_new = length(indsC)-1
-    num_keep = length(indsT)-1
-    newinds = Vector{Index}(undef,num_keep+num_new)
+
+    newlength = (length(indsC)-1) + (length(indsT)-1)
+    newinds = Vector{Index}(undef,newlength)
     n = 1
     # Copy existing indices before one we are uncombining
     for i in 1:cpos2-1
@@ -75,7 +75,8 @@ function contract!!(R::Tensor{<:Number,NR},
       newinds[n] = indsT[i]
       n += 1
     end
-    return Tensor(Dense(copy(T2data)), IndexSet(newinds))
+
+    return Tensor(Dense(copy(T2data)), IndexSet(newinds...))
   elseif is_combiner(labelsT1,labelsT2)
     # This is the case of combining
     Alabels,Blabels = compute_contraction_labels(inds(T2),inds(T1))

--- a/test/test_combiner.jl
+++ b/test/test_combiner.jl
@@ -174,17 +174,31 @@ end
     Ac = A*cmb
     U,S,V,u,v = svd(Ac, ci)
     Uc = U*cmb
+    Ua,Sa,Va,ua,va = svd(A, i, j, k)
+    replaceindex!(Ua, ua, u)
+    @test Ua ≈ Uc
     @test Uc*S*V ≈ A
     cmb, ci = combiner(i, j)
     Ac = A*cmb
     U,S,V,u,v = svd(Ac, ci)
     Uc = U*cmb
+    Ua,Sa,Va,ua,va = svd(A, i, j)
+    replaceindex!(Ua, ua, u)
+    @test Ua ≈ Uc
     @test Uc*S*V ≈ A
     cmb, ci = combiner(i, j)
     Ac = A*cmb
     U,S,V,u,v = svd(Ac, ci, k)
     Uc = U*cmb
     @test Uc*S*V ≈ A
+end
+
+@testset "mult/Combiner should play nice" begin
+    cmb, ci = combiner(i, j, k)
+    Ac = A*cmb
+    B = randomITensor(l)
+    C = Ac*B
+    @test C*cmb ≈ A*B
 end
 
 end

--- a/test/test_combiner.jl
+++ b/test/test_combiner.jl
@@ -169,5 +169,13 @@ end
     end
 end
 
+@testset "SVD/Combiner should play nice" begin
+    cmb, ci = combiner(i, j, k)
+    Ac = A*cmb
+    U,S,V,u,v = svd(Ac, ci)
+    Uc = U*cmb
+    @test Uc*S*V ≈ A
+end
+
 end
 

--- a/test/test_combiner.jl
+++ b/test/test_combiner.jl
@@ -175,6 +175,16 @@ end
     U,S,V,u,v = svd(Ac, ci)
     Uc = U*cmb
     @test Uc*S*V ≈ A
+    cmb, ci = combiner(i, j)
+    Ac = A*cmb
+    U,S,V,u,v = svd(Ac, ci)
+    Uc = U*cmb
+    @test Uc*S*V ≈ A
+    cmb, ci = combiner(i, j)
+    Ac = A*cmb
+    U,S,V,u,v = svd(Ac, ci, k)
+    Uc = U*cmb
+    @test Uc*S*V ≈ A
 end
 
 end

--- a/test/test_combiner.jl
+++ b/test/test_combiner.jl
@@ -46,6 +46,18 @@ A = randomITensor(i, j, k, l)
         D = B*C
         @test hasinds(D, i, j, k, l)
         @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        B = C*A
+        @test hasinds(B, i, l)
+        @test c == commonindex(B, C)
+        D = B*C
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
     end
     for inds_jl ∈ permutations([j,l])
         C,c = combiner(inds_jl...)
@@ -55,6 +67,18 @@ A = randomITensor(i, j, k, l)
         D = B*C
         @test hasinds(D, i, j, k, l)
         @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        B = C*A
+        @test hasinds(B, i, k)
+        @test c == commonindex(B, C)
+        D = B*C
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
     end
     for inds_kl ∈ permutations([k,l])
         C,c = combiner(inds_kl...)
@@ -62,6 +86,18 @@ A = randomITensor(i, j, k, l)
         @test hasinds(B, i, j)
         @test c == commonindex(B, C)
         D = B*C
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        B = C*A
+        @test hasinds(B, i, j)
+        @test c == commonindex(B, C)
+        D = B*C
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        D = C*B
         @test hasinds(D, i, j, k, l)
         @test D ≈ A
     end
@@ -76,6 +112,18 @@ end
         D = B*C
         @test hasinds(D, i, j, k, l)
         @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        B = C*A
+        @test hasindex(B, k)
+        @test c == commonindex(B, C)
+        D = B*C
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
     end
     for inds_ijk ∈ permutations([i,j,k])
         C,c = combiner(inds_ijk...)
@@ -85,6 +133,18 @@ end
         D = B*C
         @test hasinds(D, i, j, k, l)
         @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        B = C*A
+        @test hasindex(B, l)
+        @test c == commonindex(B, C)
+        D = B*C
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
     end
     for inds_jkl ∈ permutations([j,k,l])
         C,c = combiner(inds_jkl...)
@@ -92,6 +152,18 @@ end
         @test hasindex(B, i)
         @test c == commonindex(B, C)
         D = B*C
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        D = C*B
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        B = C*A
+        @test hasindex(B, i)
+        @test c == commonindex(B, C)
+        D = B*C
+        @test hasinds(D, i, j, k, l)
+        @test D ≈ A
+        D = C*B
         @test hasinds(D, i, j, k, l)
         @test D ≈ A
     end

--- a/test/test_combiner.jl
+++ b/test/test_combiner.jl
@@ -173,11 +173,16 @@ end
     cmb, ci = combiner(i, j, k)
     Ac = A*cmb
     U,S,V,u,v = svd(Ac, ci)
-    Uc = U*cmb
+    Uc = cmb*U
     Ua,Sa,Va,ua,va = svd(A, i, j, k)
     replaceindex!(Ua, ua, u)
+    @test A ≈ cmb*Ac 
+    @test A ≈ Ac*cmb
+    @test Ua*cmb ≈ U
+    @test cmb*Ua ≈ U
     @test Ua ≈ Uc
     @test Uc*S*V ≈ A
+    @test (cmb*Ua)*S*V ≈ Ac
     cmb, ci = combiner(i, j)
     Ac = A*cmb
     U,S,V,u,v = svd(Ac, ci)
@@ -185,12 +190,10 @@ end
     Ua,Sa,Va,ua,va = svd(A, i, j)
     replaceindex!(Ua, ua, u)
     @test Ua ≈ Uc
+    @test Ua*cmb ≈ U
+    @test cmb*Ua ≈ U
     @test Uc*S*V ≈ A
-    cmb, ci = combiner(i, j)
-    Ac = A*cmb
-    U,S,V,u,v = svd(Ac, ci, k)
-    Uc = U*cmb
-    @test Uc*S*V ≈ A
+    @test (cmb*Ua)*S*V ≈ Ac
 end
 
 @testset "mult/Combiner should play nice" begin

--- a/test/test_combiner.jl
+++ b/test/test_combiner.jl
@@ -204,5 +204,11 @@ end
     @test C*cmb ≈ A*B
 end
 
+@testset "Replace index combiner" begin
+    C,nl = combiner(l, tags="nl")
+    B = A*C
+    replaceindex!(B, nl, l)
+    @test B == A 
 end
 
+end

--- a/test/test_phys_site_types.jl
+++ b/test/test_phys_site_types.jl
@@ -157,7 +157,7 @@ using ITensors,
 end
 
 
-const MySite = makeTagType("MySite")
+const MySite = ITensors.TagType"MySite"
 
 @testset "Custom Site Tag Type" begin
 

--- a/test/test_qn.jl
+++ b/test/test_qn.jl
@@ -6,25 +6,25 @@ import ITensors.SmallString
 
   @testset "QNVal Basics" begin
     qv = QNVal()
-    @test !isActive(qv)
+    @test !isactive(qv)
 
     qv = QNVal("Sz",0)
     @test name(qv) == SmallString("Sz")
     @test val(qv) == 0
     @test modulus(qv) == 1
-    @test isActive(qv)
+    @test isactive(qv)
 
     qv = QNVal("A",1,2)
     @test name(qv) == SmallString("A")
     @test val(qv) == 1
     @test modulus(qv) == 2
-    @test !isFermionic(qv)
+    @test !isfermionic(qv)
 
     qv = QNVal("Nf",1,-1)
     @test name(qv) == SmallString("Nf")
     @test val(qv) == 1
     @test modulus(qv) == -1
-    @test isFermionic(qv)
+    @test isfermionic(qv)
   end
 
   @testset "QN Basics" begin
@@ -33,23 +33,23 @@ import ITensors.SmallString
 
     q = QN(("Sz",1))
     @test length(sprint(show,q)) > 1
-    @test isActive(q[1])
+    @test isactive(q[1])
     @test val(q,"Sz") == 1
 
     q = QN("Sz",1)
     @test length(sprint(show,q)) > 1
-    @test isActive(q[1])
+    @test isactive(q[1])
     @test val(q,"Sz") == 1
 
     q = QN("P",1,2)
     @test length(sprint(show,q)) > 1
-    @test isActive(q[1])
+    @test isactive(q[1])
     @test val(q,"P") == 1
     @test modulus(q,"P") == 2
 
     q = QN(("A",1),("B",2))
-    @test isActive(q[1])
-    @test isActive(q[2])
+    @test isactive(q[1])
+    @test isactive(q[2])
     @test val(q,"A") == 1
     @test val(q,"B") == 2
     @test modulus(q,"A") == 1


### PR DESCRIPTION
Fixes this unpleasantness:
```
julia> using ITensors

julia> i = Index(2, "i"); j = Index(3, "j"); k = Index(4, "k"); a = Index(5, "a");

julia> A = randomITensor(i, j, k, a);

julia> cmb, ci = combiner(i, j, k, tags="CMB");

julia> Ac = A*cmb;

julia> cmb*Ac == Ac*cmb
false
```
and adds tests to keep it from happening again. The `combiner` tests pass, other tests are broken on master, at least on rusty...