### PR TITLE
overload conj for Tensor and tensor storage

### DIFF
--- a/src/Tensors/blocksparse/blocksparse.jl
+++ b/src/Tensors/blocksparse/blocksparse.jl
@@ -80,6 +80,8 @@ end
 # TODO: this could be a generic TensorStorage function
 Base.complex(D::BlockSparse{T}) where {T} = BlockSparse{complex(T)}(complex(data(D)),
                                                                     blockoffsets(D))
+Base.conj(D::BlockSparse{<: Real}) = D
+Base.conj(D::BlockSparse) = BlockSparse(conj(data(D)), copy(blockoffsets(D)))
 
 Base.eltype(::BlockSparse{T}) where {T} = eltype(T)
 # This is necessary since for some reason inference doesn't work

--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -60,6 +60,9 @@ Base.similar(D::Dense,::Type{T}) where {T<:Number} = Dense(similar(data(D),T))
 Base.copy(D::Dense) = Dense(copy(data(D)))
 Base.copyto!(D1::Dense,D2::Dense) = copyto!(data(D1),data(D2))
 
+Base.conj(D::Dense{<:Real,VecT}) where {VecT} = D
+Base.conj(D::Dense{<:Complex,VecT}) where {VecT} = Dense(conj(data(D)))
+
 Base.fill!(D::Dense,v) = fill!(data(D),v)
 
 # TODO: should this do something different for SubArray?

--- a/src/Tensors/diag.jl
+++ b/src/Tensors/diag.jl
@@ -32,6 +32,9 @@ Base.complex(D::Diag) = Diag(complex(data(D)))
 
 Base.copy(D::Diag) = Diag(copy(data(D)))
 
+Base.conj(D::Diag{<:Real, VecT}) where {VecT} = D
+Base.conj(D::Diag{<:Complex, VecT}) where {VecT} = Diag(conj(data(D)))
+
 Base.eltype(::Diag{ElT}) where {ElT} = ElT
 Base.eltype(::Type{<:Diag{ElT}}) where {ElT} = ElT
 

--- a/src/Tensors/tensor.jl
+++ b/src/Tensors/tensor.jl
@@ -38,6 +38,8 @@ Base.copy(T::Tensor) = Tensor(copy(store(T)),copy(inds(T)))
 
 Base.complex(T::Tensor) = Tensor(complex(store(T)),copy(inds(T)))
 
+Base.conj(T::Tensor) = Tensor(conj(store(T)), copy(inds(T)))
+
 Random.randn!(T::Tensor) = (randn!(store(T)); return T)
 
 #function Base.similar(::Type{<:Tensor{ElT,N,StoreT}},dims) where {ElT,N,StoreT}

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -75,6 +75,7 @@ using ITensors,
   A = BlockSparseTensor(ComplexF64,locs,indsA)
   randn!(A)
   @test conj(data(store(A))) == data(store(conj(A)))
+  @test typeof(conj(A)) <: BlockSparseTensor
 
   @testset "BlockSparseTensor setindex! add block" begin
     T = BlockSparseTensor([2,3],[4,5])

--- a/test/Tensors/blocksparse.jl
+++ b/test/Tensors/blocksparse.jl
@@ -72,6 +72,10 @@ using ITensors,
     @test A[I] == Ap[permute(I,(2,1))]
   end
 
+  A = BlockSparseTensor(ComplexF64,locs,indsA)
+  randn!(A)
+  @test conj(data(store(A))) == data(store(conj(A)))
+
   @testset "BlockSparseTensor setindex! add block" begin
     T = BlockSparseTensor([2,3],[4,5])
 

--- a/test/Tensors/dense.jl
+++ b/test/Tensors/dense.jl
@@ -47,4 +47,8 @@ for I in eachindex(A)
   @test A[I] == Ap[permute(I,(2,1))]
 end
 
+t = Tensor(ComplexF64,100,100)
+randn!(t)
+@test conj(data(store(t))) == data(store(conj(t)))
+
 end

--- a/test/Tensors/dense.jl
+++ b/test/Tensors/dense.jl
@@ -50,5 +50,6 @@ end
 t = Tensor(ComplexF64,100,100)
 randn!(t)
 @test conj(data(store(t))) == data(store(conj(t)))
+@test typeof(conj(t)) <: DenseTensor
 
 end

--- a/test/Tensors/diag.jl
+++ b/test/Tensors/diag.jl
@@ -1,0 +1,10 @@
+using ITensors,
+      Test
+
+@testset "DiagTensor basic functionality" begin
+
+  t = Tensor(Diag(rand(ComplexF64,100)), (100,100))
+  @test conj(data(store(t))) == data(store(conj(t)))
+  @test typeof(conj(t)) <: DiagTensor
+
+end

--- a/test/Tensors/runtests.jl
+++ b/test/Tensors/runtests.jl
@@ -3,7 +3,8 @@ using ITensors, Test
 @testset "Tensors.jl" begin
     @testset "$filename" for filename in (
         "dense.jl",
-        "blocksparse.jl"
+        "blocksparse.jl",
+        "diag.jl"
     )
       println("Running $filename")
       include(filename)


### PR DESCRIPTION
This is a temporary fix for https://github.com/ITensor/ITensors.jl/issues/198.

One thing to point out is that  `conj(::DenseTensor{<:Real,N})` is non-copying (because it doesn't have to do anything) while `conj(::DenseTensor{<:Complex,N})` is creating a copy (this is also true without this fix when the generic fallback from Base is used). This true also for base Julia (i.e with `Array{Float64,N}` vs. `Array{ComplexF64,N}`). 
This might lead to undesired behavior of `dag` - `dag(t::ITensor)` will contain the same dense storage as `t` when the elements of `t` are real but not when they are complex. I guess either one of those behaviors is OK, but there might be a problem with the inconsistency. 
