### PR TITLE
Rename many functions to follow lowercase convention

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -16,8 +16,8 @@ export IndexSet,
        uniqueinds,
        uniqueindex,
        dims,
-       minDim,
-       maxDim,
+       mindim,
+       maxdim,
        push,
        permute
 
@@ -120,13 +120,13 @@ StaticArrays.similar_type(::Type{<:IndexSet},::Type{Val{N}}) where {N} = IndexSe
 sim(is::IndexSet{N}) where {N} = IndexSet{N}(ntuple(i->sim(is[i]),Val(N)))
 
 """
-minDim(is::IndexSet)
+mindim(is::IndexSet)
 
 Get the minimum dimension of the indices in the index set.
 
 Returns 1 if the IndexSet is empty.
 """
-function minDim(is::IndexSet)
+function mindim(is::IndexSet)
   length(is) == 0 && (return 1)
   md = dim(is[1])
   for n ∈ 2:length(is)
@@ -136,13 +136,13 @@ function minDim(is::IndexSet)
 end
 
 """
-maxDim(is::IndexSet)
+maxdim(is::IndexSet)
 
 Get the maximum dimension of the indices in the index set.
 
 Returns 1 if the IndexSet is empty.
 """
-function maxDim(is::IndexSet)
+function maxdim(is::IndexSet)
   length(is) == 0 && (return 1)
   md = dim(is[1])
   for n ∈ 2:length(is)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -8,7 +8,7 @@ export ITensor,
        expHermitian,
        replaceindex!,
        inds,
-       isNull,
+       isnull,
        scale!,
        normalize!,
        randn!,
@@ -274,7 +274,7 @@ Base.size(A::ITensor) = dims(inds(A))
 Base.size(A::ITensor{N}, d::Int) where {N} = d in 1:N ? dim(inds(A)[d]) :
   d>0 ? 1 : error("arraysize: dimension out of range")
 
-isNull(T::ITensor) = (eltype(T) === Nothing)
+isnull(T::ITensor) = (eltype(T) === Nothing)
 
 Base.copy(T::ITensor{N}) where {N} = ITensor{N}(copy(tensor(T)))
 
@@ -636,7 +636,7 @@ end
 function Base.show(io::IO,T::ITensor)
   summary(io,T)
   print(io,"\n")
-  if !isNull(T)
+  if !isnull(T)
     Base.show(io,MIME"text/plain"(),tensor(T))
   end
 end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -5,7 +5,7 @@ export ITensor,
        delta,
        δ,
        exp,
-       expHermitian,
+       exphermitian,
        replaceindex!,
        inds,
        isnull,
