### PR TITLE
Add BlockSparseTensor contraction

### DIFF
--- a/src/Tensors/blocksparse/blocksparsetensor.jl
+++ b/src/Tensors/blocksparse/blocksparsetensor.jl
@@ -29,41 +29,36 @@ function offset(T::BlockSparseTensor{ElT,N},
   return offset(blockoffsets(T),block)
 end
 
-# Get the offset if the nth block in the block-offsets
-# list
-offset(T::BlockSparseTensor,n::Int) = offset(blockoffsets(T),n)
+"""
+offset(T::BlockSparseTensor,pos::Int)
+
+Get the offset of the block at position pos
+in the block-offsets list.
+"""
+offset(T::BlockSparseTensor,n::Int) = offset(store(T),n)
 
 """
 blockdim(T::BlockSparseTensor,pos::Int)
 
-Get the block dimension of the block at position pos.
+Get the block dimension of the block at position pos
+in the block-offset list.
 """
-function blockdim(T::BlockSparseTensor,
-                  pos::Int)
-  if nnzblocks(T)==0
-    return 0
-  elseif pos==nnzblocks(T)
-    return nnz(T)-offset(T,pos)
-  end
-  return offset(T,pos+1)-offset(T,pos)
-end
+blockdim(T::BlockSparseTensor,pos::Int) = blockdim(store(T),pos)
 
 findblock(T::BlockSparseTensor{ElT,N},
-          block::Block{N}) where {ElT,N} = findblock(blockoffsets(T),block)
+          block::Block{N}) where {ElT,N} = findblock(store(T),block)
 
 new_block_pos(T::BlockSparseTensor{ElT,N},
               block::Block{N}) where {ElT,N} = new_block_pos(blockoffsets(T),block)
+
 """
 isblocknz(T::BlockSparseTensor,
           block::Block)
 
 Check if the specified block is non-zero
 """
-function isblocknz(T::BlockSparseTensor{ElT,N},
-                   block::Block{N}) where {ElT,N}
-  isnothing(findblock(T,block)) && return false
-  return true
-end
+isblocknz(T::BlockSparseTensor{ElT,N},
+          block::Block{N}) where {ElT,N} = isblocknz(store(T),block)
 
 function BlockSparseTensor(::Type{ElT},
                            ::UndefInitializer,
@@ -291,7 +286,7 @@ end
 # Given a specified block, return a Dense Tensor that is a view to the data
 # in that block
 function blockview(T::BlockSparseTensor{ElT,N},
-                   block) where {ElT,N}
+                   block::Block{N}) where {ElT,N}
   !isblocknz(T,block) && error("Block must be structurally non-zero to get a view")
   blockoffsetT = offset(T,block)
   blockdimsT = blockdims(T,block)

--- a/src/Tensors/blocksparse/blocksparsetensor.jl
+++ b/src/Tensors/blocksparse/blocksparsetensor.jl
@@ -347,50 +347,39 @@ function Base.permutedims(T::BlockSparseTensor{<:Number,N},
 end
 
 # TODO: handle case with different element types in R and T
-function permutedims!!(R::BlockSparseTensor{<:Number,N},
-                       T::BlockSparseTensor{<:Number,N},
-                       perm::NTuple{N,Int}) where {N}
-  blockoffsetsTp,indsTp = permute(blockoffsets(T),inds(T),perm)
-  if blockoffsets(Tp) == blockoffsets(R)
-    R = permutedims!(R,T,perm)
-    return R
-  end
-  R = similar(T,blockoffsetsR,indsR)
-  permutedims!(R,T,perm)
-  return R
-end
+#function permutedims!!(R::BlockSparseTensor{<:Number,N},
+#                       T::BlockSparseTensor{<:Number,N},
+#                       perm::NTuple{N,Int}) where {N}
+#  blockoffsetsTp,indsTp = permute(blockoffsets(T),inds(T),perm)
+#  if blockoffsetsTp == blockoffsets(R)
+#    R = permutedims!(R,T,perm)
+#    return R
+#  end
+#  R = similar(T,blockoffsetsTp,indsTp)
+#  permutedims!(R,T,perm)
+#  return R
+#end
 
 # TODO: handle case with different element types in R and T
 function permutedims!!(R::BlockSparseTensor{<:Number,N},
                        T::BlockSparseTensor{<:Number,N},
                        perm::NTuple{N,Int},
-                       f::Function) where {N}
+                       f::Function=(r,t)->t) where {N}
   blockoffsetsTp,indsTp = permute(blockoffsets(T),inds(T),perm)
