### PR TITLE
Add prime(A,not(i)) syntax

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -5,6 +5,7 @@ export IndexSet,
        findindex,
        findinds,
        indexposition,
+       not,
        swaptags,
        swaptags!,
        swapprime,
@@ -414,6 +415,40 @@ function indexpositions(inds, match)
 end
 # Version for matching a list of indices
 indexpositions(inds, match_inds::Index...) = indexpositions(inds, IndexSet(match_inds...))
+
+#
+# not syntax (to prime or tag the compliment 
+# of the specified indices)
+#
+
+struct Not{T}
+  pattern::T
+  Not(p::T) where {T} = new{T}(p)
+end
+
+not(ts::Union{AbstractString,TagSet}) = Not(TagSet(ts))
+
+not(is::IndexSet) = Not(is)
+not(inds::Index...) = not(IndexSet(inds...))
+not(inds::NTuple{<:Any,<:Index}) = not(IndexSet(inds))
+
+function indexpositions(inds, match::Not{TagSet})
+  is = IndexSet(inds)
+  pos = Int[]
+  for (j,I) ∈ enumerate(is)
+    !hastags(I,match.pattern) && push!(pos,j)
+  end
+  return pos
+end
+
+function indexpositions(inds, match::Not{<:IndexSet})
+  is = IndexSet(inds)
+  pos = Int[]
+  for (j,I) ∈ enumerate(is)
+    !hasindex(match.pattern,I) && push!(pos,j)
+  end
+  return pos
+end
 
 #
 # Tagging functions

--- a/test/not.jl
+++ b/test/not.jl
@@ -1,0 +1,30 @@
+using ITensors,
+      Test
+
+@testset "not" begin
+  i = Index(2,"i")
+  j = Index(2,"j")
+  k = Index(2,"k")
+
+  A = randomITensor(i,j,k)
+
+  Ap = prime(A,not("j"))
+
+  @test hassameinds(Ap,(i',j,k'))
+
+  At = addtags(A,"x",not("k"))
+
+  @test hassameinds(At,(addtags(i,"x"),addtags(j,"x"),k))
+
+  Ap2 = prime(A,2,not(i))
+
+  @test hassameinds(Ap2,(i,j'',k''))
+
+  Ap3 = prime(A,3,not(i,k))
+
+  @test hassameinds(Ap3,(i,j''',k))
+
+  At2 = settags(A,"y",not(IndexSet(j,k)))
+
+  @test hassameinds(At2,(settags(i,"y"),j,k))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using ITensors, Test
         "smallstring.jl",
         "index.jl",
         "indexset.jl",
+        "not.jl",
         "itensor_dense.jl",
         "itensor_diag.jl",
         "itensor_blocksparse.jl",


### PR DESCRIPTION
This implements the idea in #136 to add syntax like `prime(A,not(i))` to prime/tag the complement of the specified indices.

For example:

```julia
i = Index(2,"i")
j = Index(2,"j")
k = Index(2,"k")
A = randomITensor(i,j,k)

prime(A,not("j"))  # has indices (i',j,k')

addtags(A,"x",not("k"))  # has indices (addtags(i,"x"),addtags(j,"x"),k)

setprime(A,2,not(i,j))  # has indices (i,j,k'')
```
This can help clean up some priming and tagging code.

A further possibility is to add other kinds of logic, for example `prime(A,or("i","j"))` to prime indices containing either the tags "i" or "j", but we can wait to see if that turns out to be useful.