### PR TITLE
Compatibility for GPU/PEPS stuff

### DIFF
--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -51,7 +51,7 @@ import Base.adjoint,
 #####################################
 # Global Variables
 #
-const warnTensorOrder = 10
+const warnTensorOrder = 14
 const GLOBAL_TIMER = TimerOutput()
 
 #####################################

--- a/src/iterativesolvers.jl
+++ b/src/iterativesolvers.jl
@@ -77,7 +77,9 @@ function davidson(A,
 
   nrm = norm(phi)
   if nrm < 1E-18 
-    phi = randomITensor(inds(phi))
+    phi_ = similar(phi)
+    randn!(phi_)
+    phi = phi_ 
     nrm = norm(phi)
   end
   scale!(phi,1.0/nrm)


### PR DESCRIPTION
Bumped the tensor warn order because in the PEPS code we often have tensors of rank 12.

The change to randomizing phi lets the GPU code use the same Davidson method. Plussers has the change it does because it needs to be overloaded by the GPU code to avoid a very slow transfer of the plusser to the device.

Changed the sites mechanism bc the old version was giving me errors when I did `multMPO` with MPOs where the site indices aren't primed versions of each other.