### PR TITLE
Random MPS implementation for dim > 1

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -122,7 +122,7 @@ function randomizeMPS!(M::MPS, sites, bond_dim=1)
       M[b+db] = S*V
       M[b+db] /= norm(M[b+db])
     end
-    if dim(commonind(M[c],M[c+1])) >= bond_dim
+    if half==2 && dim(commonind(M[c],M[c+1])) >= bond_dim
       break
     end
   end
@@ -141,6 +141,7 @@ function randomMPS(::Type{T}, sites, bond_dim=1) where {T<:Number}
   end
   M.llim_ = 0
   M.rlim_ = 2
+
   if bond_dim > 1
     randomizeMPS!(M,sites,bond_dim)
   end

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -98,18 +98,56 @@ function Base.show(io::IO, M::MPS)
   end
 end
 
-function randomMPS(::Type{T}, sites) where {T<:Number}
+function randomizeMPS!(M::MPS, sites, bond_dim=1)
+  N = length(sites)
+  c = div(N,2)
+  max_pass = 100
+  for pass=1:max_pass,half=1:2
+    if half==1
+      (db,brange) = (+1, 1:1:N-1)
+    else
+      (db,brange) = (-1, N:-1:2)
+    end
+    for b=brange
+      s1 = sites[b]
+      s2 = sites[b+db]
+      mdim = dim(s1)*dim(s2)
+      RM = randn(mdim,mdim)
+      Q,_ = Tensors.qr_positive(RM)
+      G = itensor(Q,dag(s1),dag(s2),s1',s2')
+      T = noprime(G*M[b]*M[b+db])
+      rinds = uniqueinds(M[b],M[b+db])
+      U,S,V = svd(T,rinds;maxdim=bond_dim)
+      M[b] = U
+      M[b+db] = S*V
+      M[b+db] /= norm(M[b+db])
+    end
+    if dim(commonind(M[c],M[c+1])) >= bond_dim
+      break
+    end
+  end
+  M.llim_ = 0
+  M.rlim_ = 2
+  if dim(commonind(M[c],M[c+1])) < bond_dim
+    error("MPS center bond dim less than requested")
+  end
+end
+
+function randomMPS(::Type{T}, sites, bond_dim=1) where {T<:Number}
   M = MPS(T, sites)
   for i in eachindex(sites)
     randn!(M[i])
     normalize!(M[i])
   end
-  M.llim_ = 1
-  M.rlim_ = length(M)
+  M.llim_ = 0
+  M.rlim_ = 2
+  if bond_dim > 1
+    randomizeMPS!(M,sites,bond_dim)
+  end
   return M
 end
 
-randomMPS(sites) = randomMPS(Float64, sites)
+randomMPS(sites,bond_dim=1) = randomMPS(Float64,sites,bond_dim)
 
 function productMPS(::Type{T}, ivals::Vector{<:IndexVal}) where {T<:Number}
   N = length(ivals)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -288,4 +288,29 @@ end
     @test length(s) == N
   end
 
+  @testset "randomMPS with chi > 1" begin
+    N = 20
+    chi = 8
+    sites = siteinds(2,N)
+    M = randomMPS(sites,chi)
+
+    @test leftlim(M) == 0
+    @test rightlim(M) == 2
+
+    @test norm(M[1]) ≈ 1.0
+
+    c = div(N,2)
+    @test dim(linkind(M,c)) == chi
+
+    # Test for right-orthogonality
+    R = M[N]*prime(M[N],"Link")
+    r = linkind(M,N-1)
+    @test norm(R-delta(r,r')) < 1E-10
+    for j in reverse(2:N-1)
+      R = R*M[j]*prime(M[j],"Link")
+      r = linkind(M,j-1)
+      @test norm(R-delta(r,r')) < 1E-10
+    end
+  end
+
 end


### PR DESCRIPTION
This PR implements a random MPS algorithm for bond dimensions greater than one. It uses a TEBD style algorithm, but with a circuit of *random* unitary gates to generate the result. This style of algorithm could be straightforward to a QN-conserving version by choosing the random unitaries to be themselves QN-conserving (have flux zero).

The results of this code were tested by computing connected correlation functions, making sure that the randomly generated MPS have non-trivial correlation lengths, which increase with larger bond dimensions.