### PR TITLE
Iterating of an Index iterates over the range of possible IndexVals

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -387,12 +387,13 @@ Prime an Index using the notation `i^3`.
 """
 Base.:^(i::Index, pl::Int) = prime(i, pl)
 
-# Iterating over Index I gives
-# integers from 1...dim(I)
-# TODO: should this iterate through the IndexVals?
+"""
+Iterating over Index `I` gives the IndexVals
+`I(1)` through `I(dim(I))`.
+"""
 function Base.iterate(i::Index, state::Int = 1)
   (state > dim(i)) && return nothing
-  return (state, state+1)
+  return (i(state), state+1)
 end
 
 # This is a trivial definition for use in NDTensors

--- a/test/index.jl
+++ b/test/index.jl
@@ -73,7 +73,7 @@ import ITensors: In,Out,Neither
     i = Index(10)
     c = 1
     for n in i
-      @test n == c
+      @test n == i(c)
       c += 1
     end
   end

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -81,12 +81,12 @@ end
 
     M1 = matrix(TM)
     for ni in i, nj in j
-      @test M1[ni,nj] ≈ TM[i(ni),j(nj)]
+      @test M1[val(ni),val(nj)] ≈ TM[ni,nj]
     end
 
     M2 = Matrix(TM,j,i)
     for ni in i, nj in j
-      @test M2[nj,ni] ≈ TM[i(ni),j(nj)]
+      @test M2[val(nj),val(ni)] ≈ TM[ni,nj]
     end
 
     T3 = randomITensor(i,j,k)
@@ -98,19 +98,19 @@ end
 
     V = vector(TV)
     for ni in i
-      @test V[ni] ≈ TV[i(ni)]
+      @test V[val(ni)] ≈ TV[ni]
     end
     V = Vector(TV)
     for ni in i
-      @test V[ni] ≈ TV[i(ni)]
+      @test V[val(ni)] ≈ TV[ni]
     end
     V = Vector(TV, i)
     for ni in i
-      @test V[ni] ≈ TV[i(ni)]
+      @test V[val(ni)] ≈ TV[ni]
     end
     V = Vector{ComplexF64}(TV)
     for ni in i
-      @test V[ni] ≈ complex(TV[i(ni)])
+      @test V[val(ni)] ≈ complex(TV[ni])
     end
 
     T2 = randomITensor(i,j)


### PR DESCRIPTION
Previously, iterating over an Index `i` iterated over the integers `1:dim(i)`. Instead, in this PR it iterates over the IndexVals `i(1)` to `i(dim(i))`. This seems more useful in the context of ITensors. This means you can do:
```julia
using ITensors
i = Index(2)
A = randomITensor(i,i')
for iv in i, ipv in i'
  @show A[iv,ipv]
end
```

I'm not sure how much this featured is used right now, but it would be nice to generally have better iteration features for iterating through IndexSets and ITensors as well (i.e. iterating over an IndexSet could iterate over all IndexVals of the IndexSet. I was even thinking we could define an `IndexValSet = IndexSet{<:IndexVal}`).