### PR TITLE
Make IndexSet storage immutable (use SVector storage)

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -7,11 +7,8 @@ export IndexSet,
        indexposition,
        not,
        swaptags,
-       swaptags!,
        swapprime,
-       swapprime!,
        mapprime,
-       mapprime!,
        commoninds,
        commonindex,
        uniqueinds,
@@ -23,8 +20,7 @@ export IndexSet,
        hasqns
 
 struct IndexSet{N,IndexT<:Index}
-  inds::SizedVector{N,IndexT}
-  IndexSet{N}(inds::SizedVector{N,IndexT}) where {N,IndexT<:Index} = new{N,IndexT}(inds)
+  store::SVector{N,IndexT}
   IndexSet{N}(inds::SVector{N,IndexT}) where {N,IndexT<:Index} = new{N,IndexT}(inds)
   IndexSet{N}(inds::MVector{N,IndexT}) where {N,IndexT<:Index} = new{N,IndexT}(inds)
   IndexSet{0}(::MVector{0}) = new{0,Index}(())
@@ -50,7 +46,7 @@ function IndexSet(vi::Vector{Index})
   return IndexSet{N}(NTuple{N,Index}(vi))
 end
 
-Tensors.store(is::IndexSet) = is.inds
+Tensors.store(is::IndexSet) = is.store
 
 # Empty constructor
 IndexSet() = IndexSet{0}()
@@ -93,31 +89,23 @@ IndexSet(inds::NTuple{2,IndexSet}) = IndexSet(inds...)
 Index(is::IndexSet) = length(is)==1 ? is[1] : error("Number of Index in IndexSet ≠ 1")
 
 function Base.show(io::IO, is::IndexSet)
-  for i in is.inds
+  for i in store(is)
     print(io,i)
     print(io," ")
   end
 end
 
-Base.getindex(is::IndexSet,n::Integer) = getindex(is.inds,n)
+Base.getindex(is::IndexSet,n::Integer) = getindex(store(is),n)
 Base.getindex(is::IndexSet,v::AbstractVector) = IndexSet(getindex(Tuple(is),v))
 
-function Base.setindex!(is::IndexSet,i::Index,n::Integer)
-  setindex!(is.inds,i,n)
-  return is
-end
-
 function StaticArrays.setindex(is::IndexSet,i::Index,n::Integer)
-  # TODO: should this be deepcopy?
-  isR = copy(is)
-  setindex!(isR.inds,i,n)
-  return isR
+  return IndexSet(setindex(store(is),i,n))
 end
 
 Base.length(is::IndexSet{N}) where {N} = N
 Base.length(::Type{<:IndexSet{N}}) where {N} = N
 order(is::IndexSet) = length(is)
-Base.copy(is::IndexSet) = IndexSet(copy(is.inds))
+Base.copy(is::IndexSet) = IndexSet(copy(store(is)))
 Tensors.dims(is::IndexSet{N}) where {N} = ntuple(i->dim(is[i]),Val(N))
 Base.ndims(::IndexSet{N}) where {N} = N
 Base.ndims(::Type{<:IndexSet{N}}) where {N} = N
@@ -152,7 +140,7 @@ end
 Base.strides(is::IndexSet) = Base.size_to_strides(1, dims(is)...)
 Base.stride(is::IndexSet,k::Integer) = strides(is)[k]
 
-Tensors.dag(is::IndexSet) = IndexSet(dag.(is.inds))
+Tensors.dag(is::IndexSet) = IndexSet(dag.(store(is)))
 
 # Allow iteration
 Base.iterate(is::IndexSet{N},state::Int=1) where {N} = state > N ? nothing : (is[state], state+1)
@@ -163,8 +151,8 @@ Base.eltype(is::IndexSet{N,IndexT}) where {N,IndexT} = IndexT
 # Needed for findfirst (I think)
 Base.keys(is::IndexSet{N}) where {N} = 1:N
 
