### PR TITLE
return spectrum and truncation error from factorization functions

### DIFF
--- a/examples/ctmrg/ctmrg.jl
+++ b/examples/ctmrg/ctmrg.jl
@@ -145,7 +145,7 @@ function leftright_move!(T,(Clu,Cru,Cld,Crd),(Al,Ar,Au,Ad);dir="left",maxdim=5)
       elseif dir=="up" || dir=="down"
         utags = "$dir,link,x=$iy,y=$ixp"
       end
-      U,S,Vh,u,v = svd(ρ, (li,si); utags=utags, vtags="tmp", maxdim=maxdim, cutoff=0.0)
+      U,S,Vh,spec,u,v = svd(ρ, (li,si); utags=utags, vtags="tmp", maxdim=maxdim, cutoff=0.0)
       V = dag(Vh)
       U *= δ(u,v)
       invsqrtS = S

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -37,20 +37,21 @@ end
       dir = ha==1 ? "fromleft" : "fromright"
 
 @timeit_debug GLOBAL_TIMER "replaceBond!" begin
-      replaceBond!(psi,b,phi;
-                   maxdim=maxdim(sweeps,sw),
-                   mindim=mindim(sweeps,sw),
-                   cutoff=cutoff(sweeps,sw),
-                   dir=dir,
-                   which_factorization=which_factorization)
+      spec = replaceBond!(psi,b,phi;
+                          maxdim=maxdim(sweeps,sw),
+                          mindim=mindim(sweeps,sw),
+                          cutoff=cutoff(sweeps,sw),
+                          dir=dir,
+                          which_factorization=which_factorization)
 end
 
       measure!(obs;energy=energy,
-                   psi=psi,
-                   bond=b,
-                   sweep=sw,
-                   half_sweep=ha,
-                   quiet=quiet)
+               psi=psi,
+               bond=b,
+               sweep=sw,
+               half_sweep=ha,
+               spec = spec,
+               quiet=quiet)
     end
     end
     if !quiet

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -36,7 +36,7 @@ end
 
       dir = ha==1 ? "fromleft" : "fromright"
 
