### PR TITLE
Improve SVD with no truncation

### DIFF
--- a/src/Tensors/blocksparse/linearalgebra.jl
+++ b/src/Tensors/blocksparse/linearalgebra.jl
@@ -3,6 +3,22 @@ const BlockSparseMatrix{ElT,StoreT,IndsT} = BlockSparseTensor{ElT,2,StoreT,IndsT
 const DiagBlockSparseMatrix{ElT,StoreT,IndsT} = DiagBlockSparseTensor{ElT,2,StoreT,IndsT}
 const DiagMatrix{ElT,StoreT,IndsT} = DiagTensor{ElT,2,StoreT,IndsT}
 
+function _truncated_blockdim(S::DiagMatrix,
+                             docut::Float64;
+                             singular_values=false,
+                             truncate=true)
+  !truncate && return diaglength(S)
+  newdim = 0
+	val = singular_values ? getdiagindex(S,newdim+1)^2 : getdiagindex(S,newdim+1)
+  while newdim+1 ≤ diaglength(S) && val ≥ docut
+    newdim += 1
+    if newdim+1 ≤ diaglength(S)
+      val = singular_values ? getdiagindex(S,newdim+1)^2 : getdiagindex(S,newdim+1)
+    end
+  end
+  return newdim
+end
+
 """
 svd(T::BlockSparseTensor{<:Number,2}; kwargs...)
 
@@ -15,29 +31,8 @@ computed from the dense svds of seperate blocks.
 """
 function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
                            kwargs...) where {ElT}
-  truncate = haskey(kwargs,:maxdim) || haskey(kwargs,:cutoff)
+  truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
 
-  if truncate
-    return _svd_truncate(T; kwargs...)
-  else
-    return _svd_no_truncate(T; kwargs...)
-  end
-end
-
-function _truncated_blockdim(S::DiagMatrix, docut::Float64; singular_values=false)
-  newdim = 0
-	val = singular_values ? getdiagindex(S,newdim+1)^2 : getdiagindex(S,newdim+1)
-  while newdim+1 ≤ diaglength(S) && val ≥ docut
-    newdim += 1
-    if newdim+1 ≤ diaglength(S)
-      val = singular_values ? getdiagindex(S,newdim+1)^2 : getdiagindex(S,newdim+1)
-    end
-  end
-  return newdim
-end
-
-function _svd_truncate(T::BlockSparseMatrix{ElT};
-                       kwargs...) where {ElT}
   Us = Vector{BlockSparseMatrix{ElT}}(undef,nnzblocks(T))
   Ss = Vector{DiagBlockSparseMatrix{real(ElT)}}(undef,nnzblocks(T))
   Vs = Vector{BlockSparseMatrix{ElT}}(undef,nnzblocks(T))
