### PR TITLE
Fixed Typo in `davidson` iterative solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 benchmark/mult
 Manifest.toml
+.DS_Store

--- a/src/iterativesolvers.jl
+++ b/src/iterativesolvers.jl
@@ -69,7 +69,7 @@ function davidson(A,
   end
 
   maxiter = get(kwargs,:maxiter,2)
-  miniter = get(kwargs,:maxiter,1)
+  miniter = get(kwargs,:miniter,1)
   errgoal = get(kwargs,:errgoal,1E-14)
   Northo_pass = get(kwargs,:Northo_pass,1)
 


### PR DESCRIPTION
Found and fixed typo in `davidson` iterative solver, which would interpret the keyword argument `maxiter` both as `maxiter` and `miniter`.

Secondly, as I am developing on a Mac, I added `.DS_Store` to `.gitignore`. I hope this is fine?? I'm new to this..