### PR TITLE
AutoMPO in-place addition with broadcasting

### DIFF
--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -176,6 +176,25 @@ function Base.:+(ampo::AutoMPO,
   return ampo_plus_term
 end
 
+#
+# ampo .+= ("Sz",1) syntax using broadcasting
+#
+
+struct AutoMPOStyle <: Broadcast.BroadcastStyle end
+Base.BroadcastStyle(::Type{<:AutoMPO}) = AutoMPOStyle()
+
+# This makes sure the custom BroadcastStyle is used
+Base.broadcastable(ampo::AutoMPO) = ampo
+
+function Broadcast.materialize!(ampo::AutoMPO,
+                                ampo_plus_term::Broadcast.Broadcasted{Broadcast.Unknown,
+                                                                      Nothing,
+                                                                      typeof(+),
+                                                                      <:Tuple{AutoMPO,<:Tuple}})
+  add!(ampo,ampo_plus_term.args[2]...)
+  return ampo
+end
+
 function Base.show(io::IO,
                    ampo::AutoMPO) 
   println(io,"AutoMPO:")


### PR DESCRIPTION
This adds an in-place syntax `ampo .+= ("Sz",1)` to AutoMPO to avoid copying. This required some minimal overloads to Julia's broadcast system.

Here is a timing comparison:
```julia
using ITensors

let
  ampo = AutoMPO()
  N = 1_000_000
  for j=1:N-2
    ampo .+= ("Sz",j,"Sz",j+1)
  end

  @time ampo += ("Sz",N-1,"Sz",N)

  ampo_inplace = copy(ampo)

  @time ampo_inplace .+= ("Sz",N-1,"Sz",N)
end
```
gives:
```julia
julia> include("run.jl");
  0.007575 seconds (8 allocations: 15.259 MiB)
  0.003429 seconds (5 allocations: 7.630 MiB)
```