### PR TITLE
Add nothing values to unit tests

### DIFF
--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -746,3 +746,5 @@ end
   end
 
 end
+
+nothing

--- a/test/combiner.jl
+++ b/test/combiner.jl
@@ -234,3 +234,5 @@ end
 end
 
 end
+
+nothing

--- a/test/contract.jl
+++ b/test/contract.jl
@@ -257,3 +257,4 @@ end
 
 end
 
+nothing

--- a/test/ctmrg.jl
+++ b/test/ctmrg.jl
@@ -110,3 +110,4 @@ end
   @test abs(m)≈ising_magnetization(β)
 end
 
+nothing

--- a/test/decomp.jl
+++ b/test/decomp.jl
@@ -48,3 +48,5 @@ A = itensor(At + transpose(At), k, k')
   @test entropy(Spectrum([1.0], 0.0)) == 0.0 
   @test entropy(Spectrum([0.0], 0.0)) == 0.0 
 end
+
+nothing

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -179,3 +179,5 @@ using ITensors, Test, Random
     @test (-6.5 < energy < -6.4)
   end
 end
+
+nothing

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -21,3 +21,5 @@ using ITensors,
   end
 
 end
+
+nothing

--- a/test/index.jl
+++ b/test/index.jl
@@ -78,3 +78,5 @@ import ITensors: In,Out,Neither
     end
   end
 end
+
+nothing

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -156,3 +156,5 @@ using ITensors,
     @test j' ∈ J
   end
 end
+
+nothing

--- a/test/itensor_blocksparse.jl
+++ b/test/itensor_blocksparse.jl
@@ -1140,3 +1140,4 @@ end
 
 end
 
+nothing

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -781,3 +781,5 @@ end
 
 
 end # End Dense ITensor basic functionality
+
+nothing

--- a/test/itensor_diag.jl
+++ b/test/itensor_diag.jl
@@ -446,3 +446,4 @@ using ITensors,
   end
 end
 
+nothing

--- a/test/itensor_diagblocksparse.jl
+++ b/test/itensor_diagblocksparse.jl
@@ -50,3 +50,4 @@ using ITensors,
 
 end
 
+nothing

--- a/test/iterativesolvers.jl
+++ b/test/iterativesolvers.jl
@@ -27,3 +27,4 @@ Base.size(M::ITensorMap) = dim(IndexSet(inds(M.A;plev=0)...))
     
 end
 
+nothing

--- a/test/lattices.jl
+++ b/test/lattices.jl
@@ -11,3 +11,5 @@ end
     tL = triangular_lattice(3, 4)
     @test length(tL) == 23
 end
+
+nothing

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -287,3 +287,4 @@ end
   @test_throws ErrorException linkind(MPO(N, fill(ITensor(), N), 0, N + 1), 1)
 end
 
+nothing

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -326,3 +326,5 @@ end
   end
 
 end
+
+nothing

--- a/test/not.jl
+++ b/test/not.jl
@@ -28,3 +28,5 @@ using ITensors,
 
   @test hassameinds(At2,(settags(i,"y"),j,k))
 end
+
+nothing

--- a/test/phys_site_types.jl
+++ b/test/phys_site_types.jl
@@ -217,3 +217,5 @@ const MySite = ITensors.TagType"MySite"
   @test state(i,"One") == i(1)
   @test state(i,"Two") == i(2)
 end
+
+nothing

--- a/test/qn.jl
+++ b/test/qn.jl
@@ -125,3 +125,5 @@ using ITensors,
   end
 
 end
+
+nothing

--- a/test/qnindex.jl
+++ b/test/qnindex.jl
@@ -32,3 +32,5 @@ using ITensors,
   end
 
 end
+
+nothing

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -103,3 +103,6 @@ using ITensors,
   rm("data.h5",force=true)
 
 end
+
+nothing
+nothing

--- a/test/smallstring.jl
+++ b/test/smallstring.jl
@@ -77,3 +77,4 @@ import ITensors.SmallString,
 
 end
 
+nothing

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -65,3 +65,5 @@ using ITensors,
   end
 
 end
+
+nothing

--- a/test/tag_types.jl
+++ b/test/tag_types.jl
@@ -26,3 +26,5 @@ using ITensors,
     @test SySy ≈ matmul(Sy,Sy)
   end
 end
+
+nothing

--- a/test/tagset.jl
+++ b/test/tagset.jl
@@ -80,3 +80,4 @@ using ITensors,
   end
 end
 
+nothing

--- a/test/trg.jl
+++ b/test/trg.jl
@@ -104,3 +104,4 @@ end
   @test κ≈exp(-β*ising_free_energy(β)) atol=1e-4
 end
 
+nothing


### PR DESCRIPTION
This PR adds a line with just the value `nothing` to the end of each unit test file in ITensors.jl, for the purpose of running the tests individually in the REPL. As far as I can tell, these lines don't do anything to interfere with the tests, but they do prevent a very large output sometimes which can occur when the Test object gets returned after a test finishes running when being included in the REPL.