### PR TITLE
AutoMPO `-=` and `.-=` syntax

### DIFF
--- a/examples/dmrg/1d_Heisenberg_dmrg.jl
+++ b/examples/dmrg/1d_Heisenberg_dmrg.jl
@@ -19,9 +19,9 @@ let
   # Input operator terms which define a Hamiltonian
   ampo = AutoMPO()
   for j=1:N-1
-      add!(ampo,"Sz",j,"Sz",j+1)
-      add!(ampo,0.5,"S+",j,"S-",j+1)
-      add!(ampo,0.5,"S-",j,"S+",j+1)
+      ampo += ("Sz",j,"Sz",j+1)
+      ampo += (0.5,"S+",j,"S-",j+1)
+      ampo += (0.5,"S-",j,"S+",j+1)
   end
   # Convert these terms to an MPO tensor network
   H = toMPO(ampo,sites)

--- a/examples/dmrg/2ddmrg.jl
+++ b/examples/dmrg/2ddmrg.jl
@@ -12,9 +12,9 @@ let
 
   ampo = AutoMPO()
   for b in lattice
-    add!(ampo,0.5,"S+",b.s1,"S-",b.s2)
-    add!(ampo,0.5,"S-",b.s1,"S+",b.s2)
-    add!(ampo,    "Sz",b.s1,"Sz",b.s2)
+    ampo += (0.5,"S+",b.s1,"S-",b.s2)
+    ampo += (0.5,"S-",b.s1,"S+",b.s2)
+    ampo += ("Sz",b.s1,"Sz",b.s2)
   end
   H = toMPO(ampo,sites)
 

