### PR TITLE
Make combiner just return ITensor, not (ITensor,Index)

### DIFF
--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -53,11 +53,13 @@ function LinearAlgebra.svd(A::ITensor,
   Lis = commoninds(A,IndexSet(Linds...))
   Ris = uniqueinds(A,Lis)
 
-  CL,cL = combiner(Lis...)
-  CR,cR = combiner(Ris...)
+  CL = combiner(Lis...)
+  CR = combiner(Ris...)
 
   AC = A*CR*CL
 
+  cL = combinedind(CL)
+  cR = combinedind(CR)
   if inds(AC) != IndexSet(cL,cR)
     AC = permute(AC,cL,cR)
   end
@@ -140,11 +142,13 @@ function LinearAlgebra.eigen(A::ITensor,
   Lis = commoninds(A,IndexSet(Linds))
   Ris = commoninds(A,IndexSet(Rinds))
 
-  CL,cL = combiner(Lis...)
-  CR,cR = combiner(Ris...)
+  CL = combiner(Lis...)
+  CR = combiner(Ris...)
 
   AC = A*CR*CL
 
+  cL = combinedind(CL)
+  cR = combinedind(CR)
   if inds(AC) != IndexSet(cL,cR)
     AC = permute(AC,cL,cR)
   end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -631,20 +631,23 @@ function combiner(inds::IndexSet;
   tags = get(kwargs, :tags, "CMB,Link")
   new_ind = Index(prod(dims(inds)), tags)
   new_is = IndexSet(new_ind, inds...)
-  return itensor(Combiner(),new_is),new_ind
+  return itensor(Combiner(), new_is)
 end
 
 combiner(inds::Index...;
          kwargs...) = combiner(IndexSet(inds...); kwargs...)
+
 combiner(inds::Tuple{Vararg{Index}};
          kwargs...) = combiner(inds...; kwargs...)
 
 # Special case when no indices are combined (useful for generic code)
 function combiner(; kwargs...)
-  return itensor(Combiner(),IndexSet()),nothing
+  return itensor(Combiner(), IndexSet())
 end
 
 combinedind(T::ITensor) = store(T) isa Combiner ? inds(T)[1] : nothing
+
+combinedind(T::ITensor{0}) = nothing
 
 LinearAlgebra.norm(T::ITensor) = norm(tensor(T))
 

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -445,7 +445,7 @@ function applympo_naive(A::MPO, psi::MPS; kwargs...)::MPS
   for b=1:(N-1)
     Al = commonind(A[b],A[b+1])
     pl = commonind(psi[b],psi[b+1])
-    C,_ = combiner(Al,pl)
+    C = combiner(Al,pl)
     psi_out[b] *= C
     psi_out[b+1] *= dag(C)
   end

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -61,9 +61,11 @@ function combiner(inds::QNIndex...; kwargs...)
   new_ind = settags(new_ind,tags)
   comb_ind,perm,comb = combineblocks(new_ind)
   return itensor(Combiner(perm,comb),
-                 IndexSet(comb_ind, dag.(inds)...)), comb_ind
+                 IndexSet(comb_ind, dag.(inds)...))
 end
-combiner(inds::Tuple{Vararg{QNIndex}}; kwargs...) = combiner(inds...; kwargs...)
+
+combiner(inds::Tuple{Vararg{QNIndex}};
+         kwargs...) = combiner(inds...; kwargs...)
 
 #
 # DiagBlockSparse ITensor constructors

--- a/test/combiner.jl
+++ b/test/combiner.jl
@@ -11,7 +11,7 @@ l = Index(5,"l")
 A = randomITensor(i, j, k, l)
 
 @testset "Basic combiner properties" begin
-    C,c = combiner(i, j, k)
+    C = combiner(i, j, k)
     @test eltype(store(C)) === Number
     @test_throws ErrorException ITensors.data(C)
     @test NDTensors.uncombinedinds(NDTensors.tensor(C)) == IndexSet(i, j, k)
@@ -19,7 +19,8 @@ end
 
 @testset "Two index combiner" begin
     for inds_ij ∈ permutations([i,j])
-        C,c = combiner(inds_ij...)
+        C = combiner(inds_ij...)
+        c = combinedind(C)
         B = A*C
         @test hasinds(B, l, k, c)
         @test c == commonind(B, C)
@@ -31,7 +32,8 @@ end
         @test isnothing(combinedind(D))
     end
     for inds_il ∈ permutations([i,l])
-        C,c = combiner(inds_il...)
+        C = combiner(inds_il...)
+        c = combinedind(C)
         B = A*C
         @test hasinds(B, j, k)
         @test c == commonind(B, C)
@@ -40,7 +42,8 @@ end
         @test D ≈ A
     end
     for inds_ik ∈ permutations([i,k])
-        C,c = combiner(inds_ik...)
+        C = combiner(inds_ik...)
+        c = combinedind(C)
         B = A*C
         @test hasinds(B, j, l)
         @test c == commonind(B, C)
@@ -49,7 +52,8 @@ end
         @test D ≈ A
     end
     for inds_jk ∈ permutations([j,k])
-        C,c = combiner(inds_jk...)
+        C = combiner(inds_jk...)
+        c = combinedind(C)
         B = A*C
         @test hasinds(B, i, l)
         @test c == commonind(B, C)
@@ -70,7 +74,8 @@ end
         @test D ≈ A
     end
     for inds_jl ∈ permutations([j,l])
-        C,c = combiner(inds_jl...)
+        C = combiner(inds_jl...)
+        c = combinedind(C)
         B = A*C
         @test hasinds(B, i, k)
         @test c == commonind(B, C)
@@ -91,7 +96,8 @@ end
         @test D ≈ A
     end
     for inds_kl ∈ permutations([k,l])
-        C,c = combiner(inds_kl...)
+        C = combiner(inds_kl...)
+        c = combinedind(C)
         B = A*C
         @test hasinds(B, i, j)
         @test c == commonind(B, C)
@@ -115,7 +121,8 @@ end
 
 @testset "Three index combiner" begin
     for inds_ijl ∈ permutations([i,j,l])
-        C,c = combiner(inds_ijl...)
+        C = combiner(inds_ijl...)
+        c = combinedind(C)
         B = A*C
         @test hasind(B, k)
         @test c == commonind(B, C)
@@ -136,7 +143,8 @@ end
         @test D ≈ A
     end
     for inds_ijk ∈ permutations([i,j,k])
-        C,c = combiner(inds_ijk...)
+        C = combiner(inds_ijk...)
+        c = combinedind(C)
         B = A*C
         @test hasind(B, l)
         @test c == commonind(B, C)
@@ -157,7 +165,8 @@ end
         @test D ≈ A
     end
     for inds_jkl ∈ permutations([j,k,l])
-        C,c = combiner(inds_jkl...)
+        C = combiner(inds_jkl...)
+        c = combinedind(C)
         B = A*C
         @test hasind(B, i)
         @test c == commonind(B, C)
@@ -180,44 +189,47 @@ end
 end
 
 @testset "SVD/Combiner should play nice" begin
-    cmb, ci = combiner(i, j, k)
-    Ac = A*cmb
-    U,S,V,spec,u,v = svd(Ac, ci)
-    Uc = cmb*U
+    C = combiner(i, j, k)
+    c = combinedind(C)
+    Ac = A*C
+    U,S,V,spec,u,v = svd(Ac, c)
+    Uc = C*U
     Ua,Sa,Va,spec,ua,va = svd(A, i, j, k)
     replaceind!(Ua, ua, u)
-    @test A ≈ cmb*Ac 
-    @test A ≈ Ac*cmb
-    @test Ua*cmb ≈ U
-    @test cmb*Ua ≈ U
+    @test A ≈ C*Ac 
+    @test A ≈ Ac*C
+    @test Ua*C ≈ U
+    @test C*Ua ≈ U
     @test Ua ≈ Uc
     @test Uc*S*V ≈ A
-    @test (cmb*Ua)*S*V ≈ Ac
-    cmb, ci = combiner(i, j)
-    Ac = A*cmb
-    U,S,V,spec,u,v = svd(Ac, ci)
-    Uc = U*cmb
+    @test (C*Ua)*S*V ≈ Ac
+    C = combiner(i, j)
+    c = combinedind(C)
+    Ac = A*C
+    U,S,V,spec,u,v = svd(Ac, c)
+    Uc = U*C
     Ua,Sa,Va,spec,ua,va = svd(A, i, j)
     replaceind!(Ua, ua, u)
     @test Ua ≈ Uc
-    @test Ua*cmb ≈ U
-    @test cmb*Ua ≈ U
+    @test Ua*C ≈ U
+    @test C*Ua ≈ U
     @test Uc*S*V ≈ A
-    @test (cmb*Ua)*S*V ≈ Ac
+    @test (C*Ua)*S*V ≈ Ac
 end
 
 @testset "mult/Combiner should play nice" begin
-    cmb, ci = combiner(i, j, k)
-    Ac = A*cmb
+    C = combiner(i, j, k)
+    Ac = A*C
     B = randomITensor(l)
-    C = Ac*B
-    @test C*cmb ≈ A*B
+    AB = Ac*B
+    @test AB*C ≈ A*B
 end
 
 @testset "Replace index combiner" begin
-    C,nl = combiner(l, tags="nl")
+    C = combiner(l, tags="nl")
+    c = combinedind(C)
     B = A*C
-    replaceind!(B, nl, l)
+    replaceind!(B, c, l)
     @test B == A 
 end
 

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -212,7 +212,8 @@ Random.seed!(1234)
       i1 = Index([QN(0,2)=>2,QN(1,2)=>2],"i1")
       A = randomITensor(QN(),i1,dag(i1'))
 
-      C,c = combiner()
+      C = combiner()
+      c = combinedind(C)
       @test isnothing(c)
       AC = A*C
       @test nnz(AC) == nnz(A)
@@ -236,7 +237,7 @@ Random.seed!(1234)
              (dag(i1'),i1)]
 
       for is in iss
-        C,c = combiner(is; tags="c")
+        C = combiner(is; tags="c")
         AC = A*C
         @test nnz(AC) == nnz(A)
         Ap = AC*dag(C)
@@ -251,7 +252,8 @@ Random.seed!(1234)
 
       A = randomITensor(QN(0),i,dag(i)',dag(i)'')
 
-      C,c = combiner(i,dag(i)'')
+      C = combiner(i,dag(i)'')
+      c = combinedind(C)
 
       AC = A*C
 
@@ -296,7 +298,7 @@ Random.seed!(1234)
              (dag(i1'),i2,i1)]
 
       for is in iss
-        C,c = combiner(is; tags="c")
+        C = combiner(is; tags="c")
         AC = A*C
         @test nnz(AC) == nnz(A)
         Ap = AC*dag(C)
@@ -365,7 +367,7 @@ Random.seed!(1234)
              (dag(i2'),i2,dag(i1'),i1)]
 
       for is in iss
-        C,c = combiner(is; tags="c")
+        C = combiner(is; tags="c")
         AC = A*C
         @test nnz(AC) == nnz(A)
         Ap = AC*dag(C)
@@ -384,7 +386,8 @@ Random.seed!(1234)
 
       A = randomITensor(QN(),s1,s2,dag(s1)',dag(s2)')
 
-      C,c = combiner(dag(s1)',dag(s2)')
+      C = combiner(dag(s1)',dag(s2)')
+      c = combinedind(C)
 
       AC = A*C
 
@@ -416,7 +419,8 @@ Random.seed!(1234)
 
       A = randomITensor(QN(),dag(s2)',s2,dag(s1)',s1)
 
-      C,c = combiner(dag(s2)',dag(s1)')
+      C = combiner(dag(s2)',dag(s1)')
+      c = combinedind(C)
 
       AC = A*C
 
@@ -445,7 +449,8 @@ Random.seed!(1234)
 
       A = randomITensor(QN(),dag(s1)',s2,dag(s2)',s1)
 
-      C,c = combiner(dag(s2)',dag(s1)')
+      C = combiner(dag(s2)',dag(s1)')
+      c = combinedind(C)
 
       AC = A*C
 
@@ -472,7 +477,7 @@ Random.seed!(1234)
     i = Index(QN(0,2)=>2,QN(1,2)=>2; tags="i")
     j = settags(i,"j")
     A = randomITensor(QN(0,2),i,j,dag(i'),dag(j'))
-    C,_ = combiner(i,j)
+    C = combiner(i,j)
     @test norm(A*dag(C')*C-A*C*dag(C')) ≈ 0.0
   end
 
@@ -481,7 +486,7 @@ Random.seed!(1234)
     j = settags(i,"j")
     A = ITensor(i,j,dag(i'))
     A[1,1,1] = 1.0
-    C,_ = combiner(i,j; tags="c")
+    C = combiner(i,j; tags="c")
     AC = A*C
     Ap = AC*dag(C)
     @test norm(A-Ap) ≈ 0.0


### PR DESCRIPTION
This changes the notation to just return an ITensor, not a tuple of the ITensor and combined Index.

This is pretty breaking, and a bit hard to give a good error message to catch it. Fortunately right now we haven't defined iteration over an ITensor, so the old notation gives the error:
```julia
julia> using ITensors

julia> i = Index(2)
(dim=2|id=564)

julia> C,c = combiner(i)
ERROR: MethodError: no method matching iterate(::ITensor{2})
Closest candidates are:
  iterate(::Core.SimpleVector) at essentials.jl:603
  iterate(::Core.SimpleVector, ::Any) at essentials.jl:603
  iterate(::ExponentialBackOff) at error.jl:253
  ...
Stacktrace:
 [1] indexed_iterate(::ITensor{2}, ::Int64) at ./tuple.jl:84
 [2] top-level scope at REPL[3]:1
```
We could overload `Base.iterate(::ITensor)` and for now give people an error message that says they may have been trying to use the old combiner notation and to explain the new interface.