### PR TITLE
Make getindex and setindex! for DenseTensor a bit faster

### DIFF
--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -25,7 +25,7 @@ function Dense(data::VecT) where {VecT<:AbstractVector{ElT}} where {ElT}
   return Dense{ElT,VecT}(data)
 end
 
-function Dense{ElR}(data) where {ElR}
+function Dense{ElR}(data::AbstractVector{ElT}) where {ElR,ElT}
   ElT == ElR ? Dense(data) : Dense(ElR.(data))
 end
 

--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -6,7 +6,6 @@ export Dense,
        contract,
        outer,
        read,
-       scale!,
        permutedims!!,
        write,
        ⊗
@@ -17,9 +16,17 @@ export Dense,
 
 struct Dense{ElT,VecT<:AbstractVector} <: TensorStorage{ElT}
   data::VecT
-  function Dense(data::VecT) where {VecT<:AbstractVector{ElT}} where {ElT}
+  function Dense{ElT,VecT}(data) where {ElT,VecT<:AbstractVector{ElT}}
     return new{ElT,VecT}(data)
   end
+end
+
+function Dense(data::VecT) where {VecT<:AbstractVector{ElT}} where {ElT}
+  return Dense{ElT,VecT}(data)
+end
+
+function Dense{ElR}(data) where {ElR}
+  ElT == ElR ? Dense(data) : Dense(ElR.(data))
 end
 
 Dense{ElT}(dim::Integer) where {ElT} = Dense(zeros(ElT,dim))