-StaticArrays.push(is::IndexSet{N},i::Index) where {N} = IndexSet{N+1}(push(is.inds,i))
-StaticArrays.pushfirst(is::IndexSet{N},i::Index) where {N} = IndexSet{N+1}(pushfirst(is.inds,i))
+StaticArrays.push(is::IndexSet{N},i::Index) where {N} = IndexSet{N+1}(push(store(is),i))
+StaticArrays.pushfirst(is::IndexSet{N},i::Index) where {N} = IndexSet{N+1}(pushfirst(store(is),i))
 
 # TODO: this assumes there is no overlap between the sets
 unioninds(is1::IndexSet{N1},is2::IndexSet{N2}) where {N1,N2} = IndexSet{N1+N2}(is1...,is2...)
@@ -437,55 +425,37 @@ end
 # Tagging functions
 #
 
-function prime!(is::IndexSet, plinc::Integer, args...; kwargs...)
+function prime(is::IndexSet, plinc::Integer, args...; kwargs...)
   pos = indexpositions(is, args...; kwargs...)
   for jj ∈ pos
-    is[jj] = prime(is[jj],plinc)
+    is = setindex(is,prime(is[jj],plinc),jj)
   end
   return is
 end
-prime!(is::IndexSet,vargs...; kwargs...) = prime!(is,1,vargs...; kwargs...)
-prime(is::IndexSet,vargs...; kwargs...) = prime!(copy(is),vargs...; kwargs...)
+prime(is::IndexSet,vargs...; kwargs...) = prime(is,1,vargs...; kwargs...)
 # For is' notation
 Base.adjoint(is::IndexSet) = prime(is)
 
-function setprime!(is::IndexSet, plev::Integer, args...; kwargs...)
+function setprime(is::IndexSet, plev::Integer, args...; kwargs...)
   pos = indexpositions(is, args...; kwargs...)
   for jj ∈ pos
-    is[jj] = setprime(is[jj],plev)
+    is = setindex(is,setprime(is[jj],plev),jj)
   end
   return is
 end
-setprime(is::IndexSet, vargs...; kwargs...) = setprime!(copy(is), vargs...; kwargs...)
 
-noprime!(is::IndexSet, args...; kwargs...) = setprime!(is, 0, args...; kwargs...)
-noprime(is::IndexSet, args...; kwargs...) = noprime!(copy(is), args...; kwargs...)
+noprime(is::IndexSet, args...; kwargs...) = setprime(is, 0, args...; kwargs...)
 
-function swapprime!(is::IndexSet, 
-                    pl1::Int,
-                    pl2::Int,
-                    args...; kwargs...) 
+function swapprime(is::IndexSet, 
+                   pl1::Int,
+                   pl2::Int,
+                   args...; kwargs...) 
   pos = indexpositions(is,args...; kwargs...)
   for n in pos
     if plev(is[n])==pl1
-      is[n] = setprime(is[n],pl2)
+      is = setindex(is,setprime(is[n],pl2),n)
     elseif plev(is[n])==pl2
-      is[n] = setprime(is[n],pl1)
-    end
-  end
-  return is
-end
-
-swapprime(is::IndexSet,pl1::Int,pl2::Int,args...; kwargs...) = swapprime!(copy(is),pl1,pl2,args...; kwargs...)
-
-function mapprime!(is::IndexSet,
-                   plold::Integer,
-                   plnew::Integer,
-                   args...; kwargs...)
-  pos = indexpositions(is, args...; kwargs...)
-  for n in pos
-    if plev(is[n])==plold 
-      is[n] = setprime(is[n],plnew)
+      is = setindex(is,setprime(is[n],pl1),n)
     end
   end
   return is
@@ -495,70 +465,70 @@ function mapprime(is::IndexSet,
                   plold::Integer,
                   plnew::Integer,
                   args...; kwargs...)
-  return mapprime!(copy(is),plold,plnew,args...;kwargs...)
-end
-
-
-function addtags!(is::IndexSet,
-                  tags,
-                  args...; kwargs...)
   pos = indexpositions(is, args...; kwargs...)
-  for jj ∈ pos
-    is[jj] = addtags(is[jj],tags)
+  for n in pos
+    if plev(is[n])==plold 
+      is = setindex(is,setprime(is[n],plnew),n)
+    end
   end
   return is
 end
