### PR TITLE
Add mul! for in-place tensor contraction (dense so far)

### DIFF
--- a/src/Tensors/dense.jl
+++ b/src/Tensors/dense.jl
@@ -446,7 +446,8 @@ function contract!!(R::Tensor{<:Number,NR},
                     T1::Tensor{<:Number,N1},
                     labelsT1::NTuple{N1},
                     T2::Tensor{<:Number,N2},
-                    labelsT2::NTuple{N2}) where {NR,N1,N2}
+                    labelsT2::NTuple{N2},
+                    α::Number=1, β::Number=0) where {NR,N1,N2}
   if N1==0
     # TODO: replace with an add! function?
     # What about doing `R .= T1[] .* PermutedDimsArray(T2,perm)`?
@@ -466,17 +467,30 @@ function contract!!(R::Tensor{<:Number,NR},
       R = permutedims!!(R,copy(R),perm)
     end
   else
-    R = _contract!!(R,labelsR,T1,labelsT1,T2,labelsT2)
+    R = _contract!!(R, labelsR,
+                    T1, labelsT1,
+                    T2, labelsT2,
+                    α, β)
   end
   return R
 end
 
 # Move to tensor.jl? Overload this function
 # for immutable storage types
-function _contract!!(R::Tensor,labelsR,
-                     T1::Tensor,labelsT1,
-                     T2::Tensor,labelsT2)
-  contract!(R,labelsR,T1,labelsT1,T2,labelsT2)
+function _contract!!(R::Tensor, labelsR,
+                     T1::Tensor, labelsT1,
+                     T2::Tensor, labelsT2,
+                     α, β)
+  if α == 1 && β == 0
+    contract!(R, labelsR,
+              T1, labelsT1,
+              T2, labelsT2)
+  else
+    contract!(R, labelsR,
+              T1, labelsT1,
+              T2, labelsT2,
+              α, β)
+  end
   return R
 end
 
@@ -486,7 +500,8 @@ function contract!(R::DenseTensor{<:Number,NR},
                    labelsT1,
                    T2::DenseTensor{ElT2,N2},
                    labelsT2,
-                   α::Number=1,β::Number=0) where {ElT1,ElT2,N1,N2,NR}
+                   α::Number=1,
+                   β::Number=0) where {ElT1,ElT2,N1,N2,NR}
   if N1+N2==NR
     outer!(R,T1,T2)
     labelsRp = tuplecat(labelsT1,labelsT2)
@@ -525,7 +540,8 @@ function _contract!(CT::DenseTensor{El,NC},
                     AT::DenseTensor{El,NA},
                     BT::DenseTensor{El,NB},
                     props::ContractionProperties,
-                    α::Number=one(El),β::Number=zero(El)) where {El,NC,NA,NB}
+                    α::Number=one(El),
+                    β::Number=zero(El)) where {El,NC,NA,NB}
   # TODO: directly use Tensor instead of Array
   C = array(CT)
   A = array(AT)