-@timeit_debug GLOBAL_TIMER "replaceBond!" begin
+@timeit_debug GLOBAL_TIMER "replacebond!" begin
       spec = replacebond!(psi,b,phi;
                           maxdim=maxdim(sweeps,sw),
                           mindim=mindim(sweeps,sw),

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -469,7 +469,7 @@ function multMPO(A::MPO, B::MPO; kwargs...)::MPO
     # in case we primed A
     A_ind = uniqueindex(findinds(A_[N-1], "Site"), findinds(B_[N-1], "Site"))
     Lis = IndexSet(A_ind, sites_B[N-1], commonindex(res[N-2], res[N-1]))
-    U, V, ci = factorize(nfork,Lis,dir="fromright",cutoff=cutoff,which_factorization="svd",tags="Link,n=$(N-1)",maxdim=maxdim,mindim=mindim)
+    U, V = factorize(nfork,Lis,dir="fromright",cutoff=cutoff,which_factorization="svd",tags="Link,n=$(N-1)",maxdim=maxdim,mindim=mindim)
     res[N-1] = U
     res[N] = V
     truncate!(res;kwargs...)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -186,7 +186,7 @@ function replacebond!(M::MPS,
                       b::Int,
                       phi::ITensor;
                       kwargs...)
-  FU,FV,_,spec = factorize(phi,inds(M[b]); which_factorization="automatic",
+  FU,FV,spec = factorize(phi,inds(M[b]); which_factorization="automatic",
                            tags=tags(linkindex(M,b)), kwargs...)
   M[b]   = FU
   M[b+1] = FV

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -186,8 +186,8 @@ function replaceBond!(M::MPS,
                       b::Int,
                       phi::ITensor;
                       kwargs...)
-  FU,FV = factorize(phi,inds(M[b]); which_factorization="automatic",
-                        tags=tags(linkindex(M,b)), kwargs...)
+  FU,FV,_,spec = factorize(phi,inds(M[b]); which_factorization="automatic",
+                           tags=tags(linkindex(M,b)), kwargs...)
   M[b]   = FU
   M[b+1] = FV
 
@@ -199,6 +199,7 @@ function replaceBond!(M::MPS,
     M.llim_ == b-1 && (M.llim_ += 1)
     M.rlim_ == b+1 && (M.rlim_ += 1)
   end
+  return spec
 end
 
 """

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -5,7 +5,7 @@ export AbstractObserver,
        DMRGObserver,
        measurements,
        energies,
-       truncErrors
+       truncerrors
 
 
 abstract type AbstractObserver end
@@ -45,7 +45,7 @@ measurements(o::DMRGObserver) = o.measurements
 energies(o::DMRGObserver) = o.energies
 sites(obs::DMRGObserver) = obs.sites
 ops(obs::DMRGObserver) = obs.ops
-truncErrors(obs::DMRGObserver) = obs.truncerrs
+truncerrors(obs::DMRGObserver) = obs.truncerrs
 
 function measureLocalOps!(obs::DMRGObserver,
                           wf::ITensor,
@@ -63,7 +63,7 @@ function measure!(obs::DMRGObserver;
   b = kwargs[:bond]
   energy = kwargs[:energy]
   psi = kwargs[:psi]
-  truncerr = truncErr(kwargs[:spec])
+  truncerr = truncerror(kwargs[:spec])
 
   if half_sweep==2
     N = length(psi)
@@ -72,7 +72,7 @@ function measure!(obs::DMRGObserver;
       for o in ops(obs)
         push!(measurements(obs)[o],zeros(N))
       end
-      push!(truncErrors(obs),0.0)
+      push!(truncerrors(obs),0.0)
     end
 
     # when sweeping left the orthogonality center is located
@@ -86,7 +86,7 @@ function measure!(obs::DMRGObserver;
       push!(energies(obs), energy)
       measureLocalOps!(obs,wf,b)
     end
-    truncerr > truncErrors(obs)[end] && (truncErrors(obs)[end] = truncerr)
+    truncerr > truncerrors(obs)[end] && (truncerrors(obs)[end] = truncerr)
   end
 end
 

--- a/src/tensor/dense.jl
+++ b/src/tensor/dense.jl
@@ -491,10 +491,10 @@ function LinearAlgebra.svd(T::DenseTensor{<:Number,N,IndsT},
                            Rpos::NTuple{NR,Int};
                            kwargs...) where {N,IndsT,NL,NR}
   M = permute_reshape(T,Lpos,Rpos)
-  UM,S,VM = svd(M;kwargs...)
+  UM,S,VM,spec = svd(M;kwargs...)
   u = ind(UM,2)
   v = ind(VM,2)
-  
+
   Linds = similar_type(IndsT,Val(NL))(ntuple(i->inds(T)[Lpos[i]],Val(NL)))
   Uinds = push(Linds,u)
 
@@ -505,7 +505,7 @@ function LinearAlgebra.svd(T::DenseTensor{<:Number,N,IndsT},
   U = reshape(UM,Uinds)
   V = reshape(VM,Vinds)
 
-  return U,S,V
+  return U,S,V,spec
 end
 
 # eigendecomposition of an order-n tensor according to 
@@ -515,12 +515,12 @@ function eigenHermitian(T::DenseTensor{<:Number,N,IndsT},
                         Rpos::NTuple{NR,Int};
                         kwargs...) where {N,IndsT,NL,NR}
   M = permute_reshape(T,Lpos,Rpos)
-  UM,D = eigenHermitian(M;kwargs...)
+  UM,D,spec = eigenHermitian(M;kwargs...)
   u = ind(UM,2)
   Linds = similar_type(IndsT,Val(NL))(ntuple(i->inds(T)[Lpos[i]],Val(NL)))
   Uinds = push(Linds,u)
   U = reshape(UM,Uinds)
-  return U,D
+  return U,D,spec
 end
 
 # qr decomposition of an order-n tensor according to 

--- a/src/tensor/linearalgebra.jl
+++ b/src/tensor/linearalgebra.jl
@@ -5,7 +5,7 @@
 # and passable to BLAS/LAPACK, it cannot
 # be made <: StridedArray
 export eigs,
-       truncErr,
+       truncerror,
        entropy
 
 function Base.:*(T1::Tensor{ElT1,2,StoreT1,IndsT1},
@@ -40,7 +40,7 @@ struct Spectrum
 end
 
 eigs(s::Spectrum) = s.eigs
-truncErr(s::Spectrum) = s.truncerr
+truncerror(s::Spectrum) = s.truncerr
 
 function entropy(s::Spectrum)
   S = 0.0

--- a/src/tensor/linearalgebra.jl
+++ b/src/tensor/linearalgebra.jl
@@ -1,10 +1,12 @@
-
 #
 # Linear Algebra of order 2 Tensors
 #
 # Even though DenseTensor{_,2} is strided
 # and passable to BLAS/LAPACK, it cannot
 # be made <: StridedArray
+export eigs,
+       truncErr,
+       entropy
 
 function Base.:*(T1::Tensor{ElT1,2,StoreT1,IndsT1},
                  T2::Tensor{ElT2,2,StoreT2,IndsT2}) where
@@ -27,7 +29,28 @@ function expHermitian(T::DenseTensor{ElT,2}) where {ElT}
   return Tensor(Dense(vec(expTM)),inds(T))
 end
 
-# svd of an order-2 tensor
+"""
+  Spectrum
+contains the (truncated) density matrix eigenvalue spectrum which is computed during a
+decomposition done by `svd` or `eigenHermitian`. In addition stores the truncation error.
+"""
+struct Spectrum
+  eigs::Vector{Float64}
+  truncerr::Float64
+end
+
+eigs(s::Spectrum) = s.eigs
+truncErr(s::Spectrum) = s.truncerr
+
+function entropy(s::Spectrum)
+  S = 0.0
+  for p in eigs(s)
+    p > 1e-13 && (S -= p*log(p))
+  end
+  return S
+end
+
+#svd of an order-2 tensor
 function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
                            kwargs...) where {ElT,IndsT}
   maxdim::Int = get(kwargs,:maxdim,minimum(dims(T)))
@@ -45,11 +68,12 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
   conj!(MV)
 
   P = MS.^2
-  truncate!(P;mindim=mindim,
-              maxdim=maxdim,
-              cutoff=cutoff,
-              absoluteCutoff=absoluteCutoff,
-              doRelCutoff=doRelCutoff)
+  truncerr,_ = truncate!(P;mindim=mindim,
+                         maxdim=maxdim,
+                         cutoff=cutoff,
+                         absoluteCutoff=absoluteCutoff,
+                         doRelCutoff=doRelCutoff)
+  spec = Spectrum(P,truncerr)
   dS = length(P)
   if dS < length(MS)
     MU = MU[:,1:dS]
@@ -66,7 +90,7 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
   U = Tensor(Dense(vec(MU)),Uinds)
   S = Tensor(Diag(MS),Sinds)
   V = Tensor(Dense(vec(MV)),Vinds)
-  return U,S,V
+  return U,S,V,spec
 end
 
 function eigenHermitian(T::DenseTensor{ElT,2,IndsT};
@@ -86,17 +110,19 @@ function eigenHermitian(T::DenseTensor{ElT,2,IndsT};
   UM = UM[:,p]
 
   if ispossemidef
-    truncate!(DM;maxdim=maxdim,
-                 cutoff=cutoff,
-                 absoluteCutoff=absoluteCutoff,
-                 doRelCutoff=doRelCutoff)
+    truncerr,_ = truncate!(DM;maxdim=maxdim,
+                           cutoff=cutoff,
+                           absoluteCutoff=absoluteCutoff,
+                           doRelCutoff=doRelCutoff)
     dD = length(DM)
     if dD < size(UM,2)
       UM = UM[:,1:dD]
     end
   else
     dD = length(DM)
+    truncerr = 0.0
   end
+  spec = Spectrum(DM,truncerr)
 
   # Make the new indices to go onto U and V
   u = eltype(IndsT)(dD)
@@ -105,7 +131,7 @@ function eigenHermitian(T::DenseTensor{ElT,2,IndsT};
   Dinds = IndsT((u,v))
   U = Tensor(Dense(vec(UM)),Uinds)
   D = Tensor(Diag(DM),Dinds)
-  return U,D
+  return U,D,spec
 end
 
 function LinearAlgebra.qr(T::DenseTensor{ElT,2,IndsT}) where {ElT,

--- a/test/test_combiner.jl
+++ b/test/test_combiner.jl
@@ -172,9 +172,9 @@ end
 @testset "SVD/Combiner should play nice" begin
     cmb, ci = combiner(i, j, k)
     Ac = A*cmb
-    U,S,V,u,v = svd(Ac, ci)
+    U,S,V,spec,u,v = svd(Ac, ci)
     Uc = cmb*U
-    Ua,Sa,Va,ua,va = svd(A, i, j, k)
+    Ua,Sa,Va,spec,ua,va = svd(A, i, j, k)
     replaceindex!(Ua, ua, u)
     @test A ≈ cmb*Ac 
     @test A ≈ Ac*cmb
@@ -185,9 +185,9 @@ end
     @test (cmb*Ua)*S*V ≈ Ac
     cmb, ci = combiner(i, j)
     Ac = A*cmb
-    U,S,V,u,v = svd(Ac, ci)
+    U,S,V,spec,u,v = svd(Ac, ci)
     Uc = U*cmb
-    Ua,Sa,Va,ua,va = svd(A, i, j)
+    Ua,Sa,Va,spec,ua,va = svd(A, i, j)
     replaceindex!(Ua, ua, u)
     @test Ua ≈ Uc
     @test Ua*cmb ≈ U

--- a/test/test_decomp.jl
+++ b/test/test_decomp.jl
@@ -21,12 +21,12 @@ A = randomITensor(i,j)
   S ./= norm(S)
   A = ITensor(U*diagm(0=>S)*V', i,j)
 
-  _,_,_,_,_,spec = svd(A,i)
+  spec = svd(A,i).spec
 
   @test eigs(spec) ≈ S .^2
-  @test truncErr(spec) == 0.0
+  @test truncerror(spec) == 0.0
 
-  _,_,_,_,_,spec = svd(A,i; maxdim=length(S)-3)
-  @test truncErr(spec) ≈ sum(S[end-2:end].^2)
+  spec = svd(A,i; maxdim=length(S)-3).spec
+  @test truncerror(spec) ≈ sum(S[end-2:end].^2)
 
 end

--- a/test/test_decomp.jl
+++ b/test/test_decomp.jl
@@ -11,3 +11,22 @@ i = Index(2,"i")
 j = Index(2,"j")
 A = randomITensor(i,j)
 @test_throws ArgumentError factorize(A, i, dir="fakedir")
+
+
+@testset "Spectrum" begin
+  i = Index(100,"i")
+  j = Index(100,"j")
+
+  U,S,V = svd(rand(100,100))
+  S ./= norm(S)
+  A = ITensor(U*diagm(0=>S)*V', i,j)
+
+  _,_,_,_,_,spec = svd(A,i)
+
+  @test eigs(spec) ≈ S .^2
+  @test truncErr(spec) == 0.0
+
+  _,_,_,_,_,spec = svd(A,i; maxdim=length(S)-3)
+  @test truncErr(spec) ≈ sum(S[end-2:end].^2)
+
+end

--- a/test/test_dmrg.jl
+++ b/test/test_dmrg.jl
@@ -77,9 +77,9 @@ using ITensors, Test
     @test all(length.(measurements(observer)["Sz"]) .== N)
     @test all(length.(measurements(observer)["Sx"]) .== N)
     @test length(energies(observer))==3
-    @test length(truncErrors(observer))==3
+    @test length(truncerrors(observer))==3
     @test energies(observer)[end]==E
-    @test all(truncErrors(observer) .< 1E-12)
+    @test all(truncerrors(observer) .< 1E-12)
 
     orthogonalize!(psi,1)
     m = scalar(dag(psi[1])*noprime(op(sites, "Sz", 1)*psi[1]))

--- a/test/test_dmrg.jl
+++ b/test/test_dmrg.jl
@@ -77,7 +77,9 @@ using ITensors, Test
     @test all(length.(measurements(observer)["Sz"]) .== N)
     @test all(length.(measurements(observer)["Sx"]) .== N)
     @test length(energies(observer))==3
+    @test length(truncErrors(observer))==3
     @test energies(observer)[end]==E
+    @test all(truncErrors(observer) .< 1E-12)
 
     orthogonalize!(psi,1)
     m = scalar(dag(psi[1])*noprime(op(sites, "Sz", 1)*psi[1]))

--- a/test/test_itensor_dense.jl
+++ b/test/test_itensor_dense.jl
@@ -478,7 +478,7 @@ end
     A = randomITensor(SType,i,j,k,l)
 
     @testset "Test SVD of an ITensor" begin
-      U,S,V,u,v = svd(A,(j,l))
+      U,S,V,spec,u,v = svd(A,(j,l))
       @test store(S) isa Diag{Float64,Vector{Float64}}
       @test A≈U*S*V
       @test U*dag(prime(U,u))≈δ(SType,u,u') atol=1e-14
@@ -524,7 +524,7 @@ end
       is = IndexSet(i,j)
       T = randomITensor(is...,prime(is)...)
       T = T + swapprime(dag(T),0,1)
-      U,D,u = eigenHermitian(T)
+      U,D,spec,u = eigenHermitian(T)
       @test T ≈ U*D*prime(dag(U))
       UUᴴ =  U*prime(dag(U),u)
       @test UUᴴ ≈ δ(u,u') atol=1e-14


### PR DESCRIPTION
This PR implements a `Spectrum` object which is used to return the density matrix eigenvalue spectrum and truncation error from  `svd`, `eigenHermitian`, `factorize` and `replaceBond!` (similar to the C++ version) as discussed in https://github.com/ITensor/ITensors.jl/issues/104.

I also added tracking of the maximal truncation error in each sweep to the built-in DMRGObserver.

In https://github.com/ITensor/ITensors.jl/issues/104 Miles suggested to also add the number of discarded eigenvalues (which is otherwise not accessible from the spectrum because it is already truncated in place in `truncate!`), but I saw this is not available in the C++ version. Is this actually something that someone would like to track, should I add it? 
