### PR TITLE
Replace davidson with eigsolve from KrylovKit in dmrg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -22,4 +23,4 @@ Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Combinatorics", "QuadGK","Suppressor","Test"]
+test = ["Combinatorics", "QuadGK", "Suppressor", "Test"]

--- a/examples/dmrg/1d_Heisenberg_dmrg.jl
+++ b/examples/dmrg/1d_Heisenberg_dmrg.jl
@@ -1,5 +1,6 @@
 using ITensors
 using Printf
+using Random
 
 # Use DMRG to solve the spin 1, 1D Heisenberg model on 100 sites
 # For the Heisenberg model in one dimension

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -6,7 +6,8 @@ using Random,
       StaticArrays,
       TimerOutputs,
       Reexport,
-      HDF5
+      HDF5,
+      KrylovKit
 
 # TODO: move imports to individual files
 import Base.adjoint,

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -10,8 +10,24 @@ function dmrg(H::MPO,
   quiet::Bool = get(kwargs,:quiet,false)
 
   # eigsolve kwargs
-  krylovdim = get(kwargs,:maxiter,2)+1
-  tol = get(kwargs,:errgoal,1E-14)
+  eigsolve_tol::Float64 = get(kwargs,:eigsolve_tol,1E-14)
+  eigsolve_krylovdim::Int = get(kwargs,:eigsolve_krylovdim,3)
+  eigsolve_maxiter::Int = get(kwargs,:eigsolve_maxiter,1)
+  eigsolve_verbosity::Int = get(kwargs,:eigsolve_verbosity,0)
+
+  # TODO: add support for non-Hermitian DMRG
+  ishermitian::Bool = true #get(kwargs,:ishermitian,true)
+
+  # TODO: add support for targeting other states with DMRG
+  # (such as the state with the largest eigenvalue)
+  eigsolve_which_eigenvalue::Symbol = :SR #get(kwargs,:eigsolve_which_eigenvalue,:SR)
+
+  # Keyword argument deprecations
+  haskey(kwargs,:maxiter) && error("""maxiter keyword has been replace by eigsolve_krylovdim.
+                                      Note: compared to the C++ version of ITensor,
+                                      setting eigsolve_krylovdim 3 is the same as setting
+                                      a maxiter of 2.""")
+  haskey(kwargs,:errgoal) && error("errgoal keyword has been replace by eigsolve_tol.")
 
   psi = copy(psi0)
   N = length(psi)
@@ -34,10 +50,10 @@ end
 end
 
 @timeit_debug GLOBAL_TIMER "eigsolve" begin
-      vals,vecs = eigsolve(PH,phi,1,:SR; ishermitian=true,
-                                         tol=tol,
-                                         krylovdim=krylovdim,
-                                         maxiter=1)
+      vals,vecs = eigsolve(PH,phi,1,eigsolve_which_eigenvalue; ishermitian=ishermitian,
+                                                               tol=eigsolve_tol,
+                                                               krylovdim=eigsolve_krylovdim,
+                                                               maxiter=eigsolve_maxiter)
 end
       energy,phi = vals[1],vecs[1]
 

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -10,7 +10,7 @@ function dmrg(H::MPO,
   quiet::Bool = get(kwargs,:quiet,false)
 
   # eigsolve kwargs
-  krylovdim = get(kwargs,:maxiter,2)
+  krylovdim = get(kwargs,:maxiter,2)+1
   tol = get(kwargs,:errgoal,1E-14)
 
   psi = copy(psi0)

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -33,6 +33,7 @@ using ITensors, Test, Random
   @testset "Transverse field Ising" begin
     N = 32
     sites = siteinds("S=1/2",N)
+    Random.seed!(432)
     psi0 = randomMPS(sites)
 
     ampo = AutoMPO()
@@ -42,7 +43,7 @@ using ITensors, Test, Random
     end
     H = toMPO(ampo,sites)
 
-    sweeps = Sweeps(3)
+    sweeps = Sweeps(5)
     maxdim!(sweeps,10,20)
     cutoff!(sweeps,1E-12)
     energy,psi = dmrg(H,psi0,sweeps,quiet=true)
@@ -50,7 +51,7 @@ using ITensors, Test, Random
     # Exact energy for transverse field Ising model
     # with open boundary conditions at criticality
     energy_exact = 0.25 - 0.25/sin(π/(2*(2*N+1)))
-    @test abs(energy - energy_exact) < 0.05
+    @test abs((energy-energy_exact)/energy_exact) < 6e-4
   end
 
   @testset "DMRGObserver" begin

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -51,7 +51,7 @@ using ITensors, Test, Random
     # Exact energy for transverse field Ising model
     # with open boundary conditions at criticality
     energy_exact = 0.25 - 0.25/sin(π/(2*(2*N+1)))
-    @test abs((energy-energy_exact)/energy_exact) < 6e-4
+    @test abs((energy-energy_exact)/energy_exact) < 1e-6
   end
 
   @testset "DMRGObserver" begin


### PR DESCRIPTION
This fixes #234. Besides that issue, I have seen that `eigsolve` and `davidson` give very similar results for DMRG, for example for `example/dmrg/1d_Heisenberg_dmrg.jl` (using a fixed seed):

This branch (dmrg using `eigsolve`)
```julia
After sweep 1 energy=-137.585233665598 maxlinkdim=9 time=0.152
After sweep 2 energy=-138.935109267445 maxlinkdim=20 time=0.354
After sweep 3 energy=-138.940079055055 maxlinkdim=92 time=1.360
After sweep 4 energy=-138.940086046771 maxlinkdim=100 time=3.040
After sweep 5 energy=-138.940086072140 maxlinkdim=96 time=3.309
Final energy = -138.940086072140
```
On master (dmrg using `davidson`)
```julia
After sweep 1 energy=-137.585233665598 maxlinkdim=9 time=0.148
After sweep 2 energy=-138.935109267445 maxlinkdim=20 time=0.430
After sweep 3 energy=-138.940079055055 maxlinkdim=92 time=1.312
After sweep 4 energy=-138.940086046771 maxlinkdim=100 time=3.415
After sweep 5 energy=-138.940086072140 maxlinkdim=96 time=3.808
Final energy = -138.940086072140
```
so it seems like a pretty safe replacement.