### PR TITLE
Changes to MPS/MPO api

### DIFF
--- a/docs/src/MPSandMPO.md
+++ b/docs/src/MPSandMPO.md
@@ -1,8 +1,60 @@
 # MPS and MPO
 
+## Types
+
+```@docs
+MPS
+MPO
+```
+
+## MPS Constructors
+
+```@docs
+MPS(::Int)
+MPS(::Type{<:Number}, ::Any)
+MPS(::Any)
+randomMPS
+productMPS
+```
+
+## MPO Constructors
+
+```@docs
+MPO(::Int)
+MPO(::Any, ::Vector{String})
+MPO(::Any, ::String)
+```
+
+## Properties
+
+```@docs
+length(::ITensors.AbstractMPS)
+maxlinkdim(::ITensors.AbstractMPS)
+```
+
+## Priming and tagging
+
+```@docs
+prime!(::ITensors.AbstractMPS)
+```
+
 ## Operations
 
 ```@docs
+dag(::ITensors.AbstractMPS)
+orthogonalize!
+truncate!
+replacebond!(::MPS, ::Int, ::ITensor; kwargs...)
+sample(::MPS)
+sample!(::MPS)
+```
+
+## Algebra Operations
+
+```@docs
 dot(::MPS, ::MPS)
++(::MPS, ::MPS)
++(::MPO, ::MPO)
+*(::MPO, ::MPS)
 ```
 

--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -43,7 +43,7 @@ arguments provided. The following keyword arguments are recognized:
 * `use_relative_cutoff` [Bool] Default value: true.
 * `utags` [String] Default value: "Link,u".
 * `vtags` [String] Default value: "Link,v".
-* `fastSVD` [Bool] Defaut value: false.
+* `fastsvd` [Bool] Defaut value: false.
 """
 function LinearAlgebra.svd(A::ITensor,
                            Linds...;

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -155,17 +155,18 @@ export
 # mps/dmrg.jl
   dmrg,
 
+# mps/abstractmps.jl
+  add,
+  mul,
+
 # mps/mpo.jl
   # Types
   MPO,
   # Methods
-  applympo,
-  error_mpoprod,
+  error_mul,
   maxlinkdim,
-  multmpo,
   orthogonalize!,
   randomMPO,
-  sum,
   truncate!,
 
 # mps/mps.jl

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -1,43 +1,58 @@
 
+"""
+    MPO
+
+A finite size matrix product operator type. 
+Keeps track of the orthogonality center.
+"""
 mutable struct MPO <: AbstractMPS
   length::Int
   data::Vector{ITensor}
   llim::Int
   rlim::Int
-
-  MPO() = new(0,Vector{ITensor}(), 0, 0)
-
   function MPO(N::Int,
                A::Vector{<:ITensor},
                llim::Int = 0,
                rlim::Int = N+1)
     new(N, A, llim, rlim)
   end
-
-  function MPO(sites::Vector{<:Index})
-    N = length(sites)
-    v = Vector{ITensor}(undef, N)
-    l = [Index(1, "Link,l=$ii") for ii ∈ 1:N-1]
-    for ii ∈ eachindex(sites)
-      s = sites[ii]
-      sp = prime(s)
-      if ii == 1
-        v[ii] = ITensor(s, sp, l[ii])
-      elseif ii == N
-        v[ii] = ITensor(l[ii-1], s, sp)
-      else
-        v[ii] = ITensor(l[ii-1], s, sp, l[ii])
-      end
-    end
-    new(N,v,0,N+1)
-  end
- 
 end
 
-MPO(A::Vector{<:ITensor}) = MPO(length(A),A,0,length(A)+1)
+MPO() = MPO(0, Vector{ITensor}(), 0, 0)
 
-MPO(N::Int) = MPO(N,fill(ITensor(),N))
+function MPO(sites::Vector{<:Index})
+  N = length(sites)
+  v = Vector{ITensor}(undef, N)
+  l = [Index(1, "Link,l=$ii") for ii in 1:N-1]
+  for ii ∈ eachindex(sites)
+    s = sites[ii]
+    sp = prime(s)
+    if ii == 1
+      v[ii] = ITensor(s, sp, l[ii])
+    elseif ii == N
+      v[ii] = ITensor(l[ii-1], s, sp)
+    else
+      v[ii] = ITensor(l[ii-1], s, sp, l[ii])
+    end
+  end
+  return MPO(N, v)
+end
+ 
+MPO(A::Vector{<:ITensor}) = MPO(length(A), A)
 
+"""
+    MPO(N::Int)
+
+Make an MPO of length `N` filled with default ITensors.
+"""
+MPO(N::Int) = MPO(N, fill(ITensor(), N))
+
+"""
+    MPO(sites, ops::Vector{String})
+
+Make an MPO with pairs of sites `s[i]` and `s[i]'`
+and operators `ops` on each site.
+"""
 function MPO(sites,
              ops::Vector{String})
   N = length(sites)
@@ -70,9 +85,15 @@ function MPO(sites,
     end
     its[ii] = this_it
   end
-  MPO(N,its)
+  MPO(N, its)
 end
 
+"""
+    MPO(sites, ops::Vector{String})
+
+Make an MPO with pairs of sites `s[i]` and `s[i]'`
+and operators `ops` on each site.
+"""
 MPO(sites, ops::String) = MPO(sites, fill(ops, length(sites)))
 
 function randomMPO(sites, m::Int=1)
@@ -108,26 +129,38 @@ end
 
 Get the site indices of MPO `A` that are unique to
 `A` (not shared with MPS `x`), as a `Vector{<:Index}`.
+
+This is the same as getting the `siteinds` of `A|x>`, i.e.
+`siteinds(A * x)`, without doing the contraction.
 """
 siteinds(A::MPO, x::MPS) = [siteind(A, x, j) for j in eachindex(A)]
 
 """
-dot(y::MPS, A::MPO, x::MPS)
-inner(y::MPS, A::MPO, x::MPS)
+    dot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool = true)
+    inner(y::MPS, A::MPO, x::MPS; make_inds_match::Bool = true)
 
-Compute <y|A|x>
+Compute `<y|A|x> = <y|Ax>.
+
+If `make_inds_match = true`, the function attempts to make
+the site indices of `A*x` match with the site indices of `y`
+before contracting (so for example, the inputs `y` and `A*x` 
+can have different site indices, as long as they have the same 
+dimensions or QN blocks).
+
+`A` and `x` must have common site indices.
 """
