### PR TITLE
Add A[i=>2,j=>3] syntax for getting and setting values

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -260,17 +260,27 @@ struct IndexVal{IndexT<:Index}
 end
 
 IndexVal() = IndexVal(Index(),1)
+IndexVal(iv::Pair{<:Index,Int}) = IndexVal(iv.first,iv.second)
+
+const PairIndexInt{IndexT} = Pair{IndexT,Int}
+const IndexValOrPairIndexInt{IndexT} = Union{IndexVal{IndexT},PairIndexInt{IndexT}}
+
+Base.convert(::Type{IndexVal},iv::Pair{<:Index,Int}) = IndexVal(iv)
+Base.convert(::Type{IndexVal{IndexT}},iv::Pair{IndexT,Int}) where {IndexT<:Index} = IndexVal(iv)
 
 Base.getindex(i::Index, j::Int) = IndexVal(i, j)
 #Base.getindex(i::Index, c::Colon) = [IndexVal(i, j) for j in 1:dim(i)]
 
 (i::Index)(n::Int) = IndexVal(i,n)
 
-val(iv::IndexVal) = iv.val
 ind(iv::IndexVal) = iv.ind
+val(iv::IndexVal) = iv.val
 
-Base.:(==)(i::Index,iv::IndexVal) = (i==ind(iv))
-Base.:(==)(iv::IndexVal,i::Index) = (i==iv)
+ind(iv::PairIndexInt) = iv.first
+val(iv::PairIndexInt) = iv.second
+
+Base.:(==)(i::Index,iv::IndexValOrPairIndexInt) = (i==ind(iv))
+Base.:(==)(iv::IndexValOrPairIndexInt,i::Index) = (i==iv)
 
 plev(iv::IndexVal) = plev(ind(iv))
 prime(iv::IndexVal,inc::Integer=1) = IndexVal(prime(ind(iv),inc),val(iv))

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -122,7 +122,7 @@ Random.seed!(1234)
     @test nnzblocks(B) == 2
 
     for ii in dim(i), jj in dim(j)
-      @test 2*A[i(ii),j(jj)] == B[i(ii),j(jj)]
+      @test 2*A[i=>ii,j=>jj] == B[i=>ii,j=>jj]
     end
   end
 
