### PR TITLE
Remove prime level from TagSet

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -43,8 +43,8 @@ struct Index{T}
   function Index(id,space::T,dir,tags,plev) where {T}
     return new{T}(id,space,dir,tags,plev)
   end
-
 end
+Index{SpaceT}(space::SpaceT,args...;vargs...) where {SpaceT} = Index(space,args...;vargs...)
 
 Index() = Index(0,1,Neither,"",0)
 
@@ -58,6 +58,7 @@ Example: create a two dimensional index with tag `l`:
 function Index(dim::Integer;tags="",plev=0)
   return Index(rand(IDType),dim,Neither,tags,plev)
 end
+
 
 Index(dim::Integer,tags::Union{AbstractString,TagSet}) = Index(dim; tags=tags)
 

--- a/src/index.jl
+++ b/src/index.jl
@@ -39,18 +39,14 @@ struct Index{T}
   space::T
   dir::Arrow
   tags::TagSet
-
-  function Index(id::IDType,dim::T,dir::Arrow,tags::TagSet) where {T}
-    # By default, an Index has a prime level of 0
-    # A prime level less than 0 is interpreted as the
-    # prime level not being set
-    !hasplev(tags) && (tags = setprime(tags,0))
-    return new{T}(id,dim,dir,tags)
+  plev::Int
+  function Index(id,space::T,dir,tags,plev) where {T}
+    return new{T}(id,space,dir,tags,plev)
   end
 
 end
 
-Index() = Index(IDType(0),1,Neither,TagSet(("",0)))
+Index() = Index(0,1,Neither,"",0)
 
 """
   Index(dim::Integer, tags=("",0))
@@ -59,9 +55,8 @@ Create an `Index` with a unique `id` and a tagset given by `tags`.
 Example: create a two dimensional index with tag `l`:
     Index(2, "l")
 """
-function Index(dim::Integer;tags=("",0))
-  ts = TagSet(tags)
-  return Index(rand(IDType),dim,Neither,ts)
+function Index(dim::Integer;tags="",plev=0)
+  return Index(rand(IDType),dim,Neither,tags,plev)
 end
 
 Index(dim::Integer,tags::Union{AbstractString,TagSet}) = Index(dim; tags=tags)
@@ -96,12 +91,7 @@ tags(i::Index) = i.tags
     plev(i::Index)
 Obtain the prime level of an Index
 """
-plev(i::Index) = plev(tags(i))
-
-# Overload for use in AbstractArray interface for Tensor
-#Base.length(i::Index) = dim(i)
-#Base.UnitRange(i::Index) = 1:dim(i)
-#Base.checkindex(::Type{Bool}, i::Index, val::Int64) = (val ≤ dim(i) && val ≥ 1)
+plev(i::Index) = i.plev
 
 """
 ==(i1::Index, i1::Index)
@@ -111,28 +101,28 @@ then the prime levels are compared, and finally the
 tags are compared.
 """
 function Base.:(==)(i1::Index,i2::Index)
-  return id(i1) == id(i2) && tags(i1) == tags(i2)
+  return id(i1) == id(i2) && tags(i1) == tags(i2) && plev(i1) == plev(i2)
 end
 
 """
     copy(i::Index)
 Create a copy of index `i` with identical `id`, `dim`, `dir` and `tags`.
 """
-Base.copy(i::Index) = Index(id(i),copy(space(i)),dir(i),copy(tags(i)))
+Base.copy(i::Index) = Index(id(i),copy(space(i)),dir(i),copy(tags(i)),plev(i))
 
 """
   sim(i::Index; tags=tags(i), dir=dir(i))
 Similar to `copy(i::Index)` except `sim` will produce an `Index` with a new, unique `id` instead of the same `id`.
 """
-function Tensors.sim(i::Index; tags=copy(tags(i)), dir=dir(i))
-  return Index(rand(IDType),copy(space(i)),dir,TagSet(tags))
+function Tensors.sim(i::Index; tags=copy(tags(i)), plev=plev(i), dir=dir(i))
+  return Index(rand(IDType),copy(space(i)),dir,tags,plev)
 end
 
 """
     dag(i::Index)
 Copy an index `i` and reverse it's direction
 """
-Tensors.dag(i::Index) = Index(id(i),copy(space(i)),-dir(i),copy(tags(i)))
+Tensors.dag(i::Index) = Index(id(i),copy(space(i)),-dir(i),copy(tags(i)),plev(i))
 
 """
     isdefault(i::Index)
@@ -167,12 +157,7 @@ Example:
     hastags(j,"Link") == true
     hastags(j,"n=4,Link") == true
 """
-function settags(i::Index, strts)
-  ts = TagSet(strts)
-  # By default, an Index has a prime level of 0
-  !hasplev(ts) && (ts = setprime(ts,0))
-  Index(id(i),copy(space(i)),dir(i),ts)
-end
+settags(i::Index, ts) = Index(id(i),copy(space(i)),dir(i),ts,plev(i))
 
 """
     addtags(i::Index,ts)
