### PR TITLE
Add more broadcast operations

### DIFF
--- a/src/iterativesolvers.jl
+++ b/src/iterativesolvers.jl
@@ -4,24 +4,17 @@ function get_vecs!((phi,q),M,V,AV,ni)
   F = eigen(Hermitian(M))
   lambda = F.values[1]
   u = F.vectors[:,1]
-  #phi = u[1]*V[1]
-  mul!(phi,u[1],V[1])
-  #q = u[1]*AV[1]
-  mul!(q,u[1],AV[1])
+  phi .= u[1] .* V[1]
+  q .= u[1] .* AV[1]
   for n=2:ni
-    #phi += u[n]*V[n]
-    add!(phi,u[n],V[n])
-    #q += u[n]*AV[n]
-    add!(q,u[n],AV[n])
+    phi .+= u[n] .* V[n]
+    q .+= u[n] .* AV[n]
   end
-  #q -= lambda*phi
-  add!(q,-lambda,phi)
+  q .-= lambda .* phi
   #Fix sign
   if real(u[1]) < 0.0
-    #phi *= -1
-    scale!(phi,-1)
-    #q *= -1
-    scale!(q,-1)
+    phi .*= -1
+    q .*= -1
   end
   return lambda
 end
@@ -30,15 +23,14 @@ function orthogonalize!(q::ITensor,V,ni)
   q0 = copy(q)
   for k=1:ni
     Vq0k = dot(V[k],q0)
-    #q += -Vq0k*V[k]
-    add!(q,-Vq0k,V[k])
+    q .+= -Vq0k .* V[k]
   end
   qnrm = norm(q)
   if qnrm < 1E-10 #orthog failure, try randomizing
     randn!(q)
     qnrm = norm(q)
   end
-  scale!(q,1.0/qnrm)
+  q .*= 1.0/qnrm
   return 
 end
 
@@ -82,7 +74,7 @@ function davidson(A,
     phi = phi_ 
     nrm = norm(phi)
   end
-  scale!(phi,1.0/nrm)
+  phi .*= 1.0/nrm
 
   maxsize = size(A)[1]
   actual_maxiter = min(maxiter,maxsize-1)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -578,10 +578,14 @@ function Tensors.truncate!(M::Union{MPS,MPO}; kwargs...)
 
 end
 
+# TODO: scale the tensors between the left limit
+# and right limit by x^(1/N)
+# where N is the distance between the left limit
+# and right limit
 function Base.:*(x::Number,M::Union{MPS,MPO})
   N = deepcopy(M)
   c = div(length(N), 2)
-  scale!(N[c],x)
+  N[c] .*= x
   return N
 end
 

--- a/test/itensor_broadcast.jl
+++ b/test/itensor_broadcast.jl
@@ -71,5 +71,78 @@ using ITensors,
     @test_throws ErrorException C .= A .* B
   end
 
+  @testset "General functions" begin
+    absA = abs.(A)
+
+    @test absA[1,1] == abs(A[1,1])
+    @test absA[2,1] == abs(A[2,1])
+
+    Bc = copy(B)
+    Bc .= sqrt.(absA)
+
+    @test Bc[1,1] == sqrt(absA[1,1])
+    @test Bc[2,1] == sqrt(absA[1,2])
+
+    Bc2 = copy(B)
+    Bc2 .+= sqrt.(absA)
+
+    @test Bc2[1,1] == B[1,1]+sqrt(absA[1,1])
+    @test Bc2[2,1] == B[2,1]+sqrt(absA[1,2])
+  end
+
+  @testset "Some other operations" begin
+    i = Index(2)
+    A = randomITensor(i)
+    B = randomITensor(i)
+
+    absA = abs.(A)
+
+    @test absA[1] == abs(A[1])
+    @test absA[2] == abs(A[2])
+
+    Bc = copy(B)
+    Bc .= sqrt.(absA)
+
+    @test Bc[1] == sqrt(absA[1])
+    @test Bc[2] == sqrt(absA[2])
+
+    Bc2 = copy(B)
+    Bc2 .+= sqrt.(absA)
+
+    @test Bc2[1] == B[1]+sqrt(absA[1])
+    @test Bc2[2] == B[2]+sqrt(absA[2])
+
+    Bc3 = copy(B)
+    Bc3 .= sqrt.(absA) .+ sin.(Bc3)
+
+    @test Bc3[1] == sin(B[1])+sqrt(absA[1])
+    @test Bc3[2] == sin(B[2])+sqrt(absA[2])
+
+    sqrtabsA = sqrt.(abs.(A))
+
+    @test sqrtabsA[1] == sqrt(abs(A[1]))
+    @test sqrtabsA[2] == sqrt(abs(A[2]))
+
+    sqrtabsA = cos.(sin.(sqrt.(abs.(A))))
+
+    @test sqrtabsA[1] == cos(sin(sqrt(abs(A[1]))))
+    @test sqrtabsA[2] == cos(sin(sqrt(abs(A[2]))))
+
+    Ap = A .+ 3
+
+    @test Ap[1] == A[1] + 3
+    @test Ap[2] == A[2] + 3
+
+    Apow1 = A .^ 2.0
+
+    @test Apow1[1] == A[1]^2
+    @test Apow1[2] == A[2]^2
+
+    Apow2 = A .^ 3
+
+    @test Apow2[1] == A[1]^3
+    @test Apow2[2] == A[2]^3
+  end
+
 end
 


### PR DESCRIPTION
This replaces uses of `add!`, `mul!` and `scale!` with the equivalent broadcast operations throughout the library. It also adds more broadcast operations, for example elementwise function operations (like `A .^ 2` to square each element of the ITensor).