@@ -533,7 +549,8 @@ function _contract!(CT::DenseTensor{El,NC},
 
   tA = 'N'
   if props.permuteA
-    AM = reshape(permutedims(A,NTuple{NA,Int}(props.PA)),props.dmid,props.dleft)
+    AM = reshape(permutedims(A,NTuple{NA,Int}(props.PA)),
+                 props.dmid, props.dleft)
     tA = 'T'
   else
     #A doesn't have to be permuted
@@ -547,7 +564,8 @@ function _contract!(CT::DenseTensor{El,NC},
 
   tB = 'N'
   if props.permuteB
-    BM = reshape(permutedims(B,NTuple{NB,Int}(props.PB)),props.dmid,props.dright)
+    BM = reshape(permutedims(B,NTuple{NB,Int}(props.PB)),
+                 props.dmid, props.dright)
   else
     if Btrans(props)
       BM = reshape(B,props.dright,props.dmid)
@@ -565,12 +583,9 @@ function _contract!(CT::DenseTensor{El,NC},
   else
     if Ctrans(props)
       CM = reshape(C,props.dleft,props.dright)
-      if tA=='N' && tB=='N'
-        (AM,BM) = (BM,AM)
-        tA = tB = 'T'
-      elseif tA=='T' && tB=='T'
-        (AM,BM) = (BM,AM)
-        tA = tB = 'N'
+      (AM,BM) = (BM,AM)
+      if tA==tB
+        tA = tB = (tA == 'T' ? 'N' : 'T')
       end
     else
       CM = reshape(C,props.dleft,props.dright)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -700,13 +700,26 @@ modified such that they no longer compare equal - for more
 information see the documentation on Index objects.
 """
 function Base.:*(A::ITensor, B::ITensor)
-  (Alabels,Blabels) = compute_contraction_labels(inds(A),inds(B))
-  CT = contract(tensor(A),Alabels,tensor(B),Blabels)
+  (labelsA,labelsB) = compute_contraction_labels(inds(A),inds(B))
+  CT = contract(tensor(A),labelsA,tensor(B),labelsB)
   C = itensor(CT)
   warnTensorOrder = GLOBAL_PARAMS["WarnTensorOrder"]
   if warnTensorOrder > 0 && order(C) >= warnTensorOrder
     @warn "Contraction resulted in ITensor with $(order(C)) indices"
   end
+  return C
+end
+
+function LinearAlgebra.mul!(C::ITensor, A::ITensor, B::ITensor,
+                            α::Number=1, β::Number=0)
+  (labelsC,labelsA,labelsB) = compute_contraction_labels(inds(C),
+                                                         inds(A),
+                                                         inds(B))
+  CT = Tensors.contract!!(tensor(C), labelsC,
+                          tensor(A), labelsA,
+                          tensor(B), labelsB,
+                          α, β)
+  C = itensor(CT)
   return C
 end
 

--- a/test/contract.jl
+++ b/test/contract.jl
@@ -255,6 +255,5 @@ end
     @test array(permute(C, i, j)) ≈ kron(array(A), transpose(array(B)))
   end 
 
-
 end
 

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -182,6 +182,68 @@ end
   @test dot(A, B) == 11.0
 end
 
+@testset "mul!" begin
+  i = Index(2; tags="i")
+  j = Index(2; tags="j")
+  k = Index(2; tags="k")
+
+  A = randomITensor(i, j)
+  B = randomITensor(j, k)
+  C = randomITensor(i, k)
+  mul!(C, A, B)
+  @test C ≈ A*B
+
+  A = randomITensor(i, j)
+  B = randomITensor(j, k)
+  C = randomITensor(k, i)
+  mul!(C, A, B)
+  @test C ≈ A*B
+
+  A = randomITensor(i, j)
+  B = randomITensor(k, j)
+  C = randomITensor(i, k)
+  mul!(C, A, B)
+  @test C ≈ A*B
+
+  A = randomITensor(i, j)
+  B = randomITensor(k, j)
+  C = randomITensor(k, i)
+  mul!(C, A, B)
+  @test C ≈ A*B
+
+  A = randomITensor(j, i)
+  B = randomITensor(j, k)
+  C = randomITensor(i, k)
+  mul!(C, A, B)
+  @test C ≈ A*B
+
+  A = randomITensor(j, i)
+  B = randomITensor(j, k)
+  C = randomITensor(k, i)
+  mul!(C, A, B)
+  @test C ≈ A*B
+
+  A = randomITensor(j, i)
+  B = randomITensor(k, j)
+  C = randomITensor(i, k)
+  mul!(C, A, B)
+  @test C ≈ A*B
+
+  A = randomITensor(j, i)
+  B = randomITensor(k, j)
+  C = randomITensor(k, i)
+  mul!(C, A, B)
+  @test C ≈ A*B
+
+  A = randomITensor(i, j)
+  B = randomITensor(k, j)
+  C = randomITensor(k, i)
+  α = 2
+  β = 3
+  R = mul!(copy(C), A, B, α, β)
+  @test α*A*B+β*C ≈ R
+end
+
 @testset "exponentiate" begin
   s1 = Index(2,"s1")
   s2 = Index(2,"s2")


### PR DESCRIPTION
This adds a 5-arg `mul!(C, A, B, a=1, b=0)` function for contracting ITensors in-place, which is the operation `C = a*A*B + b*C`. It mostly just works for Dense contractions so far (other storage types may not have implemented `contract!!`).

This is in preparation of extending broadcast syntax, so this can be called with `C .= a .* A .* B .+ b .* C` or `@. C = a * A * B + b * C`. This can also be useful for out-of-place operations, since one could use `C = a .* A .* B .+ b .* C` as a way to fuse all of those operations into one, and only allocate once at the end.

I believe it fixes the bug brought up a while ago in #44, it would be good to translate those test cases into the new syntax to make sure.