### PR TITLE
Fix copy(::BlockSparse)

### DIFF
--- a/src/Tensors/blocksparse/blocksparse.jl
+++ b/src/Tensors/blocksparse/blocksparse.jl
@@ -64,10 +64,10 @@ function Base.similar(D::BlockSparse{ElT}) where {ElT}
 end
 
 Base.similar(D::BlockSparse,
-             ::Type{ElT}) where {ElT} = BlockSparse{T}(similar(data(D),T),
-                                                       blockoffsets(D))
-Base.copy(D::BlockSparse{T}) where {T} = BlockSparse{T}(copy(data(D)),
-                                                        blockoffsets(D))
+             ::Type{ElT}) where {ElT} = BlockSparse(similar(data(D),ElT),
+                                                    copy(blockoffsets(D)))
+Base.copy(D::BlockSparse) = BlockSparse(copy(data(D)),
+                                        copy(blockoffsets(D)))
 
 # TODO: check the offsets are the same?
 function Base.copyto!(D1::BlockSparse,D2::BlockSparse)

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -46,6 +46,9 @@ using ITensors,
     s = Index([QN(0)=>1,QN(1)=>1],"s")
     T = randomITensor(QN(0),s,s')
     cT = copy(T)
+    for ss in dim(s), ssp in dim(s')
+      @test T[s(ss),s'(ssp)] == cT[s(ss),s'(ssp)]
+    end
   end
 
   @testset "Permute" begin

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -42,6 +42,12 @@ using ITensors,
     end
   end
 
+  @testset "Copy" begin
+    s = Index([QN(0)=>1,QN(1)=>1],"s")
+    T = randomITensor(QN(0),s,s')
+    cT = copy(T)
+  end
+
   @testset "Permute" begin
     i = Index([QN(0)=>1,QN(1)=>2],"i")
     j = Index([QN(0)=>3,QN(1)=>4],"j")


### PR DESCRIPTION
This should fix copying QN ITensors.