### PR TITLE
fix the seed in DMRGObserver test

### DIFF
--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -1,4 +1,4 @@
-using ITensors, Test
+using ITensors, Test, Random
 
 @testset "Basic DMRG" begin
   @testset "Spin-one Heisenberg" begin
@@ -56,6 +56,7 @@ using ITensors, Test
   @testset "DMRGObserver" begin
     N = 10
     sites = siteinds("S=1/2",N)
+    Random.seed!(42)
     psi0 = randomMPS(sites)
 
     ampo = AutoMPO()


### PR DESCRIPTION
The truncation error test was failing on some (not so common) occasions due to a bad random initial state. We agreed that it is better to fix the seed to remove randomness in the unit test.