### PR TITLE
DMRG over sum of MPOs

### DIFF
--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -62,6 +62,7 @@ include("mps/mps.jl")
 include("mps/mpo.jl")
 include("mps/sweeps.jl")
 include("mps/projmpo.jl")
+include("mps/projmposum.jl")
 include("mps/observer.jl")
 include("mps/dmrg.jl")
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -194,6 +194,9 @@ export
   rproj,
   product,
 
+# mps/projmposum.jl
+  ProjMPOSum,
+
 # mps/sweeps.jl
   Sweeps,
   nsweep,

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -7,6 +7,14 @@ function dmrg(H::MPO,
   return dmrg(PH,psi0,sweeps;kwargs...)
 end
 
+function dmrg(Hs::Vector{MPO},
+              psi0::MPS,
+              sweeps::Sweeps;
+              kwargs...)
+  PHS = ProjMPOSum(Hs)
+  return dmrg(PHS,psi0,sweeps;kwargs...)
+end
+
 function dmrg(PH,
               psi0::MPS,
               sweeps::Sweeps;

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -2,7 +2,15 @@
 function dmrg(H::MPO,
               psi0::MPS,
               sweeps::Sweeps;
-              kwargs...)::Tuple{Float64,MPS}
+              kwargs...)
+  PH = ProjMPO(H)
+  return dmrg(PH,psi0,sweeps;kwargs...)
+end
+
+function dmrg(PH,
+              psi0::MPS,
+              sweeps::Sweeps;
+              kwargs...)
   which_decomp::String = get(kwargs, :which_decomp, "automatic")
   obs = get(kwargs,:observer, NoObserver())
   quiet::Bool = get(kwargs, :quiet, false)
@@ -32,7 +40,6 @@ function dmrg(H::MPO,
   psi = copy(psi0)
   N = length(psi)
 
-  PH = ProjMPO(H)
   position!(PH,psi0,1)
   energy = 0.0
 

--- a/src/mps/projmposum.jl
+++ b/src/mps/projmposum.jl
@@ -1,0 +1,39 @@
+
+mutable struct ProjMPOSum
+  pm::Vector{ProjMPO}
+end
+
+ProjMPOSum(mpos::Vector{MPO}) = ProjMPOSum([ProjMPO(M) for M in mpos])
+
+ProjMPOSum(Ms::MPO...) = ProjMPOSum([Ms...])
+
+nsite(P::ProjMPOSum) = nsite(P.pm[1])
+
+Base.length(P::ProjMPOSum) = length(P.pm[1])
+
+function product(P::ProjMPOSum,
+                 v::ITensor)::ITensor
+  Pv = product(P.pm[1],v)
+  for n=2:length(P.pm)
+    Pv += product(P.pm[n],v)
+  end
+  return Pv
+end
+
+function Base.eltype(P::ProjMPOSum)
+  elT = eltype(P.pm[1])
+  for n=2:length(P.pm)
+    elT = promote_type(elT,eltype(P.pm[n]))
+  end
+  return elT
+end
+
+(P::ProjMPOSum)(v::ITensor) = product(P,v)
+
+Base.size(P::ProjMPOSum) = size(P.pm[1])
+
+function position!(P::ProjMPOSum,psi::MPS,pos::Int) 
+  for M in P.pm
+    position!(M,psi,pos)
+  end
+end


### PR DESCRIPTION
This PR adds a variant of DMRG which accepts a Vector of MPOs, treating them as if they were summed. The algorithm handles this summation efficiently through a type called `ProjMPOSum`, which wraps a collection of `ProjMPO` objects.