### PR TITLE
Reshape blocksparse

### DIFF
--- a/src/Tensors/blocksparse/blockdims.jl
+++ b/src/Tensors/blocksparse/blockdims.jl
@@ -63,12 +63,21 @@ function dim(ds::BlockDims{N}) where {N}
 end
 
 """
+nblocks(::BlockDim)
+
+The number of blocks of the BlockDim.
+"""
+function nblocks(ind::BlockDim)
+  return length(ind)
+end
+
+"""
 nblocks(::BlockDims,i::Integer)
 
 The number of blocks in the specified dimension.
 """
 function nblocks(inds::BlockDims,i::Integer)
-  return length(inds[i])
+  return nblocks(inds[i])
 end
 
 """

--- a/src/Tensors/blocksparse/blocksparse.jl
+++ b/src/Tensors/blocksparse/blocksparse.jl
@@ -53,7 +53,9 @@ BlockSparse(::UndefInitializer,
 
 blockoffsets(D::BlockSparse) = D.blockoffsets
 nnzblocks(D::BlockSparse) = length(blockoffsets(D))
-nnz(D::BlockSparse) = length(data(D))
+Base.length(D::BlockSparse) = length(data(D))
+Base.size(D::BlockSparse) = (length(D),)
+nnz(D::BlockSparse) = length(D)
 offset(D::BlockSparse,block::Block) = offset(blockoffsets(D),block)
 offset(D::BlockSparse,n::Int) = offset(blockoffsets(D),n)
 

--- a/src/Tensors/blocksparse/blocksparsetensor.jl
+++ b/src/Tensors/blocksparse/blocksparsetensor.jl
@@ -319,19 +319,20 @@ function blockview(T::BlockSparseTensor,
   return Tensor(Dense(dataTslice),blockdimsT)
 end
 
-struct EachBlock{ElT,N,StoreT,IndsT}
-  T::BlockSparseTensor{ElT,N,StoreT,IndsT}
-end
-
-function Base.iterate(iter::EachBlock,state=(blockview(iter.T,1),1))
-  block,ind = state
-  ind > nnzblocks(iter.T) && return nothing
-  return blockview(iter.T,ind),ind+1
-end
-
-function eachblock(T::BlockSparseTensor)
-  return EachBlock(T)
-end
+# TODO: this is not working right now
+#struct EachBlock{ElT,N,StoreT,IndsT}
+#  T::BlockSparseTensor{ElT,N,StoreT,IndsT}
+#end
+#
+#function Base.iterate(iter::EachBlock,state=(blockview(iter.T,1),1))
+#  block,ind = state
+#  ind > nnzblocks(iter.T) && return nothing
+#  return blockview(iter.T,ind),ind+1
+#end
+#
+#function eachblock(T::BlockSparseTensor)
+#  return EachBlock(T)
+#end
 
 # convert to Dense
 function dense(T::TensorT) where {TensorT<:BlockSparseTensor}
@@ -653,39 +654,8 @@ function permute_combine(boffs::BlockOffsets,
   boffsp,indsp = permute(boffs,inds,perm)
   indsR = combine(indsp,pos...)
   boffsR = reshape(boffsp,indsp,indsR)
-  #nblocksp = nblocks(indsp)
-  #nblocksR = nblocks(indsR)
-	#boffsR = BlockOffsets{N}(undef,nnzblocks(boffsp))
-	#for (i,(blockp_i,offsetp_i)) in enumerate(boffsp)
-		# Convert the block location
-		#blockR_i = CartesianIndices(nblocksR)[LinearIndices(nblocksp)[CartesianIndex(blockp_i)]]
-		#boffsR[i] = blockR_i => offsetp_i
-	#end
-	return boffsR,indsR
+  return boffsR,indsR
 end
-
-#function Base.reshape(inds::IndsT,pos::Vararg{IntOrIntTuple,N}) where {IndsT,N}
-#  IndT = eltype(IndsT)
-#  newinds = SizedVector{N,IndT}(undef)
-#  inds_pos = 1
-#  for i ∈ 1:N
-#    ninds = length(pos[i])
-#    newind_i = inds[inds_pos]
-#    inds_pos += 1
-#    for p in 2:ninds
-#      newind_i = newind_i ⊗ inds[inds_pos]
-#      inds_pos += 1
-#    end
-#    newinds[i] = newind_i
-#  end
-#  IndsR = similar_type(IndsT,Val{N})
-#  return IndsR(Tuple(newinds))
-#end
-
-#function Base.reshape(block::Block{NT},
-#                      pos::Tuple{PermReshape{N}}) where {NT,N}
-#  return blockR
-#end
 
 function Base.reshape(boffsT::BlockOffsets{NT},
                       indsT,

--- a/src/Tensors/blocksparse/blocksparsetensor.jl
+++ b/src/Tensors/blocksparse/blocksparsetensor.jl
@@ -660,10 +660,10 @@ end
 function Base.reshape(boffsT::BlockOffsets{NT},
                       indsT,
                       indsR) where {NT}
-	NR = length(indsR)
+  NR = length(indsR)
   boffsR = BlockOffsets{NR}(undef,nnzblocks(boffsT))
-	nblocksT = nblocks(indsT)
-	nblocksR = nblocks(indsR)
+  nblocksT = nblocks(indsT)
+  nblocksR = nblocks(indsR)
   for (i,(blockT,offsetT)) in enumerate(boffsT)
     blockR = Tuple(CartesianIndices(nblocksR)[LinearIndices(nblocksT)[CartesianIndex(blockT)]])
     boffsR[i] = blockR => offsetT
@@ -713,8 +713,8 @@ function permute_combine(T::BlockSparseTensor{ElT,NT,IndsT},
 
   if !is_trivial_permutation(perm)
     Tp = permutedims(T,perm)
-	else
-		Tp = copy(T)
+  else
+    Tp = copy(T)
   end
   NR==NT && return Tp
   R = reshape(Tp,boffsR,indsR)

--- a/src/Tensors/combiner.jl
+++ b/src/Tensors/combiner.jl
@@ -26,7 +26,7 @@ function contraction_output(::TensorT1,
                                                  TensorT2<:DenseTensor,
                                                  IndsR}
   TensorR = contraction_output_type(TensorT1,TensorT2,IndsR)
-  return _similar(TensorR,indsR)
+  return similar(TensorR,indsR)
 end
 
 function contraction_output(T1::TensorT1,

--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -156,16 +156,21 @@ Tensor(::UndefInitializer,
 Base.IndexStyle(::Type{<:DenseTensor}) = IndexLinear()
 
 
-# TODO: Naming _similar because of method ambiguity with 
-# similar(::AbstractArray,dims), how to avoid?
-function _similar(::Type{<:DenseTensor{ElT}},
+function Base.similar(::Type{<:DenseTensor{ElT}},
                   inds) where {ElT}
   return DenseTensor(ElT,undef,inds)
 end
 
-# TODO: Naming _similar because of method ambiguity with 
-# similar(::AbstractArray,dims), how to avoid?
-_similar(T::DenseTensor,inds) = _similar(typeof(T),inds)
+# To fix method ambiguity with similar(::AbstractArray,::Tuple)
+function Base.similar(::Type{<:DenseTensor{ElT}},
+                      inds::Dims) where {ElT}
+  return DenseTensor(ElT,undef,inds)
+end
+
+Base.similar(T::DenseTensor,inds) = similar(typeof(T),inds)
+
+# To fix method ambiguity with similar(::AbstractArray,::Tuple)
+Base.similar(T::DenseTensor,inds::Dims) = similar(typeof(T),inds)
 
 # Slicing
 Base.@propagate_inbounds function _getindex(T::DenseTensor{ElT,N},
@@ -308,7 +313,7 @@ end
 # TODO: move to tensor.jl?
 function Base.permutedims(T::Tensor{<:Number,N},
                           perm::NTuple{N,Int}) where {N}
-  Tp = _similar(T,permute(inds(T),perm))
+  Tp = similar(T,permute(inds(T),perm))
   Tp = permutedims!!(Tp,T,perm)
   return Tp
 end
@@ -413,7 +418,7 @@ function contraction_output(::TensorT1,
                                                  TensorT2<:DenseTensor,
                                                  IndsR}
   TensorR = contraction_output_type(TensorT1,TensorT2,IndsR)
-  return _similar(TensorR,indsR)
+  return similar(TensorR,indsR)
 end
 
 # TODO: move to tensor.jl?

--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -155,10 +155,14 @@ Tensor(::UndefInitializer,
 # Basic functionality for AbstractArray interface
 Base.IndexStyle(::Type{<:DenseTensor}) = IndexLinear()
 
-
 function Base.similar(::Type{<:DenseTensor{ElT}},
-                  inds) where {ElT}
+                      inds) where {ElT}
   return DenseTensor(ElT,undef,inds)
+end
+
+# To fix method ambiguity with similar(::AbstractArray,::Type)
+function Base.similar(T::DenseTensor,::Type{ElT}) where {ElT}
+  return Tensor(similar(store(T),ElT),copy(inds(T)))
 end
 
 # To fix method ambiguity with similar(::AbstractArray,::Tuple)

--- a/src/Tensors/tensor.jl
+++ b/src/Tensors/tensor.jl
@@ -57,7 +57,7 @@ Base.similar(T::Tensor) = Tensor(similar(store(T)),copy(inds(T)))
 # To handle method ambiguity with AbstractArray
 #Base.similar(T::Tensor,dims::Dims) = _similar_from_dims(T,dims)
 
-Base.similar(T::Tensor,::Type{S}) where {S<:Number} = Tensor(similar(store(T),S),copy(inds(T)))
+Base.similar(T::Tensor,::Type{S}) where {S} = Tensor(similar(store(T),S),copy(inds(T)))
 
 Base.similar(T::Tensor,::Type{S},dims) where {S<:Number} = _similar_from_dims(T,S,dims)
 

--- a/src/Tensors/tensor.jl
+++ b/src/Tensors/tensor.jl
@@ -52,10 +52,10 @@ Base.similar(T::Tensor) = Tensor(similar(store(T)),copy(inds(T)))
 
 # TODO: for BlockSparse, this needs to include the offsets
 # TODO: for Diag, the storage is not just the total dimension
-Base.similar(T::Tensor,dims) = _similar_from_dims(T,dims)
+#Base.similar(T::Tensor,dims) = _similar_from_dims(T,dims)
 
 # To handle method ambiguity with AbstractArray
-Base.similar(T::Tensor,dims::Dims) = _similar_from_dims(T,dims)
+#Base.similar(T::Tensor,dims::Dims) = _similar_from_dims(T,dims)
 
 Base.similar(T::Tensor,::Type{S}) where {S<:Number} = Tensor(similar(store(T),S),copy(inds(T)))
 

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -199,7 +199,7 @@ using ITensors,
     A = BlockSparseTensor(locsA,indsA...)
     randn!(A)
 
-		indsB = ([8,12,10,15],)
+    indsB = ([8,12,10,15],)
     B = reshape(A,indsB)
 
     @test nnzblocks(A)==nnzblocks(B)
@@ -222,13 +222,13 @@ using ITensors,
     @test nnzblocks(A)==nnzblocks(B)
     @test nnz(A)==nnz(B)
 		
-		Ap = permutedims(A,(3,2,1))
+    Ap = permutedims(A,(3,2,1))
 
-		for i in 1:nnzblocks(A)
-			blockAp = blockview(Ap,i)
-			blockB = blockview(B,i)
-			@test reshape(blockAp,size(blockB))==blockB
-		end
+    for i in 1:nnzblocks(A)
+      blockAp = blockview(Ap,i)
+      blockB = blockview(B,i)
+      @test reshape(blockAp,size(blockB))==blockB
+    end
   end
 
 end

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -193,6 +193,26 @@ using ITensors,
     end
   end
 
+  @testset "reshape" begin
+    indsA = ([2,3],[4,5])
+    locsA = [(2,1),(1,2)]
+    A = BlockSparseTensor(locsA,indsA...)
+    randn!(A)
+
+		indsB = ([8,12,10,15],)
+		locsB = [(2,),(3,)]
+    B = reshape(A,locsB,indsB)
+
+    @test nnzblocks(A)==nnzblocks(A)
+    @test nnz(A)==nnz(A)
+    for i in 1:nnzblocks(B)
+      blockA = blockview(A,i)
+      blockB = blockview(B,i)
+      @test reshape(blockA,size(blockB))==blockB
+    end
+
+  end
+
   @testset "permute_reshape" begin
     indsA = ([2,3],[4,5])
     locsA = [(2,1),(1,2)]

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -200,30 +200,35 @@ using ITensors,
     randn!(A)
 
 		indsB = ([8,12,10,15],)
-		locsB = [(2,),(3,)]
-    B = reshape(A,locsB,indsB)
+    B = reshape(A,indsB)
 
-    @test nnzblocks(A)==nnzblocks(A)
-    @test nnz(A)==nnz(A)
+    @test nnzblocks(A)==nnzblocks(B)
+    @test nnz(A)==nnz(B)
     for i in 1:nnzblocks(B)
       blockA = blockview(A,i)
       blockB = blockview(B,i)
       @test reshape(blockA,size(blockB))==blockB
     end
-
   end
 
-  @testset "permute_reshape" begin
-    indsA = ([2,3],[4,5])
-    locsA = [(2,1),(1,2)]
+  @testset "permute_combine" begin
+    indsA = ([2,3],[4,5],[6,7,8])
+    locsA = [(2,1,1),(1,2,1),(2,2,3)]
     A = BlockSparseTensor(locsA,indsA...)
     randn!(A)
 
-    @show A
+    B = Tensors.permute_combine(A,3,(2,1))
 
-    B = Tensors.permute_reshape(A,(2,1))
+    @test nnzblocks(A)==nnzblocks(B)
+    @test nnz(A)==nnz(B)
+		
+		Ap = permutedims(A,(3,2,1))
 
-    @show B
+		for i in 1:nnzblocks(A)
+			blockAp = blockview(Ap,i)
+			blockB = blockview(B,i)
+			@test reshape(blockAp,size(blockB))==blockB
+		end
   end
 
 end

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -193,5 +193,18 @@ using ITensors,
     end
   end
 
+  @testset "permute_reshape" begin
+    indsA = ([2,3],[4,5])
+    locsA = [(2,1),(1,2)]
+    A = BlockSparseTensor(locsA,indsA...)
+    randn!(A)
+
+    @show A
+
+    B = Tensors.permute_reshape(A,(2,1))
+
+    @show B
+  end
+
 end
 


### PR DESCRIPTION
This adds some functionality for reshaping BlockSparseTensors, including a function called `permute_combine` that permutes and reshapes in a single step. It is a step towards having combiner functionality for BlockSparseTensors, but doesn't permute data within the dimensions to merge blocks (as is done when QN blocks are combined, which requires some sort of information from the QNs).