### PR TITLE
Improve broadcasting of IndexSet

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -1,13 +1,4 @@
 
-# These are explicitly imported
-# so that they can be exported
-# from ITensors (they are not
-# exported from NDTensors)
-import .NDTensors: dim,
-                   dir,
-                   sim,
-                   dag
-
 const IDType = UInt64
 
 """
@@ -32,7 +23,8 @@ struct Index{T}
   end
 end
 
-# Used in NDTensors, mostly for internal usage
+# Used in NDTensors for generic code,
+# mostly for internal usage
 Index{T}(dim::T) where {T} = Index(dim)
 
 function Index(id, space::T, dir, tags, plev) where {T}
@@ -119,7 +111,7 @@ id(i::Index) = i.id
 
 Obtain the dimension of an Index.
 """
-dim(i::Index) = i.space
+NDTensors.dim(i::Index) = i.space
 
 space(i::Index) = i.space
 
@@ -129,6 +121,9 @@ space(i::Index) = i.space
 Obtain the direction of an Index (In, Out, or Neither).
 """
 dir(i::Index) = i.dir
+
+# Used for generic code in NDTensors
+NDTensors.dir(i::Index) = dir(i)
 
 """
     setdir(i::Index, dir::Arrow)
@@ -196,12 +191,18 @@ sim(i::Index;
                         tags,
                         plev)
 
+# Used for internal use in NDTensors
+NDTensors.sim(i::Index) = sim(i)
+
 """
     dag(i::Index)
 
 Copy an index `i` and reverse its direction.
 """
 dag(i::Index) = Index(id(i), copy(space(i)), -dir(i), tags(i), plev(i))
+
+# For internal use in NDTensors
+NDTensors.dag(i::Index) = dag(i)
 
 """
     isdefault(i::Index)
@@ -526,3 +527,4 @@ function HDF5.read(parent::Union{HDF5File,HDF5Group},
   plev = read(g,"plev")
   return Index(id,dim,dir,tags,plev)
 end
+

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1,10 +1,4 @@
 
-# This is explicitly imported
-# so that it can be exported from
-# ITensors (it is not exported from
-# NDTensors)
-import .NDTensors: dag
-
 """
 An ITensor is a tensor whose interface is 
 independent of its memory layout. Therefore
@@ -49,28 +43,31 @@ owns the storage data).
 ITensor(st::TensorStorage, is) = itensor(copy(st), is)
 
 """
-inds(T::ITensor)
+    inds(T::ITensor)
 
 Return the indices of the ITensor as an IndexSet.
 """
 NDTensors.inds(T::ITensor) = T.inds
 
 """
-ind(T::ITensor, i::Int)
+    ind(T::ITensor, i::Int)
 
 Get the Index of the ITensor along dimension i.
 """
 NDTensors.ind(T::ITensor, i::Int) = inds(T)[i]
 
+# Explicit import since there are some deprecations
+# involving store for other types.
+import .NDTensors: store
 """
-store(T::ITensor)
+    store(T::ITensor)
 
 Return a view of the TensorStorage of the ITensor.
 """
-NDTensors.store(T::ITensor) = T.store
+store(T::ITensor) = T.store
 
 """
-data(T::ITensor)
+    data(T::ITensor)
 
 Return a view of the raw data of the ITensor.
 
@@ -1081,8 +1078,8 @@ function HDF5.write(parent::Union{HDF5File,HDF5Group},
   g = g_create(parent,name)
   attrs(g)["type"] = "ITensor"
   attrs(g)["version"] = 1
-  write(g,"inds",inds(T))
-  write(g,"store",store(T))
+  write(g,"inds", inds(T))
+  write(g,"store", store(T))
 end
 
 #function HDF5.read(parent::Union{HDF5File,HDF5Group},

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -297,6 +297,7 @@ provided as keyword arguments.
 
 @deprecate orthoCenter(args...; kwargs...) orthocenter(args...; kwargs...)
 
+import .NDTensors.store
 @deprecate store(m::AbstractMPS) data(m)
 
 @deprecate replacesites!(args...; kwargs...) ITensors.replacesiteinds!(args...; kwargs...)

--- a/src/qn/qn.jl
+++ b/src/qn/qn.jl
@@ -308,5 +308,6 @@ function Base.show(io::IO,q::QN)
   print(io,")")
 end
 
+import .NDTensors.store
 @deprecate store(qn::QN) data(qn)
 

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -148,4 +148,11 @@ using ITensors,
       @test hastags(j,"Link")
     end
   end
+  @testset "broadcasting" begin
+    I = IndexSet(i, j)
+    J = prime.(I)
+    @test J isa IndexSet
+    @test i' ∈ J
+    @test j' ∈ J
+  end
 end


### PR DESCRIPTION
This improves broadcasting of IndexSets (for example, calling `prime.(is)` or `dag.(is)`). Before this, it went through some generic code that returned a `Vector{<:Index}`, which allocated and was slower than it could have been. Now, IndexSets broadcast more like Julia Tuples, and don't allocate:
```julia
julia> using ITensors

julia> i = Index(2; tags="i");

julia> is = IndexSet(i,i')
(dim=2|id=245|"i") (dim=2|id=245|"i")' 

julia> @btime prime.($is)
  0.016 ns (0 allocations: 0 bytes)
(dim=2|id=245|"i")' (dim=2|id=245|"i")'' 
```
Of course for that function, one can call `prime(is)` (which also doesn't allocate), but I figure if that notation is allowed (which it is by default) it should be fast.