### PR TITLE
Fix errorMPOprod and allow scaling MPOs

### DIFF
--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -571,13 +571,13 @@ end
 
 function Base.:*(x::Number,M::Union{MPS,MPO})
     N = deepcopy(M)
-    N.A_[div(size(N), 2)] = N.A_[div(size(N), 2)] .* x
+    N[div(length(N), 2)] = N[div(length(N), 2)] * x
     return N
 end
 
 function Base.:-(M::Union{MPS,MPO})
     N = deepcopy(M)
-    N.A_[div(size(N), 2)] = -1.0*N.A_[div(size(N), 2)]
+    N[div(length(N), 2)] = -1.0*N[div(length(N), 2)]
     return N
 end
 

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -6,8 +6,7 @@ export MPO,
        maxlinkdim,
        orthogonalize!,
        truncate!,
-       sum,
-       overlap
+       sum
 
 mutable struct MPO
   N_::Int
@@ -572,22 +571,14 @@ end
 
 function Base.:*(x::Number,M::Union{MPS,MPO})
     N = deepcopy(M)
-    N.A_ = N.A_ .* x
+    N.A_[div(size(N), 2)] = N.A_[div(size(N), 2)] .* x
     return N
 end
 
 function Base.:-(M::Union{MPS,MPO})
     N = deepcopy(M)
-    N.A_ = [-1.0 * A for A in N.A_]
+    N.A_[div(size(N), 2)] = -1.0*N.A_[div(size(N), 2)]
     return N
-end
-
-function overlap(ψ::M, ϕ::M) where {M<:Union{MPS, MPO}}
-    L = dag(ψ[1]) * ϕ[1]
-    for ii in 2:length(ψ)
-        L *= dag(ψ[ii]) * ϕ[ii]
-    end
-    return scalar(L)
 end
 
 @doc """

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -84,6 +84,20 @@ include("util.jl")
     end
     @test psipsi[] ≈ inner(psi,psi)
   end
+  
+  @testset "scaling MPS" begin
+    psi = randomMPS(sites)
+    twopsidag = 2.0*dag(psi)
+    primelinks!(twopsidag)
+    @test inner(twopsidag, psi) ≈ 2.0*inner(psi,psi)
+  end
+  
+  @testset "flip sign of MPS" begin
+    psi = randomMPS(sites)
+    minuspsidag = -dag(psi)
+    primelinks!(minuspsidag)
+    @test inner(minuspsidag, psi) ≈ -inner(psi,psi)
+  end
 
   @testset "add MPS" begin
     psi = randomMPS(sites)


### PR DESCRIPTION
`errorMPOprod` couldn't handle the case where the `MPO` has different site indices (e.g. it has `t` outputs and `s` inputs, rather than `s'` and `s`). Also added a little routine so that you can do `2*A` where `A` is an `MPO`.