@@ -131,7 +131,7 @@ Random.seed!(1234)
     T = randomITensor(QN(0),s,s')
     cT = copy(T)
     for ss in dim(s), ssp in dim(s')
-      @test T[s(ss),s'(ssp)] == cT[s(ss),s'(ssp)]
+      @test T[s=>ss,s'=>ssp] == cT[s=>ss,s'=>ssp]
     end
   end
 
@@ -234,18 +234,6 @@ Random.seed!(1234)
       B = ITensor(QN(0),i',c)
       @test nnz(B) == nnz(AC)
       @test nnzblocks(B) == nnzblocks(AC)
-
-      #Ablock_221 = vec(permutedims(blockview(tensor(A),(2,2,1)),(1,3,2)))
-      #ACblock_32 = vec(blockview(tensor(AC),(3,2)))
-      #@test Ablock_221 == ACblock_32
-
-      #Ablock_111 = vec(permutedims(blockview(tensor(A),(1,1,1)),(1,3,2)))
-      #ACblock_21_1 = vec(blockview(tensor(AC),(2,1)))[1:length(Ablock_111)]
-      #@test Ablock_111 == ACblock_21_1
-
-      #Ablock_212 = vec(permutedims(blockview(tensor(A),(2,1,2)),(1,3,2)))
-      #ACblock_21_2 = vec(blockview(tensor(AC),(2,1)))[length(Ablock_111)+1:end]
-      #@test Ablock_212 == ACblock_21_2
 
       Ap = AC*dag(C)
 

--- a/test/itensor_broadcast.jl
+++ b/test/itensor_broadcast.jl
@@ -9,6 +9,24 @@ using ITensors,
   α = 2
   β = 3
 
+  @testset "Copy" begin
+    Bc = copy(B)
+    Bc .= A
+    @test Bc[1,1] == A[1,1]
+    @test Bc[2,1] == A[1,2]
+    @test Bc[1,2] == A[2,1]
+    @test Bc[2,2] == A[2,2]
+  end
+
+  @testset "Fill" begin
+    Bc = copy(B)
+    Bc .= α
+    @test Bc[1,1] == α
+    @test Bc[2,1] == α
+    @test Bc[1,2] == α
+    @test Bc[2,2] == α
+  end
+
   @testset "Scaling" begin
     Bc = copy(B)
     Bc .*= α

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -118,7 +118,7 @@ end
   A = randomITensor(i,j)
   B = complex(A)
   for ii ∈ dim(i), jj ∈ dim(j)
-    @test complex(A[i(ii),j(jj)]) == B[i(ii),j(jj)]
+    @test complex(A[i=>ii,j=>jj]) == B[i=>ii,j=>jj]
   end
 end
 
@@ -137,6 +137,14 @@ end
   j = Index(2,"j")
   A = randomITensor(i,j)
   fill!(A, 1.0)
+  @test all(data(store(A)) .== 1.0)
+end
+
+@testset "fill! using broadcast" begin
+  i = Index(2,"i")
+  j = Index(2,"j")
+  A = randomITensor(i,j)
+  A .= 1.0
   @test all(data(store(A)) .== 1.0)
 end
 
@@ -420,8 +428,8 @@ end
     @test typeof(S1.store) == Dense{ComplexF64,Vector{ComplexF64}}
     @test typeof(S2.store) == Dense{ComplexF64,Vector{ComplexF64}}
     for ii=1:dim(i),jj=1:dim(j)
-      @test S1[i(ii),j(jj)] ≈ TC[i(ii),j(jj)]+TR[i(ii),j(jj)]
-      @test S2[i(ii),j(jj)] ≈ TC[i(ii),j(jj)]+TR[i(ii),j(jj)]
+      @test S1[i=>ii,j=>jj] ≈ TC[i=>ii,j=>jj]+TR[i=>ii,j=>jj]
+      @test S2[i=>ii,j=>jj] ≈ TC[i=>ii,j=>jj]+TR[i=>ii,j=>jj]
     end
   end
 
@@ -438,10 +446,10 @@ end
   @testset "Set and get values with IndexVals" begin
     A = ITensor(SType,i,j,k)
     for ii ∈ 1:dim(i), jj ∈ 1:dim(j), kk ∈ 1:dim(k)
-      A[k(kk),j(jj),i(ii)] = digits(SType,ii,jj,kk)
+      A[k=>kk,j=>jj,i=>ii] = digits(SType,ii,jj,kk)
     end
     for ii ∈ 1:dim(i), jj ∈ 1:dim(j), kk ∈ 1:dim(k)
-      @test A[j(jj),k(kk),i(ii)]==digits(SType,ii,jj,kk)
+      @test A[j=>jj,k=>kk,i=>ii]==digits(SType,ii,jj,kk)
     end
     @test_throws MethodError A[1]
   end
@@ -452,24 +460,24 @@ end
     @test j==inds(permA)[2]
     @test i==inds(permA)[3]
     for ii ∈ 1:dim(i), jj ∈ 1:dim(j), kk ∈ 1:dim(k)
-      @test A[k(kk),i(ii),j(jj)]==permA[i(ii),j(jj),k(kk)]
+      @test A[k=>kk,i=>ii,j=>jj]==permA[i=>ii,j=>jj,k=>kk]
     end
     for ii ∈ 1:dim(i), jj ∈ 1:dim(j), kk ∈ 1:dim(k)
-      @test A[k(kk),i(ii),j(jj)]==permA[i(ii),j(jj),k(kk)]
+      @test A[k=>kk,i=>ii,j=>jj]==permA[i=>ii,j=>jj,k=>kk]
     end
     # TODO: I think this was doing slicing, but what is the output
     # of slicing an ITensor?
     #@testset "getindex and setindex with vector of IndexVals" begin
-    #    k_inds = [k(kk) for kk ∈ 1:dim(k)]
+    #    k_inds = [k=>kk for kk ∈ 1:dim(k)]
     #    for ii ∈ 1:dim(i), jj ∈ 1:dim(j)
-    #      @test A[k_inds,i(ii),j(jj)]==permA[i(ii),j(jj),k_inds...]
+    #      @test A[k_inds,i=>ii,j=>jj]==permA[i=>ii,j=>jj,k_inds...]
     #    end
     #    for ii ∈ 1:dim(i), jj ∈ 1:dim(j)
-    #        A[k_inds,i(ii),j(jj)]=collect(1:length(k_inds))
+    #        A[k_inds,i=>ii,j=>jj]=collect(1:length(k_inds))
     #    end
     #    permA = permute(A,k,j,i)
     #    for ii ∈ 1:dim(i), jj ∈ 1:dim(j)
-    #      @test A[k_inds,i(ii),j(jj)]==permA[i(ii),j(jj),k_inds...]
+    #      @test A[k_inds,i=>ii,j=>jj]==permA[i=>ii,j=>jj,k_inds...]
     #    end
     #end
   end
@@ -500,7 +508,7 @@ end
     B = randomITensor(SType,k,i,j)
     C = A+B
     for ii ∈ 1:dim(i), jj ∈ 1:dim(j), kk ∈ 1:dim(k)
-      @test C[i(ii),j(jj),k(kk)]==A[j(jj),i(ii),k(kk)]+B[i(ii),k(kk),j(jj)]
+      @test C[i=>ii,j=>jj,k=>kk]==A[j=>jj,i=>ii,k=>kk]+B[i=>ii,k=>kk,j=>jj]
     end
     @test array(permute(C,i,j,k))==array(permute(A,i,j,k))+array(permute(B,i,j,k))
   end

--- a/test/itensor_diag.jl
+++ b/test/itensor_diag.jl
@@ -24,9 +24,9 @@ using ITensors,
       @test eltype(D) == Float64
       for ii = 1:d, jj = 1:d
         if ii == jj
-          @test D[i(ii),j(jj)] == 0.0
+          @test D[i=>ii,j=>jj] == 0.0
         else
-          @test D[i(ii),j(jj)] == 0.0
+          @test D[i=>ii,j=>jj] == 0.0
         end
       end
     end
@@ -37,9 +37,9 @@ using ITensors,
       @test eltype(D) == Float64
       for ii = 1:d, jj = 1:d, kk = 1:d
         if ii == jj == kk
-          @test D[i(ii),j(jj),k(kk)] == 0.0
+          @test D[i=>ii,j=>jj,k=>kk] == 0.0
         else
-          @test D[i(ii),j(jj),k(kk)] == 0.0
+          @test D[i=>ii,j=>jj,k=>kk] == 0.0
         end
       end
     end
@@ -50,9 +50,9 @@ using ITensors,
       @test eltype(D) == ComplexF64
       for ii = 1:d, jj = 1:d
         if ii == jj
-          @test D[i(ii),j(jj)] == complex(0.0)
+          @test D[i=>ii,j=>jj] == complex(0.0)
         else
-          @test D[i(ii),j(jj)] == complex(0.0)
+          @test D[i=>ii,j=>jj] == complex(0.0)
         end
       end
     end
@@ -63,9 +63,9 @@ using ITensors,
       @test eltype(D) == Float64
       for ii = 1:d, jj = 1:d
         if ii == jj
-          @test D[i(ii),j(jj)] == v[ii]
+          @test D[i=>ii,j=>jj] == v[ii]
         else
-          @test D[i(ii),j(jj)] == 0.0
+          @test D[i=>ii,j=>jj] == 0.0
         end
       end
     end
@@ -76,9 +76,9 @@ using ITensors,
       @test eltype(D) == Float64
       for ii = 1:d, jj = 1:d, kk = 1:d
         if ii == jj == kk
-          @test D[i(ii),j(jj),k(kk)] == v[ii]
+          @test D[i=>ii,j=>jj,k=>kk] == v[ii]
         else
-          @test D[i(ii),j(jj),k(kk)] == 0.0
+          @test D[i=>ii,j=>jj,k=>kk] == 0.0
         end
       end
     end
@@ -90,9 +90,9 @@ using ITensors,
       @test eltype(D) == ComplexF64
       for ii = 1:d, jj = 1:d, kk = 1:d
         if ii == jj == kk
-          @test D[i(ii),j(jj),k(kk)] == vc[ii]
+          @test D[i=>ii,j=>jj,k=>kk] == vc[ii]
         else
-          @test D[i(ii),j(jj),k(kk)] == complex(0.0)
+          @test D[i=>ii,j=>jj,k=>kk] == complex(0.0)
         end
       end
     end
@@ -101,7 +101,7 @@ using ITensors,
       D = diagITensor(ones(d), i,j,k)
       D = fill!(D, 2.0)
       for ii = 1:d
-        @test D[i(ii),j(ii),k(ii)] == 2.0
+        @test D[i=>ii,j(ii),k(ii)] == 2.0
       end
 
       @test eltype(D) == Float64
@@ -111,15 +111,15 @@ using ITensors,
       D = diagITensor(i,j,k)
 
       for ii = 1:d
-        D[i(ii),j(ii),k(ii)] = ii
+        D[i=>ii,j(ii),k(ii)] = ii
       end
 
       @test eltype(D) == Float64
       for ii = 1:d, jj = 1:d, kk = 1:d
         if ii == jj == kk
-          @test D[i(ii),j(jj),k(kk)] == ii
+          @test D[i=>ii,j=>jj,k=>kk] == ii
         else
-          @test D[i(ii),j(jj),k(kk)] == 0.0
+          @test D[i=>ii,j=>jj,k=>kk] == 0.0
         end
       end
 
@@ -137,7 +137,7 @@ using ITensors,
         if ii == jj == kk
           @test T[ii,ii,ii] == ii
         else
-          @test T[i(ii),j(jj),k(kk)] == 0.0
+          @test T[i=>ii,j=>jj,k=>kk] == 0.0
         end
       end
     end
@@ -290,9 +290,9 @@ using ITensors,
       @test eltype(D) == Float64
       for ii = 1:d, jj = 1:d
         if ii == jj
-          @test D[i(ii),j(jj)] == 1.0
+          @test D[i=>ii,j=>jj] == 1.0
         else
-          @test D[i(ii),j(jj)] == 0.0
+          @test D[i=>ii,j=>jj] == 0.0
         end
       end
     end
@@ -303,9 +303,9 @@ using ITensors,
       @test eltype(D) == Float64
       for ii = 1:dim(i), jj = 1:dim(j), kk = 1:dim(k)
         if ii == jj == kk
-          @test D[i(ii),j(jj),k(kk)] == 1.0
+          @test D[i=>ii,j=>jj,k=>kk] == 1.0
         else
-          @test D[i(ii),j(jj),k(kk)] == 0.0
+          @test D[i=>ii,j=>jj,k=>kk] == 0.0
         end
       end
     end
@@ -332,7 +332,7 @@ using ITensors,
         if ii == jj == kk
           @test T[ii,ii,ii] == 1.0
         else
-          @test T[i(ii),j(jj),k(kk)] == 0.0
+          @test T[i=>ii,j=>jj,k=>kk] == 0.0
         end
       end
     end


### PR DESCRIPTION
Also fills in a few more broadcasting features, like `A .= c` for `fill!(A,c)` and `A .= B` for `copyto!(A,B)`.