--- a/examples/dmrg/dmrg_with_observer.jl
+++ b/examples/dmrg/dmrg_with_observer.jl
@@ -13,10 +13,10 @@ function tfimMPO(sites,
   N = length(sites)
   ampo = AutoMPO()
   for j=1:N-1
-    add!(ampo,-1.,"Sz",j,"Sz",j+1)
-    add!(ampo,h,"Sx",j)
+    ampo += (-1.,"Sz",j,"Sz",j+1)
+    ampo += (h,"Sx",j)
   end
-  add!(ampo,h,"Sx",N)
+  ampo += (h,"Sx",N)
   # Convert these terms to an MPO tensor network
   return toMPO(ampo,sites)
 end

--- a/examples/dmrg/qns/1d_heisenberg.jl
+++ b/examples/dmrg/qns/1d_heisenberg.jl
@@ -14,15 +14,15 @@ let
   println("Using AutoMPO")
   ampo = AutoMPO()
   for j=1:N-1
-    add!(ampo,"Sz",j,"Sz",j+1)
-    add!(ampo,0.5,"S+",j,"S-",j+1)
-    add!(ampo,0.5,"S-",j,"S+",j+1)
+    ampo += ("Sz",j,"Sz",j+1)
+    ampo += (0.5,"S+",j,"S-",j+1)
+    ampo += (0.5,"S-",j,"S+",j+1)
   end
   J2 = 0.1
   for j=1:N-2
-    add!(ampo,J2,"Sz",j,"Sz",j+2)
-  #  add!(ampo,0.5*J2,"S+",j,"S-",j+2)
-  #  add!(ampo,0.5*J2,"S-",j,"S+",j+2)
+    ampo += (J2,"Sz",j,"Sz",j+2)
+  #  ampo += (0.5*J2,"S+",j,"S-",j+2)
+  #  ampo += (0.5*J2,"S-",j,"S+",j+2)
   end
   H = toMPO(ampo,sites)
 

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -50,16 +50,18 @@ end
 coef(op::MPOTerm) = op.coef
 ops(op::MPOTerm) = op.ops
 
-function Base.:(==)(t1::MPOTerm,t2::MPOTerm)
-  return (t1.ops==t2.ops && isapprox(t1.coef,t2.coef))
+function Base.:(==)(t1::MPOTerm,
+                    t2::MPOTerm)
+  return coef(t1) ≈ coef(t2) && ops(t1) == ops(t2)
 end
 
-function Base.isless(t1::MPOTerm,t2::MPOTerm)::Bool
+function Base.isless(t1::MPOTerm, t2::MPOTerm)::Bool
   if !isapprox(coef(t1),coef(t2))
     ct1 = coef(t1)
     ct2 = coef(t2)
     #"lexicographic" ordering on  complex numbers
-    return real(ct1) < real(ct2) || (real(ct1) == real(ct2) && imag(ct1) < imag(ct2))
+    return real(ct1) < real(ct2) || 
+           (real(ct1) == real(ct2) && imag(ct1) < imag(ct2))
   end
   return ops(t1) < ops(t2)
 end
@@ -122,6 +124,9 @@ end
 AutoMPO() = AutoMPO(Vector{MPOTerm}())
 terms(ampo::AutoMPO) = ampo.terms
 
+Base.:(==)(ampo1::AutoMPO,
+           ampo2::AutoMPO) = terms(ampo1) == terms(ampo2)
+
 Base.copy(ampo::AutoMPO) = AutoMPO(copy(terms(ampo)))
 
 Base.size(ampo::AutoMPO) = size(terms(ampo))
@@ -155,26 +160,46 @@ function add!(ampo::AutoMPO,
 end
 
 function add!(ampo::AutoMPO,
-              op1::String, i1::Int,
-              op2::String, i2::Int,
-              ops...)
-  push!(terms(ampo),MPOTerm(1.0,op1,i1,op2,i2,ops...))
-  return
-end
-
-function add!(ampo::AutoMPO,
               coef::Number,
               op1::String, i1::Int,
               op2::String, i2::Int,
               ops...)
-  push!(terms(ampo),MPOTerm(coef,op1,i1,op2,i2,ops...))
-  return
+  push!(terms(ampo), MPOTerm(coef, op1, i1, op2, i2, ops...))
+  return ampo
 end
+
+add!(ampo::AutoMPO,
+     op1::String, i1::Int,
+     op2::String, i2::Int,
+     ops...) = add!(ampo, 1.0, op1, i1, op2, i2, ops...)
+
+subtract!(ampo::AutoMPO,
+          op1::String, i1::Int,
+          op2::String, i2::Int,
+          ops...) = add!(ampo, -1.0, op1, i1, op2, i2, ops...)
+
+function subtract!(ampo::AutoMPO,
+                   coef::Number,
+                   op1::String, i1::Int,
+                   op2::String, i2::Int,
+                   ops...)
+  push!(terms(ampo), -MPOTerm(coef, op1, i1, op2, i2, ops...))
+  return ampo
+end
+
+Base.:-(t::MPOTerm) = MPOTerm(-coef(t), ops(t))
 
 function Base.:+(ampo::AutoMPO,
                  term::Tuple)
   ampo_plus_term = copy(ampo)
-  add!(ampo_plus_term,term...)
+  add!(ampo_plus_term, term...)
+  return ampo_plus_term
+end
+
+function Base.:-(ampo::AutoMPO,
+                 term::Tuple)
+  ampo_plus_term = copy(ampo)
+  subtract!(ampo_plus_term, term...)
   return ampo_plus_term
 end
 
@@ -189,13 +214,28 @@ struct AutoMPOAddTermStyle <: Broadcast.BroadcastStyle end
 
 Base.broadcastable(ampo::AutoMPO) = ampo
 
-Base.BroadcastStyle(::AutoMPOStyle, ::Broadcast.Style{Tuple}) = AutoMPOAddTermStyle()
+Base.BroadcastStyle(::AutoMPOStyle,
+                    ::Broadcast.Style{Tuple}) = AutoMPOAddTermStyle()
 
 Broadcast.instantiate(bc::Broadcast.Broadcasted{AutoMPOAddTermStyle}) = bc
 
 function Base.copyto!(ampo,
-                      bc::Broadcast.Broadcasted{AutoMPOAddTermStyle})
-  add!(ampo,bc.args[2]...)
+                      bc::Broadcast.Broadcasted{AutoMPOAddTermStyle,
+                                                <:Any,
+                                                typeof(+)})
+  add!(ampo, bc.args[2]...)
+  return ampo
+end
+
+#
+# ampo .-= ("Sz",1) syntax using broadcasting
+#
+
+function Base.copyto!(ampo,
+                      bc::Broadcast.Broadcasted{AutoMPOAddTermStyle,
+                                                <:Any,
+                                                typeof(-)})
+  subtract!(ampo, bc.args[2]...)
   return ampo
 end
 

--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -509,6 +509,14 @@ end
       #@test maxlinkdim(Ha) == 8
     end
 
+    @testset "-= syntax" begin
+      ampo = AutoMPO()
+      ampo += (-1,"Sz",1,"Sz",2)
+      ampo2 = AutoMPO()
+      ampo2 -= ("Sz",1,"Sz",2)
+      @test ampo == ampo2
+    end
+
     @testset "Onsite Regression Test" begin
       sites = siteinds("S=1",4)
       ampo = AutoMPO()
@@ -533,7 +541,7 @@ end
 
   end
 
-  @testset ".+= syntax" begin
+  @testset ".+= and .-= syntax" begin
 
     @testset "Show MPOTerm" begin
       ampo = AutoMPO()
@@ -547,6 +555,14 @@ end
       ampo .+= ("Sz",2,"Sz",3)
       expected_string = "AutoMPO:\n  \"Sz\"(1)\"Sz\"(2)\n  \"Sz\"(2)\"Sz\"(3)\n"
       @test sprint(show,ampo) == expected_string
+    end
+
+    @testset ".-= syntax" begin
+      ampo = AutoMPO()
+      ampo .+= (-1,"Sz",1,"Sz",2)
+      ampo2 = AutoMPO()
+      ampo2 .-= ("Sz",1,"Sz",2)
+      @test ampo == ampo2
     end
 
     @testset "Single creation op" begin


### PR DESCRIPTION
This adds syntax for `-=` and `.-=` for adding terms with a negative coefficient to an AutoMPO.

Closes #237.