### PR TITLE
update examples with new siteinds syntax

### DIFF
--- a/benchmark/2ddmrg.jl
+++ b/benchmark/2ddmrg.jl
@@ -6,7 +6,7 @@ function main()
 
   N = Nx*Ny
 
-  sites = spinHalfSites(N;conserveQNs=false)
+  sites = siteinds("S=1/2",N)
 
   lattice = squareLattice(Nx,Ny,yperiodic=false)
   #lattice = triangularLattice(Nx,Ny,yperiodic=false)

--- a/examples/dmrg/1d_Heisenberg_dmrg.jl
+++ b/examples/dmrg/1d_Heisenberg_dmrg.jl
@@ -8,11 +8,11 @@ using Printf
 # We'll work in units where J=1
 
 let
-  N = 100                             
+  N = 100
   # Create N spin-one degrees of freedom
-  sites = spinOneSites(N)
+  sites = siteinds("S=1",N)
   # Alternatively can make spin-half sites instead
-  #sites = spinHalfSites(N)
+  #sites = siteinds("S=1/2",N)
 
   # Input operator terms which define a Hamiltonian
   ampo = AutoMPO()
@@ -33,7 +33,7 @@ let
   maxdim!(sweeps, 10,20,100,100,200)
   # Set maximum truncation error allowed when adapting bond dimensions
   cutoff!(sweeps, 1E-10)
-  @show sweeps               
+  @show sweeps
 
   # Run the DMRG algorithm, returning energy and optimized MPS
   energy, psi = dmrg(H,psi0, sweeps)

--- a/examples/dmrg/2ddmrg.jl
+++ b/examples/dmrg/2ddmrg.jl
@@ -6,7 +6,7 @@ let
 
   N = Nx*Ny
 
-  sites = spinHalfSites(N;conserveQNs=false)
+  sites = siteinds("S=1/2",N)
 
   lattice = squareLattice(Nx,Ny,yperiodic=false)
 

--- a/examples/dmrg/dmrg_with_observer.jl
+++ b/examples/dmrg/dmrg_with_observer.jl
@@ -23,7 +23,7 @@ end
 
 let
   N = 100
-  sites = spinHalfSites(N)
+  sites = siteinds("S=1/2",N)
   psi0 = randomMPS(sites)
 
   # define parameters for DMRG sweeps


### PR DESCRIPTION
This PR updates the DMRG examples to use the correct function (`siteinds`) when building the site index set. 