@@ -205,14 +190,14 @@ replacetags(i::Index, tsold, tsnew) = settags(i, replacetags(tags(i), tsold, tsn
 Return a copy of Index `i` with its
 prime level incremented by the amount `plinc`
 """
-prime(i::Index, plinc = 1) = settags(i, prime(tags(i), plinc))
+prime(i::Index, plinc=1) = setprime(i, plev(i)+plinc)
 
 """
     setprime(i::Index,plev)
 Return a copy of Index `i` with its
 prime level set to `plev`
 """
-setprime(i::Index, plev) = settags(i, setprime(tags(i), plev))
+setprime(i::Index, plev) = Index(id(i),copy(space(i)),dir(i),copy(tags(i)),plev)
 
 """
     noprime(i::Index)
@@ -239,13 +224,26 @@ function Tensors.outer(i1::Index,i2::Index; tags="")
   return Index(dim(i1)*dim(i2),tags)
 end
 
+function primestring(plev)
+  if plev<0
+    return " (warning: prime level $plev is less than 0)"
+  end
+  if plev==0
+    return ""
+  elseif plev > 3
+    return "'$plev"
+  else
+    return "'"^plev
+  end
+end
+
 function Base.show(io::IO,
                    i::Index) 
   idstr = "$(id(i) % 1000)"
   if length(tags(i)) > 0
-    print(io,"(dim=$(space(i))|id=$(idstr)|\"$(tagstring(tags(i)))\")$(primestring(tags(i)))")
+    print(io,"(dim=$(space(i))|id=$(idstr)|\"$(tagstring(tags(i)))\")$(primestring(plev(i)))")
   else
-    print(io,"(dim=$(space(i))|id=$(idstr))$(primestring(tags(i)))")
+    print(io,"(dim=$(space(i))|id=$(idstr))$(primestring(plev(i)))")
   end
 end
 
@@ -317,6 +315,7 @@ function HDF5.write(parent::Union{HDF5File,HDF5Group},
   write(g,"dim",dim(I))
   write(g,"dir",Int(dir(I)))
   write(g,"tags",tags(I))
+  write(g,"plev",plev(I))
 end
 
 function HDF5.read(parent::Union{HDF5File,HDF5Group},
@@ -330,5 +329,6 @@ function HDF5.read(parent::Union{HDF5File,HDF5Group},
   dim = read(g,"dim")
   dir = Arrow(read(g,"dir"))
   tags = read(g,"tags",TagSet)
-  return Index(id,dim,dir,tags)
+  plev = read(g,"plev")
+  return Index(id,dim,dir,tags,plev)
 end

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -444,8 +444,8 @@ function prime!(is::IndexSet, plinc::Integer, args...; kwargs...)
   end
   return is
 end
-prime!(is::IndexSet,vargs...) = prime!(is,1,vargs...)
-prime(is::IndexSet,vargs...) = prime!(copy(is),vargs...)
+prime!(is::IndexSet,vargs...; kwargs...) = prime!(is,1,vargs...; kwargs...)
+prime(is::IndexSet,vargs...; kwargs...) = prime!(copy(is),vargs...; kwargs...)
 # For is' notation
 Base.adjoint(is::IndexSet) = prime(is)
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -412,6 +412,13 @@ function Base.fill!(T::ITensor,
   return T
 end
 
+hasindex(A::ITensor,i::Index) = hasindex(inds(A),i)
+hasinds(A::ITensor,is::Index...) = hasinds(inds(A),is...)
+hasinds(A::ITensor,is) = hasinds(inds(A),is)
+hassameinds(A::ITensor,is) = hassameinds(inds(A),is)
+hassameinds(is,A::ITensor) = hassameinds(A,is)
+hassameinds(A::ITensor,B::ITensor) = hassameinds(inds(A),inds(B))
+
 # TODO: implement in terms of delta tensors (better for QNs)
 function replaceindex!(A::ITensor,i::Index,j::Index)
   pos = indexpositions(A,i)
@@ -438,29 +445,29 @@ end
 
 # TODO: implement more in-place versions
 
-prime!(A::ITensor,vargs...)= ( prime!(inds(A),vargs...); return A )
-prime(A::ITensor,vargs...)= ITensor(store(A),prime(inds(A),vargs...))
+prime!(A::ITensor,vargs...;kwargs...)= ( prime!(inds(A),vargs...;kwargs...); return A )
+prime(A::ITensor,vargs...;kwargs...)= ITensor(store(A),prime(inds(A),vargs...;kwargs...))
 Base.adjoint(A::ITensor) = prime(A)
 
-setprime(A::ITensor,vargs...) = ITensor(store(A),setprime(inds(A),vargs...))
+setprime(A::ITensor,vargs...;kwargs...) = ITensor(store(A),setprime(inds(A),vargs...;kwargs...))
 
-noprime(A::ITensor,vargs...) = ITensor(store(A),noprime(inds(A),vargs...))
+noprime(A::ITensor,vargs...;kwargs...) = ITensor(store(A),noprime(inds(A),vargs...;kwargs...))
 
-mapprime(A::ITensor,vargs...) = ITensor(store(A),mapprime(inds(A),vargs...))
+mapprime(A::ITensor,vargs...;kwargs...) = ITensor(store(A),mapprime(inds(A),vargs...;kwargs...))
 
-swapprime(A::ITensor,vargs...) = ITensor(store(A),swapprime(inds(A),vargs...))
+swapprime(A::ITensor,vargs...;kwargs...) = ITensor(store(A),swapprime(inds(A),vargs...;kwargs...))
 
-addtags(A::ITensor,vargs...) = ITensor(store(A),addtags(inds(A),vargs...))
+addtags(A::ITensor,vargs...;kwargs...) = ITensor(store(A),addtags(inds(A),vargs...;kwargs...))
 
-removetags(A::ITensor,vargs...) = ITensor(store(A),removetags(inds(A),vargs...))
+removetags(A::ITensor,vargs...;kwargs...) = ITensor(store(A),removetags(inds(A),vargs...;kwargs...))
 
-replacetags!(A::ITensor,vargs...) = ( replacetags!(inds(A),vargs...); return A )
-replacetags(A::ITensor,vargs...) = ITensor(store(A),replacetags(inds(A),vargs...))
+replacetags!(A::ITensor,vargs...;kwargs...) = ( replacetags!(inds(A),vargs...;kwargs...); return A )
+replacetags(A::ITensor,vargs...;kwargs...) = ITensor(store(A),replacetags(inds(A),vargs...;kwargs...))
 
-settags!(A::ITensor,vargs...) = ( settags!(inds(A),vargs...); return A )
-settags(A::ITensor,vargs...) = ITensor(store(A),settags(inds(A),vargs...))
+settags!(A::ITensor,vargs...;kwargs...) = ( settags!(inds(A),vargs...;kwargs...); return A )
+settags(A::ITensor,vargs...;kwargs...) = ITensor(store(A),settags(inds(A),vargs...;kwargs...))
 
-swaptags(A::ITensor,vargs...) = ITensor(store(A),swaptags(inds(A),vargs...))
+swaptags(A::ITensor,vargs...;kwargs...) = ITensor(store(A),swaptags(inds(A),vargs...;kwargs...))
 
 # TODO: implement in a better way (more generically for other storage)
 Base.:(==)(A::ITensor,B::ITensor) = (norm(A-B) == zero(promote_type(eltype(A),eltype(B))))

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -258,22 +258,22 @@ function inner(B::MPO,
   Bdag = dag(B)
   prime!(Bdag)
   # Swap prime levels 1 -> 2 and 2 -> 1.
-  @inbounds for j ∈ eachindex(Bdag)
+  for j ∈ eachindex(Bdag)
     Axcommon = commonindex(A[j], x[j])
     ABcommon = uniqueindex(findinds(A[j], "Site"), IndexSet(Axcommon))
     swapprime!(inds(Bdag[j]),2,3)
     swapprime!(inds(Bdag[j]),1,2)
     swapprime!(inds(Bdag[j]),3,1)
-    noprime!(inds(Bdag[j]), tags(prime(ABcommon, 2)))
+    noprime!(inds(Bdag[j]),prime(ABcommon,2))
   end
   yB = ydag[1] * Bdag[1]
   Ax = A[1] * x[1]
   O = yB*Ax
-  @inbounds for j ∈ eachindex(y)[2:end]
-      yB = ydag[j] * Bdag[j]
-      Ax = A[j] * x[j]
-      yB *= O
-      O = yB * Ax 
+  for j ∈ eachindex(y)[2:end]
+    yB = ydag[j] * Bdag[j]
+    Ax = A[j] * x[j]
+    yB *= O
+    O = yB * Ax 
   end
   return O[]
 end
@@ -373,63 +373,65 @@ function applyMPO(A::MPO, psi::MPS; kwargs...)::MPS
 end
 
 function densityMatrixApplyMPO(A::MPO, psi::MPS; kwargs...)::MPS
-    n = length(A)
-    n != length(psi) && throw(DimensionMismatch("lengths of MPO ($n) and MPS ($(length(psi))) do not match"))
-    psi_out         = similar(psi)
-    cutoff::Float64 = get(kwargs, :cutoff, 1e-13)
+  n = length(A)
+  n != length(psi) && throw(DimensionMismatch("lengths of MPO ($n) and MPS ($(length(psi))) do not match"))
+  psi_out         = similar(psi)
+  cutoff::Float64 = get(kwargs, :cutoff, 1e-13)
 
-    maxdim::Int     = get(kwargs,:maxdim,maxlinkdim(psi))
-    mindim::Int     = max(get(kwargs,:mindim,1), 1)
-    normalize::Bool = get(kwargs, :normalize, false) 
-    all(x -> x != Index(), [siteindex(A, psi, j) for j in 1:n]) || throw(ErrorException("MPS and MPO have different site indices in applyMPO method 'DensityMatrix'"))
+  maxdim::Int     = get(kwargs,:maxdim,maxlinkdim(psi))
+  mindim::Int     = max(get(kwargs,:mindim,1), 1)
+  normalize::Bool = get(kwargs, :normalize, false) 
+  all(x -> x != Index(), [siteindex(A, psi, j) for j in 1:n]) || throw(ErrorException("MPS and MPO have different site indices in applyMPO method 'DensityMatrix'"))
 
-    rand_plev = 14741
-    psi_c     = dag(copy(psi))
-    A_c       = dag(copy(A))
-    prime!(psi_c, rand_plev)
-    prime!(A_c, rand_plev)
-    for j in 1:n-1
-        unique_site_ind = setdiff(findinds(A_c[j], "Site"), findindex(psi_c[j], "Site"))[1]
-        pl = id(unique_site_ind) == id(commonindex(A_c[j], psi_c[j])) ? 1 : 0
-        A_c[j] = setprime(A_c[j], pl, unique_site_ind)
-    end
-    E = Vector{ITensor}(undef, n-1)
-    E[1] = psi[1]*A[1]*A_c[1]*psi_c[1]
-    for j in 2:n-1
-        E[j] = E[j-1]*psi[j]*A[j]*A_c[j]*psi_c[j]
-    end
-    O     = psi[n] * A[n]
-    ρ     = E[n-1] * O * dag(prime(O, rand_plev))
-    ts    = tags(commonindex(psi[n], psi[n-1]))
-    Lis   = commonindex(ρ, A[n])
-    Ris   = prime(Lis, rand_plev)
-    FU, D = eigen(ρ, Lis, Ris; ishermitian=true, 
+  rand_plev = 14741
+  psi_c     = dag(copy(psi))
+  A_c       = dag(copy(A))
+  prime!(psi_c, rand_plev)
+  prime!(A_c, rand_plev)
+  for j in 1:n-1
+    unique_site_ind = setdiff(findinds(A_c[j], "Site"), findindex(psi_c[j], "Site"))[1]
+    pl = id(unique_site_ind) == id(commonindex(A_c[j], psi_c[j])) ? 1 : 0
+    A_c[j] = setprime(A_c[j], pl, unique_site_ind)
+  end
+  E = Vector{ITensor}(undef, n-1)
+  E[1] = psi[1]*A[1]*A_c[1]*psi_c[1]
+  for j in 2:n-1
+    E[j] = E[j-1]*psi[j]*A[j]*A_c[j]*psi_c[j]
+  end
+  O     = psi[n] * A[n]
+  ρ     = E[n-1] * O * dag(prime(O, rand_plev))
+  ts    = tags(commonindex(psi[n], psi[n-1]))
+  Lis   = commonindex(ρ, A[n])
+  Ris   = prime(Lis, rand_plev)
+  @show inds(ρ)
+  @show Lis
+  @show Ris
+  FU, D = eigen(ρ, Lis, Ris; ishermitian=true, 
+                             tags=ts, 
+                             kwargs...)
+  psi_out[n] = setprime(dag(FU), 0, "Site")
+  O     = O * FU * psi[n-1] * A[n-1]
+  O     = noprime(O, "Site")
+  for j in reverse(2:n-1)
+    dO  = prime(dag(O), rand_plev)
+    ρ   = E[j-1] * O * dO
+    ts  = tags(commonindex(psi[j], psi[j-1]))
+    Lis = IndexSet(commonindex(ρ, A[j]), commonindex(ρ, psi_out[j+1])) 
+    Ris = prime(Lis, rand_plev)
+    FU, D = eigen(ρ, Lis, Ris; ishermitian=true,
                                tags=ts, 
                                kwargs...)
-    psi_out[n] = setprime(dag(FU), 0, "Site")
-    O     = O * FU * psi[n-1] * A[n-1]
-    O     = prime(O, -1, "Site")
-    for j in reverse(2:n-1)
-        dO  = prime(dag(O), rand_plev)
-        ρ   = E[j-1] * O * dO
-        ts  = tags(commonindex(psi[j], psi[j-1]))
-        Lis = IndexSet(commonindex(ρ, A[j]), commonindex(ρ, psi_out[j+1])) 
-        #Ris = uniqueinds(ρ, Lis)
-        Ris = prime(Lis, rand_plev)
-        FU, D = eigen(ρ, Lis, Ris; ishermitian=true,
-                                   tags=ts, 
-                                   kwargs...)
-        psi_out[j] = dag(FU)
-        O = O * FU * psi[j-1] * A[j-1]
-        O = prime(O, -1, "Site")
-    end
-    if normalize
-        O /= norm(O)
-    end
-    psi_out[1]    = copy(O)
-    psi_out.llim_ = 0
-    psi_out.rlim_ = 2
-    return psi_out
+    psi_out[j] = dag(FU)
+    O = O * FU * psi[j-1] * A[j-1]
+    O = noprime(O, "Site")
+  end
+  if normalize
+    O /= norm(O)
+  end
+  psi_out[1]    = copy(O)
+  psi_out.llim_ = 0
+  psi_out.rlim_ = 2
+  return psi_out
 end
 
 function naiveApplyMPO(A::MPO, psi::MPS; kwargs...)::MPS

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -164,7 +164,7 @@ function siteindex(M::MPS,j::Integer)
   elseif j == N
     si = uniqueindex(M[j],M[j-1])
   else
-    si = uniqueindex(M[j],(M[j-1],M[j+1]))
+    si = uniqueindex(M[j],M[j-1],M[j+1])
   end
   return si
 end

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -13,23 +13,13 @@ const MTagSetStorage = MVector{maxTags,IntTag}  # A mutable tag storage
 
 struct TagSet
   tags::TagSetStorage
-  plev::Int
   length::Int
   function TagSet() 
     ts = TagSetStorage(ntuple(_ -> IntTag(0),Val(4)))
-    plev = -1
-    new(ts,plev,0)
+    new(ts,0)
   end
-  TagSet(tags::TagSetStorage,plev::Int,len::Int) = new(tags,plev,len)
+  TagSet(tags::TagSetStorage,len::Int) = new(tags,len)
 end
-
-#function TagSet(tags::TagSetStorage,plev::Int=-1)
-#  len = 0
-#  while tags[len+1] ≠ IntTag(0)
-#    len += 1
-#  end
-#  TagSet(tags,plev,len)
-#end
 
 TagSet(ts::TagSet) = ts
 
@@ -56,24 +46,17 @@ function _addtag_ordered!(ts::MTagSetStorage, ntags::Int, tag::IntTag)
   return ntags+1
 end
 
-function _addtag!(ts::MTagSetStorage, plev::Int, ntags::Int, tag::IntTag)
-  plnew = plev
+function _addtag!(ts::MTagSetStorage, ntags::Int, tag::IntTag)
   t = Tag(tag)
   if !isnull(t)
     if isint(t)
-      error("""Cannot use a bare integer as a tag.
-            If you are looking to set the prime level, use the syntax ("x",1)
-            (instead of "x,1")""")
-      #plev ≥ 0 && error("You can only make a TagSet with one prime level/integer tag.")
-      #plnew = parse(Int,t)
+      error("Cannot use a bare integer as a tag.")
     else
       ntags = _addtag_ordered!(ts, ntags,tag)  
     end
   end
-  return plnew, ntags
+  return ntags
 end
-
-#isnull(v::MTagStorage) = v[0] == IntChar(0)
 
 function reset!(v::MTagStorage, nchar::Int)
   for i = 1:nchar
@@ -88,12 +71,11 @@ function TagSet(str::AbstractString)
   ts = MTagSetStorage(ntuple(_ -> IntTag(0),Val(maxTags)))
   nchar = 0
   ntags = 0
-  plev = -1
   for n = 1:length(str)
     @inbounds current_char = str[n]
     if current_char == ','
       if nchar != 0
-        plev, ntags = _addtag!(ts,plev,ntags,cast_to_uint64(current_tag))
+        ntags = _addtag!(ts,ntags,cast_to_uint64(current_tag))
         # Reset the current tag
         reset!(current_tag,nchar)
         nchar = 0
@@ -106,43 +88,17 @@ function TagSet(str::AbstractString)
   end
   # Store the final tag
   if nchar != 0
-    plev, ntags = _addtag!(ts,plev,ntags,cast_to_uint64(current_tag))
+    ntags = _addtag!(ts,ntags,cast_to_uint64(current_tag))
   end
-  return TagSet(TagSetStorage(ts),plev,ntags)
-end
-
-function TagSet((str,plev)::Tuple{<:AbstractString,<:Integer})
-  ts = TagSet(str)
-  return setprime(ts,plev)
+  return TagSet(TagSetStorage(ts),ntags)
 end
 
 Base.convert(::Type{TagSet}, str::String) = TagSet(str)
 
 tags(T::TagSet) = T.tags
-plev(T::TagSet) = T.plev
 Base.length(T::TagSet) = T.length
 Base.getindex(T::TagSet,n::Int) = Tag(getindex(tags(T),n))
-#Base.setindex!(T::TagSet,val,n::Int) = TagSet(setindex(tags(T),val,n),plev(T),length(T))
-Base.copy(ts::TagSet) = TagSet(tags(ts),plev(ts),length(ts))
-
-# A TagSet is considered to have a prime level if
-# the prime level is greater than or equal to zero
-hasplev(ts::TagSet) = (plev(ts) ≥ 0)
-
-setprime(ts::TagSet,pl::Int) = TagSet(tags(ts),pl,length(ts))
-function prime(T::TagSet,plinc::Int=1)
-  if !hasplev(T)
-    return setprime(T,plinc)
-  else
-    return setprime(T,plev(T)+plinc)
-  end
-end
-
-# TODO: define iteration?
-#Base.iterate(ts::TagSet,state::Int=1) = iterate(tags(ts),state)
-
-# TODO: define `in` in terms of hastags?
-#Base.in(s, ts::TagSet) = hastags(ts, TagSet(s))
+Base.copy(ts::TagSet) = TagSet(tags(ts),length(ts))
 
 # Cast SVector of IntTag of length 4 to SVector of UInt128 of length 2
 # This is to make TagSet comparison a little bit faster
@@ -151,7 +107,6 @@ function cast_to_uint128(a::TagSetStorage)
 end
 
 function Base.:(==)(ts1::TagSet,ts2::TagSet)
-  plev(ts1) ≠ plev(ts2) && return false
   # Block the bits together to make the comparison faster
   return cast_to_uint128(tags(ts1)) == cast_to_uint128(tags(ts2))
 end
@@ -167,7 +122,6 @@ end
 
 function hastags(ts2::TagSet, tags1)
   ts1 = TagSet(tags1)
-  (hasplev(ts1) && plev(ts1) ≠ plev(ts2)) && return false
   l1 = length(ts1)
   l2 = length(ts2)
   l1 > l2 && return false
@@ -182,17 +136,12 @@ function addtags(ts::TagSet, tagsadd)
     throw(ErrorException("Cannot add tag: TagSet already maximum size"))
   end
   tsadd = TagSet(tagsadd)
-  (hasplev(ts) && hasplev(tsadd)) && error("In addtags(::TagSet,...), cannot add a prime level")
   res_ts = MVector(tags(ts))
-  res_plev = plev(ts)
   ntags = length(ts)
   for n = 1:length(tsadd)
     @inbounds ntags = _addtag_ordered!(res_ts, ntags,IntSmallString(tsadd[n]))
   end
-  if !hasplev(ts) && hasplev(tsadd)
-    res_plev = plev(tsadd)
-  end
-  return TagSet(TagSetStorage(res_ts),res_plev,ntags)
+  return TagSet(TagSetStorage(res_ts),ntags)
 end
 
 function _removetag!(ts::MTagSetStorage, ntags::Int, t::Tag)
@@ -211,28 +160,20 @@ end
 #TODO: optimize this function
 function removetags(ts::TagSet, tagsremove)
   tsremove = TagSet(tagsremove)
-  hasplev(tsremove) && error("In removetags(::TagSet,...), cannot remove a prime level")
   res_ts = MVector(tags(ts))
-  res_plev = plev(ts)
   ntags = length(ts)
   for n=1:length(tsremove)
     @inbounds ntags = _removetag!(res_ts, ntags, tsremove[n])
   end
-  return TagSet(TagSetStorage(res_ts),res_plev,ntags)
+  return TagSet(TagSetStorage(res_ts),ntags)
 end
 
 #TODO: optimize this function
 function replacetags(ts::TagSet, tagsremove, tagsadd)
   tsremove = TagSet(tagsremove)
   tsadd = TagSet(tagsadd)
-  if hasplev(tsremove) != hasplev(tsadd)
-    error("In replacetags(::TagSet,...), cannot remove or add a prime level")
-  end
   res_ts = MVector(tags(ts))
-  res_plev = plev(ts)
   ntags = length(ts)
-  # The TagSet must have the same prime level as the one being replaced
-  (hasplev(tsremove) && (res_plev≠plev(tsremove))) && return ts
   # The TagSet must have the tags to be replaced
   !hastags(ts,tsremove) && return ts
   for n = 1:length(tsremove)
@@ -241,24 +182,7 @@ function replacetags(ts::TagSet, tagsremove, tagsadd)
   for n = 1:length(tsadd)
     @inbounds ntags = _addtag_ordered!(res_ts, ntags,IntSmallString(tsadd[n]))
   end
-  if hasplev(ts) && (plev(ts)==plev(tsremove))
-    res_plev = plev(tsadd)
-  end
-  return TagSet(TagSetStorage(res_ts),res_plev,ntags)
-end
-
-function primestring(ts::TagSet)
-  if !hasplev(ts)
-    return " (warning: no prime level)"
-  end
-  pl = plev(ts)
-  if pl==0
-    return ""
-  elseif pl > 3
-    return "'$pl"
-  else
-    return "'"^pl
-  end
+  return TagSet(TagSetStorage(res_ts),ntags)
 end
 
 function tagstring(T::TagSet)
@@ -281,7 +205,6 @@ function show(io::IO, T::TagSet)
     end
   end
   print(io,")")
-  print(io,primestring(T))
 end
 
 function readcpp(io::IO,::Type{TagSet}; kwargs...)
@@ -296,8 +219,7 @@ function readcpp(io::IO,::Type{TagSet}; kwargs...)
         ntags = _addtag_ordered!(mstore,ntags,IntSmallString(t))
       end
     end
-    plev = convert(Int,read(io,Int32))
-    ts = TagSet(TagSetStorage(mstore),plev,ntags)
+    ts = TagSet(TagSetStorage(mstore),ntags)
   else
     throw(ArgumentError("read TagSet: format=$format not supported"))
   end
@@ -310,7 +232,6 @@ function HDF5.write(parent::Union{HDF5File,HDF5Group},
   g = g_create(parent,name)
   attrs(g)["type"] = "TagSet"
   attrs(g)["version"] = 1
-  write(g,"plev",plev(T))
   write(g,"tags",tagstring(T))
 end
 
@@ -321,7 +242,6 @@ function HDF5.read(parent::Union{HDF5File,HDF5Group},
   if read(attrs(g)["type"]) != "TagSet"
     error("HDF5 group '$name' does not contain TagSet data")
   end
-  plev = read(g,"plev")
   tstring = read(g,"tags")
-  return TagSet((tstring,plev))
+  return TagSet(tstring)
 end

--- a/test/ctmrg.jl
+++ b/test/ctmrg.jl
@@ -86,13 +86,15 @@ end
   # Normalize MPS tensor
   trA² = Clu*mapprime(Clu,0,1,"up")*Al*
          mapprime(Al,0,1,"link")*
-         mapprime(replacetags(Clu,("up",0),("down",1)),0,1,"left")*
+         mapprime(replacetags(mapprime(Clu,0,1,"up"),"up","down"),0,1,"left")*
          replacetags(mapprime(Clu,0,1,"left"),"up","down")
   Al = Al/sqrt(scalar(trA²))
 
   ## Get environment tensors for a single site measurement
   Ar = mapprime(replacetags(Al,"left","right","site"),0,1,"link")
-  Au = replacetags(replacetags(replacetags(Al,"left","up","site"),"down","left","link"),"up","right","link")
+  Au = replacetags(replacetags(replacetags(Al,"left","up","site"),
+                                              "down","left","link"),
+                                              "up","right","link")
   Ad  = mapprime(replacetags(Au,"up","down","site"),0,1,"link")
   Cld = mapprime(replacetags(Clu,"up","down"),0,1,"left")
   Cru = mapprime(replacetags(Clu,"left","right"),0,1,"up")

--- a/test/index.jl
+++ b/test/index.jl
@@ -11,7 +11,7 @@ import ITensors: In,Out,Neither
     @test dir(i) == Neither
     @test -dir(i) == Neither
     @test plev(i) == 0
-    @test tags(i) == TagSet(("",0))
+    @test tags(i) == TagSet("")
   end
   @testset "Index with dim" begin
     i = Index(2)
@@ -19,21 +19,21 @@ import ITensors: In,Out,Neither
     @test dim(i) == 2
     @test dir(i) == Neither
     @test plev(i) == 0
-    @test tags(i) == TagSet(("",0))
+    @test tags(i) == TagSet("")
   end
   @testset "Index with all args" begin
-    i = Index(UInt64(1), 2, In, TagSet(("Link",1)))
+    i = Index(1, 2, In, "Link", 1)
     @test id(i) == 1
     @test dim(i) == 2
     @test dir(i) == In
     @test plev(i) == 1 
-    @test tags(i) == TagSet(("Link",1))
+    @test tags(i) == TagSet("Link")
     j = copy(i)
     @test id(j) == 1
     @test dim(j) == 2
     @test dir(j) == In
     @test plev(j) == 1 
-    @test tags(j) == TagSet(("Link",1))
+    @test tags(j) == TagSet("Link")
     @test j == i
   end
   @testset "prime" begin

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -52,17 +52,17 @@ using ITensors,
     @test hassameinds(I1,(k,j,i))
     @test uniqueindex(I1,(I2,I3)) == i
     @test isnothing(uniqueindex(I1,IndexSet(k, j, i)))
-    @test uniqueinds(I1,I2) == IndexSet(i,j)
-    @test setdiff(I1,I2) == IndexSet(i,j)
+    @test hassameinds(uniqueinds(I1,I2),IndexSet(i,j))
+    @test hassameinds(setdiff(I1,I2),IndexSet(i,j))
     @test hassameinds(uniqueinds(I1,I2),(j,i))
-    @test commoninds(I1,I2) == IndexSet(k)
+    @test hassameinds(commoninds(I1,I2),IndexSet(k))
     @test commonindex(I1,I2) == k
     @test isnothing(commonindex(I1,IndexSet(l)))
-    @test commoninds(I1,(j,l)) == IndexSet(j)
+    @test hassameinds(commoninds(I1,(j,l)),IndexSet(j))
     @test commonindex(I1,(j,l)) == j
-    @test commoninds(I1,(j,k)) == IndexSet(j,k)
+    @test hassameinds(commoninds(I1,(j,k)),IndexSet(j,k))
     @test hassameinds(commoninds(I1,(j,k,l)),(j,k))
-    @test findinds(I1,"i") == IndexSet(i)
+    @test hassameinds(findinds(I1,"i"),IndexSet(i))
     @test findindex(I1,"j") == j
     @test isnothing(findindex(I1,"l"))
     @test indexposition(I1,i) == 1
@@ -75,8 +75,8 @@ using ITensors,
     J = IndexSet(j,l,i)
     # Test that commoninds respects the ordering
     # of the indices in the first IndexSet
-    @test commoninds(I,J) == IndexSet(i,j)
-    @test commoninds(J,I) == IndexSet(j,i)
+    @test hassameinds(commoninds(I,J),IndexSet(i,j))
+    @test hassameinds(commoninds(J,I),IndexSet(j,i))
   end
   @testset "adjoint" begin
     I = IndexSet(i,k,j)

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -52,16 +52,22 @@ using ITensors,
     @test hassameinds(I1,(k,j,i))
     @test uniqueindex(I1,(I2,I3)) == i
     @test isnothing(uniqueindex(I1,IndexSet(k, j, i)))
+    @test uniqueinds(I1,I2) == IndexSet(i,j)
+    @test setdiff(I1,I2) == IndexSet(i,j)
     @test hassameinds(uniqueinds(I1,I2),IndexSet(i,j))
     @test hassameinds(setdiff(I1,I2),IndexSet(i,j))
     @test hassameinds(uniqueinds(I1,I2),(j,i))
+    @test commoninds(I1,I2) == IndexSet(k)
     @test hassameinds(commoninds(I1,I2),IndexSet(k))
     @test commonindex(I1,I2) == k
     @test isnothing(commonindex(I1,IndexSet(l)))
+    @test commoninds(I1,(j,l)) == IndexSet(j)
     @test hassameinds(commoninds(I1,(j,l)),IndexSet(j))
     @test commonindex(I1,(j,l)) == j
+    @test commoninds(I1,(j,k)) == IndexSet(j,k)
     @test hassameinds(commoninds(I1,(j,k)),IndexSet(j,k))
     @test hassameinds(commoninds(I1,(j,k,l)),(j,k))
+    @test findinds(I1,"i") == IndexSet(i)
     @test hassameinds(findinds(I1,"i"),IndexSet(i))
     @test findindex(I1,"j") == j
     @test isnothing(findindex(I1,"l"))

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -318,26 +318,27 @@ end
   s1 = Index(2,"Site,s=1")
   s2 = Index(2,"Site,s=2")
   l = Index(3,"Link")
+  ltmp = settags(l,"Temp")
   A1 = randomITensor(s1,l,l')
   A2 = randomITensor(s2,l',l'')
   @testset "findindex(::ITensor,::String)" begin
     @test s1==findindex(A1,"Site")
     @test s1==findindex(A1,"s=1")
     @test s1==findindex(A1,"s=1,Site")
-    @test l==findindex(A1,("Link",0))
-    @test l'==findindex(A1,("",1))
-    @test l'==findindex(A1,("Link",1))
+    @test l==findindex(A1,"Link";plev=0)
+    @test l'==findindex(A1;plev=1)
+    @test l'==findindex(A1,"Link";plev=1)
     @test s2==findindex(A2,"Site")
     @test s2==findindex(A2,"s=2")
     @test s2==findindex(A2,"Site")
-    @test s2==findindex(A2,("",0))
-    @test s2==findindex(A2,("s=2",0))
-    @test s2==findindex(A2,("Site",0))
-    @test s2==findindex(A2,("s=2,Site",0))
-    @test l'==findindex(A2,("",1))
-    @test l'==findindex(A2,("Link",1))
-    @test l''==findindex(A2,("",2))
-    @test l''==findindex(A2,("Link",2))
+    @test s2==findindex(A2,plev=0)
+    @test s2==findindex(A2,"s=2";plev=0)
+    @test s2==findindex(A2,"Site";plev=0)
+    @test s2==findindex(A2,"s=2,Site";plev=0)
+    @test l'==findindex(A2;plev=1)
+    @test l'==findindex(A2,"Link";plev=1)
+    @test l''==findindex(A2;plev=2)
+    @test l''==findindex(A2,"Link";plev=2)
   end
   @testset "addtags(::ITensor,::String,::String)" begin
     s1u = addtags(s1,"u")
@@ -349,21 +350,24 @@ end
     A1u = addtags(A1,"u","Link")
     @test hasinds(A1u,s1,lu,lu')
 
-    A1u = addtags(A1,"u",("",0))
+    A1u = addtags(A1,"u";plev=0)
     @test hasinds(A1u,s1u,lu,l')
 
-    A1u = addtags(A1,"u",("Link",0))
+    A1u = addtags(A1,"u";tags="Link",plev=0)
     @test hasinds(A1u,s1,lu,l')
 
-    A1u = addtags(A1,"u",("Link",1))
+    A1u = addtags(A1,"u","Link";plev=1)
     @test hasinds(A1u,s1,l,lu')
   end
   @testset "removetags(::ITensor,::String,::String)" begin
     A2r = removetags(A2,"Site")
     @test hasinds(A2r,removetags(s2,"Site"),l',l'')
 
-    A2r = removetags(A2,"Link",("",1))
+    A2r = removetags(A2,"Link";plev=1)
     @test hasinds(A2r,s2,removetags(l,"Link")',l'')
+
+    A2r = replacetags(A2,"Link","Temp";plev=1)
+    @test hasinds(A2r,s2,ltmp',l'')
   end
   @testset "replacetags(::ITensor,::String,::String)" begin
     s2tmp = replacetags(s2,"Site","Temp")
@@ -374,20 +378,6 @@ end
 
     A2r = replacetags(A2,"Link","Temp")
     @test hasinds(A2r,s2,ltmp',ltmp'')
-
-    A2r = replacetags(A2,"Link","Temp",("",1))
-    @test hasinds(A2r,s2,ltmp',l'')
-
-    A2r = replacetags(A2,("Link",2),("Temp",3))
-    @test hasinds(A2r,s2,l',ltmp''')
-
-    A2r = replacetags(A2,("",1),("",5))
-    @test hasinds(A2r,s2,prime(l,5),l'')
-
-    #In-place version
-    cA2 = copy(A2)
-    replacetags!(cA2,("",1),("",5))
-    @test hasinds(cA2,s2,prime(l,5),l'')
   end
   @testset "prime(::ITensor,::String)" begin
     A2p = prime(A2)

--- a/test/iterativesolvers.jl
+++ b/test/iterativesolvers.jl
@@ -7,7 +7,7 @@ struct ITensorMap
   A::ITensor
 end
 Base.eltype(M::ITensorMap) = eltype(M.A)
-Base.size(M::ITensorMap) = dim(findinds(M.A,("",0)))
+Base.size(M::ITensorMap) = dim(IndexSet(findinds(M.A;plev=0)...))
 (M::ITensorMap)(v::ITensor) = noprime(M.A*v)
 
 @testset "Complex davidson" begin

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -120,7 +120,7 @@ end
       phiJdagKpsi = phiJdagKpsi*phidag[j]*Jdag[j]*K[j]*psi[j]
     end
 
-    @test scalar(phiJdagKpsi) ≈ inner(J,phi,K,psi)
+    @test phiJdagKpsi[] ≈ inner(J,phi,K,psi)
 
     ## Do contraction manually.
     #O = 1.


### PR DESCRIPTION
This removes the prime level from the TagSet and moves it into the Index.

There is also some code cleanup. Some notation is added to various functions to use keyword args to find/filter for indices with specified tags and prime levels, for example:
```julia
julia> i = Index(2; tags="Site", plev=2)
(dim=2|id=725|"Site")''

julia> j = Index(2; tags="Site", plev=1)
(dim=2|id=349|"Site")'

julia> is = IndexSet(i,j)
(dim=2|id=725|"Site")'' (dim=2|id=349|"Site")' 

julia> isp = prime(is; tags="Site", plev=2)
(dim=2|id=725|"Site")''' (dim=2|id=349|"Site")' 

julia> findindex(isp; plev=3)
(dim=2|id=725|"Site")'''
```