### PR TITLE
Fix setelt to work for Pair{Index,Int}

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -347,7 +347,7 @@ delta(is::Index...) = delta(IndexSet(is...))
 
 const δ = delta
 
-function setelt(iv::IndexVal)
+function setelt(iv::Union{IndexVal,PairIndexInt})
   A = ITensor(ind(iv))
   A[val(iv)] = 1.0
   return A

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -57,6 +57,31 @@ Random.seed!(1234)
     @test_throws ErrorException randomITensor(i,dag(j))
   end
 
+
+  @testset "QN setelt" begin
+    i = Index(QN(0)=>2,QN(1)=>2,tags="i")
+
+    T = setelt(i(1))
+    @test T[i(1)] ≈ 1.0
+    @test T[i(2)] ≈ 0.0
+    @test T[i(3)] ≈ 0.0
+    @test T[i(4)] ≈ 0.0
+
+    T = setelt(i(2))
+    @test T[i(1)] ≈ 0.0
+    @test T[i(2)] ≈ 1.0
+    @test T[i(3)] ≈ 0.0
+    @test T[i(4)] ≈ 0.0
+
+    # Test setelt taking Pair{Index,Int}
+    T = setelt(i=>3)
+    @test T[i(1)] ≈ 0.0
+    @test T[i(2)] ≈ 0.0
+    @test T[i(3)] ≈ 1.0
+    @test T[i(4)] ≈ 0.0
+  end
+
+
   @testset "setindex!" begin
 
     @testset "Test 1" begin

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -212,6 +212,23 @@ end
   @test Aexp ≈ Aexp_from_mat
 end
 
+@testset "setelt" begin
+  i = Index(2,"i")
+
+  T = setelt(i(1))
+  @test T[i(1)] ≈ 1.0
+  @test T[i(2)] ≈ 0.0
+
+  T = setelt(i(2))
+  @test T[i(1)] ≈ 0.0
+  @test T[i(2)] ≈ 1.0
+
+  # Test setelt taking Pair{Index,Int}
+  T = setelt(i=>2)
+  @test T[i(1)] ≈ 0.0
+  @test T[i(2)] ≈ 1.0
+end
+
 
 @testset "add and axpy" begin
   i = Index(2,"i")


### PR DESCRIPTION
Fix setelt to work for both IndexVal and Pair{Index,Int} while giving a reasonably good error message if anything else is passed.