-addtags(is, args...; kwargs...) = addtags!(copy(is), args...; kwargs...)
 
-function settags!(is::IndexSet,
-                  ts,
-                  args...; kwargs...)
+function addtags(is::IndexSet,
+                 tags,
+                 args...; kwargs...)
   pos = indexpositions(is, args...; kwargs...)
   for jj ∈ pos
-    is[jj] = settags(is[jj],ts)
+    is = setindex(is,addtags(is[jj],tags),jj)
   end
   return is
 end
-settags(is, args...; kwargs...) = settags!(copy(is), args...; kwargs...)
 
-function removetags!(is::IndexSet,
-                     tags,
+function settags(is::IndexSet,
+                 ts,
+                 args...; kwargs...)
+  pos = indexpositions(is, args...; kwargs...)
+  for jj ∈ pos
+    is = setindex(is,settags(is[jj],ts),jj)
+  end
+  return is
+end
+
+function removetags(is::IndexSet,
+                    tags,
+                    args...; kwargs...)
+  pos = indexpositions(is, args...; kwargs...)
+  for jj ∈ pos
+    is = setindex(is,removetags(is[jj],tags),jj)
+  end
+  return is
+end
+
+function replacetags(is::IndexSet,
+                     tags_old, tags_new,
                      args...; kwargs...)
   pos = indexpositions(is, args...; kwargs...)
   for jj ∈ pos
-    is[jj] = removetags(is[jj],tags)
+    is = setindex(is,replacetags(is[jj],tags_old,tags_new),jj)
   end
   return is
 end
-removetags(is, args...; kwargs...) = removetags!(copy(is), args...; kwargs...)
-
-function replacetags!(is::IndexSet,
-                      tags_old, tags_new,
-                      args...; kwargs...)
-  pos = indexpositions(is, args...; kwargs...)
-  for jj ∈ pos
-    is[jj] = replacetags(is[jj],tags_old,tags_new)
-  end
-  return is
-end
-replacetags(is, args...; kwargs...) = replacetags!(copy(is), args...; kwargs...)
 
 # TODO: write more efficient version in terms
-# of indexpositions like swapprime!
-function swaptags!(is::IndexSet,
-                   tags1, tags2,
-                   args...; kwargs...)
+# of indexpositions like swapprime
+function swaptags(is::IndexSet,
+                  tags1, tags2,
+                  args...; kwargs...)
   ts1 = TagSet(tags1)
   ts2 = TagSet(tags2)
   # TODO: add debug check that this "random" tag
   # doesn't clash with ts1 or ts2
   tstemp = TagSet("e43efds")
-  replacetags!(is, ts1, tstemp, args...; kwargs...)
-  replacetags!(is, ts2, ts1, args...; kwargs...)
-  replacetags!(is, tstemp, ts2, args...; kwargs...)
+  is = replacetags(is, ts1, tstemp, args...; kwargs...)
+  is = replacetags(is, ts2, ts1, args...; kwargs...)
+  is = replacetags(is, tstemp, ts2, args...; kwargs...)
   return is
 end
-swaptags(is, args...; kwargs...) = swaptags!(copy(is), args...; kwargs...)
 
 Tensors.dense(::Type{<:IndexSet}) = IndexSet
 

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -259,10 +259,10 @@ function inner(B::MPO,
   for j ∈ eachindex(Bdag)
     Axcommon = commonindex(A[j], x[j])
     ABcommon = uniqueindex(findinds(A[j], "Site"), IndexSet(Axcommon))
-    swapprime!(inds(Bdag[j]),2,3)
-    swapprime!(inds(Bdag[j]),1,2)
-    swapprime!(inds(Bdag[j]),3,1)
-    noprime!(inds(Bdag[j]),prime(ABcommon,2))
+    swapprime!(Bdag[j],2,3)
+    swapprime!(Bdag[j],1,2)
+    swapprime!(Bdag[j],3,1)
+    noprime!(Bdag[j],prime(ABcommon,2))
   end
   yB = ydag[1] * Bdag[1]
   Ax = A[1] * x[1]
@@ -386,10 +386,10 @@ function densityMatrixApplyMPO(A::MPO, psi::MPS; kwargs...)::MPS
   A_c       = dag(copy(A))
   prime!(psi_c, rand_plev)
   prime!(A_c, rand_plev)
+  sites = siteinds(A,psi)
+  dagsites = siteinds(A_c,psi_c)
   for j in 1:n
-    s = siteindex(A[j],psi[j])
-    s_dag = siteindex(A_c[j],psi_c[j])
-    replaceindex!(A_c[j],s_dag,s)
+    replaceindex!(A_c[j],dagsites[j],sites[j])
   end
   E = Vector{ITensor}(undef, n-1)
   E[1] = psi[1]*A[1]*A_c[1]*psi_c[1]

--- a/src/qnitensor.jl
+++ b/src/qnitensor.jl
@@ -194,8 +194,8 @@ function replaceindex!(A::ITensor,i::QNIndex,j::QNIndex)
   pos = indexpositions(A,i)
   isempty(pos) && error("Index not found")
   curdir = dir(inds(A)[pos[1]])
-  inds(A)[pos[1]] = setdir(j,curdir)
-  return A
+  j = setdir(j,curdir)
+  return setinds!(A,setindex(inds(A),j,pos[1]))
 end
 
 flux(T::ITensor,vals::Int...) = flux(inds(T),vals...)

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -96,7 +96,7 @@ using ITensors,
     J = IndexSet(i,j,k')
     @test mapprime(J,0,2) == IndexSet(i'',j'',k')
 
-    mapprime!(J,1,5)
+    J = mapprime(J,1,5)
     @test J == IndexSet(i,j,k^5)
   end
   @testset "strides" begin
@@ -134,7 +134,7 @@ using ITensors,
     @test swapprime(I,2,1) == IndexSet(i,k',j')
     # In-place version:
     I = IndexSet(i,k'',j''')
-    swapprime!(I,2,0)
+    I = swapprime(I,2,0)
     @test I == IndexSet(i'',k,j''')
     # With tags specified:
     I = IndexSet(i,k,j)

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -110,9 +110,9 @@ end
     Jdag = dag(J)
     prime!(Jdag)
     for j ∈ eachindex(Jdag)
-      swapprime!(inds(Jdag[j]),2,3)
-      swapprime!(inds(Jdag[j]),1,2)
-      swapprime!(inds(Jdag[j]),3,1)
+      swapprime!(Jdag[j],2,3)
+      swapprime!(Jdag[j],1,2)
+      swapprime!(Jdag[j],3,1)
     end
 
     phiJdagKpsi = phidag[1]*Jdag[1]*K[1]*psi[1]


### PR DESCRIPTION
This changes the storage of IndexSet from SizedVector to SVector, which means that IndexSet is fully immutable now (both the type and the storage are immutable). It also means that they are now non-allocating:
```julia
julia> using ITensors

julia> i = Index(2,"i");

julia> j = Index(3,"j");

julia> @btime IndexSet($i,$j)
  0.089 ns (0 allocations: 0 bytes)
(dim=2|id=86|"i") (dim=3|id=4|"j") 
```
while on master it is:
```
julia> using ITensors

julia> i = Index(2,"i");

julia> j = Index(3,"j");

julia> @btime IndexSet($i,$j)
  158.176 ns (3 allocations: 256 bytes)
(dim=2|id=653|"i") (dim=3|id=556|"j") 
```
Using the SizedVector storage wasn't ideal, since it is just a wrapper around a Vector so it is technically still dynamically sized and allocated. MVector doesn't make sense as a storage since for QNs, the indices have dynamically sized containers (the QN storage), so MVector doesn't generically allow modifying the elements anyway.

The main disadvantage of this is that you can't set elements of an IndexSet using notation like `is[2] = j`, but this should mostly be something that is done internally and can easily be replaced by `is = setindex(is,j,2)`.

Note that indices of an ITensor can still be modified in-place, for example with functions like `prime!(A)`, by replacing the entire IndexSet of the ITensor (like how certain in-place operations of the ITensor are done by replacing the storage). So the ITensor interface should not change from this.