### PR TITLE
Fix to recursive SVD

### DIFF
--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -658,9 +658,9 @@ end
 # positions Lpos and Rpos
 function LinearAlgebra.qr(T::DenseTensor{<:Number,N,IndsT},
                           Lpos::NTuple{NL,Int},
-                          Rpos::NTuple{NR,Int}) where {N,IndsT,NL,NR}
+                          Rpos::NTuple{NR,Int};kwargs...) where {N,IndsT,NL,NR}
   M = permute_reshape(T,Lpos,Rpos)
-  QM,RM = qr(M)
+  QM,RM = qr(M;kwargs...)
   q = ind(QM,2)
   r = ind(RM,1)
   # TODO: simplify this by permuting inds(T) by (Lpos,Rpos)

--- a/src/Tensors/linearalgebra.jl
+++ b/src/Tensors/linearalgebra.jl
@@ -138,11 +138,29 @@ function eigenHermitian(T::DenseTensor{ElT,2,IndsT};
   return U,D,spec
 end
 
-function LinearAlgebra.qr(T::DenseTensor{ElT,2,IndsT}) where {ElT,
-                                                              IndsT}
+function qr_positive(M::AbstractMatrix)
+  sparseQ,R = qr(M)
+  Q = convert(Matrix,sparseQ)
+  nc = size(Q,2)
+  for c=1:nc
+    if real(R[c,c]) < 0.0
+      R[c,c:end] *= -1
+      Q[:,c] *= -1
+    end
+  end
+  return (Q,R)
+end
+
+function LinearAlgebra.qr(T::DenseTensor{ElT,2,IndsT}
+                          ;kwargs...) where {ElT,IndsT}
+  positive = get(kwargs,:positive,false)
   # TODO: just call qr on T directly (make sure
   # that is fast)
-  QM,RM = qr(matrix(T))
+  if positive
+    QM,RM = qr_positive(matrix(T))
+  else
+    QM,RM = qr(matrix(T))
+  end
   # Make the new indices to go onto Q and R
   q,r = inds(T)
   q = dim(q) < dim(r) ? sim(q) : sim(r)

--- a/src/Tensors/svd.jl
+++ b/src/Tensors/svd.jl
@@ -1,17 +1,5 @@
 export svd_recursive
 
-function uniqueQR(M::AbstractMatrix)
-  sparseQ,R = qr(M)
-  Q = convert(Array,sparseQ)
-  nc = size(Q,2)
-  for c=1:nc
-    if real(R[c,c]) < 0.0
-      R[c,c:end] *= -1
-      Q[:,c] *= -1
-    end
-  end
-  return (Q,R)
-end
 
 function checkSVDDone(S::Vector,
                       thresh::Float64)
@@ -49,7 +37,7 @@ function svd_recursive(M::AbstractMatrix;
 
   V = M'*U
 
-  V,R = uniqueQR(V)
+  V,R = qr_positive(V)
   for n=1:Nd
     D[n] = R[n,n]
   end

--- a/src/Tensors/svd.jl
+++ b/src/Tensors/svd.jl
@@ -1,5 +1,4 @@
-export orthog!,
-       svd_recursive
+export svd_recursive
 
 function uniqueQR(M::AbstractMatrix)
   sparseQ,R = qr(M)

--- a/src/Tensors/svd.jl
+++ b/src/Tensors/svd.jl
@@ -1,42 +1,17 @@
 export orthog!,
        svd_recursive
 
-function orthog!(M::AbstractMatrix{T};
-                 npass::Int=2) where {T}
-  nkeep = min(size(M)...)
-  dots = zeros(T,nkeep)
-  for i=1:nkeep
-    coli = view(M,:,i)
-    nrm = norm(coli)
-    if nrm < 1E-10
-      rand!(coli)
-      nrm = norm(coli)
-    end
-    coli ./= nrm
-    (i==1) && continue
-
-    Mcols = view(M,:,1:i-1)
-    dotsref = view(dots,1:i-1)
-    for pass=1:npass
-      mul!(dotsref,Mcols',coli)
-      #BLAS.gemv!('N',1.0,Mcols,dotsref,-1.0,coli)
-      coli .-= Mcols*dotsref
-      nrm = norm(coli)
-      if nrm < 1E-3 #orthog is suspect
-        pass = pass-1
-      end
-      if nrm < 1E-10
-        rand!(coli)
-        nrm = norm(coli)
-      end
-      coli ./= nrm
+function uniqueQR(M::AbstractMatrix)
+  sparseQ,R = qr(M)
+  Q = convert(Array,sparseQ)
+  nc = size(Q,2)
+  for c=1:nc
+    if real(R[c,c]) < 0.0
+      R[c,c:end] *= -1
+      Q[:,c] *= -1
     end
   end
-end
-
-function pos_sqrt(x::Float64)::Float64
-  (x < 0.0) && return 0.0
-  return sqrt(x)
+  return (Q,R)
 end
 
 function checkSVDDone(S::Vector,
@@ -72,12 +47,13 @@ function svd_recursive(M::AbstractMatrix;
   D,U = eigen(Hermitian(rho),1:size(rho,1))
 
   Nd = length(D)
-  for n=1:Nd
-    D[n] = pos_sqrt(-D[n])
-  end
 
   V = M'*U
-  orthog!(V,npass=north_pass)
+
+  V,R = uniqueQR(V)
+  for n=1:Nd
+    D[n] = R[n,n]
+  end
 
   (done,start) = checkSVDDone(D,thresh)
 

--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -10,7 +10,7 @@ function LinearAlgebra.qr(A::ITensor,
   Lis = commoninds(inds(A),IndexSet(Linds...))
   Ris = uniqueinds(inds(A),Lis)
   Lpos,Rpos = getperms(inds(A),Lis,Ris)
-  QT,RT = qr(tensor(A),Lpos,Rpos)
+  QT,RT = qr(tensor(A),Lpos,Rpos;kwargs...)
   Q,R = ITensor(QT),ITensor(RT)
   q = commonindex(Q,R)
   settags!(Q,tags,q)

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -79,7 +79,7 @@ using ITensors, Test
     @test length(energies(observer))==3
     @test length(truncerrors(observer))==3
     @test energies(observer)[end]==E
-    @test all(truncerrors(observer) .< 1E-12)
+    @test all(truncerrors(observer) .< 1E-11)
 
     orthogonalize!(psi,1)
     m = scalar(dag(psi[1])*noprime(op(sites, "Sz", 1)*psi[1]))

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -3,19 +3,6 @@ using ITensors,
 
 @testset "SVD Algorithms" begin
 
-  @testset "Test Orthog" begin
-    M1 = [1.0 2.0 5.0 4.0;
-         1.0 1.0 1.0 1.0;
-         0.0 0.5 0.5 1.0;
-         0.0 1.0 1.0 2.0]
-    orthog!(M1)
-    @test norm(M1'*M1-ITensors.LinearAlgebra.Diagonal(ones(size(M1,1)))) < 1E-12
-
-    M2 = rand(10,10)
-    orthog!(M2)
-    @test norm(M2'*M2-ITensors.LinearAlgebra.Diagonal(ones(size(M2,1)))) < 1E-12
-  end
-
   @testset "Matrix With Zero Sing Val" begin
     M = [1.0 2.0 5.0 4.0;
          1.0 1.0 1.0 1.0;
@@ -43,6 +30,38 @@ using ITensors,
     M = rand(ComplexF64,15,10)
     U,S,V = svd_recursive(M)
     @test norm(U*ITensors.LinearAlgebra.Diagonal(S)*V'-M) < 1E-13
+  end
+
+  @testset "Regression Test 1" begin
+    # Implementation of the SVD was giving low
+    # accuracy for this case
+    M = rand(2,2,2,2)
+
+    M[:, :, 1, 1] =
+    [7.713134067177845   -0.16367628720441685;
+     -1.5253996568409225   1.3577749944302373]
+
+    M[:, :, 2, 1] =
+     [0.0                -2.1219889218225276;
+      -8.320068013774126   0.43565608213298096]
+
+    M[:, :, 1, 2] =
+     [0.0  -8.662721825820825;
+      0.0  -0.46817091771736885]
+
+    M[:, :, 2, 2] =
+     [0.0   0.0;
+      0.0  -8.159570989998151]
+
+    t1 = Index(2,"t1")
+    t2 = Index(2,"t2")
+    u1 = Index(2,"u1")
+    u2 = Index(2,"u2")
+
+    T = ITensor(M,t1,t2,u1,u2)
+
+    U,S,V = svd(T,(u1,t1))
+    @test norm(U*S*V-T)/norm(T) < 1E-10
   end
 
 end


### PR DESCRIPTION
Fixes #160. The fix used here is to use positive QR orthogonalization of the matrix `V*S` to recover both V and the singular values S. QR, based on Householder, is a much more numerically stable algorithm than Gram-Schmidt and by making the diagonal of R positive, computing QR for `V*S` gives `Q=V` and `R=S`.

Created a regression test to catch this inaccuracy issue if it happens again.