@@ -37,19 +44,12 @@ Dense(::Type{ElT},
 
 Dense(::UndefInitializer,dim::Integer) = Dense(Float64,undef,dim)
 
-function Dense{ElR}(data::VecT) where {ElR,VecT<:AbstractVector{ElT}} where {ElT}
-  ElT == ElR ? Dense(data) : Dense(ElR.(data))
-end
-
 Dense{ElT}() where {ElT} = Dense(ElT[])
 Dense(::Type{ElT}) where {ElT} = Dense{ElT}()
 
-Base.length(D::Dense) = length(data(D))
-Base.size(D::Dense) = size(data(D))
+Base.copy(D::Dense) = Dense(copy(data(D)))
 
-# Functions to make Dense storage act like a vector
-Base.@propagate_inbounds Base.getindex(D::Dense,i::Integer) = data(D)[i]
-Base.@propagate_inbounds Base.setindex!(D::Dense,v,i::Integer) = (data(D)[i] = v)
+Base.complex(::Type{Dense{ElT,Vector{ElT}}}) where {ElT} = Dense{complex(ElT),Vector{complex(ElT)}}
 
 Base.similar(D::Dense) = Dense(similar(data(D)))
 
@@ -57,26 +57,9 @@ Base.similar(D::Dense,length::Int) = Dense(similar(data(D),length))
 Base.similar(::Type{<:Dense{ElT,VecT}},length::Int) where {ElT,VecT} = Dense(similar(VecT,length))
 
 Base.similar(D::Dense,::Type{T}) where {T<:Number} = Dense(similar(data(D),T))
-Base.copy(D::Dense) = Dense(copy(data(D)))
-Base.copyto!(D1::Dense,D2::Dense) = copyto!(data(D1),data(D2))
-
-Base.conj(D::Dense{<:Real,VecT}) where {VecT} = D
-Base.conj(D::Dense{<:Complex,VecT}) where {VecT} = Dense(conj(data(D)))
-
-Base.fill!(D::Dense,v) = fill!(data(D),v)
 
 # TODO: should this do something different for SubArray?
 Base.zeros(::Type{<:Dense{ElT}},dim::Int) where {ElT} = Dense{ElT}(dim)
-
-# convert to complex
-# TODO: this could be a generic TensorStorage function
-Base.complex(D::Dense) = Dense(complex(data(D)))
-
-Base.eltype(::Dense{ElT}) where {ElT} = ElT
-# This is necessary since for some reason inference doesn't work
-# with the more general definition (eltype(Nothing) === Any)
-Base.eltype(::Dense{Nothing}) = Nothing
-Base.eltype(::Type{<:Dense{ElT}}) where {ElT} = ElT
 
 function Base.promote_rule(::Type{<:Dense{ElT1,VecT1}},
                            ::Type{<:Dense{ElT2,VecT2}}) where {ElT1,VecT1,
@@ -107,6 +90,7 @@ end
 Base.convert(::Type{<:Dense{ElR,VecR}},
              D::Dense) where {ElR,VecR} = Dense(convert(VecR,data(D)))
 
+# Make generic to all storage types?
 Base.:*(D::Dense,x::Number) = Dense(x*data(D))
 Base.:*(x::Number,D::Dense) = D*x
 
@@ -162,6 +146,10 @@ Tensor(A::Array{<:Number,N},inds::Dims{N}) where {N} = Tensor(Dense(vec(A)),inds
 # Basic functionality for AbstractArray interface
 Base.IndexStyle(::Type{<:DenseTensor}) = IndexLinear()
 
+# Override CartesianIndices iteration to iterate
+# linearly through the Dense storage (faster)
+Base.iterate(T::DenseTensor,args...) = iterate(store(T),args...)
+
 function Base.similar(::Type{<:DenseTensor{ElT}},
                       inds) where {ElT}
   return DenseTensor(ElT,undef,inds)
@@ -183,7 +171,60 @@ Base.similar(T::DenseTensor,inds) = similar(typeof(T),inds)
 # To fix method ambiguity with similar(::AbstractArray,::Tuple)
 Base.similar(T::DenseTensor,inds::Dims) = similar(typeof(T),inds)
 
+#
+# Single index
+#
+
+Base.@propagate_inbounds function _getindex(T::DenseTensor{<:Number,N},
+                                            I::CartesianIndex{N}) where {N}
+  return store(T)[@inbounds LinearIndices(T)[CartesianIndex(I)]]
+end
+
+Base.@propagate_inbounds function Base.getindex(T::DenseTensor{<:Number,N},
+                                                I::Vararg{Int,N}) where {N}
+  return _getindex(T,CartesianIndex(I))
+end
+
+Base.@propagate_inbounds function Base.getindex(T::DenseTensor{<:Number,N},
+                                                I::CartesianIndex{N}) where {N}
+  return _getindex(T,I)
+end
+
+Base.@propagate_inbounds function _setindex!(T::DenseTensor{<:Number,N},
+                                             x::Number,
+                                             I::CartesianIndex{N}) where {N}
+  store(T)[@inbounds LinearIndices(T)[CartesianIndex(I)]] = x
+  return T
+end
+
+Base.@propagate_inbounds function Base.setindex!(T::DenseTensor{<:Number,N},
+                                                 x::Number,
+                                                 I::Vararg{Int,N}) where {N}
+  _setindex!(T,x,CartesianIndex(I))
+  return T
+end
+
+Base.@propagate_inbounds function Base.setindex!(T::DenseTensor{<:Number,N},
+                                                 x::Number,
+                                                 I::CartesianIndex{N}) where {N}
+  _setindex!(T,x,I)
+  return T
+end
+
+#
+# Linear indexing
+#
+
+Base.@propagate_inbounds Base.getindex(T::DenseTensor,i::Int) = store(T)[i]
+
+Base.@propagate_inbounds Base.setindex!(T::DenseTensor,v,i::Int) = (store(T)[i] = v; T)
+
+#
 # Slicing
+# TODO: this doesn't allow colon right now
+# Create a DenseView that stores a Dense and an offset?
+#
+
 Base.@propagate_inbounds function _getindex(T::DenseTensor{ElT,N},
                                             I::CartesianIndices{N}) where {ElT,N}
   storeR = Dense(vec(@view array(T)[I]))
@@ -191,49 +232,9 @@ Base.@propagate_inbounds function _getindex(T::DenseTensor{ElT,N},
   return Tensor(storeR,indsR)
 end
 
-# Get single index
-Base.@propagate_inbounds function _getindex(T::DenseTensor{ElT,N},
-                                            I::CartesianIndex{N}) where {ElT,N}
-  return store(T)[LinearIndices(T)[CartesianIndex(I)]]
-end
-
-# Slicing (allow mixture of ranges and integers)
 Base.@propagate_inbounds function Base.getindex(T::DenseTensor{ElT,N},
                                                 I...) where {ElT,N}
   return _getindex(T,CartesianIndices(I))
-end
-
-Base.@propagate_inbounds function Base.getindex(T::DenseTensor{ElT,N},
-                                                I::CartesianIndex{N}) where {ElT,N}
-  return _getindex(T,I)
-end
-
-Base.@propagate_inbounds function Base.getindex(T::DenseTensor{ElT,N},
-                                                I::Vararg{Int,N}) where {ElT,N}
-  return _getindex(T,CartesianIndex(I))
-end
-
-Base.@propagate_inbounds Base.getindex(T::DenseTensor,i::Int) = store(T)[i]
-
-Base.@propagate_inbounds Base.setindex!(T::DenseTensor,v,i::Int) = (store(T)[i] = v)
-
-#Base.fill!(T::DenseTensor,v) = fill!(store(T),v)
-
-# How does Julia map from IndexCartesian to IndexLinear?
-#Base.getindex(T::DenseTensor{<:Number,N},
-#              i::Vararg{Int,N}) where {N} = 
-#store(T)[sum(i.*strides(T))+1-sum(strides(T))]
-#Base.setindex!(T::DenseTensor{<:Number,N},
-#               v,i::Vararg{Int,N}) where {N} = 
-#(store(T)[sum(i.*strides(T))+1-sum(strides(T))] = v)
-
-# This is for BLAS/LAPACK
-Base.strides(T::DenseTensor) = strides(inds(T))
-
-# Needed for passing Tensor{T,2} to BLAS/LAPACK
-function Base.unsafe_convert(::Type{Ptr{ElT}},
-                             T::DenseTensor{ElT}) where {ElT}
-  return Base.unsafe_convert(Ptr{ElT},data(store(T)))
 end
 
 # Reshape a DenseTensor using the specified dimensions
@@ -242,11 +243,13 @@ function Base.reshape(T::DenseTensor,dims)
   dim(T)==dim(dims) || error("Total new dimension must be the same as the old dimension")
   return Tensor(store(T),dims)
 end
+
 # This version fixes method ambiguity with AbstractArray reshape
 function Base.reshape(T::DenseTensor,dims::Dims)
   dim(T)==dim(dims) || error("Total new dimension must be the same as the old dimension")
   return Tensor(store(T),dims)
 end
+
 function Base.reshape(T::DenseTensor,dims::Int...)
   return Tensor(store(T),tuple(dims...))
 end
@@ -270,14 +273,6 @@ function Base.permutedims!(R::DenseTensor{<:Number,N},
   permutedims!(array(R),array(T),perm)
   return R
 end
-
-#function scale!(T::DenseTensor,
-#                α::Number)
-#  A = array(T)
-#  # This is faster than A .*= α
-#  rmul!(A,α)
-#  return T
-#end
 
 function apply!(R::DenseTensor,
                 T::DenseTensor,
@@ -631,8 +626,6 @@ function permute_reshape(T::DenseTensor{ElT,NT,IndsT},
   return reshape(T,newinds)
 end
 
-LinearAlgebra.norm(T::DenseTensor) = norm(store(T))
-
 # svd of an order-n tensor according to positions Lpos
 # and Rpos
 function LinearAlgebra.svd(T::DenseTensor{<:Number,N,IndsT},
@@ -656,21 +649,6 @@ function LinearAlgebra.svd(T::DenseTensor{<:Number,N,IndsT},
 
   return U,S,V,spec
 end
-
-# eigendecomposition of an order-n tensor according to 
-# positions Lpos and Rpos
-#function eigen(T::DenseTensor{<:Number,N,IndsT},
-#               Lpos::NTuple{NL,Int},
-#               Rpos::NTuple{NR,Int};
-#               kwargs...) where {N,IndsT,NL,NR}
-#  M = permute_reshape(T,Lpos,Rpos)
-#  UM,D,spec = eigen(M;kwargs...)
-#  u = ind(UM,2)
-#  Linds = similar_type(IndsT,Val{NL})(ntuple(i->inds(T)[Lpos[i]],Val(NL)))
-#  Uinds = push(Linds,u)
-#  U = reshape(UM,Uinds)
-#  return U,D,spec
-#end
 
 # qr decomposition of an order-n tensor according to 
 # positions Lpos and Rpos

--- a/src/Tensors/tensorstorage.jl
+++ b/src/Tensors/tensorstorage.jl
@@ -11,7 +11,7 @@ Base.eltype(::TensorStorage{ElT}) where {ElT} = ElT
 
 Base.eltype(::Type{<:TensorStorage{ElT}}) where {ElT} = ElT
 
-iterate(S::TensorStorage,args...) = iterate(data(S),args...)
+Base.iterate(S::TensorStorage,args...) = iterate(data(S),args...)
 
 # This is necessary since for some reason inference doesn't work
 # with the more general definition (eltype(Nothing) === Any)

--- a/src/Tensors/tensorstorage.jl
+++ b/src/Tensors/tensorstorage.jl
@@ -1,21 +1,49 @@
 export data,
        TensorStorage,
-       randn!
+       randn!,
+       scale!
 
 abstract type TensorStorage{ElT} <: AbstractVector{ElT} end
 
 data(S::TensorStorage) = S.data
 
+Base.eltype(::TensorStorage{ElT}) where {ElT} = ElT
+
+Base.eltype(::Type{<:TensorStorage{ElT}}) where {ElT} = ElT
+
+# This is necessary since for some reason inference doesn't work
+# with the more general definition (eltype(Nothing) === Any)
+Base.eltype(::TensorStorage{Nothing}) = Nothing
+
+Base.length(D::TensorStorage) = length(data(D))
+
+Base.size(D::TensorStorage) = size(data(D))
+
 Base.@propagate_inbounds Base.getindex(S::TensorStorage,
-                                       i::Integer) = getindex(data(S),i)
+                                       i::Integer) = data(S)[i]
 Base.@propagate_inbounds Base.setindex!(S::TensorStorage,v,
-                                        i::Integer) = setindex!(data(S),v,i)
+                                        i::Integer) = (setindex!(data(S),v,i); S)
 
-Random.randn!(S::TensorStorage) = randn!(data(S))
+# Needed for passing Tensor{T,2} to BLAS/LAPACK
+function Base.unsafe_convert(::Type{Ptr{ElT}},
+                             T::TensorStorage{ElT}) where {ElT}
+  return Base.unsafe_convert(Ptr{ElT},data(T))
+end
 
-Base.fill!(S::TensorStorage,v) = fill!(data(S),v)
+# This may need to be overloaded, since storage types
+# often have other fields besides data
+Base.conj(S::T) where {T<:TensorStorage} = T(conj(data(S)))
 
-scale!(S::TensorStorage,v) = scale!(data(S),v)
+Base.complex(S::T) where {T<:TensorStorage} = complex(T)(complex(data(S)))
+
+Base.copyto!(S1::TensorStorage,S2::TensorStorage) = (copyto!(data(S1),data(S2)); S1)
+
+Random.randn!(S::TensorStorage) = (randn!(data(S)); S)
+
+Base.fill!(S::TensorStorage,v) = (fill!(data(S),v); S)
+
+LinearAlgebra.rmul!(S::TensorStorage,v::Number) = (rmul!(data(S),v); S)
+scale!(S::TensorStorage,v::Number) = rmul!(S,v)
 
 LinearAlgebra.norm(S::TensorStorage) = norm(data(S))
 
@@ -31,8 +59,6 @@ Return a vector of the non-zero blocks of the BlockSparse storage.
 nzblocks(T::TensorStorage) = nzblocks(blockoffsets(T))
 
 nnzblocks(D::TensorStorage) = length(blockoffsets(D))
-Base.length(D::TensorStorage) = length(data(D))
-Base.size(D::TensorStorage) = (length(D),)
 nnz(D::TensorStorage) = length(D)
 
 offset(D::TensorStorage,block) = offset(blockoffsets(D),block)

--- a/src/Tensors/tensorstorage.jl
+++ b/src/Tensors/tensorstorage.jl
@@ -11,13 +11,15 @@ Base.eltype(::TensorStorage{ElT}) where {ElT} = ElT
 
 Base.eltype(::Type{<:TensorStorage{ElT}}) where {ElT} = ElT
 
+iterate(S::TensorStorage,args...) = iterate(data(S),args...)
+
 # This is necessary since for some reason inference doesn't work
 # with the more general definition (eltype(Nothing) === Any)
 Base.eltype(::TensorStorage{Nothing}) = Nothing
 
-Base.length(D::TensorStorage) = length(data(D))
+Base.length(S::TensorStorage) = length(data(S))
 
-Base.size(D::TensorStorage) = size(data(D))
+Base.size(S::TensorStorage) = size(data(S))
 
 Base.@propagate_inbounds Base.getindex(S::TensorStorage,
                                        i::Integer) = data(S)[i]
@@ -47,9 +49,9 @@ scale!(S::TensorStorage,v::Number) = rmul!(S,v)
 
 LinearAlgebra.norm(S::TensorStorage) = norm(data(S))
 
-Base.convert(::Type{T},D::T) where {T<:TensorStorage} = D
+Base.convert(::Type{T},S::T) where {T<:TensorStorage} = S
 
-blockoffsets(D::TensorStorage) = D.blockoffsets
+blockoffsets(S::TensorStorage) = S.blockoffsets
 
 """
 nzblocks(T::TensorStorage)
@@ -58,12 +60,10 @@ Return a vector of the non-zero blocks of the BlockSparse storage.
 """
 nzblocks(T::TensorStorage) = nzblocks(blockoffsets(T))
 
-nnzblocks(D::TensorStorage) = length(blockoffsets(D))
-nnz(D::TensorStorage) = length(D)
+nnzblocks(S::TensorStorage) = length(blockoffsets(S))
+nnz(S::TensorStorage) = length(S)
 
-offset(D::TensorStorage,block) = offset(blockoffsets(D),block)
+offset(S::TensorStorage,block) = offset(blockoffsets(S),block)
 
-block(D::TensorStorage,n::Int) = block(blockoffsets(D),n)
-
-
+block(S::TensorStorage,n::Int) = block(blockoffsets(S),n)
 

--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -298,7 +298,7 @@ function LinearAlgebra.eigen(A::ITensor,
 
   U = UC*dag(CL)
 
-  u = commonindex(U,D)
+  u = commonindex(D,U)
   settags!(U,lefttags,u)
   settags!(D,lefttags,u)
   u = settags(u,lefttags)


### PR DESCRIPTION
This PR makes `getindex`, `setindex!` and `iterate` for `DenseTensor` a bit faster.

For example, timing the following code:
```julia
using ITensors

function sum(A)
  x = zero(eltype(A))
  for i in A
    x += i
  end
  return x
end

let
  n = 200
  T = Tensor(n,n)
  randn!(T)
  A = randn(n,n)

  println("getindex Array")
  @btime $A[4,4]

  println("getindex Tensor")
  @btime $T[4,4]

  println("setindex! Array")
  @btime $A[4,4] = 2.0

  println("setindex! Tensor")
  @btime $T[4,4] = 2.0

  println("iterate Array")
  @btime sum($A)

  println("iterate Tensor")
  @btime sum($T)

  nothing
end
```

On master:
```julia
julia> include("run.jl")
getindex Array
  1.448 ns (0 allocations: 0 bytes)
getindex Tensor
  2.578 ns (0 allocations: 0 bytes)
setindex! Array
  1.415 ns (0 allocations: 0 bytes)
setindex! Tensor
  1.839 ns (0 allocations: 0 bytes)
iterate Array
  36.467 μs (0 allocations: 0 bytes)
iterate Tensor
  57.448 μs (0 allocations: 0 bytes)
```
and on this branch:
```julia
julia> include("run.jl")
getindex Array
  1.382 ns (0 allocations: 0 bytes)
getindex Tensor
  1.418 ns (0 allocations: 0 bytes)
setindex! Array
  1.415 ns (0 allocations: 0 bytes)
setindex! Tensor
  1.386 ns (0 allocations: 0 bytes)
iterate Array
  36.477 μs (0 allocations: 0 bytes)
iterate Tensor
  36.490 μs (0 allocations: 0 bytes)
```

For `getindex` and `setindex!`, the problem was that two bounds checks were happening, so I turned off one of them (first the CartesianIndex was being converted to a LinearIndex, which did one bounds check, then the storage was indexed with the LinearIndex, which did another). For `iterate`, the improvement was to make sure it was using Julia's `iterate` function for the `Vector` data, instead of a generic iteration function.

This speeds up DMRG a little bit. For example for the 1D spin-1 Heisenberg model with 100 sites and no QNs, on master:
```julia
After sweep 1 energy=-137.340778003834 maxlinkdim=9 time=0.150
After sweep 2 energy=-138.934529420032 maxlinkdim=20 time=0.410
After sweep 3 energy=-138.940074388108 maxlinkdim=95 time=1.493
After sweep 4 energy=-138.940086000816 maxlinkdim=100 time=3.273
After sweep 5 energy=-138.940086076384 maxlinkdim=96 time=3.776
```
and on this branch:
```julia
After sweep 1 energy=-137.663060169546 maxlinkdim=9 time=0.141
After sweep 2 energy=-138.933857520027 maxlinkdim=20 time=0.398
After sweep 3 energy=-138.940070648285 maxlinkdim=92 time=1.284
After sweep 4 energy=-138.940085932745 maxlinkdim=100 time=2.900
After sweep 5 energy=-138.940086074873 maxlinkdim=95 time=3.183
```