-  if blockoffsets(Tp) == blockoffsets(R)
+  indsTp != inds(R) && error("In permutedims!!, output indices are not permutation of input")
+  if blockoffsetsTp == blockoffsets(R)
     R = permutedims!(R,T,perm,f)
     return R
   end
-  R = similar(T,blockoffsetsR,indsR)
+  R = similar(T,blockoffsetsTp,indsTp)
   permutedims!(R,T,perm,f)
   return R
 end
 
 function Base.permutedims!(R::BlockSparseTensor{<:Number,N},
                            T::BlockSparseTensor{<:Number,N},
-                           perm::NTuple{N,Int}) where {N}
-  for (blockT,_) in blockoffsets(T)
-    # Loop over non-zero blocks of T/R
-    Tblock = blockview(T,blockT)
-    Rblock = blockview(R,permute(blockT,perm))
-    permutedims!(Rblock,Tblock,perm)
-  end
-  return R
-end
-
-function Base.permutedims!(R::BlockSparseTensor{<:Number,N},
-                           T::BlockSparseTensor{<:Number,N},
                            perm::NTuple{N,Int},
-                           f::Function) where {N}
+                           f::Function=(r,t)->t) where {N}
   for (blockT,_) in blockoffsets(T)
     # Loop over non-zero blocks of T/R
     Tblock = blockview(T,blockT)