-function LinearAlgebra.dot(y::MPS,
-                           A::MPO,
-                           x::MPS)::Number
+function LinearAlgebra.dot(y::MPS, A::MPO, x::MPS;
+                           make_inds_match::Bool = true)::Number
   N = length(A)
   if length(y) != N || length(x) != N
       throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y))"))
   end
   ydag = dag(y)
   simlinkinds!(ydag)
-  sAx = siteinds(A, x)
-  replacesiteinds!(ydag, sAx)
+  if make_inds_match
+    sAx = siteinds(A, x)
+    replacesiteinds!(ydag, sAx)
+  end
   O = ydag[1]*A[1]*x[1]
   for j in 2:N
     O = O*ydag[j]*A[j]*x[j]
@@ -135,16 +168,27 @@ function LinearAlgebra.dot(y::MPS,
   return O[]
 end
 
-"""
-dot(B::MPO, y::MPS, A::MPO, x::MPS)
-inner(B::MPO, y::MPS, A::MPO, x::MPS)
+inner(y::MPS, A::MPO, x::MPS) = dot(y, A, x)
 
-Compute <By|A|x>
 """
-function LinearAlgebra.dot(B::MPO,
-                           y::MPS,
-                           A::MPO,
-                           x::MPS)::Number
+    dot(B::MPO, y::MPS, A::MPO, x::MPS; make_inds_match::Bool = true)
+    inner(B::MPO, y::MPS, A::MPO, x::MPS; make_inds_match::Bool = true)
+
+Compute `<By|A|x> = <By|Ax>`.
+
+If `make_inds_match = true`, the function attempts to make
+the site indices of `A*x` match with the site indices of `B*y`
+before contracting (so for example, the inputs `B*y` and `A*x`
+can have different site indices, as long as they have the same
+dimensions or QN blocks).
+
+`A` and `x` must have common site indices, and `B` and `y`
+must have common site indices.
+"""
+function LinearAlgebra.dot(B::MPO, y::MPS,
+                           A::MPO, x::MPS;
+                           make_inds_match::Bool = true)::Number
+  !make_inds_match && error("make_inds_match = false not currently supported in dot(::MPO, ::MPS, ::MPO, ::MPS)")
   N = length(B)
   if length(y) != N || length(x) != N || length(A) != N
       throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y)) or $(length(A))"))
@@ -174,38 +218,62 @@ function LinearAlgebra.dot(B::MPO,
   return O[]
 end
 
+inner(B::MPO, y::MPS, A::MPO, x::MPS) = dot(B, y, A, x)
+
 """
-error_mpoprod(y::MPS, A::MPO, x::MPS)
+    error_mul(y::MPS, A::MPO, x::MPS; make_inds_match::Bool = true)
+    error_mul(y::MPS, x::MPS, x::MPO; make_inds_match::Bool = true)
 
 Compute the distance between A|x> and an approximation MPS y:
-| |y> - A|x> |/| A|x> | = √(1 + (<y|y> - 2*real(<y|A|x>))/<Ax|A|x>)
+`| |y> - A|x> |/| A|x> | = √(1 + (<y|y> - 2*real(<y|A|x>))/<Ax|A|x>)`.
+
+If `make_inds_match = true`, the function attempts match the site 
+indices of `y` with the site indices of `A` that are not common
+with `x`.
 """
-function error_mpoprod(y::MPS, A::MPO, x::MPS)
+function error_mul(y::MPS, A::MPO, x::MPS; kwargs...)
   N = length(A)
   if length(y) != N || length(x) != N
     throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y))"))
   end
-  iyy = inner(y, y)
-  iyax = inner(y, A, x)
-  iaxax = inner(A, x, A, x) 
+  iyy   = dot(y, y; kwargs...)
+  iyax  = dot(y, A, x; kwargs...)
+  iaxax = dot(A, x, A, x; kwargs...)
   return sqrt(abs(1. + (iyy - 2*real(iyax))/iaxax))
 end
 
-function applympo(A::MPO, psi::MPS; kwargs...)::MPS
+error_mul(y::MPS, x::MPS, A::MPO) = error_mul(y, A, x)
+
+"""
+    mul(::MPS, ::MPO; kwargs...)
+    *(::MPS, ::MPO; kwargs...)
+
+    mul(::MPO, ::MPS; kwargs...)
+    *(::MPO, ::MPS; kwargs...)
+
+Contract the MPO with the MPS, returning an MPS with the unique
+site indices of the MPO.
+
+Choose the method with the `method` keyword, for example
+"densitymatrix" and "naive".
+"""
+function Base.:*(A::MPO, psi::MPS; kwargs...)::MPS
   method = get(kwargs, :method, "densitymatrix")
   if method == "DensityMatrix"
-    @warn "In applympo, method DensityMatrix is deprecated in favor of densitymatrix"
+    @warn "In mul, method DensityMatrix is deprecated in favor of densitymatrix"
     method = "densitymatrix"
   end
   if method == "densitymatrix"
-    return applympo_densitymatrix(A, psi; kwargs...)
+    return _mul_densitymatrix(A, psi; kwargs...)
   elseif method == "naive" || method == "Naive"
-    return applympo_naive(A, psi; kwargs...)
+    return _mul_naive(A, psi; kwargs...)
   end
   throw(ArgumentError("Method $method not supported"))
 end
 
-function applympo_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
+Base.:*(psi::MPS, A::MPO; kwargs...) = *(A, psi; kwargs...)
+
+function _mul_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
   n = length(A)
   n != length(psi) && throw(DimensionMismatch("lengths of MPO ($n) and MPS ($(length(psi))) do not match"))
   psi_out         = similar(psi)
@@ -216,7 +284,7 @@ function applympo_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
   normalize::Bool = get(kwargs, :normalize, false) 
   all(x -> x != Index(),
       [siteind(A, psi, j) for j in 1:n]) || 
-  throw(ErrorException("MPS and MPO have different site indices in applympo method 'DensityMatrix'"))
+  throw(ErrorException("MPS and MPO have different site indices in mul method 'densitymatrix'"))
 
   rand_plev = 14741
   psi_c     = dag(copy(psi))
@@ -241,21 +309,20 @@ function applympo_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
   FU, D = eigen(ρ, Lis, Ris; ishermitian=true, 
                              tags=ts, 
                              kwargs...)
-  psi_out[n] = setprime(dag(FU), 0, "Site")
+  psi_out[n] = dag(FU)
   O     = O * FU * psi[n-1] * A[n-1]
-  O     = noprime(O, "Site")
   for j in reverse(2:n-1)
     dO  = prime(dag(O), rand_plev)
     ρ   = E[j-1] * O * dO
     ts  = tags(commonind(psi[j], psi[j-1]))
-    Lis = IndexSet(commonind(ρ, A[j]), commonind(ρ, psi_out[j+1])) 
+    Lis = IndexSet(commonind(ρ, A[j]),
+                   commonind(ρ, psi_out[j+1])) 
     Ris = prime(Lis, rand_plev)
     FU, D = eigen(ρ, Lis, Ris; ishermitian=true,
                                tags=ts, 
                                kwargs...)
     psi_out[j] = dag(FU)
     O = O * FU * psi[j-1] * A[j-1]
-    O = noprime(O, "Site")
   end
   if normalize
     O /= norm(O)
@@ -266,7 +333,7 @@ function applympo_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
   return psi_out
 end
 
-function applympo_naive(A::MPO, psi::MPS; kwargs...)::MPS
+function _mul_naive(A::MPO, psi::MPS; kwargs...)::MPS
   truncate = get(kwargs,:truncate,true)
 
   N = length(A)
@@ -276,7 +343,7 @@ function applympo_naive(A::MPO, psi::MPS; kwargs...)::MPS
 
   psi_out = MPS(N)
   for j=1:N
-    psi_out[j] = noprime(A[j]*psi[j])
+    psi_out[j] = A[j]*psi[j]
   end
 
   for b=1:(N-1)
@@ -294,84 +361,77 @@ function applympo_naive(A::MPO, psi::MPS; kwargs...)::MPS
   return psi_out
 end
 
-function multmpo(A::MPO, B::MPO; kwargs...)::MPO
-    cutoff::Float64 = get(kwargs, :cutoff, 1e-14)
-    resp_degen::Bool = get(kwargs, :respect_degenerate, true)
-    maxdim::Int = get(kwargs,:maxdim,maxlinkdim(A)*maxlinkdim(B))
-    mindim::Int = max(get(kwargs,:mindim,1), 1)
-    N = length(A)
-    N != length(B) && throw(DimensionMismatch("lengths of MPOs A ($N) and B ($(length(B))) do not match"))
-    A_ = copy(A)
-    orthogonalize!(A_, 1)
-    B_ = copy(B)
-    orthogonalize!(B_, 1)
+function Base.:*(A::MPO, B::MPO; kwargs...)
+  cutoff::Float64 = get(kwargs, :cutoff, 1e-14)
+  resp_degen::Bool = get(kwargs, :respect_degenerate, true)
+  maxdim::Int = get(kwargs,:maxdim,maxlinkdim(A)*maxlinkdim(B))
+  mindim::Int = max(get(kwargs,:mindim,1), 1)
+  N = length(A)
+  N != length(B) && throw(DimensionMismatch("lengths of MPOs A ($N) and B ($(length(B))) do not match"))
+  A_ = copy(A)
+  orthogonalize!(A_, 1)
+  B_ = copy(B)
+  orthogonalize!(B_, 1)
 
-    links_A = inds.(A.data, "Link")
-    links_B = inds.(B.data, "Link")
+  links_A = inds.(A.data, "Link")
+  links_B = inds.(B.data, "Link")
 
-    for i in 1:N
-        if length(intersect(inds(A_[i], "Site"), inds(B_[i], "Site"))) == 2
-            A_[i] = prime(A_[i], "Site")
-        end
+  res = deepcopy(A_)
+  for i in 1:N-1
+    ci = commonind(res[i], res[i+1])
+    new_ci = Index(dim(ci), tags(ci))
+    replaceind!(res[i], ci, new_ci)
+    replaceind!(res[i+1], ci, new_ci)
+    @assert commonind(res[i], res[i+1]) != commonind(A[i], A[i+1])
+  end
+  sites_A = Index[]
+  sites_B = Index[]
+  for (AA, BB) in zip(data(A_), data(B_))
+    sda = setdiff(inds(AA, "Site"), inds(BB, "Site"))
+    sdb = setdiff(inds(BB, "Site"), inds(AA, "Site"))
+    length(sda) != 1 && error("In mul(::MPO, ::MPO), MPOs must have exactly one shared site index")
+    length(sdb) != 1 && error("In mul(::MPO, ::MPO), MPOs must have exactly one shared site index")
+    push!(sites_A, sda[1])
+    push!(sites_B, sdb[1])
+  end
+  res[1] = ITensor(sites_A[1], sites_B[1], commonind(res[1], res[2]))
+  for i in 1:N-2
+    if i == 1
+      clust = A_[i] * B_[i]
+    else
+      clust = nfork * A_[i] * B_[i]
     end
-    res = deepcopy(A_)
-    for i in 1:N-1
-        ci = commonind(res[i], res[i+1])
-        new_ci = Index(dim(ci), tags(ci))
-        replaceind!(res[i], ci, new_ci)
-        replaceind!(res[i+1], ci, new_ci)
-        @assert commonind(res[i], res[i+1]) != commonind(A[i], A[i+1])
-    end
-    sites_A = Index[]
-    sites_B = Index[]
-    @inbounds for (AA, BB) in zip(data(A_), data(B_))
-        sda = setdiff(inds(AA, "Site"), inds(BB, "Site"))
-        sdb = setdiff(inds(BB, "Site"), inds(AA, "Site"))
-        sda_ind = setprime(sda[1], 0) == sdb[1] ? plev(sda[1]) == 1 ? sda[1] : setprime(sda[1], 1) : setprime(sda[1], 0)
-        push!(sites_A, sda_ind)
-        push!(sites_B, sdb[1])
-    end
-    res[1] = ITensor(sites_A[1], sites_B[1], commonind(res[1], res[2]))
-    for i in 1:N-2
-        if i == 1
-            clust = A_[i] * B_[i]
-        else
-            clust = nfork * A_[i] * B_[i]
-        end
-        lA = commonind(A_[i], A_[i+1])
-        lB = commonind(B_[i], B_[i+1])
-        nfork = ITensor(lA, lB, commonind(res[i], res[i+1]))
-        res[i], nfork = factorize(mapprime(clust,2,1),
-                                  inds(res[i]),
-                                  ortho="left",
-                                  tags=tags(lA),
-                                  cutoff=cutoff,
-                                  maxdim=maxdim,
-                                  mindim=mindim)
-        mid = dag(commonind(res[i], nfork))
-        res[i+1] = ITensor(mid,
-                           sites_A[i+1],
-                           sites_B[i+1],
-                           commonind(res[i+1], res[i+2]))
-    end
-    clust = nfork * A_[N-1] * B_[N-1]
-    nfork = clust * A_[N] * B_[N]
+    lA = commonind(A_[i], A_[i+1])
+    lB = commonind(B_[i], B_[i+1])
+    nfork = ITensor(lA, lB, commonind(res[i], res[i+1]))
+    res[i], nfork = factorize(clust,
+                              inds(res[i]),
+                              ortho="left",
+                              tags=tags(lA),
+                              cutoff=cutoff,
+                              maxdim=maxdim,
+                              mindim=mindim)
+    mid = dag(commonind(res[i], nfork))
+    res[i+1] = ITensor(mid,
+                       sites_A[i+1],
+                       sites_B[i+1],
+                       commonind(res[i+1], res[i+2]))
+  end
+  clust = nfork * A_[N-1] * B_[N-1]
+  nfork = clust * A_[N] * B_[N]
 
-    # in case we primed A
-    A_ind = uniqueind(inds(A_[N-1], "Site"), inds(B_[N-1], "Site"))
-    Lis = IndexSet(A_ind, sites_B[N-1], commonind(res[N-2], res[N-1]))
-    U, V = factorize(nfork, Lis; 
-                     ortho="right",
-                     cutoff=cutoff,
-                     tags="Link,n=$(N-1)",
-                     maxdim=maxdim,
-                     mindim=mindim)
-    res[N-1] = U
-    res[N] = V
-    truncate!(res;kwargs...)
-    for i in 1:N
-        res[i] = mapprime(res[i], 2, 1)
-    end
-    return res
+  # in case we primed A
+  A_ind = uniqueind(inds(A_[N-1], "Site"), inds(B_[N-1], "Site"))
+  Lis = IndexSet(A_ind, sites_B[N-1], commonind(res[N-2], res[N-1]))
+  U, V = factorize(nfork, Lis; 
+                   ortho="right",
+                   cutoff=cutoff,
+                   tags="Link,n=$(N-1)",
+                   maxdim=maxdim,
+                   mindim=mindim)
+  res[N-1] = U
+  res[N] = V
+  truncate!(res;kwargs...)
+  return res
 end
 

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -36,15 +36,15 @@ end
   K = randomMPO(sites)
   @test ITensors.data(MPO(copy(ITensors.data(K)))) == ITensors.data(K)
 
-  @testset "orthogonalize" begin
+  @testset "orthogonalize!" begin
     phi = randomMPS(sites)
     K = randomMPO(sites)
     orthogonalize!(phi, 1)
     orthogonalize!(K, 1)
-    orig_inner = inner(phi, K, phi)
+    orig_inner = ⋅(phi, K, phi)
     orthogonalize!(phi, div(N, 2))
     orthogonalize!(K, div(N, 2))
-    @test inner(phi, K, phi) ≈ orig_inner
+    @test ⋅(phi, K, phi) ≈ orig_inner
   end
 
   @testset "inner <y|A|x>" begin
@@ -122,23 +122,12 @@ end
 
     @test phiJdagKpsi[] ≈ inner(J,phi,K,psi)
 
-    ## Do contraction manually.
-    #O = 1.
-    #for j ∈ eachindex(phi)
-    #    psij = reshape(array(psi[j]),2)
-    #    phij = reshape(array(phi[j]),2)
-    #    Kj = reshape(array(K[j]),2,2)
-    #    Jj = reshape(array(J[j]),2,2)
-    #    O *= ((transpose(Jj)*phij)'*transpose(Kj)*psij)[]
-    #end
-    #@test O ≈ inner(J,phi,K,psi)
-
     badsites = [Index(2,"Site") for n=1:N+1]
     badpsi = randomMPS(badsites)
     @test_throws DimensionMismatch inner(J,phi,K,badpsi)
   end
 
-  @testset "error_mpoprod" begin
+  @testset "error_mul" begin
     phi = makeRandomMPS(sites)
     K = makeRandomMPO(sites,chi=2)
 
@@ -146,97 +135,98 @@ end
 
     dist = sqrt(abs(1 + (inner(phi,phi) - 2*real(inner(phi,K,psi)))
                         /inner(K,psi,K,psi)))
-    @test dist ≈ error_mpoprod(phi,K,psi)
+    @test dist ≈ error_mul(phi,K,psi)
 
     badsites = [Index(2,"Site") for n=1:N+1]
     badpsi = randomMPS(badsites)
-    # Apply K to phi and check that error_mpoprod is close to 0.
-    Kphi = applympo(K,phi;method="naive", cutoff=1E-8)
-    @test error_mpoprod(Kphi, K, phi) ≈ 0. atol=1e-4
+    # Apply K to phi and check that error_mul is close to 0.
+    Kphi = mul(K, phi; method="naive", cutoff=1E-8)
+    @test error_mul(Kphi, K, phi) ≈ 0. atol=1e-4
 
-    @test_throws DimensionMismatch applympo(K,badpsi;method="naive", cutoff=1E-8)
-    @test_throws DimensionMismatch error_mpoprod(phi,K,badpsi)
+    @test_throws DimensionMismatch mul(K,badpsi;method="naive", cutoff=1E-8)
+    @test_throws DimensionMismatch error_mul(phi,K,badpsi)
   end
 
-  @testset "applympo" begin
+  @testset "mul" begin
     phi = randomMPS(sites)
     K   = randomMPO(sites)
     @test maxlinkdim(K) == 1
     psi = randomMPS(sites)
-    psi_out = applympo(K, psi,maxdim=1)
+    psi_out = mul(K, psi,maxdim=1)
     @test inner(phi,psi_out) ≈ inner(phi,K,psi)
-    @test_throws ArgumentError applympo(K, psi, method="fakemethod")
+    @test_throws ArgumentError mul(K, psi, method="fakemethod")
 
     badsites = [Index(2,"Site") for n=1:N+1]
     badpsi = randomMPS(badsites)
-    @test_throws DimensionMismatch applympo(K,badpsi)
+    @test_throws DimensionMismatch mul(K,badpsi)
 
     # make bigger random MPO...
     for link_dim in 2:5
-        mpo_tensors  = ITensor[ITensor() for ii in 1:N]
-        mps_tensors  = ITensor[ITensor() for ii in 1:N]
-        mps_tensors2 = ITensor[ITensor() for ii in 1:N]
-        mpo_link_inds = [Index(link_dim, "r$ii,Link") for ii in 1:N-1]
-        mps_link_inds = [Index(link_dim, "r$ii,Link") for ii in 1:N-1]
-        mpo_tensors[1] = randomITensor(mpo_link_inds[1], sites[1], sites[1]') 
-        mps_tensors[1] = randomITensor(mps_link_inds[1], sites[1]) 
-        mps_tensors2[1] = randomITensor(mps_link_inds[1], sites[1]) 
-        for ii in 2:N-1
-            mpo_tensors[ii] = randomITensor(mpo_link_inds[ii], mpo_link_inds[ii-1], sites[ii], sites[ii]') 
-            mps_tensors[ii] = randomITensor(mps_link_inds[ii], mps_link_inds[ii-1], sites[ii]) 
-            mps_tensors2[ii] = randomITensor(mps_link_inds[ii], mps_link_inds[ii-1], sites[ii]) 
-        end
-        mpo_tensors[N] = randomITensor(mpo_link_inds[N-1], sites[N], sites[N]')
-        mps_tensors[N] = randomITensor(mps_link_inds[N-1], sites[N])
-        mps_tensors2[N] = randomITensor(mps_link_inds[N-1], sites[N])
-        K   = MPO(N, mpo_tensors, 0, N+1)
-        psi = MPS(N, mps_tensors, 0, N+1)
-        phi = MPS(N, mps_tensors2, 0, N+1)
-        orthogonalize!(psi, 1; maxdim=link_dim)
-        orthogonalize!(K, 1; maxdim=link_dim)
-        orthogonalize!(phi, 1; normalize=true, maxdim=link_dim)
-        psi_out = applympo(deepcopy(K), deepcopy(psi); maxdim=10*link_dim, cutoff=0.0)
-        @test inner(phi, psi_out) ≈ inner(phi, K, psi)
+      mpo_tensors  = ITensor[ITensor() for ii in 1:N]
+      mps_tensors  = ITensor[ITensor() for ii in 1:N]
+      mps_tensors2 = ITensor[ITensor() for ii in 1:N]
+      mpo_link_inds = [Index(link_dim, "r$ii,Link") for ii in 1:N-1]
+      mps_link_inds = [Index(link_dim, "r$ii,Link") for ii in 1:N-1]
+      mpo_tensors[1] = randomITensor(mpo_link_inds[1], sites[1], sites[1]') 
+      mps_tensors[1] = randomITensor(mps_link_inds[1], sites[1]) 
+      mps_tensors2[1] = randomITensor(mps_link_inds[1], sites[1]) 
+      for ii in 2:N-1
+        mpo_tensors[ii] = randomITensor(mpo_link_inds[ii], mpo_link_inds[ii-1], sites[ii], sites[ii]') 
+        mps_tensors[ii] = randomITensor(mps_link_inds[ii], mps_link_inds[ii-1], sites[ii]) 
+        mps_tensors2[ii] = randomITensor(mps_link_inds[ii], mps_link_inds[ii-1], sites[ii]) 
+      end
+      mpo_tensors[N] = randomITensor(mpo_link_inds[N-1], sites[N], sites[N]')
+      mps_tensors[N] = randomITensor(mps_link_inds[N-1], sites[N])
+      mps_tensors2[N] = randomITensor(mps_link_inds[N-1], sites[N])
+      K   = MPO(N, mpo_tensors, 0, N+1)
+      psi = MPS(N, mps_tensors, 0, N+1)
+      phi = MPS(N, mps_tensors2, 0, N+1)
+      orthogonalize!(psi, 1; maxdim=link_dim)
+      orthogonalize!(K, 1; maxdim=link_dim)
+      orthogonalize!(phi, 1; normalize=true, maxdim=link_dim)
+      psi_out = mul(deepcopy(K), deepcopy(psi); maxdim=10*link_dim, cutoff=0.0)
+      @test inner(phi, psi_out) ≈ inner(phi, K, psi)
     end
   end
-  @testset "add" begin
-    shsites = siteinds("S=1/2",N)
+
+  @testset "add(::MPO, ::MPO)" begin
+    shsites = siteinds("S=1/2", N)
     K = randomMPO(shsites)
     L = randomMPO(shsites)
-    M = sum(K, L)
+    M = add(K, L)
     @test length(M) == N
     psi = randomMPS(shsites)
-    k_psi = applympo(K, psi, maxdim=1)
-    l_psi = applympo(L, psi, maxdim=1)
-    @test inner(psi, sum(k_psi, l_psi)) ≈ inner(psi, M, psi) atol=5e-3
-    @test inner(psi, sum([k_psi, l_psi])) ≈ inner(psi, M, psi) atol=5e-3
+    k_psi = mul(K, psi, maxdim=1)
+    l_psi = mul(L, psi, maxdim=1)
+    @test inner(psi, k_psi + l_psi) ≈ ⋅(psi, M, psi) atol=5e-3
+    @test inner(psi, sum([k_psi, l_psi])) ≈ dot(psi, M, psi) atol=5e-3
     for dim in 2:4
         shsites = siteinds("S=1/2",N)
         K = basicRandomMPO(N, shsites; dim=dim)
         L = basicRandomMPO(N, shsites; dim=dim)
-        M = sum(K, L)
+        M = K + L
         @test length(M) == N
         psi = randomMPS(shsites)
-        k_psi = applympo(K, psi)
-        l_psi = applympo(L, psi)
-        @test inner(psi, sum(k_psi, l_psi)) ≈ inner(psi, M, psi) atol=5e-3
+        k_psi = mul(K, psi)
+        l_psi = mul(L, psi)
+        @test inner(psi, k_psi + l_psi) ≈ dot(psi, M, psi) atol=5e-3
         @test inner(psi, sum([k_psi, l_psi])) ≈ inner(psi, M, psi) atol=5e-3
         psi = randomMPS(shsites)
-        M = sum(K, L; cutoff=1E-9)
-        k_psi = applympo(K, psi)
-        l_psi = applympo(L, psi)
-        @test inner(psi, sum(k_psi, l_psi)) ≈ inner(psi, M, psi) atol=5e-3
+        M = add(K, L; cutoff=1E-9)
+        k_psi = mul(K, psi)
+        l_psi = mul(L, psi)
+        @test inner(psi, k_psi + l_psi) ≈ inner(psi, M, psi) atol=5e-3
     end
   end
 
-  @testset "multmpo" begin
+  @testset "mul(::MPO, ::MPO)" begin
     psi = randomMPS(sites)
     K = randomMPO(sites)
     L = randomMPO(sites)
     @test maxlinkdim(K) == 1
     @test maxlinkdim(L) == 1
-    KL = multmpo(K, L, maxdim=1)
-    psi_kl_out = applympo(K, applympo(L, psi, maxdim=1), maxdim=1)
+    KL = mul(prime(K), L, maxdim=1)
+    psi_kl_out = mul(K, mul(L, psi, maxdim=1), maxdim=1)
     @test inner(psi,KL,psi) ≈ inner(psi, psi_kl_out) atol=5e-3
 
     # where both K and L have differently labelled sites
@@ -245,18 +235,48 @@ end
     K = randomMPO(sites)
     L = randomMPO(sites)
     for ii in 1:N
-        replaceind!(K[ii], sites[ii]', othersitesk[ii])
-        replaceind!(L[ii], sites[ii]', othersitesl[ii])
+      replaceind!(K[ii], sites[ii]', othersitesk[ii])
+      replaceind!(L[ii], sites[ii]', othersitesl[ii])
     end
-    KL = multmpo(K, L, maxdim=1)
+    KL = mul(K, L, maxdim=1)
     psik = randomMPS(othersitesk)
     psil = randomMPS(othersitesl)
-    psi_kl_out = applympo(K, applympo(L, psil, maxdim=1), maxdim=1)
+    psi_kl_out = mul(K, mul(L, psil, maxdim=1), maxdim=1)
     @test inner(psik,KL,psil) ≈ inner(psik, psi_kl_out) atol=5e-3
     
     badsites = [Index(2,"Site") for n=1:N+1]
     badL = randomMPO(badsites)
-    @test_throws DimensionMismatch multmpo(K,badL)
+    @test_throws DimensionMismatch mul(K,badL)
+  end
+
+  @testset "*(::MPO, ::MPO)" begin
+    psi = randomMPS(sites)
+    K = randomMPO(sites)
+    L = randomMPO(sites)
+    @test maxlinkdim(K) == 1
+    @test maxlinkdim(L) == 1
+    KL = *(prime(K), L, maxdim=1)
+    psi_kl_out = *(K, *(L, psi, maxdim=1), maxdim=1)
+    @test ⋅(psi, KL, psi) ≈ dot(psi, psi_kl_out) atol=5e-3
+
+    # where both K and L have differently labelled sites
+    othersitesk = [Index(2,"Site,aaa") for n=1:N]
+    othersitesl = [Index(2,"Site,bbb") for n=1:N]
+    K = randomMPO(sites)
+    L = randomMPO(sites)
+    for ii in 1:N
+      replaceind!(K[ii], sites[ii]', othersitesk[ii])
+      replaceind!(L[ii], sites[ii]', othersitesl[ii])
+    end
+    KL = *(K, L, maxdim=1)
+    psik = randomMPS(othersitesk)
+    psil = randomMPS(othersitesl)
+    psi_kl_out = *(K, *(L, psil, maxdim=1), maxdim=1)
+    @test dot(psik, KL, psil) ≈ psik ⋅ psi_kl_out atol=5e-3
+    
+    badsites = [Index(2,"Site") for n=1:N+1]
+    badL = randomMPO(badsites)
+    @test_throws DimensionMismatch K * badL
   end
 
   sites = siteinds("S=1/2",N)
@@ -266,3 +286,4 @@ end
   @test_throws ArgumentError randomMPO(sites, 2)
   @test_throws ErrorException linkind(MPO(N, fill(ITensor(), N), 0, N + 1), 1)
 end
+

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -114,12 +114,24 @@ include("util.jl")
   @testset "add MPS" begin
     psi = randomMPS(sites)
     phi = deepcopy(psi)
-    xi = sum(psi, phi)
+    xi = add(psi, phi)
     @test inner(xi, xi) ≈ 4.0 * inner(psi, psi) 
     # sum of many MPSs
     Ks = [randomMPS(sites) for i in 1:3]
-    K12  = sum(Ks[1], Ks[2])
-    K123 = sum(K12, Ks[3])
+    K12  = add(Ks[1], Ks[2])
+    K123 = add(K12, Ks[3])
+    @test inner(sum(Ks), K123) ≈ inner(K123,K123)
+  end
+
+  @testset "+ MPS" begin
+    psi = randomMPS(sites)
+    phi = deepcopy(psi)
+    xi = psi + phi
+    @test inner(xi, xi) ≈ 4.0 * inner(psi, psi) 
+    # sum of many MPSs
+    Ks = [randomMPS(sites) for i in 1:3]
+    K12  = Ks[1] + Ks[2]
+    K123 = K12 + Ks[3]
     @test inner(sum(Ks), K123) ≈ inner(K123,K123)
   end
 


### PR DESCRIPTION
This implements some of the proposed changes in issue #285. In particular, this includes:

- Changing `applympo` to `mul`/`*` 
- Changing `multmpo` to `mul`/`*`
- Changing `sum(::MPS/MPO, ::MPS/MPO)` to `add`/`+` (this leaves `sum(::Vector{MPS/MPO})` as is, which is more in line with the Julia convention that `sum` acts on a collection while `+` acts on a list).
- A keyword argument in `dot`/`inner` that lets you choose if the site indices get matched automatically, which is on by default.

Also, I noticed that `applympo` and `multmpo` did not have the same behavior as the C++ version. In the C++ version, `applympo(A, x) -> Ax` results in an MPS `Ax` with the site indices of `A` that are not common with `x`, and `multmpo` wasn't requiring that only one pair of site indices was common between the MPOs. Given the new API, these operations are now treated more literally as contractions between the input MPS/MPO. We can add APIs that do smarter things with the indices in a future PR, for example a function `product(::MPO, ::MPS)` that wraps `mul(::MPO, ::MPS)` and maps the indices back to the original ones, and `matmul(A::MPO, B::MPO)` that allows MPO inputs with all the same site indices and performs something like `mapprime(mul(prime(A), B), 2, 1)`.

This also adds some priming/tagging functions and docstrings for MPS/MPO functions, though more are needed.