@@ -511,7 +511,7 @@ function LinearAlgebra.exp(A::ITensor,
   return ITensor(expAT)
 end
 
-function expHermitian(A::ITensor,
+function exphermitian(A::ITensor,
                       Linds,
                       Rinds = prime(IndexSet(Linds))) 
   return exp(A,Linds,Rinds;ishermitian=true)
@@ -652,14 +652,14 @@ function Base.similar(T::ITensor,
   return ITensor(similar(tensor(T),element_type))
 end
 
-function multSiteOps(A::ITensor,
-                     B::ITensor)
-  R = prime(A,"Site")
+function matmul(A::ITensor,
+                B::ITensor)
+  R = mapprime(mapprime(A,1,2),0,1)
   R *= B
   return mapprime(R,2,1)
 end
 
-function readCpp!(io::IO,T::ITensor;kwargs...)
+function read_cpp!(T::ITensor,io::IO;kwargs...)
   T.inds = read(io,IndexSet;kwargs...)
   read(io,12) # ignore scale factor
   storage_type = read(io,Int32) # see StorageType enum above
@@ -689,7 +689,7 @@ function Base.read(io::IO,::Type{ITensor};kwargs...)
   format = get(kwargs,:format,"hdf5")
   T = ITensor()
   if format=="cpp"
-    readCpp!(io,T;kwargs...)
+    read_cpp!(T,io;kwargs...)
   else
     throw(ArgumentError("read ITensor: format=$format not supported"))
   end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -12,7 +12,7 @@ export ITensor,
        scale!,
        normalize!,
        randn!,
-       multSiteOps,
+       matmul,
        order,
        permute,
        randomITensor,
@@ -120,7 +120,7 @@ The storage will have Diag type.
 """
 function diagITensor(::Type{T},
                      is::IndexSet{N}) where {T<:Number,N}
-  return ITensor{N}(Diag(zeros(T,minDim(is))),is)
+  return ITensor{N}(Diag(zeros(T,mindim(is))),is)
 end
 
 """
@@ -142,7 +142,7 @@ The storage will have Diag type.
 """
 function diagITensor(v::Vector{T},
                      is::IndexSet) where {T<:Number}
-  length(v) ≠ minDim(is) && error("Length of vector for diagonal must equal minimum of the dimension of the input indices")
+  length(v) ≠ mindim(is) && error("Length of vector for diagonal must equal minimum of the dimension of the input indices")
   return ITensor(Diag(float(v)),is)
 end
 
@@ -187,7 +187,7 @@ The storage will have Diag type.
 """
 function diagITensor(x::T,
                      is::IndexSet) where {T<:Number}
-  return ITensor(Diag(fill(float(x),minDim(is))),is)
+  return ITensor(Diag(fill(float(x),mindim(is))),is)
 end
 
 """

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -36,8 +36,8 @@ end
 
       dir = ha==1 ? "fromleft" : "fromright"
 
-@timeit_debug GLOBAL_TIMER "replaceBond!" begin
-      replaceBond!(psi,b,phi;
+@timeit_debug GLOBAL_TIMER "replacebond!" begin
+      replacebond!(psi,b,phi;
                    maxdim=maxdim(sweeps,sw),
                    mindim=mindim(sweeps,sw),
                    cutoff=cutoff(sweeps,sw),
@@ -54,7 +54,7 @@ end
     end
     end
     if !quiet
-      @printf("After sweep %d energy=%.12f maxLinkDim=%d time=%.3f\n",sw,energy,maxLinkDim(psi),sw_time)
+      @printf("After sweep %d energy=%.12f maxlinkdim=%d time=%.3f\n",sw,energy,maxlinkdim(psi),sw_time)
     end
     checkdone!(obs;quiet=quiet) && break
   end

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -1,9 +1,9 @@
 export MPO,
        randomMPO,
        applyMPO,
-       nmultMPO,
+       multMPO,
        errorMPOProd,
-       maxLinkDim,
+       maxlinkdim,
        orthogonalize!,
        truncate!
 
@@ -87,22 +87,22 @@ end
 
 length(m::MPO) = m.N_
 tensors(m::MPO) = m.A_
-leftLim(m::MPO) = m.llim_
-rightLim(m::MPO) = m.rlim_
+leftlim(m::MPO) = m.llim_
+rightlim(m::MPO) = m.rlim_
 
-function setLeftLim!(m::MPO,new_ll::Int)
+function set_leftlim!(m::MPO,new_ll::Int)
   m.llim_ = new_ll
 end
 
-function setRightLim!(m::MPO,new_rl::Int)
+function set_rightlim!(m::MPO,new_rl::Int)
   m.rlim_ = new_rl
 end
 
 getindex(m::MPO, n::Integer) = getindex(tensors(m), n)
 
 function setindex!(M::MPO,T::ITensor,n::Integer)
-  (n <= leftLim(M)) && setLeftLim!(M,n-1)
-  (n >= rightLim(M)) && setRightLim!(M,n+1)
+  (n <= leftlim(M)) && set_leftlim!(M,n-1)
+  (n >= rightlim(M)) && set_rightlim!(M,n+1)
   setindex!(tensors(M),T,n)
 end
 
@@ -177,12 +177,12 @@ function simlinks!(M::T) where {T <: Union{MPS,MPO}}
 end
 
 """
-maxLinkDim(M::MPS)
-maxLinkDim(M::MPO)
+maxlinkdim(M::MPS)
+maxlinkdim(M::MPO)
 
 Get the maximum link dimension of the MPS or MPO.
 """
-function maxLinkDim(M::T) where {T <: Union{MPS,MPO}}
+function maxlinkdim(M::T) where {T <: Union{MPS,MPO}}
   md = 0
   for b ∈ eachindex(M)[1:end-1]
     md = max(md,dim(linkindex(M,b)))
@@ -342,7 +342,7 @@ function densityMatrixApplyMPO(A::MPO, psi::MPS; kwargs...)::MPS
     psi_out         = similar(psi)
     cutoff::Float64 = get(kwargs, :cutoff, 1e-13)
 
-    maxdim::Int     = get(kwargs,:maxdim,maxLinkDim(psi))
+    maxdim::Int     = get(kwargs,:maxdim,maxlinkdim(psi))
     mindim::Int     = max(get(kwargs,:mindim,1), 1)
     normalize::Bool = get(kwargs, :normalize, false) 
     all(x -> x != Index(), [siteindex(A, psi, j) for j in 1:n]) || throw(ErrorException("MPS and MPO have different site indices in applyMPO method 'DensityMatrix'"))
@@ -419,10 +419,10 @@ function naiveApplyMPO(A::MPO, psi::MPS; kwargs...)::MPS
   return psi_out
 end
 
-function nmultMPO(A::MPO, B::MPO; kwargs...)::MPO
+function multMPO(A::MPO, B::MPO; kwargs...)::MPO
     cutoff::Float64 = get(kwargs, :cutoff, 1e-14)
     resp_degen::Bool = get(kwargs, :respect_degenerate, true)
-    maxdim::Int = get(kwargs,:maxdim,maxLinkDim(A)*maxLinkDim(B))
+    maxdim::Int = get(kwargs,:maxdim,maxlinkdim(A)*maxlinkdim(B))
     mindim::Int = max(get(kwargs,:mindim,1), 1)
     N = length(A)
     N != length(B) && throw(DimensionMismatch("lengths of MPOs A ($N) and B ($(length(B))) do not match"))
@@ -482,31 +482,31 @@ end
 function orthogonalize!(M::Union{MPS,MPO},
                         j::Int;
                         kwargs...)
-  while leftLim(M) < (j-1)
-    (leftLim(M) < 0) && setLeftLim!(M,0)
-    b = leftLim(M)+1
+  while leftlim(M) < (j-1)
+    (leftlim(M) < 0) && set_leftlim!(M,0)
+    b = leftlim(M)+1
     linds = uniqueinds(M[b],M[b+1])
     Q,R = qr(M[b], linds)
     M[b] = Q
     M[b+1] *= R
-    setLeftLim!(M,b)
-    if rightLim(M) < leftLim(M)+2
-      setRightLim!(M,leftLim(M)+2)
+    set_leftlim!(M,b)
+    if rightlim(M) < leftlim(M)+2
+      set_rightlim!(M,leftlim(M)+2)
     end
   end
 
   N = length(M)
 
-  while rightLim(M) > (j+1)
-    (rightLim(M) > (N+1)) && setRightLim!(M,N+1)
-    b = rightLim(M)-2
+  while rightlim(M) > (j+1)
+    (rightlim(M) > (N+1)) && set_rightlim!(M,N+1)
+    b = rightlim(M)-2
     rinds = uniqueinds(M[b+1],M[b])
     Q,R = qr(M[b+1], rinds)
     M[b+1] = Q
     M[b] *= R
-    setRightLim!(M,b+1)
-    if leftLim(M) > rightLim(M)-2
-      setLeftLim!(M,rightLim(M)-2)
+    set_rightlim!(M,b+1)
+    if leftlim(M) > rightlim(M)-2
+      set_leftlim!(M,rightlim(M)-2)
     end
   end
 end
@@ -525,7 +525,7 @@ function truncate!(M::Union{MPS,MPO}; kwargs...)
     U,S,V = svd(M[j],rinds;kwargs...)
     M[j] = U
     M[j-1] *= (S*V)
-    setRightLim!(M,j)
+    set_rightlim!(M,j)
   end
 
 end

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -2,7 +2,7 @@ export MPO,
        randomMPO,
        applyMPO,
        multMPO,
-       errorMPOProd,
+       errorMPOprod,
        maxlinkdim,
        orthogonalize!,
        truncate!
@@ -264,12 +264,12 @@ end
 
 
 """
-errorMPOProd(y::MPS, A::MPO, x::MPS)
+errorMPOprod(y::MPS, A::MPO, x::MPS)
 
 Compute the distance between A|x> and an approximation MPS y:
 | |y> - A|x> |/| A|x> | = √(1 + (<y|y> - 2*real(<y|A|x>))/<Ax|A|x>)
 """
-function errorMPOProd(y::MPS, A::MPO, x::MPS)
+function errorMPOprod(y::MPS, A::MPO, x::MPS)
   N = length(A)
   if length(y) != N || length(x) != N
       throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y))"))

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -1,16 +1,16 @@
 export MPS,
        sample,
        sample!,
-       leftLim,
+       leftlim,
        prime!,
        primelinks!,
        simlinks!,
        inner,
+       isortho,
        productMPS,
        randomMPS,
-       replaceBond!,
-       rightLim,
-       maxLinkDim,
+       replacebond!,
+       rightlim,
        linkindex,
        siteindex,
        siteinds
@@ -53,29 +53,29 @@ end
 
 length(m::MPS) = m.N_
 tensors(m::MPS) = m.A_
-leftLim(m::MPS) = m.llim_
-rightLim(m::MPS) = m.rlim_
+leftlim(m::MPS) = m.llim_
+rightlim(m::MPS) = m.rlim_
 
-function setLeftLim!(m::MPS,new_ll::Int) 
+function set_leftlim!(m::MPS,new_ll::Int) 
   m.llim_ = new_ll
 end
 
-function setRightLim!(m::MPS,new_rl::Int) 
+function set_rightlim!(m::MPS,new_rl::Int) 
   m.rlim_ = new_rl
 end
 
-isOrtho(m::MPS) = (leftLim(m)+1 == rightLim(m)-1)
+isortho(m::MPS) = (leftlim(m)+1 == rightlim(m)-1)
 
 function orthoCenter(m::MPS)
-  !isOrtho(m) && error("MPS has no well-defined orthogonality center")
-  return leftLim(m)+1
+  !isortho(m) && error("MPS has no well-defined orthogonality center")
+  return leftlim(m)+1
 end
 
 getindex(M::MPS, n::Integer) = getindex(tensors(M),n)
 
 function setindex!(M::MPS,T::ITensor,n::Integer) 
-  (n <= leftLim(M)) && setLeftLim!(M,n-1)
-  (n >= rightLim(M)) && setRightLim!(M,n+1)
+  (n <= leftlim(M)) && set_leftlim!(M,n-1)
+  (n >= rightlim(M)) && set_rightlim!(M,n+1)
   setindex!(tensors(M),T,n)
 end
 
@@ -182,7 +182,7 @@ function inner(M1::MPS, M2::MPS)::Number
   return O[]
 end
 
-function replaceBond!(M::MPS,
+function replacebond!(M::MPS,
                       b::Int,
                       phi::ITensor;
                       kwargs...)

--- a/src/mps/projmpo.jl
+++ b/src/mps/projmpo.jl
@@ -29,8 +29,8 @@ end
 function product(pm::ProjMPO,
                  v::ITensor)::ITensor
   Hv = v
-  if isNull(LProj(pm))
-    if !isNull(RProj(pm))
+  if isnull(LProj(pm))
+    if !isnull(RProj(pm))
       Hv *= RProj(pm)
     end
     for j=pm.rpos-1:-1:pm.lpos+1
@@ -41,7 +41,7 @@ function product(pm::ProjMPO,
     for j=pm.lpos+1:pm.rpos-1
       Hv *= pm.H[j]
     end
-    if !isNull(RProj(pm))
+    if !isnull(RProj(pm))
       Hv *= RProj(pm)
     end
   end
@@ -53,10 +53,10 @@ function Base.eltype(pm::ProjMPO)
   for j = pm.lpos+2:pm.rpos-1
     elT = promote_type(elT,eltype(pm.H[j]))
   end
-  if !isNull(LProj(pm))
+  if !isnull(LProj(pm))
     elT = promote_type(elT,eltype(LProj(pm)))
   end
-  if !isNull(RProj(pm))
+  if !isnull(RProj(pm))
     elT = promote_type(elT,eltype(RProj(pm)))
   end
   return elT
@@ -66,7 +66,7 @@ end
 
 function size(pm::ProjMPO)::Tuple{Int,Int}
   d = 1
-  if !isNull(LProj(pm))
+  if !isnull(LProj(pm))
     for i in inds(LProj(pm))
       plev(i) > 0 && (d *= dim(i))
     end
@@ -76,7 +76,7 @@ function size(pm::ProjMPO)::Tuple{Int,Int}
       plev(i) > 0 && (d *= dim(i))
     end
   end
-  if !isNull(RProj(pm))
+  if !isnull(RProj(pm))
     for i in inds(RProj(pm))
       plev(i) > 0 && (d *= dim(i))
     end

--- a/src/mps/projmpo.jl
+++ b/src/mps/projmpo.jl
@@ -1,6 +1,6 @@
 export ProjMPO,
-       LProj,
-       RProj,
+       lproj,
+       rproj,
        product
 
 mutable struct ProjMPO
@@ -16,12 +16,12 @@ nsite(pm::ProjMPO) = pm.nsite
 length(pm::ProjMPO) = length(pm.H)
 
 
-function LProj(pm::ProjMPO)::ITensor
+function lproj(pm::ProjMPO)::ITensor
   (pm.lpos <= 0) && return ITensor()
   return pm.LR[pm.lpos]
 end
 
-function RProj(pm::ProjMPO)::ITensor
+function rproj(pm::ProjMPO)::ITensor
   (pm.rpos >= length(pm)+1) && return ITensor()
   return pm.LR[pm.rpos]
 end
@@ -29,20 +29,20 @@ end
 function product(pm::ProjMPO,
                  v::ITensor)::ITensor
   Hv = v
-  if isnull(LProj(pm))
-    if !isnull(RProj(pm))
-      Hv *= RProj(pm)
+  if isnull(lproj(pm))
+    if !isnull(rproj(pm))
+      Hv *= rproj(pm)
     end
     for j=pm.rpos-1:-1:pm.lpos+1
       Hv *= pm.H[j]
     end
-  else #if LProj is not null
-    Hv *= LProj(pm)
+  else #if lproj is not null
+    Hv *= lproj(pm)
     for j=pm.lpos+1:pm.rpos-1
       Hv *= pm.H[j]
     end
-    if !isnull(RProj(pm))
-      Hv *= RProj(pm)
+    if !isnull(rproj(pm))
+      Hv *= rproj(pm)
     end
   end
   return noprime(Hv)
@@ -53,11 +53,11 @@ function Base.eltype(pm::ProjMPO)
   for j = pm.lpos+2:pm.rpos-1
     elT = promote_type(elT,eltype(pm.H[j]))
   end
-  if !isnull(LProj(pm))
-    elT = promote_type(elT,eltype(LProj(pm)))
+  if !isnull(lproj(pm))
+    elT = promote_type(elT,eltype(lproj(pm)))
   end
-  if !isnull(RProj(pm))
-    elT = promote_type(elT,eltype(RProj(pm)))
+  if !isnull(rproj(pm))
+    elT = promote_type(elT,eltype(rproj(pm)))
   end
   return elT
 end
@@ -66,8 +66,8 @@ end
 
 function size(pm::ProjMPO)::Tuple{Int,Int}
   d = 1
-  if !isnull(LProj(pm))
-    for i in inds(LProj(pm))
+  if !isnull(lproj(pm))
+    for i in inds(lproj(pm))
       plev(i) > 0 && (d *= dim(i))
     end
   end
@@ -76,8 +76,8 @@ function size(pm::ProjMPO)::Tuple{Int,Int}
       plev(i) > 0 && (d *= dim(i))
     end
   end
-  if !isnull(RProj(pm))
-    for i in inds(RProj(pm))
+  if !isnull(rproj(pm))
+    for i in inds(rproj(pm))
       plev(i) > 0 && (d *= dim(i))
     end
   end
@@ -122,7 +122,7 @@ function position!(pm::ProjMPO,
   makeR!(pm,psi,pos+nsite(pm))
 
   #These next two lines are needed 
-  #when moving LProj and RProj backward
+  #when moving lproj and rproj backward
   pm.lpos = pos-1
   pm.rpos = pos+nsite(pm)
 end

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -242,7 +242,7 @@ function computeSiteProd(sites,
   for j=2:length(ops)
     (ops[j].site != i) && error("Mismatch of site number in computeSiteProd")
     opj = op(sites[i],ops[j].name)
-    T = multSiteOps(T,opj)
+    T = matmul(T,opj)
   end
   return T
 end

--- a/src/physics/site_types/electron.jl
+++ b/src/physics/site_types/electron.jl
@@ -1,11 +1,11 @@
-export ElectronSite,
-       electronSites
-
-function electronSites(N::Int; kwargs...)
-  return [Index(4,"Site,Electron,n=$n") for n=1:N]
-end
+export ElectronSite
 
 const ElectronSite = TagType"Electron"
+
+function siteinds(::ElectronSite, 
+                  N::Int; kwargs...)
+  return [Index(4,"Site,Electron,n=$n") for n=1:N]
+end
 
 function state(::ElectronSite,
                st::AbstractString)

--- a/src/physics/site_types/spinhalf.jl
+++ b/src/physics/site_types/spinhalf.jl
@@ -1,11 +1,11 @@
-export SpinHalfSite,
-       spinHalfSites
-
-function spinHalfSites(N::Int; kwargs...)
-  return [Index(2,"Site,S=1/2,n=$n") for n=1:N]
-end
+export SpinHalfSite
 
 const SpinHalfSite = Union{TagType"S=1/2", TagType"SpinHalf"}
+
+function siteinds(::SpinHalfSite,
+                  N::Int; kwargs...)
+  return [Index(2,"Site,S=1/2,n=$n") for n=1:N]
+end
 
 function state(::SpinHalfSite,
                st::AbstractString)

--- a/src/physics/site_types/spinone.jl
+++ b/src/physics/site_types/spinone.jl
@@ -1,11 +1,11 @@
-export SpinOneSite,
-       spinOneSites
-
-function spinOneSites(N::Int; kwargs...)
-  return [Index(3,"Site,S=1,n=$n") for n=1:N]
-end
+export SpinOneSite
 
 const SpinOneSite = Union{TagType"S=1", TagType"SpinOne"}
+
+function siteinds(::SpinOneSite,
+                  N::Int; kwargs...)
+  return [Index(3,"Site,S=1,n=$n") for n=1:N]
+end
 
 function state(::SpinOneSite,
                st::AbstractString)

--- a/src/physics/site_types/tj.jl
+++ b/src/physics/site_types/tj.jl
@@ -1,11 +1,11 @@
-export tJSite,
-       tJSites
-
-function tJSites(N::Int; kwargs...)
-  return [Index(3,"Site,tJ,n=$n") for n=1:N]
-end
+export tJSite
 
 const tJSite = TagType"tJ"
+
+function siteinds(::tJSite,
+                  N::Int; kwargs...)
+  return [Index(3,"Site,tJ,n=$n") for n=1:N]
+end
 
 function state(::tJSite,
                st::AbstractString)

--- a/src/physics/tag_types.jl
+++ b/src/physics/tag_types.jl
@@ -1,6 +1,7 @@
 export TagType,
        TagType_str,
        op,
+       siteinds,
        state
 
 
@@ -102,4 +103,18 @@ function state(sset::Vector{Index},
                j::Integer,
                st)::IndexVal
   return state(sset[j],st)
+end
+
+function siteinds(d::Integer,
+                  N::Integer)
+  return [Index(d,"Site,n=$n") for n=1:N]
+end
+
+function siteinds(str::String,
+                  N::Integer)
+  TType = TagType{Tag(str)}
+  if !hasmethod(siteinds,Tuple{TType,Int})
+    error("Overload of \"siteinds\" function not found for tag type \"$str\"")
+  end
+  return siteinds(TType(),N)
 end

--- a/src/physics/tag_types.jl
+++ b/src/physics/tag_types.jl
@@ -62,7 +62,7 @@ function op(s::Index,
   if !isnothing(starpos)
     op1 = opname[1:starpos.start-1]
     op2 = opname[starpos.start+1:end]
-    return multSiteOps(op(s,op1;kwargs...),op(s,op2;kwargs...))
+    return matmul(op(s,op1;kwargs...),op(s,op2;kwargs...))
   end
 
   return _call_op(s,opname;kwargs...)

--- a/src/smallstring.jl
+++ b/src/smallstring.jl
@@ -39,7 +39,7 @@ function Base.setindex(s::SmallString,val,n::Integer)
   return SmallString(setindex(s.data,val,n))
 end
 
-isNull(s::SmallString) = @inbounds s[1] == IntChar(0)
+isnull(s::SmallString) = @inbounds s[1] == IntChar(0)
 
 #function StaticArrays.push(s::SmallString,val)
 #  newlen = 1

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -59,7 +59,7 @@ end
 function _addtag!(ts::MTagSetStorage, plev::Int, ntags::Int, tag::IntTag)
   plnew = plev
   t = Tag(tag)
-  if !isNull(t)
+  if !isnull(t)
     if isint(t)
       error("""Cannot use a bare integer as a tag.
             If you are looking to set the prime level, use the syntax ("x",1)
@@ -73,7 +73,7 @@ function _addtag!(ts::MTagSetStorage, plev::Int, ntags::Int, tag::IntTag)
   return plnew, ntags
 end
 
-#isNull(v::MTagStorage) = v[0] == IntChar(0)
+#isnull(v::MTagStorage) = v[0] == IntChar(0)
 
 function reset!(v::MTagStorage, nchar::Int)
   for i = 1:nchar

--- a/src/tensor/linearalgebra.jl
+++ b/src/tensor/linearalgebra.jl
@@ -40,7 +40,7 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
   if fastSVD
     MU,MS,MV = svd(matrix(T))
   else
-    MU,MS,MV = recursiveSVD(matrix(T))
+    MU,MS,MV = svd_recursive(matrix(T))
   end
   conj!(MV)
 

--- a/src/tensor/svd.jl
+++ b/src/tensor/svd.jl
@@ -1,5 +1,5 @@
 export orthog!,
-       recursiveSVD
+       svd_recursive
 
 function orthog!(M::AbstractMatrix{T};
                  npass::Int=2) where {T}
@@ -55,13 +55,13 @@ function checkSVDDone(S::Vector,
   return (false,start)
 end
 
-function recursiveSVD(M::AbstractMatrix;
+function svd_recursive(M::AbstractMatrix;
                       thresh::Float64=1E-3,
                       north_pass::Int=2)
   Mr,Mc = size(M)
 
   if Mr > Mc
-    V,S,U = recursiveSVD(transpose(M))
+    V,S,U = svd_recursive(transpose(M))
     conj!(U)
     conj!(V)
     return U,S,V
@@ -87,7 +87,7 @@ function recursiveSVD(M::AbstractMatrix;
   v = view(V,:,start:Nd)
 
   b = u'*(M*v)
-  bu,bd,bv = recursiveSVD(b,
+  bu,bd,bv = svd_recursive(b,
                           thresh=thresh,
                           north_pass=north_pass)
 

--- a/test/test_autompo.jl
+++ b/test/test_autompo.jl
@@ -171,7 +171,7 @@ end
   @testset "Single creation op" begin
     ampo = AutoMPO()
     add!(ampo,"Cdagup",3)
-    sites = electronSites(N)
+    sites = siteinds("Electron",N)
     W = toMPO(ampo,sites)
     psi = makeRandomMPS(sites)
     cdu_psi = copy(psi)
@@ -184,7 +184,7 @@ end
     for j=1:N-1
       add!(ampo,"Sz",j,"Sz",j+1)
     end
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     Ha = toMPO(ampo,sites)
     He = isingMPO(sites)
     psi = makeRandomMPS(sites)
@@ -198,7 +198,7 @@ end
     for j=1:N-1
       add!(ampo,"Sz",j+1,"Sz",j)
     end
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     Ha = toMPO(ampo,sites)
     He = isingMPO(sites)
     psi = makeRandomMPS(sites)
@@ -219,7 +219,7 @@ end
       add!(ampo,h[j],"Sz",j)
     end
 
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     Ha = toMPO(ampo,sites)
     He = heisenbergMPO(sites,h)
     psi = makeRandomMPS(sites)
@@ -230,7 +230,7 @@ end
 
 
   @testset "Multiple Onsite Ops" begin
-    sites = spinOneSites(N)
+    sites = siteinds("S=1",N)
     ampo1 = AutoMPO()
     for j=1:N-1
       add!(ampo1,"Sz",j,"Sz",j+1)
@@ -274,7 +274,7 @@ end
     for j=1:N
       add!(ampo,h[j],"Sx",j)
     end
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     Ha = toMPO(ampo,sites)
     He = threeSiteIsingMPO(sites,h)
     psi = makeRandomMPS(sites)
@@ -288,7 +288,7 @@ end
     for j=1:N-3
       add!(ampo,"Sz",j,"Sz",j+1,"Sz",j+2,"Sz",j+3)
     end
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     Ha = toMPO(ampo,sites)
     He = fourSiteIsingMPO(sites)
     psi = makeRandomMPS(sites)
@@ -311,7 +311,7 @@ end
       add!(ampo,J2*0.5,"S+",j,"S-",j+2)
       add!(ampo,J2*0.5,"S-",j,"S+",j+2)
     end
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     Ha = toMPO(ampo,sites)
 
     He = NNheisenbergMPO(sites,J1,J2)
@@ -323,7 +323,7 @@ end
   end
 
   @testset "Onsite Regression Test" begin
-    sites = spinOneSites(4)
+    sites = siteinds("S=1",4)
     ampo = AutoMPO()
     add!(ampo, 0.5, "Sx",1)
     add!(ampo, 0.5, "Sy",1)
@@ -334,7 +334,7 @@ end
     @test norm(T-0.5*O) < 1E-8
 
       
-    sites = spinOneSites(2)
+    sites = siteinds("S=1",2)
     ampo = AutoMPO()
     add!(ampo, 0.5im, "Sx",1)
     add!(ampo, 0.5, "Sy",1)

--- a/test/test_autompo.jl
+++ b/test/test_autompo.jl
@@ -319,7 +319,7 @@ end
     Oa = inner(psi,Ha,psi)
     Oe = inner(psi,He,psi)
     @test Oa ≈ Oe
-    #@test maxLinkDim(Ha) == 8
+    #@test maxlinkdim(Ha) == 8
   end
 
   @testset "Onsite Regression Test" begin

--- a/test/test_dmrg.jl
+++ b/test/test_dmrg.jl
@@ -3,7 +3,7 @@ using ITensors, Test
 @testset "Basic DMRG" begin
   @testset "Spin-one Heisenberg" begin
     N = 100
-    sites = spinOneSites(N)
+    sites = siteinds("S=1",N)
 
     ampo = AutoMPO()
     for j=1:N-1
@@ -32,7 +32,7 @@ using ITensors, Test
 
   @testset "Transverse field Ising" begin
     N = 32
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     psi0 = randomMPS(sites)
 
     ampo = AutoMPO()
@@ -55,7 +55,7 @@ using ITensors, Test
 
   @testset "DMRGObserver" begin
     N = 10
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     psi0 = randomMPS(sites)
 
     ampo = AutoMPO()

--- a/test/test_indexset.jl
+++ b/test/test_indexset.jl
@@ -35,7 +35,7 @@ using ITensors,
     @test dim(I,2) == jdim
     @test dim(I,3) == kdim
 
-    @test maxDim(I) == max(idim,jdim,kdim)
+    @test maxdim(I) == max(idim,jdim,kdim)
   end
   @testset "Set operations" begin
     I1 = IndexSet(i,j,k)

--- a/test/test_itensor_dense.jl
+++ b/test/test_itensor_dense.jl
@@ -17,19 +17,19 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
   @testset "Default" begin
     A = ITensor()
     @test store(A) isa Dense{Nothing}
-    @test isNull(A)
+    @test isnull(A)
   end
 
   @testset "Undef with index" begin
     A = ITensor(undef, i)
     @test store(A) isa Dense{Float64}
-    @test !isNull(A)
+    @test !isnull(A)
   end
 
   @testset "Default with indices" begin
     A = ITensor(i,j)
     @test store(A) isa Dense{Float64}
-    @test !isNull(A)
+    @test !isnull(A)
   end
 
   @testset "Random" begin
@@ -39,13 +39,13 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
     @test ndims(A) == order(A) == 2 == length(inds(A))
     @test size(A) == dims(A) == (2,2)
 
-    @test !isNull(A)
+    @test !isnull(A)
 
     B = randomITensor(IndexSet(i,j))
     @test store(B) isa Dense{Float64}
     @test ndims(B) == order(B) == 2 == length(inds(B))
     @test size(B) == dims(B) == (2,2)
-    @test !isNull(B)
+    @test !isnull(B)
   end
 
   @testset "From matrix" begin

--- a/test/test_mpo.jl
+++ b/test/test_mpo.jl
@@ -185,7 +185,7 @@ include("util.jl")
     end
   end
   @testset "add" begin
-    shsites = spinHalfSites(N)
+    shsites = siteinds("S=1/2",N)
     K = randomMPO(shsites)
     L = randomMPO(shsites)
     M = sum(K, L)
@@ -211,7 +211,7 @@ include("util.jl")
     @test_throws DimensionMismatch multMPO(K,badL)
   end
 
-  sites = spinHalfSites(N)
+  sites = siteinds("S=1/2",N)
   O = MPO(sites,"Sz")
   @test length(O) == N # just make sure this works
 

--- a/test/test_mpo.jl
+++ b/test/test_mpo.jl
@@ -123,7 +123,7 @@ include("util.jl")
     @test_throws DimensionMismatch inner(J,phi,K,badpsi)
   end
 
-  @testset "errorMPOProd" begin
+  @testset "errorMPOprod" begin
     phi = makeRandomMPS(sites)
     K = makeRandomMPO(sites,chi=2)
 
@@ -131,16 +131,16 @@ include("util.jl")
 
     dist = sqrt(abs(1 + (inner(phi,phi) - 2*real(inner(phi,K,psi)))
                         /inner(K,psi,K,psi)))
-    @test dist ≈ errorMPOProd(phi,K,psi)
+    @test dist ≈ errorMPOprod(phi,K,psi)
 
     badsites = [Index(2,"Site") for n=1:N+1]
     badpsi = randomMPS(badsites)
-    # Apply K to phi and check that errorMPOProd is close to 0.
+    # Apply K to phi and check that errorMPOprod is close to 0.
     Kphi = applyMPO(K,phi;method="naive", cutoff=1E-8)
-    @test errorMPOProd(Kphi, K, phi) ≈ 0. atol=1e-4
+    @test errorMPOprod(Kphi, K, phi) ≈ 0. atol=1e-4
 
     @test_throws DimensionMismatch applyMPO(K,badpsi;method="naive", cutoff=1E-8)
-    @test_throws DimensionMismatch errorMPOProd(phi,K,badpsi)
+    @test_throws DimensionMismatch errorMPOprod(phi,K,badpsi)
   end
 
   @testset "applyMPO" begin

--- a/test/test_mpo.jl
+++ b/test/test_mpo.jl
@@ -35,7 +35,7 @@ include("util.jl")
   @testset "inner <y|A|x>" begin
     phi = randomMPS(sites)
     K = randomMPO(sites)
-    @test maxLinkDim(K) == 1
+    @test maxlinkdim(K) == 1
     psi = randomMPS(sites)
     phidag = dag(phi)
     prime!(phidag)
@@ -146,7 +146,7 @@ include("util.jl")
   @testset "applyMPO" begin
     phi = randomMPS(sites)
     K   = randomMPO(sites)
-    @test maxLinkDim(K) == 1
+    @test maxlinkdim(K) == 1
     psi = randomMPS(sites)
     psi_out = applyMPO(K, psi,maxdim=1)
     @test inner(phi,psi_out) ≈ inner(phi,K,psi)
@@ -196,19 +196,19 @@ include("util.jl")
     @test inner(psi, sum(k_psi, l_psi)) ≈ inner(psi, M, psi) atol=5e-3
   end
 
-  @testset "nmultMPO" begin
+  @testset "multMPO" begin
     psi = randomMPS(sites)
     K = randomMPO(sites)
     L = randomMPO(sites)
-    @test maxLinkDim(K) == 1
-    @test maxLinkDim(L) == 1
-    KL = nmultMPO(K, L, maxdim=1)
+    @test maxlinkdim(K) == 1
+    @test maxlinkdim(L) == 1
+    KL = multMPO(K, L, maxdim=1)
     psi_kl_out = applyMPO(K, applyMPO(L, psi, maxdim=1), maxdim=1)
     @test inner(psi,KL,psi) ≈ inner(psi, psi_kl_out) atol=5e-3
 
     badsites = [Index(2,"Site") for n=1:N+1]
     badL = randomMPO(badsites)
-    @test_throws DimensionMismatch nmultMPO(K,badL)
+    @test_throws DimensionMismatch multMPO(K,badL)
   end
 
   sites = spinHalfSites(N)

--- a/test/test_mps.jl
+++ b/test/test_mps.jl
@@ -24,7 +24,7 @@ include("util.jl")
 
   @testset "productMPS" begin
     @testset "vector of string input" begin
-      sites = spinHalfSites(N)
+      sites = siteinds("S=1/2",N)
       state = fill("",N)
       for j=1:N
         state[j] = isodd(j) ? "Up" : "Dn"
@@ -38,7 +38,7 @@ include("util.jl")
     end
 
     @testset "vector of int input" begin
-      sites = spinHalfSites(N)
+      sites = siteinds("S=1/2",N)
       state = fill(0,N)
       for j=1:N
         state[j] = isodd(j) ? 1 : 2
@@ -93,7 +93,7 @@ include("util.jl")
     @test inner(xi, xi) ≈ 4.0 * inner(psi, psi) 
   end
 
-  sites = spinHalfSites(N)
+  sites = siteinds(2,N)
   psi = MPS(sites)
   @test length(psi) == N # just make sure this works
   @test length(siteinds(psi)) == N

--- a/test/test_mps.jl
+++ b/test/test_mps.jl
@@ -100,45 +100,45 @@ include("util.jl")
 
   psi = randomMPS(sites)
   orthogonalize!(psi, N-1)
-  @test ITensors.leftLim(psi) == N-2
-  @test ITensors.rightLim(psi) == N
+  @test ITensors.leftlim(psi) == N-2
+  @test ITensors.rightlim(psi) == N
   orthogonalize!(psi, 2)
-  @test ITensors.leftLim(psi) == 1
-  @test ITensors.rightLim(psi) == 3
+  @test ITensors.leftlim(psi) == 1
+  @test ITensors.rightlim(psi) == 3
   psi = randomMPS(sites)
   psi.rlim_ = N+1 # do this to test qr from rightmost tensor
   orthogonalize!(psi, div(N, 2))
-  @test ITensors.leftLim(psi) == div(N, 2) - 1
-  @test ITensors.rightLim(psi) == div(N, 2) + 1
+  @test ITensors.leftlim(psi) == div(N, 2) - 1
+  @test ITensors.rightlim(psi) == div(N, 2) + 1
 
   @test_throws ErrorException linkindex(MPS(N, fill(ITensor(), N), 0, N + 1), 1)
 
-  @testset "replaceBond!" begin
+  @testset "replacebond!" begin
   # make sure factorization preserves the bond index tags
     psi = randomMPS(sites)
     phi = psi[1]*psi[2]
     bondindtags = tags(linkindex(psi,1))
-    replaceBond!(psi,1,phi)
+    replacebond!(psi,1,phi)
     @test tags(linkindex(psi,1)) == bondindtags
 
-    # check that replaceBond! updates llim_ and rlim_ properly
+    # check that replacebond! updates llim_ and rlim_ properly
     orthogonalize!(psi,5)
     phi = psi[5]*psi[6]
-    replaceBond!(psi,5,phi, dir="fromleft")
-    @test ITensors.leftLim(psi)==5
-    @test ITensors.rightLim(psi)==7
+    replacebond!(psi,5,phi, dir="fromleft")
+    @test ITensors.leftlim(psi)==5
+    @test ITensors.rightlim(psi)==7
 
     phi = psi[5]*psi[6]
-    replaceBond!(psi,5,phi,dir="fromright")
-    @test ITensors.leftLim(psi)==4
-    @test ITensors.rightLim(psi)==6
+    replacebond!(psi,5,phi,dir="fromright")
+    @test ITensors.leftlim(psi)==4
+    @test ITensors.rightlim(psi)==6
 
     psi.llim_ = 3
     psi.rlim_ = 7
     phi = psi[5]*psi[6]
-    replaceBond!(psi,5,phi,dir="fromleft")
-    @test ITensors.leftLim(psi)==3
-    @test ITensors.rightLim(psi)==7
+    replacebond!(psi,5,phi,dir="fromleft")
+    @test ITensors.leftlim(psi)==3
+    @test ITensors.rightlim(psi)==7
   end
 
 end
@@ -166,8 +166,8 @@ end
     M = basicRandomMPS(N)
     orthogonalize!(M,c)
 
-    @test leftLim(M) == c-1
-    @test rightLim(M) == c+1
+    @test leftlim(M) == c-1
+    @test rightlim(M) == c+1
 
     # Test for left-orthogonality
     L = M[1]*prime(M[1],"Link")
@@ -197,7 +197,7 @@ end
     M0 = copy(M)
     truncate!(M;maxdim=5)
 
-    @test rightLim(M) == 2
+    @test rightlim(M) == 2
 
     # Test for right-orthogonality
     R = M[N]*prime(M[N],"Link")

--- a/test/test_phys_site_types.jl
+++ b/test/test_phys_site_types.jl
@@ -6,7 +6,7 @@ using ITensors,
   N = 10
 
   @testset "Spin Half sites" begin
-    s = spinHalfSites(N)
+    s = siteinds("S=1/2",N)
 
     @test state(s[1],"Up") == s[1](1)
     @test state(s[1],"Dn") == s[1](2)
@@ -29,7 +29,7 @@ using ITensors,
   end
 
   @testset "Spin One sites" begin
-    s = spinOneSites(N)
+    s = siteinds("S=1",N)
 
     @test state(s[1],"Up") == s[1](1)
     @test state(s[1],"0")  == s[1](2)
@@ -58,7 +58,7 @@ using ITensors,
   end
 
   @testset "Electron sites" begin
-    s = electronSites(N)
+    s = siteinds("Electron",N)
 
     @test state(s[1],"0")    == s[1](1)
     @test state(s[1],"Up")   == s[1](2)
@@ -109,7 +109,7 @@ using ITensors,
   end
 
   @testset "tJ sites" begin
-    s = tJSites(N)
+    s = siteinds("tJ",N)
 
     @test state(s[1],"0")    == s[1](1)
     @test state(s[1],"Up")   == s[1](2)

--- a/test/test_smallstring.jl
+++ b/test/test_smallstring.jl
@@ -8,21 +8,21 @@ import ITensors.SmallString,
 @testset "SmallString" begin
   @testset "ctors" begin
       s = SmallString()
-      @test ITensors.isNull(s)
+      @test ITensors.isnull(s)
   end
 
   @testset "setindex" begin
       s = SmallString()
-      @test ITensors.isNull(s)
+      @test ITensors.isnull(s)
       t = setindex(s, IntChar(1), 1)
-      @test !ITensors.isNull(t)
+      @test !ITensors.isnull(t)
   end
 
   #@testset "push" begin
   #  s = SmallString()
-  #  @test ITensors.isNull(s)
+  #  @test ITensors.isnull(s)
   #  t = push(s, IntChar(1))
-  #  @test !ITensors.isNull(t)
+  #  @test !ITensors.isnull(t)
   #end
 
   @testset "comparison" begin

--- a/test/test_svd.jl
+++ b/test/test_svd.jl
@@ -23,27 +23,27 @@ using ITensors,
          1.0 1.0 1.0 1.0;
          0.0 0.5 0.5 1.0;
          0.0 1.0 1.0 2.0]
-    U,S,V = recursiveSVD(M)
+    U,S,V = svd_recursive(M)
     @test norm(U*Diagonal(S)*V'-M) < 1E-13
   end
 
   @testset "Real Matrix" begin
     M = rand(10,20)
-    U,S,V = recursiveSVD(M)
+    U,S,V = svd_recursive(M)
     @test norm(U*Diagonal(S)*V'-M) < 1E-13
 
     M = rand(20,10)
-    U,S,V = recursiveSVD(M)
+    U,S,V = svd_recursive(M)
     @test norm(U*Diagonal(S)*V'-M) < 1E-13
   end
 
   @testset "Cplx Matrix" begin
     M = rand(ComplexF64,10,15)
-    U,S,V = recursiveSVD(M)
+    U,S,V = svd_recursive(M)
     @test norm(U*Diagonal(S)*V'-M) < 1E-13
 
     M = rand(ComplexF64,15,10)
-    U,S,V = recursiveSVD(M)
+    U,S,V = svd_recursive(M)
     @test norm(U*Diagonal(S)*V'-M) < 1E-13
   end
 

--- a/test/test_tag_types.jl
+++ b/test/test_tag_types.jl
@@ -11,18 +11,18 @@ using ITensors,
     @test sites[1] isa Index
     Sz = op(sites,"Sz",2)
     SzSz = op(sites,"Sz * Sz",2)
-    @test SzSz ≈ multSiteOps(Sz,Sz)
+    @test SzSz ≈ matmul(Sz,Sz)
     Sy = op(sites,"Sy",2)
     SySy = op(sites,"Sy * Sy",2)
-    @test SySy ≈ multSiteOps(Sy,Sy)
+    @test SySy ≈ matmul(Sy,Sy)
 
     sites = spinOneSites(N)
     @test_throws ArgumentError op(sites, "Sp", 1)
     Sz = op(sites,"Sz",2)
     SzSz = op(sites,"Sz * Sz",2)
-    @test SzSz ≈ multSiteOps(Sz,Sz)
+    @test SzSz ≈ matmul(Sz,Sz)
     Sy = op(sites,"Sy",2)
     SySy = op(sites,"Sy * Sy",2)
-    @test SySy ≈ multSiteOps(Sy,Sy)
+    @test SySy ≈ matmul(Sy,Sy)
   end
 end

--- a/test/test_tag_types.jl
+++ b/test/test_tag_types.jl
@@ -6,7 +6,7 @@ using ITensors,
   N = 10
 
   @testset "Star in operator strings" begin
-    sites = spinHalfSites(N)
+    sites = siteinds("S=1/2",N)
     @test_throws ArgumentError op(sites, "Sp", 1)
     @test sites[1] isa Index
     Sz = op(sites,"Sz",2)
@@ -16,7 +16,7 @@ using ITensors,
     SySy = op(sites,"Sy * Sy",2)
     @test SySy ≈ matmul(Sy,Sy)
 
-    sites = spinOneSites(N)
+    sites = siteinds("S=1",N)
     @test_throws ArgumentError op(sites, "Sp", 1)
     Sz = op(sites,"Sz",2)
     SzSz = op(sites,"Sz * Sz",2)


### PR DESCRIPTION
Also replaced functions like `spinHalfSites`, `electronSites`, with a single function `siteinds` which takes a string and the number of sites. For example:
```
sh_sites = siteinds("S=1/2",N)
so_sites = siteinds("S=1",N)
e_sites = siteinds("Electron",N)
```