### PR TITLE
More concise uncombinedinds and tests

### DIFF
--- a/src/Tensors/combiner.jl
+++ b/src/Tensors/combiner.jl
@@ -29,9 +29,7 @@ Base.promote_rule(::Type{<:Combiner},StorageT::Type{<:Dense}) = StorageT
 const CombinerTensor{ElT,N,StoreT,IndsT} = Tensor{ElT,N,StoreT,IndsT} where {StoreT<:Combiner}
 
 combinedindex(T::CombinerTensor) = inds(T)[1]
-function uncombinedinds(T::CombinerTensor)
-  return popfirst(inds(T))
-end
+uncombinedinds(T::CombinerTensor) = popfirst(inds(T))
 
 blockperm(C::CombinerTensor) = blockperm(store(C))
 blockcomb(C::CombinerTensor) = blockcomb(store(C))

--- a/test/combiner.jl
+++ b/test/combiner.jl
@@ -10,6 +10,13 @@ l = Index(5,"l")
 
 A = randomITensor(i, j, k, l)
 
+@testset "Basic combiner properties" begin
+    C,c = combiner(i, j, k)
+    @test eltype(store(C)) === Nothing
+    @test_throws ErrorException data(store(C))
+    @test ITensors.Tensors.uncombinedinds(tensor(C)) == IndexSet(i, j, k)
+end
+
 @testset "Two index combiner" begin
     for inds_ij ∈ permutations([i,j])
         C,c = combiner(inds_ij...)


### PR DESCRIPTION
`uncombinedinds` can be a one-liner, I think. Just a few missing tests from coverage...