### PR TITLE
Add some broadcasting syntax for ITensors

### DIFF
--- a/test/itensor_broadcast.jl
+++ b/test/itensor_broadcast.jl
@@ -1,0 +1,75 @@
+using ITensors,
+      Test
+
+@testset "ITensor broadcast syntax" begin
+
+  i = Index(2,"i")
+  A = randomITensor(i,i')
+  B = randomITensor(i',i)
+  α = 2
+  β = 3
+
+  @testset "Scaling" begin
+    Bc = copy(B)
+    Bc .*= α
+    @test Bc[1,1] == α * B[1,1]
+    @test Bc[2,1] == α * B[2,1]
+    @test Bc[1,2] == α * B[1,2]
+    @test Bc[2,2] == α * B[2,2]
+  end
+
+  @testset "Scalar multiplication (in-place)" begin
+    Bc = copy(B)
+    Bc .= α .* A
+    @test Bc[1,1] == α * A[1,1]
+    @test Bc[2,1] == α * A[1,2]
+    @test Bc[1,2] == α * A[2,1]
+    @test Bc[2,2] == α * A[2,2]
+  end
+
+  @testset "Scalar multiplication (out-of-place)" begin
+    Bc = α .* A
+    @test Bc[1,1] == α * A[1,1]
+    @test Bc[2,1] == α * A[2,1]
+    @test Bc[1,2] == α * A[1,2]
+    @test Bc[2,2] == α * A[2,2]
+  end
+
+  @testset "Addition" begin
+    Bc = copy(B)
+    Bc .= A .+ Bc
+    @test Bc[1,1] == A[1,1] + B[1,1]
+    @test Bc[2,1] == A[1,2] + B[2,1]
+    @test Bc[1,2] == A[2,1] + B[1,2]
+    @test Bc[2,2] == A[2,2] + B[2,2]
+  end
+
+  @testset "Addition (with α)" begin
+    Bc = copy(B)
+    Bc .+= A .* α
+
+    @test Bc[1,1] == α * A[1,1] + B[1,1]
+    @test Bc[2,1] == α * A[1,2] + B[2,1]
+    @test Bc[1,2] == α * A[2,1] + B[1,2]
+    @test Bc[2,2] == α * A[2,2] + B[2,2]
+  end
+
+  @testset "Addition (with α and β)" begin
+    Bc = copy(B)
+    Bc .= α .* A .+ β .* Bc
+
+    @test Bc[1,1] == α * A[1,1] + β * B[1,1]
+    @test Bc[2,1] == α * A[1,2] + β * B[2,1]
+    @test Bc[1,2] == α * A[2,1] + β * B[1,2]
+    @test Bc[2,2] == α * A[2,2] + β * B[2,2]
+  end
+
+  @testset "Addition errors" begin
+    C = randomITensor(i,i')
+    @test_throws ErrorException C .= A .+ B
+    @test_throws ErrorException C = A .+ B
+    @test_throws ErrorException C .= A .* B
+  end
+
+end
+


### PR DESCRIPTION
This adds some broadcasting syntax to ITensors, such as:
```julia
i = Index(2,"i")
A = randomITensor(i,i')
B = randomITensor(i',i)
c = 2
B .= c .* A
```
to overwrite `B` with `c*A`, without any allocations. Internally, this will just call `mul!(B,c,A)`. Take a look at the tests for a more complete list of example operations that are supported now.

@emstoudenmire, this made me think that we could abuse the broadcasting syntax a bit to get lazy ITensor contractions. For example, it would be simple enough to make:
```julia
i = Index(2,"i")
A = randomITensor(i,i')
B = randomITensor(i',i'')
C = randomITensor(i,i'')
c = 2
C .= c .* A  .* B
```
do an in-place multiplication of `A` and `B` into `C`, scaling by `c`, without any allocations. This would be a bit of an abuse of the notation, since for Julia Arrays, this operation would not do a matrix multiplication but instead does an elementwise multiplication (a Hadamard product). However, ITensors act differently enough from Julia Arrays that maybe this is ok.