### PR TITLE
Fix to restore performance of norm(t::DenseTensor) and DMRG 

### DIFF
--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -626,6 +626,8 @@ function permute_reshape(T::DenseTensor{ElT,NT,IndsT},
   return reshape(T,newinds)
 end
 
+LinearAlgebra.norm(T::DenseTensor) = norm(store(T))
+
 # svd of an order-n tensor according to positions Lpos
 # and Rpos
 function LinearAlgebra.svd(T::DenseTensor{<:Number,N,IndsT},


### PR DESCRIPTION
As I reported in https://github.com/ITensor/ITensors.jl/issues/184,  for some reason norm(t::DenseTensor) became very slow, which also severely affects DMRG performance.  
This PR fixes that by overloading `norm(T::DenseTensor)` and calling `norm` on the storage.
To the best of my understanding that achieves the same effect as before (i.e treating the tensor as a vector and computing the vector's norm). 

I still can't figure out why `norm(t::DenseTensor)` itself became so much slower, but this seems to solve the problem at least. 

running the `1d_Heisenberg_dmrg.jl` example before the change:
```
After sweep 1 energy=-137.889012787989 maxlinkdim=9 time=11.974
After sweep 2 energy=-138.934952940994 maxlinkdim=20 time=22.388
After sweep 3 energy=-138.940077788262 maxlinkdim=91 time=189.390
```
with this PR performance is restored:
```
After sweep 1 energy=-137.791153491960 maxlinkdim=9 time=11.132
After sweep 2 energy=-138.933183889406 maxlinkdim=20 time=1.227
After sweep 3 energy=-138.940071627956 maxlinkdim=94 time=5.043
After sweep 4 energy=-138.940085926733 maxlinkdim=100 time=12.213
After sweep 5 energy=-138.940086053788 maxlinkdim=95 time=13.604
```