### PR TITLE
Clean up some ITensor constructors

### DIFF
--- a/src/Tensors/diag.jl
+++ b/src/Tensors/diag.jl
@@ -15,6 +15,8 @@ function Diag{ElR}(data::VecT) where {ElR<:Number,VecT<:AbstractVector{ElT}} whe
   ElT == ElR ? Diag(data) : Diag(ElR.(data))
 end
 
+Diag(::Type{ElT},n::Integer) where {ElT<:Number} = Diag(zeros(ElT,n))
+
 const NonuniformDiag{ElT,VecT} = Diag{ElT,VecT} where {VecT<:AbstractVector}
 const UniformDiag{ElT,VecT} = Diag{ElT,VecT} where {VecT<:Number}
 

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -96,11 +96,11 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
 
   @testset "Complex" begin
     A = ITensor(Complex,i,j)
-    @test store(A) isa Dense{ComplexF64}
+    @test store(A) isa Dense{Complex}
   end
 
   @testset "Random complex" begin
-    A = randomITensor(Complex,i,j)
+    A = randomITensor(ComplexF64,i,j)
     @test store(A) isa Dense{ComplexF64}
   end
 

--- a/test/iterativesolvers.jl
+++ b/test/iterativesolvers.jl
@@ -13,7 +13,7 @@ Base.size(M::ITensorMap) = dim(findinds(M.A,("",0)))
 @testset "Complex davidson" begin
   d = 10
   i = Index(d,"i")
-  A = randomITensor(Complex,i,prime(i))
+  A = randomITensor(ComplexF64,i,prime(i))
   A = mapprime(A*mapprime(dag(A),0,2),2,1)
   M = ITensorMap(A)
     
@@ -21,7 +21,7 @@ Base.size(M::ITensorMap) = dim(findinds(M.A,("",0)))
   λ,v = davidson(M,v;maxiter=10)
   @test M(v)≈λ*v
     
-  v = randomITensor(Complex, i)
+  v = randomITensor(ComplexF64, i)
   λ,v = davidson(M,v;maxiter=10)
   @test M(v)≈λ*v
     


### PR DESCRIPTION
This addresses  #197, and cleans up some of the ITensor constructors. Slightly breaking, since now `ITensor(Int,i,j)` is taken literally and creates an ITensor with integer storage.