### PR TITLE
Add Array(::ITensor,::Index...) functions

### DIFF
--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -242,6 +242,14 @@ array(T::DenseTensor) = reshape(data(store(T)),dims(inds(T)))
 matrix(T::DenseTensor{<:Number,2}) = array(T)
 vector(T::DenseTensor{<:Number,1}) = array(T)
 
+function Base.Array{ElT,N}(T::DenseTensor{ElT,N}) where {ElT,N}
+  return copy(array(T))
+end
+
+function Base.Array(T::DenseTensor{ElT,N}) where {ElT,N}
+  return Array{ElT,N}(T)
+end
+
 # TODO: call permutedims!(R,T,perm,(r,t)->t)?
 function Base.permutedims!(R::DenseTensor{<:Number,N},
                            T::DenseTensor{<:Number,N},

--- a/src/Tensors/diag.jl
+++ b/src/Tensors/diag.jl
@@ -1,4 +1,5 @@
-export Diag
+export Diag,
+       DiagTensor
 
 # Diag can have either Vector storage, in which case
 # it is a general Diag tensor, or scalar storage,
@@ -178,6 +179,14 @@ function array(T::DiagTensor{ElT,N}) where {ElT,N}
 end
 matrix(T::DiagTensor{<:Number,2}) = array(T)
 vector(T::DiagTensor{<:Number,1}) = array(T)
+
+function Base.Array{ElT,N}(T::DiagTensor{ElT,N}) where {ElT,N}
+  return array(T)
+end
+
+function Base.Array(T::DiagTensor{ElT,N}) where {ElT,N}
+  return Array{ElT,N}(T)
+end
 
 diag_length(T::DiagTensor) = minimum(dims(T))
 diag_length(T::DiagTensor{<:Number,0}) = 1

--- a/src/Tensors/linearalgebra.jl
+++ b/src/Tensors/linearalgebra.jl
@@ -26,7 +26,7 @@ function LinearAlgebra.exp(T::DenseTensor{ElT,2}) where {ElT}
   return Tensor(Dense(vec(expTM)),inds(T))
 end
 
-function expHermitian(T::DenseTensor{ElT,2}) where {ElT}
+function exphermitian(T::DenseTensor{ElT,2}) where {ElT}
   # exp(::Hermitian/Symmetric) returns Hermitian/Symmetric,
   # so extract the parent matrix
   expTM = parent(exp(Hermitian(matrix(T))))

--- a/src/Tensors/tensor.jl
+++ b/src/Tensors/tensor.jl
@@ -21,6 +21,7 @@ end
 store(T::Tensor) = T.store
 inds(T::Tensor) = T.inds
 ind(T::Tensor,j::Integer) = inds(T)[j]
+Base.eltype(::Tensor{ElT}) where {ElT} = ElT
 
 #
 # Generic Tensor functions

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -55,6 +55,17 @@ setinds!(T::ITensor,is...) = (T.inds = IndexSet(is...))
 setstore!(T::ITensor,st::TensorStorage) = (T.store = st)
 
 #
+# Iteration over ITensors
+#
+
+"""
+    CartesianIndices(A::ITensor)
+
+Iterate over the CartesianIndices of an ITensor.
+"""
+Base.CartesianIndices(A::ITensor) = CartesianIndices(dims(A))
+
+#
 # Dense ITensor constructors
 #
 
@@ -251,7 +262,7 @@ Base.complex(T::ITensor) = ITensor(complex(Tensor(store(T),inds(T))))
 # set operations to work with ITensors
 IndexSet(T::ITensor) = inds(T)
 
-Base.eltype(T::ITensor) = eltype(store(T))
+Base.eltype(T::ITensor) = eltype(tensor(T))
 
 """
     order(A::ITensor) = ndims(A)
@@ -282,17 +293,28 @@ isnull(T::ITensor) = (eltype(T) === Nothing)
 
 Base.copy(T::ITensor{N}) where {N} = ITensor{N}(copy(tensor(T)))
 
-# TODO: make versions where the element type can be specified
-# Should this be called `array`? (Version that makes a view, if dense)
-Tensors.array(T::ITensor) = array(tensor(T))
+"""
+    Array{ElT}(T::ITensor, i:Index...)
 
-function Tensors.array(T::ITensor{N},is::Vararg{Index,N}) where {N}
-  perm = getperm(inds(T),is)
-  return array(permutedims(tensor(T),perm))
+Given an ITensor `T` with indices `i...`, returns
+an Array with a copy of the ITensor's elements. The
+order in which the indices are provided indicates
+the order of the data in the resulting Array.
+"""
+function Base.Array{ElT,N}(T::ITensor{N},is::Vararg{Index,N}) where {ElT,N}
+  return Array{ElT,N}(tensor(permute(T,is...)))::Array{ElT,N}
+end
+
+function Base.Array{ElT}(T::ITensor{N},is::Vararg{Index,N}) where {ElT,N}
+  return Array{ElT,N}(T,is...)
+end
+
+function Base.Array(T::ITensor{N},is::Vararg{Index,N}) where {N}
+  return Array{eltype(T),N}(T,is...)::Array{<:Number,N}
 end
 
 """
-    matrix(T::ITensor, row_i:Index, col_i::Index)
+    Matrix(T::ITensor, row_i:Index, col_i::Index)
 
 Given an ITensor `T` with two indices `row_i` and `col_i`, returns
 a Matrix with a copy of the ITensor's elements. The
@@ -300,34 +322,30 @@ order in which the indices are provided indicates
 which Index is to be treated as the row index of the 
 Matrix versus the column index.
 
-    matrix(T::ITensor)
-
-Given an ITensor `T` with two indices, returns
-a Matrix with a copy of the ITensor's elements. 
-The ordering of the elements in the Matrix, in
-terms of which Index is treated as the row versus
-column, depends on the internal layout of the ITensor.
-*Therefore this method is intended for developer use
-only and not recommend for use in ITensor applications.*
 """
-function Tensors.matrix(T::ITensor{N},row_i::Index,col_i::Index) where {N}
-  N≠2 && throw(DimensionMismatch("ITensor must be order 2 to convert to a Matrix"))
-  return array(T,row_i,col_i)
+function Base.Matrix(T::ITensor{2},row_i::Index,col_i::Index)
+  return Array(T,row_i,col_i)
 end
 
-function Tensors.matrix(T::ITensor{N}) where {N}
-  N!=2 && throw(DimensionMismatch("ITensor must be order 2 to convert to a Matrix"))
-  return array(tensor(T))
+function Base.Vector(T::ITensor{1},i::Index)
+  return Array(T,i)
 end
 
-function Tensors.vector(T::ITensor{N}) where {N}
-  N!=1 && throw(DimensionMismatch("ITensor must be order 1 to convert to a Vector"))
-  return array(tensor(T))
+function Base.Vector{ElT}(T::ITensor{1}) where {ElT}
+  return Vector{ElT}(T,inds(T)...)
 end
 
-scalar(T::ITensor) = T[]
+function Base.Vector(T::ITensor{1})
+  return Vector(T,inds(T)...)
+end
+
+scalar(T::ITensor) = T[]::Number
 
 Base.getindex(T::ITensor{N},vals::Vararg{Int,N}) where {N} = tensor(T)[vals...]::Number
+
+# Version accepting CartesianIndex, useful when iterating over
+# CartesianIndices
+Base.getindex(T::ITensor{N},I::CartesianIndex{N}) where {N} = tensor(T)[I]::Number
 
 function Base.getindex(T::ITensor{N},
                        ivs::Vararg{IndexVal,N}) where {N}
@@ -353,17 +371,6 @@ function Base.setindex!(T::ITensor,x::Number,ivs::IndexVal...)
   vals = permute(val.(ivs),p)
   return T[vals...] = x
 end
-
-# TODO: what was this doing?
-#function setindex!(T::ITensor,
-#                   x::Union{<:Number, AbstractArray{<:Number}},
-#                   ivs::Union{IndexVal, AbstractVector{IndexVal}}...)
-#  remap_ivs = map(x->x isa IndexVal ? x : x[1], ivs)
-#  p = getperm(inds(T),remap_ivs)
-#  vals = map(x->x isa IndexVal ? val(x) : val.(x), ivs[p])
-#  storage_setindex!(store(T),inds(T),x,vals...)
-#  return T
-#end
 
 function Base.fill!(T::ITensor,
                     x::Number)
@@ -482,10 +489,10 @@ function dag(T::ITensor)
   return ITensor(store(TT),dag(inds(T)))
 end
 
-function Tensors.permute(T::ITensor,new_inds)
+function Tensors.permute(T::ITensor{N},new_inds) where {N}
   perm = getperm(new_inds,inds(T))
   Tp = permutedims(tensor(T),perm)
-  return ITensor(Tp)
+  return ITensor(Tp)::ITensor{N}
 end
 Tensors.permute(T::ITensor,inds::Index...) = permute(T,IndexSet(inds...))
 
@@ -528,7 +535,7 @@ Compute the exponential of the tensor `A` by treating it as a matrix ``A_{lr}`` 
 the left index `l` running over all indices in `Lis` and `r` running over all
 indices not in `Lis`. Must have `dim(Lis) == dim(inds(A))/dim(Lis)` for the exponentiation to
 be defined.
-When `hermitian=true` the exponential of `Hermitian(reshape(A, dim(Lis), :))` is
+When `ishermitian=true` the exponential of `Hermitian(A_{lr})` is
 computed internally.
 """
 function LinearAlgebra.exp(A::ITensor,
@@ -545,6 +552,13 @@ function exphermitian(A::ITensor,
                       Linds,
                       Rinds = prime(IndexSet(Linds))) 
   return exp(A,Linds,Rinds;ishermitian=true)
+end
+
+function matmul(A::ITensor,
+                B::ITensor)
+  R = mapprime(mapprime(A,1,2),0,1)
+  R *= B
+  return mapprime(R,2,1)
 end
 
 #######################################################################
@@ -652,6 +666,40 @@ Like `A .= x .* B`.
 LinearAlgebra.mul!(R::ITensor,α::Number,T::ITensor) = apply!(R,T,(r,t)->α*t )
 LinearAlgebra.mul!(R::ITensor,T::ITensor,α::Number) = mul!(R,α,T)
 
+#######################################################################
+#
+# Developer functions
+#
+
+# TODO: make versions where the element type can be specified (for type
+# inference).
+Tensors.array(T::ITensor) = array(tensor(T))
+
+"""
+    matrix(T::ITensor)
+
+Given an ITensor `T` with two indices, returns
+a Matrix with a copy of the ITensor's elements,
+or a view in the case the the ITensor's storage is Dense.
+The ordering of the elements in the Matrix, in
+terms of which Index is treated as the row versus
+column, depends on the internal layout of the ITensor.
+*Therefore this method is intended for developer use
+only and not recommended for use in ITensor applications.*
+"""
+function Tensors.matrix(T::ITensor{2})
+  return array(tensor(T))
+end
+
+function Tensors.vector(T::ITensor{1})
+  return array(tensor(T))
+end
+
+#######################################################################
+#
+# Printing, reading and writing ITensors
+#
+
 function Base.summary(io::IO,
                       T::ITensor)
   print(io,"ITensor ord=$(order(T))")
@@ -680,13 +728,6 @@ end
 function Base.similar(T::ITensor,
                       element_type=eltype(T))
   return ITensor(similar(tensor(T),element_type))
-end
-
-function matmul(A::ITensor,
-                B::ITensor)
-  R = mapprime(mapprime(A,1,2),0,1)
-  R *= B
-  return mapprime(R,2,1)
 end
 
 function readcpp(io::IO,::Type{Dense{ValT}};kwargs...) where {ValT}

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -52,9 +52,9 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
     A = ITensor(M,i,j)
     @test store(A) isa Dense{Float64}
 
-    @test M ≈ matrix(A,i,j)
-    @test M' ≈ matrix(A,j,i)
-    @test_throws DimensionMismatch vector(A)
+    @test M ≈ Matrix(A,i,j)
+    @test M' ≈ Matrix(A,j,i)
+    @test_throws MethodError vector(A)
 
     @test size(A,1) == size(M,1) == 2
     @test size(A,3) == size(M,3) == 1
@@ -73,13 +73,13 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
       @test M1[ni,nj] ≈ TM[i(ni),j(nj)]
     end
 
-    M2 = matrix(TM,j,i)
+    M2 = Matrix(TM,j,i)
     for ni in i, nj in j
       @test M2[nj,ni] ≈ TM[i(ni),j(nj)]
     end
 
     T3 = randomITensor(i,j,k)
-    @test_throws DimensionMismatch matrix(T3,i,j)
+    @test_throws MethodError Matrix(T3,i,j)
   end
 
   @testset "To Vector" begin
@@ -91,7 +91,7 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
     end
 
     T2 = randomITensor(i,j)
-    @test_throws DimensionMismatch vector(T2)
+    @test_throws MethodError vector(T2)
   end
 
   @testset "Complex" begin
@@ -244,6 +244,38 @@ end
   N = 2*M 
   B = ITensor(N,j,i)
   @test data(store(mul!(B, A, 2.0))) == 2.0*vec(transpose(M))
+end
+
+@testset "Convert to Array" begin
+  i = Index(2,"i")
+  j = Index(3,"j")
+  T = randomITensor(i,j)
+
+  A = Array{Float64}(T,i,j)
+  for I in CartesianIndices(T)
+    @test A[I] == T[I]
+  end
+
+  T11 = T[1,1]
+  T[1,1] = 1
+  @test T[1,1] == 1
+  @test T11 != 1
+  @test A[1,1] == T11
+
+  A = Matrix{Float64}(T,i,j)
+  for I in CartesianIndices(T)
+    @test A[I] == T[I]
+  end
+
+  A = Matrix(T,i,j)
+  for I in CartesianIndices(T)
+    @test A[I] == T[I]
+  end
+
+  A = Array(T,i,j)
+  for I in CartesianIndices(T)
+    @test A[I] == T[I]
+  end
 end
 
 @testset "show" begin

--- a/test/phys_site_types.jl
+++ b/test/phys_site_types.jl
@@ -16,16 +16,16 @@ using ITensors,
     @test hasinds(Sz5,s[5]',s[5])
      
     @test_throws ArgumentError op(s, "Fake", 2)
-    @test array(op(s,"S+",3),s[3]',s[3])  ≈ [ 0.0  1.0; 0.0  0.0]
-    @test array(op(s,"S-",4),s[4]',s[4])  ≈ [ 0.0  0.0; 1.0  0.0]
-    @test array(op(s,"Sx",2),s[2]',s[2])  ≈ [ 0.0  0.5; 0.5  0.0]
-    @test array(op(s,"iSy",2),s[2]',s[2]) ≈ [ 0.0  0.5;-0.5  0.0]
-    @test array(op(s,"Sy",2),s[2]',s[2])  ≈ [0.0  -0.5im; 0.5im  0.0]
-    @test array(op(s,"Sz",2),s[2]',s[2])  ≈ [ 0.5  0.0; 0.0 -0.5]
-    @test array(op(s,"projUp",2),s[2]',s[2])  ≈ [ 1.0  0.0; 0.0 0.0]
-    @test array(op(s,"projDn",2),s[2]',s[2])  ≈ [ 0.0  0.0; 0.0 1.0]
-    @test array(op(s,"Up",2),s[2])  ≈ [1.0,0.0]
-    @test array(op(s,"Dn",2),s[2])  ≈ [0.0,1.0]
+    @test Array(op(s,"S+",3),s[3]',s[3])  ≈ [ 0.0  1.0; 0.0  0.0]
+    @test Array(op(s,"S-",4),s[4]',s[4])  ≈ [ 0.0  0.0; 1.0  0.0]
+    @test Array(op(s,"Sx",2),s[2]',s[2])  ≈ [ 0.0  0.5; 0.5  0.0]
+    @test Array(op(s,"iSy",2),s[2]',s[2]) ≈ [ 0.0  0.5;-0.5  0.0]
+    @test Array(op(s,"Sy",2),s[2]',s[2])  ≈ [0.0  -0.5im; 0.5im  0.0]
+    @test Array(op(s,"Sz",2),s[2]',s[2])  ≈ [ 0.5  0.0; 0.0 -0.5]
+    @test Array(op(s,"projUp",2),s[2]',s[2])  ≈ [ 1.0  0.0; 0.0 0.0]
+    @test Array(op(s,"projDn",2),s[2]',s[2])  ≈ [ 0.0  0.0; 0.0 1.0]
+    @test Array(op(s,"Up",2),s[2])  ≈ [1.0,0.0]
+    @test Array(op(s,"Dn",2),s[2])  ≈ [0.0,1.0]
   end
 
   @testset "Spin One sites" begin
@@ -40,21 +40,21 @@ using ITensors,
     @test hasinds(Sz5,s[5]',s[5])
      
     @test_throws ArgumentError op(s, "Fake", 2)
-    @test array(op(s,"S+",3),s[3]',s[3]) ≈ [ 0 √2 0; 0 0 √2; 0 0 0]
-    @test array(op(s,"S-",3),s[3]',s[3]) ≈ [ 0 0 0; √2 0 0; 0.0 √2 0]
-    @test array(op(s,"Sx",3),s[3]',s[3]) ≈ [ 0 1/√2 0; 1/√2 0 1/√2; 0 1/√2 0]
-    @test array(op(s,"iSy",3),s[3]',s[3]) ≈ [ 0 1/√2 0; -1/√2 0 1/√2; 0 -1/√2 0]
-    @test array(op(s,"Sy",3),s[3]',s[3]) ≈ [ 0 -1/√2im 0; +1/√2im 0 -1/√2im; 0 +1/√2im 0]
-    @test array(op(s,"Sz",2),s[2]',s[2]) ≈ [1.0 0 0; 0 0 0; 0 0 -1.0]
-    @test array(op(s,"Sz2",2),s[2]',s[2]) ≈ [1.0 0 0; 0 0 0; 0 0 +1.0]
-    @test array(op(s,"Sx2",2),s[2]',s[2]) ≈ [0.5 0 0.5;0 1.0 0;0.5 0 0.5]
-    @test array(op(s,"Sy2",2),s[2]',s[2]) ≈ [0.5 0 -0.5;0 1.0 0;-0.5 0 0.5]
-    @test array(op(s,"projUp",2),s[2]',s[2]) ≈ [1.0 0 0;0 0 0;0 0 0]
-    @test array(op(s,"projZ0",2),s[2]',s[2]) ≈ [0 0 0;0 1.0 0;0 0 0]
-    @test array(op(s,"projDn",2),s[2]',s[2]) ≈ [0 0 0;0 0 0;0 0 1.0]
-    @test array(op(s,"XUp",2),s[2]) ≈ [0.5,im*√2,0.5]
-    @test array(op(s,"XZ0",2),s[2]) ≈ [im*√2,0,-im*√2]
-    @test array(op(s,"XDn",2),s[2]) ≈ [0.5,-im*√2,0.5]
+    @test Array(op(s,"S+",3),s[3]',s[3]) ≈ [ 0 √2 0; 0 0 √2; 0 0 0]
+    @test Array(op(s,"S-",3),s[3]',s[3]) ≈ [ 0 0 0; √2 0 0; 0.0 √2 0]
+    @test Array(op(s,"Sx",3),s[3]',s[3]) ≈ [ 0 1/√2 0; 1/√2 0 1/√2; 0 1/√2 0]
+    @test Array(op(s,"iSy",3),s[3]',s[3]) ≈ [ 0 1/√2 0; -1/√2 0 1/√2; 0 -1/√2 0]
+    @test Array(op(s,"Sy",3),s[3]',s[3]) ≈ [ 0 -1/√2im 0; +1/√2im 0 -1/√2im; 0 +1/√2im 0]
+    @test Array(op(s,"Sz",2),s[2]',s[2]) ≈ [1.0 0 0; 0 0 0; 0 0 -1.0]
+    @test Array(op(s,"Sz2",2),s[2]',s[2]) ≈ [1.0 0 0; 0 0 0; 0 0 +1.0]
+    @test Array(op(s,"Sx2",2),s[2]',s[2]) ≈ [0.5 0 0.5;0 1.0 0;0.5 0 0.5]
+    @test Array(op(s,"Sy2",2),s[2]',s[2]) ≈ [0.5 0 -0.5;0 1.0 0;-0.5 0 0.5]
+    @test Array(op(s,"projUp",2),s[2]',s[2]) ≈ [1.0 0 0;0 0 0;0 0 0]
+    @test Array(op(s,"projZ0",2),s[2]',s[2]) ≈ [0 0 0;0 1.0 0;0 0 0]
+    @test Array(op(s,"projDn",2),s[2]',s[2]) ≈ [0 0 0;0 0 0;0 0 1.0]
+    @test Array(op(s,"XUp",2),s[2]) ≈ [0.5,im*√2,0.5]
+    @test Array(op(s,"XZ0",2),s[2]) ≈ [im*√2,0,-im*√2]
+    @test Array(op(s,"XDn",2),s[2]) ≈ [0.5,-im*√2,0.5]
   end
 
   @testset "Electron sites" begin
@@ -70,41 +70,41 @@ using ITensors,
     @test hasinds(Nup5,s[5]',s[5])
      
     @test_throws ArgumentError op(s, "Fake", 2)
-    Nup3 = array(op(s,"Nup",3),s[3]',s[3]) 
+    Nup3 = Array(op(s,"Nup",3),s[3]',s[3]) 
     @test Nup3 ≈ [0. 0 0 0; 0 1 0 0; 0 0 0 0; 0 0 0 1]
-    Ndn3 = array(op(s,"Ndn",3),s[3]',s[3]) 
+    Ndn3 = Array(op(s,"Ndn",3),s[3]',s[3]) 
     @test Ndn3 ≈ [0. 0 0 0; 0 0 0 0; 0 0 1 0; 0 0 0 1]
-    Ntot3 = array(op(s,"Ntot",3),s[3]',s[3]) 
+    Ntot3 = Array(op(s,"Ntot",3),s[3]',s[3]) 
     @test Ntot3 ≈ [0. 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 2]
-    Cup3 = array(op(s,"Cup",3),s[3]',s[3]) 
+    Cup3 = Array(op(s,"Cup",3),s[3]',s[3]) 
     @test Cup3 ≈ [0. 1 0 0; 0 0 0 0; 0 0 0 1; 0 0 0 0]
-    Cdagup3 = array(op(s,"Cdagup",3),s[3]',s[3]) 
+    Cdagup3 = Array(op(s,"Cdagup",3),s[3]',s[3]) 
     @test Cdagup3 ≈ [0. 0 0 0; 1 0 0 0; 0 0 0 0; 0 0 1 0]
-    Cdn3 = array(op(s,"Cdn",3),s[3]',s[3]) 
+    Cdn3 = Array(op(s,"Cdn",3),s[3]',s[3]) 
     @test Cdn3 ≈ [0. 0 1 0; 0 0 0 1; 0 0 0 0; 0 0 0 0]
-    Cdagdn3 = array(op(s,"Cdagdn",3),s[3]',s[3]) 
+    Cdagdn3 = Array(op(s,"Cdagdn",3),s[3]',s[3]) 
     @test Cdagdn3 ≈ [0. 0 0 0; 0 0 0 0; 1 0 0 0; 0 1 0 0]
-    F3 = array(op(s,"F",3),s[3]',s[3]) 
+    F3 = Array(op(s,"F",3),s[3]',s[3]) 
     @test F3 ≈ [1. 0 0 0; 0 -1 0 0; 0 0 -1 0; 0 0 0 1]
-    Fup3 = array(op(s,"Fup",3),s[3]',s[3]) 
+    Fup3 = Array(op(s,"Fup",3),s[3]',s[3]) 
     @test Fup3 ≈ [1. 0 0 0; 0 -1 0 0; 0 0 1 0; 0 0 0 -1]
-    Fdn3 = array(op(s,"Fdn",3),s[3]',s[3]) 
+    Fdn3 = Array(op(s,"Fdn",3),s[3]',s[3]) 
     @test Fdn3 ≈ [1. 0 0 0; 0 1 0 0; 0 0 -1 0; 0 0 0 -1]
-    Sz3 = array(op(s,"Sz",3),s[3]',s[3]) 
+    Sz3 = Array(op(s,"Sz",3),s[3]',s[3]) 
     @test Sz3 ≈ [0. 0 0 0; 0 0.5 0 0; 0 0 -0.5 0; 0 0 0 0]
-    Sx3 = array(op(s,"Sx",3),s[3]',s[3]) 
+    Sx3 = Array(op(s,"Sx",3),s[3]',s[3]) 
     @test Sx3 ≈ [0. 0 0 0; 0 0 0.5 0; 0 0.5 0 0; 0 0 0 0]
-    Sp3 = array(op(s,"S+",3),s[3]',s[3]) 
+    Sp3 = Array(op(s,"S+",3),s[3]',s[3]) 
     @test Sp3 ≈ [0. 0 0 0; 0 0 1 0; 0 0 0 0; 0 0 0 0]
-    Sm3 = array(op(s,"S-",3),s[3]',s[3]) 
+    Sm3 = Array(op(s,"S-",3),s[3]',s[3]) 
     @test Sm3 ≈ [0. 0 0 0; 0 0 0 0; 0 1 0 0; 0 0 0 0]
-    Sem = array(op(s,"Emp",3),s[3])
+    Sem = Array(op(s,"Emp",3),s[3])
     @test Sem ≈ [1.0; 0.0; 0.0; 0.0]
-    Sup = array(op(s,"Up",3),s[3])
+    Sup = Array(op(s,"Up",3),s[3])
     @test Sup ≈ [0.0; 1.0; 0.0; 0.0]
-    Sdn = array(op(s,"Dn",3),s[3])
+    Sdn = Array(op(s,"Dn",3),s[3])
     @test Sdn ≈ [0.0; 0.0; 1.0; 0.0]
-    Supdn = array(op(s,"UpDn",3),s[3])
+    Supdn = Array(op(s,"UpDn",3),s[3])
     @test Supdn ≈ [0.0; 0.0; 0.0; 1.0]
   end
 
@@ -124,33 +124,33 @@ using ITensors,
     Ntot_2 = op(s,"Ntot",2)
     @test Ntot_2[2,2] ≈ 1.0
     @test Ntot_2[3,3] ≈ 1.0
-    Cup3 = array(op(s,"Cup",3),s[3]',s[3]) 
+    Cup3 = Array(op(s,"Cup",3),s[3]',s[3]) 
     @test Cup3 ≈ [0. 1 0; 0 0 0; 0 0 0]
-    Cdup3 = array(op(s,"Cdagup",3),s[3]',s[3]) 
+    Cdup3 = Array(op(s,"Cdagup",3),s[3]',s[3]) 
     @test Cdup3 ≈ [0 0 0; 1. 0 0; 0 0 0]
-    Cdn3 = array(op(s,"Cdn",3),s[3]',s[3]) 
+    Cdn3 = Array(op(s,"Cdn",3),s[3]',s[3]) 
     @test Cdn3 ≈ [0. 0. 1; 0 0 0; 0 0 0]
-    Cddn3 = array(op(s,"Cdagdn",3),s[3]',s[3]) 
+    Cddn3 = Array(op(s,"Cdagdn",3),s[3]',s[3]) 
     @test Cddn3 ≈ [0 0 0; 0. 0 0; 1 0 0]
-    FP3 = array(op(s,"FP",3),s[3]',s[3]) 
+    FP3 = Array(op(s,"FP",3),s[3]',s[3]) 
     @test FP3 ≈ [1.0 0. 0; 0 -1.0 0; 0 0 -1.0]
-    Fup3 = array(op(s,"Fup",3),s[3]',s[3]) 
+    Fup3 = Array(op(s,"Fup",3),s[3]',s[3]) 
     @test Fup3 ≈ [1.0 0. 0; 0 -1.0 0; 0 0 1.0]
-    Fdn3 = array(op(s,"Fdn",3),s[3]',s[3]) 
+    Fdn3 = Array(op(s,"Fdn",3),s[3]',s[3]) 
     @test Fdn3 ≈ [1.0 0. 0; 0 1.0 0; 0 0 -1.0]
-    Sz3 = array(op(s,"Sz",3),s[3]',s[3]) 
+    Sz3 = Array(op(s,"Sz",3),s[3]',s[3]) 
     @test Sz3 ≈ [0.0 0. 0; 0 0.5 0; 0 0 -0.5]
-    Sx3 = array(op(s,"Sx",3),s[3]',s[3]) 
+    Sx3 = Array(op(s,"Sx",3),s[3]',s[3]) 
     @test Sx3 ≈ [0.0 0. 0; 0 0 1; 0 1 0]
-    Sp3 = array(op(s,"Splus",3),s[3]',s[3]) 
+    Sp3 = Array(op(s,"Splus",3),s[3]',s[3]) 
     @test Sp3 ≈ [0.0 0. 0; 0 0 1.0; 0 0 0]
-    Sm3 = array(op(s,"Sminus",3),s[3]',s[3]) 
+    Sm3 = Array(op(s,"Sminus",3),s[3]',s[3]) 
     @test Sm3 ≈ [0.0 0. 0; 0 0 0; 0 1.0 0]
-    Up3 = array(op(s,"Up",3),s[3]) 
+    Up3 = Array(op(s,"Up",3),s[3]) 
     @test Up3 ≈ [0.0; 1.0; 0]
-    Dn3 = array(op(s,"Dn",3),s[3]) 
+    Dn3 = Array(op(s,"Dn",3),s[3]) 
     @test Dn3 ≈ [0.0; 0.0; 1.0]
-    Em3 = array(op(s,"Emp",3),s[3]) 
+    Em3 = Array(op(s,"Emp",3),s[3]) 
     @test Em3 ≈ [1.0; 0.0; 0.0]
   end
 


### PR DESCRIPTION
This includes a version `Array{ElT}(::ITensor,::Index...)` to help with type inference.

Fixes #158.