### PR TITLE
Restore feature of reading certain objects written from C++ version

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -279,11 +279,11 @@ adjoint(iv::IndexVal) = IndexVal(adjoint(ind(iv)),val(iv))
 
 show(io::IO,iv::IndexVal) = print(io,ind(iv),"=$(val(iv))")
 
-function Base.read(io::IO,::Type{Index}; kwargs...)
-  format = get(kwargs,:format,"hdf5")
+function readcpp(io::IO,::Type{Index}; kwargs...)
+  format = get(kwargs,:format,"v3")
   i = Index()
-  if format=="cpp"
-    tags = read(io,TagSet;kwargs...)
+  if format=="v3"
+    tags = readcpp(io,TagSet;kwargs...)
     id = read(io,IDType)
     dim = convert(Int64,read(io,Int32))
     dir_int = read(io,Int32)

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -676,13 +676,11 @@ function readcpp(io::IO,::Type{IndexSet};kwargs...)
   is = IndexSet()
   if format=="v3"
     size = read(io,Int)
-
     function readind(io,n)
       i = readcpp(io,Index;kwargs...)
       stride = read(io,UInt64)
       return i
     end
-
     is = IndexSet(ntuple(n->readind(io,n),size))
   else
     throw(ArgumentError("read IndexSet: format=$format not supported"))

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -671,17 +671,19 @@ function is_uncombiner(labelsT1,labelsT2)
          count_common(labelsT1,labelsT2) == 1
 end
 
-function Base.read(io::IO,::Type{IndexSet};kwargs...)
-  format = get(kwargs,:format,"hdf5")
+function readcpp(io::IO,::Type{IndexSet};kwargs...)
+  format = get(kwargs,:format,"v3")
   is = IndexSet()
-  if format=="cpp"
+  if format=="v3"
     size = read(io,Int)
-    resize!(is.inds,size)
-    for n=1:size
-      i = read(io,Index;kwargs...)
+
+    function readind(io,n)
+      i = readcpp(io,Index;kwargs...)
       stride = read(io,UInt64)
-      is.inds[n] = i
+      return i
     end
