### PR TITLE
Add constructor for QN ITensor with no flux

### DIFF
--- a/src/Tensors/blocksparse/blocksparsetensor.jl
+++ b/src/Tensors/blocksparse/blocksparsetensor.jl
@@ -135,13 +135,23 @@ BlockSparseTensor(blocks::Vector{Block{N}},
 Construct a block sparse tensor with the specified blocks.
 Defaults to setting structurally non-zero blocks to zero.
 """
+BlockSparseTensor(blocks::Vector{Block{N}},
+                  inds) where {N} = BlockSparseTensor(Float64,blocks,inds)
+
+function BlockSparseTensor(::Type{ElT},
+                           blocks::Vector{Block{N}},
+                           inds) where {ElT,N}
+  blockoffsets,offset_total = get_blockoffsets(blocks,inds)
+  storage = BlockSparse(ElT,blockoffsets,offset_total)
+  return Tensor(storage,inds)
+end
+
 function BlockSparseTensor(blocks::Vector{Block{N}},
                            inds) where {N}
   blockoffsets,offset_total = get_blockoffsets(blocks,inds)
   storage = BlockSparse(blockoffsets,offset_total)
   return Tensor(storage,inds)
 end
-
 """
 BlockSparseTensor(blocks::Vector{Block{N}},
                   inds...)

--- a/src/qnitensor.jl
+++ b/src/qnitensor.jl
@@ -3,7 +3,12 @@ function ITensor(::Type{ElT},
                  flux::QN,
                  inds::IndexSet) where {ElT<:Number}
   blocks = nzblocks(flux,inds)
-  T = BlockSparseTensor(blocks,inds)
+  T = BlockSparseTensor(ElT,blocks,inds)
+  return itensor(T)
+end
+
+function ITensor(inds::QNIndex...)
+  T = BlockSparseTensor(IndexSet(inds))
   return itensor(T)
 end
 
@@ -39,10 +44,12 @@ Tensors.blockoffsets(T::ITensor) = blockoffsets(tensor(T))
 
 Tensors.nnzblocks(T::ITensor) = nnzblocks(tensor(T))
 
+Tensors.nnz(T::ITensor) = nnz(tensor(T))
+
 flux(T::ITensor,block) = flux(inds(T),block)
 
 function flux(T::ITensor)
-  nnzblocks(T) == 0 && return QN()
+  nnzblocks(T) == 0 && return nothing
   bofs = blockoffsets(T)
   block1 = block(bofs,1)
   return flux(T,block1)

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -13,6 +13,29 @@ using ITensors,
     @test nnzblocks(A) == 2
   end
 
+  @testset "Empty constructor" begin
+    i = Index([QN(0)=>1,QN(1)=>2],"i")
+
+    A = ITensor(i,dag(i'))
+
+    @test nnzblocks(A) == 0
+    @test nnz(A) == 0
+    @test hasinds(A,i,i')
+    @test isnothing(flux(A))
+
+    A[i(1),i'(1)] = 1.0
+
+    @test nnzblocks(A) == 1
+    @test nnz(A) == 1
+    @test flux(A) == QN(0)
+
+    A[i(2),i'(2)] = 1.0
+
+    @test nnzblocks(A) == 2
+    @test nnz(A) == 5
+    @test flux(A) == QN(0)
+  end
+
   @testset "Random constructor" begin
     i = Index([QN(0)=>1,QN(1)=>2],"i")
     j = Index([QN(0)=>3,QN(1)=>4,QN(2)=>5],"j")


### PR DESCRIPTION
This adds the constructor:

```julia
i = Index([QN(0)=>1,QN(1)=>2],"i")
A = ITensor(i,dag(i'))
```

It makes an ITensor with BlockSparse storage but with no blocks. `flux(A)` returns nothing, and blocks can be added by setting elements (see the tests).