### PR TITLE
Fix contracting blocksparse to scalar

### DIFF
--- a/src/Tensors/blocksparse/blocksparsetensor.jl
+++ b/src/Tensors/blocksparse/blocksparsetensor.jl
@@ -262,6 +262,10 @@ Base.@propagate_inbounds function Base.getindex(T::BlockSparseTensor{ElT,N},
   return store(T)[offset]
 end
 
+Base.@propagate_inbounds function Base.getindex(T::BlockSparseTensor{ElT,0}) where {ElT}
+  return store(T)[]
+end
+
 # These may not be valid if the Tensor has no blocks
 #Base.@propagate_inbounds Base.getindex(T::BlockSparseTensor{<:Number,1},ind::Int) = store(T)[ind]
 

--- a/src/Tensors/dims.jl
+++ b/src/Tensors/dims.jl
@@ -10,12 +10,15 @@ export dense,
 # dim and dims are used in the Tensor interface, overload 
 # base Dims here
 dims(ds::Dims) = ds
+dims(::Tuple{}) = ()
 dense(ds::Dims) = ds
 dense(::Type{DimsT}) where {DimsT<:Dims} = DimsT
 dim(ds::Dims) = prod(ds)
 
-Base.ndims(ds::Dims{N}) where {N} = N
+Base.ndims(::Dims{N}) where {N} = N
 Base.ndims(::Type{Dims{N}}) where {N} = N
+Base.ndims(::Tuple{}) = 0
+Base.ndims(::Type{Tuple{}}) = 0
 
 # This may be a bad idea to overload?
 # Type piracy?

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -114,5 +114,17 @@ using ITensors,
     @test nnzblocks(C) == 1
   end
 
+  @testset "Contract to scalar" begin
+    i = Index([QN(0)=>1,QN(1)=>1],"i")
+    A = randomITensor(QN(0),i,dag(i'))
+
+    c = A*dag(A)
+
+    @test nnz(c) == 1
+    @test nnzblocks(c) == 1
+    @test c[] isa Float64
+    @test c[] ≈ norm(A)^2
+  end
+
 end
 


### PR DESCRIPTION
Also, fix getting the scalar value from a 0-order QN ITensor.