@@ -59,14 +54,23 @@ function _svd_truncate(T::BlockSparseMatrix{ElT};
   # the eigenvalues
   d .= d .^ 2
   sort!(d; rev=true)
-  truncerr,docut = truncate!(d; kwargs...)
+
+  if truncate
+    truncerr,docut = truncate!(d; kwargs...)
+  else
+    truncerr,docut = 0.0,0.0
+  end
   dropblocks = Int[]
   for n in 1:nnzblocks(T)
-    blockdim = _truncated_blockdim(Ss[n],docut; singular_values=true)
+    blockdim = _truncated_blockdim(Ss[n],
+                                   docut;
+                                   singular_values=true,
+                                   truncate=truncate)
     if blockdim == 0
       push!(dropblocks,n)
     else
-      Strunc = Tensor(Diag(store(Ss[n])[1:blockdim]),(blockdim,blockdim))
+      Strunc = Tensor(Diag(store(Ss[n])[1:blockdim]),
+                      (blockdim,blockdim))
       Ss[n] = Strunc
       Us[n] = copy(Us[n][1:dim(Us[n],1),1:blockdim])
       Vs[n] = copy(Vs[n][1:dim(Vs[n],1),1:blockdim])
@@ -88,7 +92,9 @@ function _svd_truncate(T::BlockSparseMatrix{ElT};
   # Put the blocks into U,S,V
   # 
 
-  nb1_lt_nb2 = (nblocks(T)[1] < nblocks(T)[2] || (nblocks(T)[1] == nblocks(T)[2] && dim(T,1) < dim(T,2)))
+  nb1_lt_nb2 = (nblocks(T)[1] < nblocks(T)[2] || 
+                (nblocks(T)[1] == nblocks(T)[2] && 
+                 dim(T,1) < dim(T,2)))
 
   if nb1_lt_nb2
     uind = sim(ind(T,1))
@@ -160,93 +166,6 @@ function _svd_truncate(T::BlockSparseMatrix{ElT};
   end
 
   return U,S,V,Spectrum(d,truncerr)
-end
-
-function _svd_no_truncate(T::BlockSparseMatrix{ElT};
-                          kwargs...) where {ElT}
-  nb1_lt_nb2 = (nblocks(T)[1] < nblocks(T)[2] || (nblocks(T)[1] == nblocks(T)[2] && dim(T,1) < dim(T,2)))
-
-  if nb1_lt_nb2
-    uind_from = 1
-  else
-    uind_from = 2
-  end
-
-  uind = sim(ind(T,uind_from))
-  nzblocksT = nzblocks(T)
-  for n in 1:nblocks(uind)
-    b = findfirst(i->i[uind_from]==n,nzblocksT)
-    if !isnothing(b)
-      blockT = nzblocksT[b]
-      setblockdim!(uind,minimum(blockdims(T,blockT)),n)
-    end
-  end
-
-  if dir(uind) != dir(inds(T)[1])
-    uind = dag(uind)
-  end
-
-  indsU = setindex(inds(T),dag(uind),2)
-
-  if nb1_lt_nb2
-    # Make U block diagonal by convention
-    blocksU = Block{2}[ntuple(_->i,Val(2)) for i = 1:minimum(nblocks(indsU))]
-    U = BlockSparseTensor(undef,blocksU,indsU)
-  else
-    U = BlockSparseTensor(ElT,undef,blockoffsets(T),indsU)
-  end
-  
-  vind = sim(uind)
-
-  if dir(vind) != dir(inds(T)[2])
-    vind = dag(vind)
-  end
-
-  indsV = setindex(inds(T),dag(vind),1)
-
-  if nb1_lt_nb2
-    blockoffsetsV,indsV = permutedims(blockoffsets(T),indsV,(2,1))
-    V = BlockSparseTensor(ElT,undef,blockoffsetsV,indsV)
-  else
-    blocksV = Block{2}[ntuple(_->i,Val(2)) for i = 1:minimum(nblocks(indsV))]
-    V = BlockSparseTensor(undef,blocksV,permute(indsV,(2,1)))
-  end
-
-  indsS = setindex(inds(T),uind,1)
-  indsS = setindex(indsS,vind,2)
-
-  # Make S block diagonal by convention
-  blocksS = Block{2}[ntuple(_->i,Val(2)) for i = 1:minimum(nblocks(indsS))]
-
-  S = DiagBlockSparseTensor(undef,blocksS,indsS)
-
-  for n in 1:nnzblocks(T)
-    b = block(T,n)
-    blockT = blockview(T,n)
-    Ub,Sb,Vb = svd(blockT)
-    if nb1_lt_nb2
-      # Block of V, permute since we
-      # are returning V such that T = U*S*V'
-      bV = permute(b,(2,1))
-
-      blockview(V,bV) .= Vb
-
-      blockview(U,(bV[2],bV[2])) .= Ub
-      Sblock = blockview(S,(bV[2],bV[2]))
-      for i in 1:diaglength(Sb)
-        Sblock[i,i] = getdiagindex(Sb,i)
-      end
-    else
-      blockview(U,b) .= Ub
-      blockview(V,n) .= Vb
-      Sblock = blockview(S,n)
-      for i in 1:diaglength(Sb)
-        setdiagindex!(Sblock,getdiagindex(Sb,i),i)
-      end
-    end
-  end
-  # TODO: output spec
-  return U,S,V,Spectrum(Float64[],0.0)
 end
 
 function LinearAlgebra.eigen(T::Hermitian{ElT,<:BlockSparseMatrix{ElT}};

--- a/src/Tensors/linearalgebra.jl
+++ b/src/Tensors/linearalgebra.jl
@@ -61,6 +61,8 @@ svd of an order-2 DenseTensor
 """
 function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
                            kwargs...) where {ElT,IndsT}
+  truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
+
   # Keyword argument deprecations
   use_absolute_cutoff = false
   if haskey(kwargs, :absoluteCutoff)
@@ -100,11 +102,15 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT};
   conj!(MV)
 
   P = MS.^2
-  truncerr,_ = truncate!(P;mindim=mindim,
-                         maxdim=maxdim,
-                         cutoff=cutoff,
-                         use_absolute_cutoff=use_absolute_cutoff,
-                         use_relative_cutoff=use_relative_cutoff)
+  if truncate
+    truncerr,_ = truncate!(P;mindim=mindim,
+                             maxdim=maxdim,
+                             cutoff=cutoff,
+                             use_absolute_cutoff=use_absolute_cutoff,
+                             use_relative_cutoff=use_relative_cutoff)
+  else
+    truncerr = 0.0
+  end
   spec = Spectrum(P,truncerr)
   dS = length(P)
   if dS < length(MS)

--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -66,7 +66,7 @@ function LinearAlgebra.svd(A::ITensor,
     AC = permute(AC,cL,cR)
   end
 
-  UT,ST,VT,spec = svd(tensor(AC);kwargs...)
+  UT,ST,VT,spec = svd(tensor(AC); kwargs...)
   UC,S,VC = itensor(UT),itensor(ST),itensor(VT)
 
   u = commonind(S,UC)

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -27,9 +27,24 @@ IndexSet(inds::SVector{N,<:Index}) where {N} = IndexSet{N}(inds)
 IndexSet(inds::MVector{N,<:Index}) where {N} = IndexSet{N}(inds)
 IndexSet(inds::NTuple{N,<:Index}) where {N} = IndexSet{N}(inds)
 
-# This is not defined to discourage it's use,
-# since it is not type stable
-#IndexSet(inds::Vector{<:Index}) = IndexSet(inds...)
+"""
+IndexSet(inds::Vector{<:Index})
+
+Convert a Vector of indices to an IndexSet.
+
+Note that this is not type stable, since a Vector
+is dynamically sized and an IndexSet is statically sized.
+"""
+IndexSet(inds::Vector{<:Index}) = IndexSet(inds...)
+
+"""
+IndexSet{N}(inds::Vector{<:Index})
+
+Convert a Vector of indices to an IndexSet of size N.
+
+Type stable conversion of a Vector of indices to an IndexSet
+(in contrast to `IndexSet(::Vector{<:Index})`).
+"""
 IndexSet{N}(inds::Vector{<:Index}) where {N} = IndexSet{N}(inds...)
 
 IndexSet{N,IndexT}(inds::NTuple{N,IndexT}) where {N,IndexT<:Index} = IndexSet(inds)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -60,11 +60,11 @@ Tensors.store(m::MPS) = m.A_
 leftlim(m::MPS) = m.llim_
 rightlim(m::MPS) = m.rlim_
 
-function set_leftlim!(m::MPS,new_ll::Int)
+function setleftlim!(m::MPS,new_ll::Int)
   m.llim_ = new_ll
 end
 
-function set_rightlim!(m::MPS,new_rl::Int)
+function setrightlim!(m::MPS,new_rl::Int)
   m.rlim_ = new_rl
 end
 
@@ -78,15 +78,13 @@ end
 Base.getindex(M::MPS, n::Integer) = getindex(store(M),n)
 
 function Base.setindex!(M::MPS,T::ITensor,n::Integer)
-  (n <= leftlim(M)) && set_leftlim!(M,n-1)
-  (n >= rightlim(M)) && set_rightlim!(M,n+1)
+  (n <= leftlim(M)) && setleftlim!(M,n-1)
+  (n >= rightlim(M)) && setrightlim!(M,n+1)
   setindex!(store(M),T,n)
 end
 
 Base.copy(m::MPS) = MPS(m.N_,copy(store(m)),m.llim_,m.rlim_)
 Base.similar(m::MPS) = MPS(m.N_, similar(store(m)), 0, m.N_)
-
-Base.eachindex(m::MPS) = 1:length(m)
 
 function Base.show(io::IO, M::MPS)
   print(io,"MPS")

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -1030,6 +1030,23 @@ Random.seed!(1234)
       @test norm(U*S*V-A) ≈ 0 atol=1e-15
     end
 
+    @testset "SVD no truncate bug" begin
+      s = Index(QN("Sz",-4) => 1,
+                QN("Sz",-2) => 4,
+                QN("Sz", 0) => 6,
+                QN("Sz", 2) => 4,
+                QN("Sz", 4) => 1)
+      A = ITensor(s,s')
+      addblock!(A, (5,2))
+      addblock!(A, (4,3))
+      addblock!(A, (3,4))
+      addblock!(A, (2,5))
+      randn!(A)
+
+      U,S,V = svd(A,s)
+      @test U*S*V ≈ A
+    end
+
   end
 
   @testset "Replace Index" begin

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -1036,14 +1036,47 @@ Random.seed!(1234)
                 QN("Sz", 0) => 6,
                 QN("Sz", 2) => 4,
                 QN("Sz", 4) => 1)
-      A = ITensor(s,s')
+      A = ITensor(s, s')
       addblock!(A, (5,2))
       addblock!(A, (4,3))
       addblock!(A, (3,4))
       addblock!(A, (2,5))
       randn!(A)
-
       U,S,V = svd(A,s)
+      @test U*S*V ≈ A
+    end
+
+    @testset "SVD no truncate" begin
+      s = Index(QN("Sz",-4) => 1,
+                QN("Sz",-2) => 4,
+                QN("Sz", 0) => 6,
+                QN("Sz", 2) => 4,
+                QN("Sz", 4) => 1)
+      A = ITensor(s, s')
+      addblock!(A, (5,1))
+      addblock!(A, (4,2))
+      addblock!(A, (3,3))
+      addblock!(A, (2,4))
+      addblock!(A, (1,5))
+      U,S,V = svd(A, s)
+      @test dims(S) == dims(A)
+      @test U*S*V ≈ A
+    end
+
+    @testset "SVD truncate zeros" begin
+      s = Index(QN("Sz",-4) => 1,
+                QN("Sz",-2) => 4,
+                QN("Sz", 0) => 6,
+                QN("Sz", 2) => 4,
+                QN("Sz", 4) => 1)
+      A = ITensor(s, s')
+      addblock!(A, (5,1))
+      addblock!(A, (4,2))
+      addblock!(A, (3,3))
+      addblock!(A, (2,4))
+      addblock!(A, (1,5))
+      U,S,V = svd(A, s; cutoff=0)
+      @test dims(S) == (0,0)
       @test U*S*V ≈ A
     end
 


### PR DESCRIPTION
This combines the svd code when truncation or no truncation is requested, minimizing code duplication and fixing a bug that appeared when no truncation was requested.

This also makes sure that when `cutoff=0`, null singular values are truncated.