@@ -399,6 +388,19 @@ function Base.permutedims!(R::BlockSparseTensor{<:Number,N},
   end
   return R
 end
+
+#function Base.permutedims!(R::BlockSparseTensor{<:Number,N},
+#                           T::BlockSparseTensor{<:Number,N},
+#                           perm::NTuple{N,Int},
+#                           f::Function) where {N}
+#  for (blockT,_) in blockoffsets(T)
+#    # Loop over non-zero blocks of T/R
+#    Tblock = blockview(T,blockT)
+#    Rblock = blockview(R,permute(blockT,perm))
+#    permutedims!(Rblock,Tblock,perm,f)
+#  end
+#  return R
+#end
 
 #
 # Contraction

--- a/src/Tensors/combiner.jl
+++ b/src/Tensors/combiner.jl
@@ -26,7 +26,7 @@ function contraction_output(::TensorT1,
                                                  TensorT2<:DenseTensor,
                                                  IndsR}
   TensorR = contraction_output_type(TensorT1,TensorT2,IndsR)
-  return similar(TensorR,indsR)
+  return _similar(TensorR,indsR)
 end
 
 function contraction_output(T1::TensorT1,

--- a/src/Tensors/contraction_logic.jl
+++ b/src/Tensors/contraction_logic.jl
@@ -55,7 +55,7 @@ function contract_inds(T1is,
   end
   IndsT1 = typeof(T1is)
   IndsR = similar_type(IndsT1,Val{NR})
-  return IndsR(Ris...)
+  return IndsR(tuple(Ris...))
 end
 
 mutable struct ContractionProperties{NA,NB,NC}

--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -42,6 +42,9 @@ end
 Dense{ElT}() where {ElT} = Dense(ElT[])
 Dense(::Type{ElT}) where {ElT} = Dense{ElT}()
 
+Base.length(D::Dense) = length(data(D))
+Base.size(D::Dense) = size(data(D))
+
 # Functions to make Dense storage act like a vector
 Base.@propagate_inbounds Base.getindex(D::Dense,i::Integer) = data(D)[i]
 Base.@propagate_inbounds Base.setindex!(D::Dense,v,i::Integer) = (data(D)[i] = v)
@@ -258,6 +261,15 @@ function scale!(T::DenseTensor,
   return T
 end
 
+function apply!(R::DenseTensor,
+                T::DenseTensor,
+                f=(r,t)->t)
+  RA = array(R)
+  TA = array(T)
+  RA .= f.(RA,TA)
+  return R
+end
+
 # Version that may overwrite the result or promote
 # and return the result
 # TODO: move to tensor.jl?
@@ -268,9 +280,7 @@ function permutedims!!(R::Tensor,
   if !is_trivial_permutation(perm)
     permutedims!(R,T,perm,f)
   else
-    RA = array(R)
-    TA = array(T)
-    RA .= f.(RA,TA)
+    apply!(R,T,f)
   end
   return R
 end

--- a/src/Tensors/diag.jl
+++ b/src/Tensors/diag.jl
@@ -339,9 +339,9 @@ function _contract!!(R::UniformDiagTensor{ElR,NR},labelsR,
   return R
 end
 
-function _contract!(R::DiagTensor{ElR,NR},labelsR,
-                    T1::DiagTensor{<:Number,N1},labelsT1,
-                    T2::DiagTensor{<:Number,N2},labelsT2) where {ElR,NR,N1,N2}
+function contract!(R::DiagTensor{ElR,NR},labelsR,
+                   T1::DiagTensor{<:Number,N1},labelsT1,
+                   T2::DiagTensor{<:Number,N2},labelsT2) where {ElR,NR,N1,N2}
   if NR==0  # If all indices of A and B are contracted
     # all indices are summed over, just add the product of the diagonal
     # elements of A and B
@@ -361,11 +361,11 @@ function _contract!(R::DiagTensor{ElR,NR},labelsR,
   return R
 end
 
-function _contract!(C::DenseTensor{ElC,NC},Clabels,
-                    A::DiagTensor{ElA,NA},Alabels,
-                    B::DenseTensor{ElB,NB},Blabels) where {ElA,NA,
-                                                           ElB,NB,
-                                                           ElC,NC}
+function contract!(C::DenseTensor{ElC,NC},Clabels,
+                   A::DiagTensor{ElA,NA},Alabels,
+                   B::DenseTensor{ElB,NB},Blabels) where {ElA,NA,
+                                                          ElB,NB,
+                                                          ElC,NC}
   if all(i -> i < 0, Blabels)
     # If all of B is contracted
     # TODO: can also check NC+NB==NA
@@ -445,9 +445,9 @@ function _contract!(C::DenseTensor{ElC,NC},Clabels,
     end
   end
 end
-_contract!(C::DenseTensor,Clabels,
-           A::DenseTensor,Alabels,
-           B::DiagTensor,Blabels) = _contract!(C,Clabels,
-                                               B,Blabels,
-                                               A,Alabels)
+contract!(C::DenseTensor,Clabels,
+          A::DenseTensor,Alabels,
+          B::DiagTensor,Blabels) = contract!(C,Clabels,
+                                             B,Blabels,
+                                             A,Alabels)
 

--- a/src/Tensors/tensor.jl
+++ b/src/Tensors/tensor.jl
@@ -21,6 +21,7 @@ end
 store(T::Tensor) = T.store
 inds(T::Tensor) = T.inds
 ind(T::Tensor,j::Integer) = inds(T)[j]
+Base.eachindex(T::Tensor) = CartesianIndices(dims(inds(T)))
 
 #
 # Generic Tensor functions

--- a/src/Tensors/tensorstorage.jl
+++ b/src/Tensors/tensorstorage.jl
@@ -2,9 +2,7 @@ export data,
        TensorStorage,
        randn!
 
-# TODO: define as
-# abstract type TensorStorage{El} end <: AbstractVector{El}
-abstract type TensorStorage{ElT} end
+abstract type TensorStorage{ElT} <: AbstractVector{ElT} end
 
 data(S::TensorStorage) = S.data
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -626,7 +626,7 @@ LinearAlgebra.axpy!(a::Number,v::ITensor,w::ITensor) = add!(w,a,v)
 #"""
 #w .= a .* v + b .* w
 #"""
-#LinearAlgebra.axpby!(a::Number,v::ITensor,b::Number,w::ITensor) = add!(w,b,w,a,v)
+#LinearAlgebra.axpby!(a::Number,v::ITensor,b::Number,w::ITensor) = add!(w,b,a,v)
 
 """
     scale!(A::ITensor,x::Number) = rmul!(A,x)

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -147,6 +147,30 @@ using ITensors,
     end
   end
 
+  @testset "permutedims!! with different blocks" begin
+    # Indices
+    indsA = ([2,3],[4,5])
+
+    # Locations of non-zero blocks
+    locsA = [(1,2),(2,1)]
+    A = BlockSparseTensor(locsA,indsA...)
+    randn!(A)
+
+    perm = (2,1)
+
+    locsB = [(2,1)]
+    indsB = permute(indsA,perm)
+    B = BlockSparseTensor(locsB,indsB...)
+    randn!(B)
+
+    R = permutedims!!(B,A,perm)
+
+    @test nnz(R) == nnz(A)
+    for I in eachindex(A)
+      @test R[permute(I,perm)] == A[I]
+    end
+  end
+
   @testset "Contract" begin
     indsA = ([2,3],[4,5])
     locsA = [(1,1),(2,2),(2,1),(1,2)]

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -146,5 +146,28 @@ using ITensors,
       @test R[I] == A[I] + B[I]
     end
   end
+
+  @testset "Contract" begin
+    indsA = ([2,3],[4,5])
+    locsA = [(1,1),(2,2),(2,1),(1,2)]
+    A = BlockSparseTensor(locsA,indsA...)
+    randn!(A)
+
+    indsB = ([4,5],[3,2])
+    locsB = [(1,2),(2,1),(1,1)]
+    B = BlockSparseTensor(locsB,indsB...)
+    randn!(B)
+
+    R = contract(A,(1,-1),B,(-1,2))
+
+    DA = dense(A)
+    DB = dense(B)
+    DR = contract(DA,(1,-1),DB,(-1,2))
+
+    for I in eachindex(R)
+      @test R[I] ≈ DR[I]
+    end
+  end
+
 end
 

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -40,7 +40,7 @@ using ITensors,
 
   @test D == A
 
-  for I in CartesianIndices(A)
+  for I in eachindex(A)
     @test D[I] == A[I]
   end
 
@@ -48,9 +48,8 @@ using ITensors,
 
   @test dims(A12) == (2,5)
 
-  for I in CartesianIndices(A12)
-    blockstart = CartesianIndex(0,4)
-    @test A12[I] == A[I+blockstart]
+  for I in eachindex(A12)
+    @test A12[I] == A[I+CartesianIndex(0,4)]
   end
 
   B = BlockSparseTensor(undef,locs,indsA)
@@ -58,7 +57,7 @@ using ITensors,
 
   C = A+B
 
-  for I in CartesianIndices(C)
+  for I in eachindex(C)
     @test C[I] == A[I]+B[I]
   end
 
@@ -69,14 +68,14 @@ using ITensors,
   @test nnz(A) == nnz(Ap)
   @test nnzblocks(A) == nnzblocks(Ap)
 
-  for I in CartesianIndices(C)
+  for I in eachindex(C)
     @test A[I] == Ap[permute(I,(2,1))]
   end
 
   @testset "BlockSparseTensor setindex! add block" begin
     T = BlockSparseTensor([2,3],[4,5])
 
-    for I in CartesianIndices(C)
+    for I in eachindex(C)
       @test T[I] == 0.0
     end
     @test nnz(T) == 0
@@ -126,6 +125,26 @@ using ITensors,
     @test isblocknz(T,(1,2))
     @test isblocknz(T,(2,2))
   end
- 
+
+  @testset "Add with different blocks" begin
+    # Indices
+    inds = ([2,3],[4,5])
+
+    # Locations of non-zero blocks
+    locsA = [(1,1),(1,2),(2,2)]
+    A = BlockSparseTensor(locsA,inds...)
+    randn!(A)
+
+    locsB = [(1,2),(2,1)]
+    B = BlockSparseTensor(locsB,inds...)
+    randn!(B)
+
+    R = A+B
+
+    @test nnz(R) == dim(R)
+    for I in eachindex(R)
+      @test R[I] == A[I] + B[I]
+    end
+  end
 end
 

--- a/test/Tensors/dense.jl
+++ b/test/Tensors/dense.jl
@@ -15,7 +15,7 @@ for I in eachindex(A)
   @test A[I] != 0
 end
 
-for I in CartesianIndices(A)
+for I in eachindex(A)
   @test A[I] != 0
 end
 
@@ -37,13 +37,13 @@ randn!(B)
 
 C = A+B
 
-for I in CartesianIndices(C)
+for I in eachindex(C)
   @test C[I] == A[I] + B[I]
 end
 
 Ap = permutedims(A,(2,1))
 
-for I in CartesianIndices(A)
+for I in eachindex(A)
   @test A[I] == Ap[permute(I,(2,1))]
 end
 


### PR DESCRIPTION
This pull request adds contraction between BlockSparseTensors, as well as addition and permutation of BlockSparseTensors even when the input and output tensors have different non-zero blocks.