### PR TITLE
CP-decomposition by alternating least-squares (ALS)

### DIFF
--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -87,6 +87,7 @@ include("itensor.jl")
 include("broadcast.jl")
 include("decomp.jl")
 include("iterativesolvers.jl")
+include("cp_als.jl")
 
 #####################################
 # QNs

--- a/src/cp_als.jl
+++ b/src/cp_als.jl
@@ -1,0 +1,80 @@
+export cp_als
+
+## The Alternating Least-Squares (ALS) algorithm for CP-decomposition with ITensors.jl
+# Based on "Tensor Decompositions and Applications", Tamara G. Kolda and Brett W. Bader. SIAM Review 51(3), 2009
+# Porting the code from https://www.kaggle.com/nicw102168/rank-of-random-2x2x2-tensors
+
+using ITensors
+using ITensors.LinearAlgebra
+
+
+function cp_als(X, R; maxiter=1000, test_period=1, tol=1e-10)
+    # initialize with spheric-random colunms
+    A = map([randomITensor(Iₙ, Index(R)) for Iₙ in X.inds]) do An
+        aλ = columnnorms(An)
+        rr = Index(R)
+        iλ = diagITensor(aλ.^-1, rr, An.inds[2])
+        replaceind(An, An.inds[2], rr) * iλ
+    end
+    cp_als_(X, R, A, maxiter=maxiter, test_period=test_period, tol=tol)
+end
+
+function cp_als_(X, R, A; maxiter=1000, test_period=1, tol=1e-10)
+    N = order(X)
+
+    rind = [An.inds[2] for An in A]
+    λ = nothing
+    iteration = nothing
+
+    for it in 1:maxiter
+        iteration=it
+
+        for n in 1:N
+            V = reduce((a,b)->a.*b, array(A[m])' * array(A[m]) for m in 1:N if m != n) ## is there a better, ITensor way to do that?
+            Vinv = ITensors.LinearAlgebra.pinv(V)
+
+            W = reduce(khatrirao, [A[m] for m in N:-1:1 if m != n])
+            Xn = unfold(X,n)
+            qq = diagITensor(ones(Xn.inds[2].space), Xn.inds[2], W.inds[1])
+
+            rr = Index(R)
+            newAn = Xn * qq * W * itensor(Vinv, W.inds[2], rr)
+
+            aλ = columnnorms(newAn)
+            λ = diagITensor(aλ, rind...)
+            iλ = diagITensor(aλ.^-1, rr, A[n].inds[2])
+
+            A[n] = newAn * iλ
+        end
+
+        if it % test_period==0
+            X̂ = prod(A) * λ  # calculate PARAFAC model
+
+            if norm(X - X̂) < tol
+                break
+            end
+        end
+    end
+
+    return λ, A, iteration
+end
+
+"""Mode-n matricization of tensor X, or X₍ₙ₎ in Kolda & Bader 2009."""
+function unfold(X, n)
+    matn,_ = combiner(uniqueinds(X, IndexSet(X.inds[n])))
+    X*matn
+end
+
+"""The Khatri-Rao product, or A ⊙ B."""
+function khatrirao(A, B)
+    K = A.inds[2].space
+    AB = A * B * diagITensor(ones(K), A.inds[2], B.inds[2], Index(K))
+    matk,_ = combiner(B.inds[1], A.inds[1])
+    matk * AB
+end
+
+function columnnorms(A)
+    aA = array(A)
+    R = size(aA)[2]
+    [norm(aA[:,r]) for r in 1:R]
+end

--- a/src/cp_als.jl
+++ b/src/cp_als.jl
@@ -10,11 +10,11 @@ using ITensors.LinearAlgebra
 
 function cp_als(X, R; maxiter=1000, test_period=1, tol=1e-10)
     # initialize with spheric-random colunms
-    A = map([randomITensor(Iₙ, Index(R)) for Iₙ in X.inds]) do An
+    A = map([randomITensor(Iₙ, Index(R)) for Iₙ in inds(X)]) do An
         aλ = columnnorms(An)
         rr = Index(R)
-        iλ = diagITensor(aλ.^-1, rr, An.inds[2])
-        replaceind(An, An.inds[2], rr) * iλ
+        iλ = diagITensor(aλ.^-1, rr, inds(An)[2])
+        replaceind(An, inds(An)[2], rr) * iλ
     end
     cp_als_(X, R, A, maxiter=maxiter, test_period=test_period, tol=tol)
 end
@@ -22,7 +22,7 @@ end
 function cp_als_(X, R, A; maxiter=1000, test_period=1, tol=1e-10)
     N = order(X)
 
-    rind = [An.inds[2] for An in A]
+    rind = [inds(An)[2] for An in A]
     λ = nothing
     iteration = nothing
 
@@ -35,14 +35,14 @@ function cp_als_(X, R, A; maxiter=1000, test_period=1, tol=1e-10)
 
             W = reduce(khatrirao, [A[m] for m in N:-1:1 if m != n])
             Xn = unfold(X,n)
-            qq = diagITensor(ones(Xn.inds[2].space), Xn.inds[2], W.inds[1])
+            qq = diagITensor(ones(inds(Xn)[2].space), inds(Xn)[2], inds(W)[1])
 
             rr = Index(R)
-            newAn = Xn * qq * W * itensor(Vinv, W.inds[2], rr)
+            newAn = Xn * qq * W * itensor(Vinv, inds(W)[2], rr)
 
             aλ = columnnorms(newAn)
             λ = diagITensor(aλ, rind...)
-            iλ = diagITensor(aλ.^-1, rr, A[n].inds[2])
+            iλ = diagITensor(aλ.^-1, rr, inds(A[n])[2])
 
             A[n] = newAn * iλ
         end
@@ -61,15 +61,15 @@ end
 
 """Mode-n matricization of tensor X, or X₍ₙ₎ in Kolda & Bader 2009."""
 function unfold(X, n)
-    matn,_ = combiner(uniqueinds(X, IndexSet(X.inds[n])))
+    matn = combiner(uniqueinds(X, IndexSet(inds(X)[n])))
     X*matn
 end
 
 """The Khatri-Rao product, or A ⊙ B."""
 function khatrirao(A, B)
-    K = A.inds[2].space
-    AB = A * B * diagITensor(ones(K), A.inds[2], B.inds[2], Index(K))
-    matk,_ = combiner(B.inds[1], A.inds[1])
+    K = inds(A)[2].space
+    AB = A * B * diagITensor(ones(K), inds(A)[2], inds(B)[2], Index(K))
+    matk = combiner(inds(B)[1], inds(A)[1])
     matk * AB
 end
 

--- a/src/cp_als.jl
+++ b/src/cp_als.jl
@@ -35,7 +35,7 @@ function cp_als_(X, R, A; maxiter=1000, test_period=1, tol=1e-10)
 
             W = reduce(khatrirao, [A[m] for m in N:-1:1 if m != n])
             Xn = unfold(X,n)
-            qq = diagITensor(ones(inds(Xn)[2].space), inds(Xn)[2], inds(W)[1])
+            qq = diagITensor(ones(dim(inds(Xn)[2])), inds(Xn)[2], inds(W)[1])
 
             rr = Index(R)
             newAn = Xn * qq * W * itensor(Vinv, inds(W)[2], rr)
@@ -67,14 +67,17 @@ end
 
 """The Khatri-Rao product, or A ⊙ B."""
 function khatrirao(A, B)
-    K = inds(A)[2].space
+    K = dim(inds(A)[2])
     AB = A * B * diagITensor(ones(K), inds(A)[2], inds(B)[2], Index(K))
     matk = combiner(inds(B)[1], inds(A)[1])
     matk * AB
 end
 
 function columnnorms(A)
-    aA = array(A)
-    R = size(aA)[2]
-    [norm(aA[:,r]) for r in 1:R]
+    slicenorms(A, inds(A)[2])
 end
+
+function slicenorm(A::ITensor, i::Index, val::Int)
+  return norm(A * onehot(i => val))
+end
+slicenorms(A::ITensor, i::Index) = [slicenorm(A, i, n) for n in 1:dim(i)]

--- a/test/cp_als.jl
+++ b/test/cp_als.jl
@@ -1,0 +1,30 @@
+using ITensors
+using Test
+
+@testset "CP-decomposition of random 2x2x2 tensors" begin
+    Ntrials = 111
+    for trials in 1:Ntrials
+        X = randomITensor(Index(2), Index(2), Index(2))
+
+        # """The set of 2×2×2 tensors of rank two fills about 79% of the
+        # space, while those of rank three fill 21%""" KB09
+
+        modelrank = 3
+        λ, A, iteration = cp_als(X, modelrank)
+
+        X̂ = prod(A) * λ
+        err = norm(X-X̂)
+        @test err < 1e-10
+
+        # println("Ended in $iteration iterations.")
+        # println(λ)
+        # for An in A
+        #     println(array(An))
+        # end
+        # println("INPUT")
+        # println(X)
+        # println("PARAFAC")
+        # println(X̂)
+        # println("Error: $err")
+    end
+end


### PR DESCRIPTION
This is an implementation of the classic Alternating Least-Squares (ALS) algorithm for CP-decomposition (aka Canonical Polyadic/CANDECOMP/PARAFAC), as described in "Tensor Decompositions and Applications", Kolda & Bader 2009, Figure 3.3.

The test only demonstrates that it seems to work for random 2x2x2 matrices, and further tests may be necessary. The implementation should support generic tensor orders and sizes, though.

This code was based on a [prior Python+NumPy implementation](https://www.kaggle.com/nicw102168/rank-of-random-2x2x2-tensors), and can probably be vastly improved to make a better use of ITensor features.