### PR TITLE
Change from using to import in test files for dependencies

### DIFF
--- a/test/2d_classical_ising.jl
+++ b/test/2d_classical_ising.jl
@@ -1,6 +1,5 @@
-using ITensors,
-      LinearAlgebra,
-      QuadGK
+using ITensors
+import QuadGK
 
 const βc = 0.5*log(sqrt(2.0)+1.0)
 
@@ -11,7 +10,7 @@ function ising_free_energy(β::Real,J::Real=1.0)
   xmin = 0.0
   xmax = π
   integrand(x) = log(c^2+sqrt(s^4+1-2*s^2*cos(x)))
-  integral,err = quadgk(integrand, xmin, xmax)::Tuple{Float64,Float64}
+  integral,err = QuadGK.quadgk(integrand, xmin, xmax)::Tuple{Float64,Float64}
   return -(log(2.0)+integral/π)/(2.0*β)
 end
 
@@ -31,8 +30,8 @@ function ising_mpo(sh::Tuple{Index,Index},sv::Tuple{Index,Index},
     end
     sz && (T[1,1,1,1] = -T[1,1,1,1])
     Q = [exp(β*J) exp(-β*J); exp(-β*J) exp(β*J)]
-    D,U = eigen(Symmetric(Q))
-    √Q = U*Diagonal(sqrt.(D))*U'
+    D,U = eigen(ITensors.LinearAlgebra.Symmetric(Q))
+    √Q = U*ITensors.LinearAlgebra.Diagonal(sqrt.(D))*U'
     Xh1 = ITensor(√Q,sh[1],sh[1]')
     Xh2 = ITensor(√Q,sh[2],sh[2]')
     Xv1 = ITensor(√Q,sv[1],sv[1]')

--- a/test/contract.jl
+++ b/test/contract.jl
@@ -1,7 +1,6 @@
 using ITensors,
-      LinearAlgebra, # For tr()
       Test
-using Combinatorics: permutations
+import Combinatorics
 
 digits(::Type{T},i,j,k) where {T} = T(i*10^2+j*10+k)
 
@@ -85,7 +84,7 @@ digits(::Type{T},i,j,k) where {T} = T(i*10^2+j*10+k)
       Aij = permute(Aij,i,j)
       Bij = permute(Bij,i,j)
       C = Aij*Bij
-      CArray = tr(array(Aij)*transpose(array(Bij)))
+      CArray = ITensors.LinearAlgebra.tr(array(Aij)*transpose(array(Bij)))
       @test CArray≈scalar(C)
     end
     @testset "Test contract ITensors (Matrix*Matrix -> Matrix)" begin
@@ -168,7 +167,7 @@ digits(::Type{T},i,j,k) where {T} = T(i*10^2+j*10+k)
       @test CArray≈array(permute(C,i,l))
     end
     @testset "Test contract ITensors (3-Tensor*3-Tensor -> 3-Tensor)" begin
-      for inds_ijk ∈ permutations([i,j,k]), inds_jkl ∈ permutations([j,k,l])
+      for inds_ijk ∈ Combinatorics.permutations([i,j,k]), inds_jkl ∈ Combinatorics.permutations([j,k,l])
         Aijk = permute(Aijk,inds_ijk...)
         Ajkl = permute(Ajkl,inds_jkl...)
         C = Ajkl*Aijk
@@ -177,7 +176,7 @@ digits(::Type{T},i,j,k) where {T} = T(i*10^2+j*10+k)
       end
     end
     @testset "Test contract ITensors (4-Tensor*3-Tensor -> 1-Tensor)" begin
-      for inds_ijkl ∈ permutations([i,j,k,l]), inds_jkl ∈ permutations([j,k,l])
+      for inds_ijkl ∈ Combinatorics.permutations([i,j,k,l]), inds_jkl ∈ Combinatorics.permutations([j,k,l])
         Aijkl = permute(Aijkl,inds_ijkl...)
         Ajkl = permute(Ajkl,inds_jkl...) 
         C = Ajkl*Aijkl
@@ -186,7 +185,7 @@ digits(::Type{T},i,j,k) where {T} = T(i*10^2+j*10+k)
       end
     end
     @testset "Test contract ITensors (4-Tensor*3-Tensor -> 3-Tensor)" begin
-      for inds_ijkl ∈ permutations([i,j,k,l]), inds_klα ∈ permutations([k,l,α])
+      for inds_ijkl ∈ Combinatorics.permutations([i,j,k,l]), inds_klα ∈ Combinatorics.permutations([k,l,α])
         Aijkl = permute(Aijkl,inds_ijkl...)
         Aklα = permute(Aklα,inds_klα...)
         C = Aklα*Aijkl

--- a/test/ctmrg.jl
+++ b/test/ctmrg.jl
@@ -1,5 +1,4 @@
 using ITensors,
-      Random,
       Test
 
 include("2d_classical_ising.jl")

--- a/test/decomp.jl
+++ b/test/decomp.jl
@@ -1,4 +1,5 @@
-using ITensors, Test
+using ITensors,
+      Test
 
 a = [-0.1, -0.12]
 @test ITensors.truncate!(a) == (0., 0.)
@@ -19,7 +20,7 @@ A = randomITensor(i,j)
 
   U,S,V = svd(rand(100,100))
   S ./= norm(S)
-  A = ITensor(U*diagm(0=>S)*V', i,j)
+  A = ITensor(U*ITensors.LinearAlgebra.diagm(0=>S)*V', i,j)
 
   spec = svd(A,i).spec
 

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -1,7 +1,6 @@
 using ITensors,
-      LinearAlgebra, # For tr()
-      Random,        # To set a seed
       Test
+import Random
 
 Random.seed!(12345)
 
@@ -199,7 +198,7 @@ end
   Amat = reshape(Amat+Amat'+randn(4,4)*1e-10,2,2,2,2)
   A = ITensor(Amat,i1,i2,s1,s2)
   Aexp = exp(A,(i1,i2),(s1,s2),ishermitian=true)
-  Amatexp = reshape(parent(exp(Hermitian(reshape(Amat,4,4)))),
+  Amatexp = reshape(parent(exp(ITensors.LinearAlgebra.Hermitian(reshape(Amat,4,4)))),
                     2,2,2,2)
   Aexp_from_mat = ITensor(Amatexp,i1,i2,s1,s2)
   @test Aexp ≈ Aexp_from_mat

--- a/test/itensor_diag.jl
+++ b/test/itensor_diag.jl
@@ -1,5 +1,4 @@
 using ITensors,
-      LinearAlgebra, # For tr()
       Test
 
 @testset "diagITensor" begin

--- a/test/readme.jl
+++ b/test/readme.jl
@@ -1,7 +1,5 @@
 using ITensors,
-      Test,
-      Random,
-      LinearAlgebra
+      Test
 
 @testset "README Examples" begin
 

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -1,7 +1,5 @@
 using ITensors,
-      Test,
-      Random,
-      LinearAlgebra
+      Test
 
 @testset "SVD Algorithms" begin
 
@@ -11,11 +9,11 @@ using ITensors,
          0.0 0.5 0.5 1.0;
          0.0 1.0 1.0 2.0]
     orthog!(M1)
-    @test norm(M1'*M1-Diagonal(ones(size(M1,1)))) < 1E-12
+    @test norm(M1'*M1-ITensors.LinearAlgebra.Diagonal(ones(size(M1,1)))) < 1E-12
 
     M2 = rand(10,10)
     orthog!(M2)
-    @test norm(M2'*M2-Diagonal(ones(size(M2,1)))) < 1E-12
+    @test norm(M2'*M2-ITensors.LinearAlgebra.Diagonal(ones(size(M2,1)))) < 1E-12
   end
 
   @testset "Matrix With Zero Sing Val" begin
@@ -24,27 +22,27 @@ using ITensors,
          0.0 0.5 0.5 1.0;
          0.0 1.0 1.0 2.0]
     U,S,V = svd_recursive(M)
-    @test norm(U*Diagonal(S)*V'-M) < 1E-13
+    @test norm(U*ITensors.LinearAlgebra.Diagonal(S)*V'-M) < 1E-13
   end
 
   @testset "Real Matrix" begin
     M = rand(10,20)
     U,S,V = svd_recursive(M)
-    @test norm(U*Diagonal(S)*V'-M) < 1E-13
+    @test norm(U*ITensors.LinearAlgebra.Diagonal(S)*V'-M) < 1E-13
 
     M = rand(20,10)
     U,S,V = svd_recursive(M)
-    @test norm(U*Diagonal(S)*V'-M) < 1E-13
+    @test norm(U*ITensors.LinearAlgebra.Diagonal(S)*V'-M) < 1E-13
   end
 
   @testset "Cplx Matrix" begin
     M = rand(ComplexF64,10,15)
     U,S,V = svd_recursive(M)
-    @test norm(U*Diagonal(S)*V'-M) < 1E-13
+    @test norm(U*ITensors.LinearAlgebra.Diagonal(S)*V'-M) < 1E-13
 
     M = rand(ComplexF64,15,10)
     U,S,V = svd_recursive(M)
-    @test norm(U*Diagonal(S)*V'-M) < 1E-13
+    @test norm(U*ITensors.LinearAlgebra.Diagonal(S)*V'-M) < 1E-13
   end
 
 end

--- a/test/trg.jl
+++ b/test/trg.jl
@@ -1,6 +1,6 @@
 using ITensors,
-      Random,
       Test
+import Random
 
 Random.seed!(12345)
 


### PR DESCRIPTION
This changes pulling in test dependencies from `using` to `import`, so external functions need to be explicitly called (e.g. `Combinatorics.permutations`).

The goal is to have the unit tests catch if certain ITensors.jl functions are not exported, if they are overloaded from modules that we are using in the tests.