+
+    is = IndexSet(ntuple(n->readind(io,n),size))
   else
     throw(ArgumentError("read IndexSet: format=$format not supported"))
   end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -659,39 +659,48 @@ function matmul(A::ITensor,
   return mapprime(R,2,1)
 end
 
-function read_cpp!(T::ITensor,io::IO;kwargs...)
-  T.inds = read(io,IndexSet;kwargs...)
-  read(io,12) # ignore scale factor
-  storage_type = read(io,Int32) # see StorageType enum above
-  if storage_type==0 # Null
-    T.store = Dense{Nothing}()
-  elseif storage_type==1  # DenseReal
-    T.store = read(io,Dense{Float64};kwargs...)
-  elseif storage_type==2  # DenseCplx
-    T.store = read(io,Dense{ComplexF64};kwargs...)
-  elseif storage_type==3  # Combiner
-    T.store = CombinerStorage(T.inds[1])
-  #elseif storage_type==4  # DiagReal
-  #elseif storage_type==5  # DiagCplx
-  #elseif storage_type==6  # QDenseReal
-  #elseif storage_type==7  # QDenseCplx
-  #elseif storage_type==8  # QCombiner
-  #elseif storage_type==9  # QDiagReal
-  #elseif storage_type==10 # QDiagCplx
-  #elseif storage_type==11 # ScalarReal
-  #elseif storage_type==12 # ScalarCplx
+function readcpp(io::IO,::Type{Dense{ValT}};kwargs...) where {ValT}
+  format = get(kwargs,:format,"v3")
+  if format=="v3"
+    size = read(io,UInt64)
+    data = Vector{ValT}(undef,size)
+    for n=1:size
+      data[n] = read(io,ValT)
+    end
+    return Dense(data)
   else
-    throw(ErrorException("C++ ITensor storage type $storage_type not yet supported"))
+    throw(ArgumentError("read Dense: format=$format not supported"))
   end
 end
 
-function Base.read(io::IO,::Type{ITensor};kwargs...)
-  format = get(kwargs,:format,"hdf5")
-  T = ITensor()
-  if format=="cpp"
-    read_cpp!(T,io;kwargs...)
+function readcpp(io::IO,::Type{ITensor};kwargs...)
+  format = get(kwargs,:format,"v3")
+  if format=="v3"
+    inds = readcpp(io,IndexSet;kwargs...)
+    read(io,12) # ignore scale factor by reading 12 bytes
+    storage_type = read(io,Int32)
+    if storage_type==0 # Null
+      store = Dense{Nothing}()
+    elseif storage_type==1  # DenseReal
+      store = readcpp(io,Dense{Float64};kwargs...)
+    elseif storage_type==2  # DenseCplx
+      store = readcpp(io,Dense{ComplexF64};kwargs...)
+    elseif storage_type==3  # Combiner
+      store = CombinerStorage(T.inds[1])
+    #elseif storage_type==4  # DiagReal
+    #elseif storage_type==5  # DiagCplx
+    #elseif storage_type==6  # QDenseReal
+    #elseif storage_type==7  # QDenseCplx
+    #elseif storage_type==8  # QCombiner
+    #elseif storage_type==9  # QDiagReal
+    #elseif storage_type==10 # QDiagCplx
+    #elseif storage_type==11 # ScalarReal
+    #elseif storage_type==12 # ScalarCplx
+    else
+      throw(ErrorException("C++ ITensor storage type $storage_type not yet supported"))
+    end
+    return ITensor(store,inds)
   else
     throw(ArgumentError("read ITensor: format=$format not supported"))
   end
-  return T
 end

--- a/src/readwrite.jl
+++ b/src/readwrite.jl
@@ -1,13 +1,14 @@
 
+export readcpp
 
-function Base.read(io::IO,::Type{Vector{T}};kwargs...) where {T}
-  format = get(kwargs,:format,"hdf5")
+function readcpp(io::IO,::Type{Vector{T}};kwargs...) where {T}
+  format = get(kwargs,:format,"v3")
   v = Vector{T}()
-  if format=="cpp"
+  if format=="v3"
     size = read(io,UInt64)
     resize!(v,size)
     for n=1:size
-      v[n] = read(io,T;kwargs...)
+      v[n] = readcpp(io,T;kwargs...)
     end
   else
     throw(ArgumentError("read Vector: format=$format not supported"))

--- a/src/smallstring.jl
+++ b/src/smallstring.jl
@@ -1,6 +1,6 @@
 export convert,
        setindex,
-       read
+       readcpp
 
 const IntChar = UInt8
 const IntSmallString = UInt64
@@ -133,10 +133,10 @@ function Base.show(io::IO, s::SmallString)
   end
 end
 
-function Base.read(io::IO,::Type{SmallString}; kwargs...)
-  format = get(kwargs,:format,"hdf5")
+function readcpp(io::IO,::Type{SmallString}; kwargs...)
+  format = get(kwargs,:format,"v3")
   s = SmallString()
-  if format=="cpp"
+  if format=="v3"
     for n=1:7
       c = read(io,Char)
       s = setindex(s,c,n)

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -285,14 +285,14 @@ function show(io::IO, T::TagSet)
   print(io,primestring(T))
 end
 
-function Base.read(io::IO,::Type{TagSet}; kwargs...)
-  format = get(kwargs,:format,"hdf5")
+function readcpp(io::IO,::Type{TagSet}; kwargs...)
+  format = get(kwargs,:format,"v3")
   ts = TagSet()
-  if format=="cpp"
+  if format=="v3"
     mstore = MTagSetStorage(ntuple(_ -> IntTag(0),Val(maxTags)))
     ntags = 0
     for n=1:4
-      t = read(io,Tag;kwargs...)
+      t = readcpp(io,Tag;kwargs...)
       if t != Tag()
         ntags = _addtag_ordered!(mstore,ntags,IntSmallString(t))
       end


### PR DESCRIPTION
In this update to this feature, I've renamed the functions from Base.read to readcpp. This way we can use this as an "orthogonal" feature to both basic reading of binary data (Base.read) and the upcoming support for hdf5 files (which will be called read/write but will take an HDF5Group object as the first argument rather than an IO object like Base.read does).