### PR TITLE
Test example codes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ julia = "1"
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/Project.toml
+++ b/Project.toml
@@ -21,4 +21,4 @@ Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Combinatorics", "QuadGK"]
+test = ["Combinatorics", "QuadGK","Suppressor","Test"]

--- a/examples/basic_ops/basic_ops.jl
+++ b/examples/basic_ops/basic_ops.jl
@@ -5,7 +5,11 @@ a = Index(2,"a")
 b = Index(2,"b")
 c = Index(2,"c")
 
-# Define 3 order 2 tensors
+# Note that Index tags don't have 
+# to match variable names
+i = Index(3,"Red,Link")
+
+# Define 3 order 2 tensors (matrices)
 Z = ITensor(a,b)
 X = ITensor(b,c)
 Y = ITensor(b,c)
@@ -35,20 +39,20 @@ println("R = Z * X =\n", R, "\n")
 println("S = Y + X =\n", S, "\n")
 println("S = Y - X =\n", T, "\n")
 
-# Check that incompatible tensors cause an error
+# Check that adding incompatible tensors cause an error
 try
-    U = Z + X
+  U = Z + X
 catch
-    println("Cannot add Z and X")
+  println("Cannot add Z and X")
 end
 
-## Compare calculations to Julia arrays
+# Compare calculations to Julia arrays
 jZ = [1.0 0.0;
       0.0 -1.0]
 jX = [0.0 1.0;
       1.0 0.0]
 jY = [1.0 0.0;
       0.0 1.0]
-@assert Array(R) == jZ * jX
-@assert Array(S) == jY + jX
-@assert Array(T) == jY - jX
+@assert Array(R,a,c) == jZ * jX
+@assert Array(S,b,c) == jY + jX
+@assert Array(T,b,c) == jY - jX

--- a/examples/dmrg/1d_Heisenberg_dmrg.jl
+++ b/examples/dmrg/1d_Heisenberg_dmrg.jl
@@ -9,6 +9,7 @@ using Printf
 
 let
   N = 100
+
   # Create N spin-one degrees of freedom
   sites = siteinds("S=1",N)
   # Alternatively can make spin-half sites instead
@@ -39,3 +40,4 @@ let
   energy, psi = dmrg(H,psi0, sweeps)
   @printf("Final energy = %.12f\n",energy)
 end
+

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,0 +1,23 @@
+using ITensors,
+      Test,
+      Suppressor
+
+@testset "Example Codes" begin
+
+  @testset "Basic Ops" begin
+    @test_nowarn begin 
+      @capture_out begin
+        include("../examples/basic_ops/basic_ops.jl")
+      end 
+    end
+  end
+
+  @testset "DMRG with Observer" begin
+    @test_nowarn begin 
+      @capture_out begin
+        include("../examples/dmrg/dmrg_with_observer.jl")
+      end 
+    end
+  end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ using ITensors, Test
         "svd.jl",
         "qn.jl",
         "readme.jl",
+        "examples.jl",
     )
       println("Running $filename")
       include(filename)


### PR DESCRIPTION
Begin work on automatic testing of example codes by `include`-ing them into a test file. Partially addresses issue #165.

Some improvements needed are:
- fix issue where including ctmrg code causes an error related to main function (also ctmrg is broken but that's a separate issue)
- find a good way to turn down the number of sweeps in 1d_Heisenberg_dmrg code to lighten testing load while keeping that code as simple as possible