### PR TITLE
Optimize randomMPS

### DIFF
--- a/NDTensors/src/linearalgebra.jl
+++ b/NDTensors/src/linearalgebra.jl
@@ -1,6 +1,10 @@
-export polar,
+export eigs,
+       entropy,
+       polar,
+       random_orthog,
        Spectrum,
-       svd
+       svd,
+       truncerror
 
 #
 # Linear Algebra of order 2 NDTensors
@@ -8,9 +12,6 @@ export polar,
 # Even though DenseTensor{_,2} is strided
 # and passable to BLAS/LAPACK, it cannot
 # be made <: StridedArray
-export eigs,
-       truncerror,
-       entropy
 
 function Base.:*(T1::Tensor{ElT1,2,StoreT1},
                  T2::Tensor{ElT2,2,StoreT2}) where

--- a/NDTensors/src/linearalgebra.jl
+++ b/NDTensors/src/linearalgebra.jl
@@ -208,6 +208,29 @@ function LinearAlgebra.eigen(T::DenseTensor{ElT,2,IndsT};
   return U,D
 end
 
+"""
+    random_orthog(n::Int,m::Int)
+
+Return a random matrix O of dimensions (n,m)
+such that if n >= m, transpose(O)*O is the 
+identity, or if m > n O*transpose(O) is the
+identity.
+"""
+function random_orthog(n::Int,m::Int)::Matrix
+  #TODO: optimize by using recursive Householder algorithm?
+  if n < m
+    return transpose(random_orthog(m,n))
+  end
+  F = qr(randn(n,m))
+  Q = Matrix(F.Q)
+  for c=1:size(Q,2)
+    if real(F.R[c,c]) < 0.0
+      Q[:,c] *= -1
+    end
+  end
+  return Q
+end
+
 function qr_positive(M::AbstractMatrix)
   sparseQ,R = qr(M)
   Q = convert(Matrix,sparseQ)

--- a/NDTensors/test/linearalgebra.jl
+++ b/NDTensors/test/linearalgebra.jl
@@ -1,0 +1,14 @@
+using ITensors.NDTensors,
+      Test
+using LinearAlgebra
+
+@testset "random_orthog" begin
+  n,m = 10,4
+  O1 = random_orthog(n,m)
+  @test norm(transpose(O1)*O1 - Diagonal(fill(1.,m))) < 1E-14
+
+  n,m = 4,10
+  O2 = random_orthog(n,m)
+  @test norm(O2*transpose(O2) - Diagonal(fill(1.,n))) < 1E-14
+end
+

--- a/NDTensors/test/runtests.jl
+++ b/NDTensors/test/runtests.jl
@@ -2,9 +2,10 @@ using Test
 
 @testset "NDTensors.jl" begin
     @testset "$filename" for filename in (
+        "linearalgebra.jl",
         "dense.jl",
         "blocksparse.jl",
-        "diag.jl"
+        "diag.jl",
     )
       println("Running $filename")
       include(filename)


### PR DESCRIPTION
Major optimization of randomMPS, by using thin QR to generate random unitaries. Moved `random_orthog` function to NDTensors linearalgebra.jl file.