### PR TITLE
More MPS/MPO interface changes

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -99,7 +99,6 @@ export
   inds,
   isnull,
   itensor,
-  matmul,
   mul!,
   matrix,
   mapprime!,
@@ -157,14 +156,14 @@ export
 
 # mps/abstractmps.jl
   add,
-  mul,
+  contract,
   primelinkinds!,
 
 # mps/mpo.jl
   # Types
   MPO,
   # Methods
-  error_mul,
+  error_contract,
   maxlinkdim,
   orthogonalize!,
   randomMPO,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -787,10 +787,20 @@ function LinearAlgebra.exp(A::ITensor,
   return itensor(expAT)
 end
 
-function matmul(A::ITensor,
-                B::ITensor)
-  R = mapprime(mapprime(A,1,2),0,1)
-  R *= B
+"""
+    product(A::ITensor, B::ITensor)
+
+For matrix-like ITensors (ones with pairs of primed and
+unprimed indices), perform a matrix product, i.e.
+```julia
+mapprime(prime(A) * B, 2, 1)
+```
+In the future, more general ITensors with other tag or
+prime conventions may be supported.
+"""
+function product(A::ITensor,
+                 B::ITensor)
+  R = prime(A) * B
   return mapprime(R,2,1)
 end
 
@@ -1129,4 +1139,6 @@ end
 @deprecate siteindex(args...; kwargs...) siteind(args...; kwargs...)
 
 @deprecate linkindex(args...; kwargs...) linkind(args...; kwargs...)
+
+@deprecate matmul(A::ITensor, B::ITensor) product(A, B)
 

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -213,7 +213,7 @@ end
     add(A::MPO, B::MPO; kwargs...)
     +(A::MPO, B::MPO; kwargs...)
 
-Add two MPS (or MPO) with each other, with some optional
+Add two MPS/MPO with each other, with some optional
 truncation.
 """
 function Base.:+(A::T, B::T; kwargs...) where {T <: AbstractMPS}
@@ -254,7 +254,7 @@ add(A::T, B::T;
 
     sum(A::Vector{MPO}; kwargs...)
 
-Add multiple MPS (or MPO) with each other, with some optional
+Add multiple MPS/MPO with each other, with some optional
 truncation.
 """
 function Base.sum(A::Vector{T};
@@ -328,7 +328,9 @@ function NDTensors.truncate!(M::AbstractMPS;
 
 end
 
-mul(A::AbstractMPS, B::AbstractMPS; kwargs...) = *(A, B; kwargs...)
+NDTensors.contract(A::AbstractMPS,
+                   B::AbstractMPS;
+                   kwargs...) = *(A, B; kwargs...)
 
 """
     *(x::Number, M::MPS)
@@ -386,37 +388,62 @@ using the truncation parameters (cutoff,maxdim, etc.)
 provided as keyword arguments.
 """ truncate!
 
-@deprecate orthoCenter(args...; kwargs...) orthocenter(args...; kwargs...)
+@deprecate orthoCenter(args...;
+                       kwargs...) orthocenter(args...; kwargs...)
 
 import .NDTensors.store
+
 @deprecate store(m::AbstractMPS) data(m)
 
-@deprecate replacesites!(args...; kwargs...) ITensors.replacesiteinds!(args...; kwargs...)
+@deprecate replacesites!(args...;
+                         kwargs...) ITensors.replacesiteinds!(args...; kwargs...)
 
-@deprecate applyMPO(args...; kwargs...) mul(args...; kwargs...)
+@deprecate applyMPO(args...; kwargs...) contract(args...; kwargs...)
 
-@deprecate applympo(args...; kwargs...) mul(args...; kwargs...)
+@deprecate applympo(args...; kwargs...) contract(args...; kwargs...)
 
-@deprecate errorMPOprod(args...; kwargs...) error_mul(args...; kwargs...)
+@deprecate errorMPOprod(args...;
+                        kwargs...) error_contract(args...;
+                                                  kwargs...)
 
-@deprecate error_mpoprod(args...; kwargs...) error_mul(args...; kwargs...)
+@deprecate error_mpoprod(args...;
+                         kwargs...) error_contract(args...;
+                                                   kwargs...)
 
-@deprecate multMPO(args...; kwargs...) mul(args...; kwargs...)
+@deprecate error_mul(args...;
+                     kwargs...) error_contract(args...;
+                                               kwargs...)
+
+@deprecate multMPO(args...; kwargs...) contract(args...; kwargs...)
 
 import Base.sum
 
 @deprecate sum(A::AbstractMPS,
                B::AbstractMPS; kwargs...) add(A, B; kwargs...)
 
-@deprecate multmpo(args...; kwargs...) mul(args...; kwargs...)
+@deprecate multmpo(args...;
+                   kwargs...) contract(args...; kwargs...)
 
-@deprecate set_leftlim!(args...; kwargs...) ITensors.setleftlim!(args...; kwargs...)
+@deprecate set_leftlim!(args...;
+                        kwargs...) ITensors.setleftlim!(args...;
+                                                        kwargs...)
 
-@deprecate set_rightlim!(args...; kwargs...) ITensors.setrightlim!(args...; kwargs...)
+@deprecate set_rightlim!(args...;
+                         kwargs...) ITensors.setrightlim!(args...;
+                                                          kwargs...)
 
-@deprecate tensors(args...; kwargs...) ITensors.data(args...; kwargs...)
+@deprecate tensors(args...;
+                   kwargs...) ITensors.data(args...; kwargs...)
 
-@deprecate primelinks!(args...; kwargs...) ITensors.primelinkinds!(args...; kwargs...)
+@deprecate primelinks!(args...;
+                       kwargs...) ITensors.primelinkinds!(args...;
+                                                          kwargs...)
 
-@deprecate simlinks!(args...; kwargs...) ITensors.simlinkinds!(args...; kwargs...)
+@deprecate simlinks!(args...;
+                     kwargs...) ITensors.simlinkinds!(args...;
+                                                      kwargs...)
+
+@deprecate mul(A::AbstractMPS,
+               B::AbstractMPS;
+               kwargs...) contract(A, B; kwargs...)
 

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -337,7 +337,7 @@ function computeSiteProd(sites,
   for j=2:length(ops)
     (ops[j].site != i) && error("Mismatch of site number in computeSiteProd")
     opj = op(sites[i],ops[j].name)
-    T = matmul(T,opj)
+    T = product(T, opj)
   end
   return T
 end

--- a/src/physics/tag_types.jl
+++ b/src/physics/tag_types.jl
@@ -57,7 +57,7 @@ function op(s::Index,
   if !isnothing(starpos)
     op1 = opname[1:starpos.start-1]
     op2 = opname[starpos.start+1:end]
-    return matmul(op(s,op1;kwargs...),op(s,op2;kwargs...))
+    return product(op(s,op1;kwargs...),op(s,op2;kwargs...))
   end
 
   return _call_op(s,opname;kwargs...)

--- a/test/tag_types.jl
+++ b/test/tag_types.jl
@@ -11,19 +11,19 @@ using ITensors,
     @test sites[1] isa Index
     Sz = op(sites,"Sz",2)
     SzSz = op(sites,"Sz * Sz",2)
-    @test SzSz ≈ matmul(Sz,Sz)
+    @test SzSz ≈ product(Sz, Sz)
     Sy = op(sites,"Sy",2)
     SySy = op(sites,"Sy * Sy",2)
-    @test SySy ≈ matmul(Sy,Sy)
+    @test SySy ≈ product(Sy, Sy)
 
     sites = siteinds("S=1",N)
     @test_throws ArgumentError op(sites, "Sp", 1)
     Sz = op(sites,"Sz",2)
     SzSz = op(sites,"Sz * Sz",2)
-    @test SzSz ≈ matmul(Sz,Sz)
+    @test SzSz ≈ product(Sz, Sz)
     Sy = op(sites,"Sy",2)
     SySy = op(sites,"Sy * Sy",2)
-    @test SySy ≈ matmul(Sy,Sy)
+    @test SySy ≈ product(Sy, Sy)
   end
 end
 


### PR DESCRIPTION
This implements some more MPS/MPO/ITensor interface changes, for example changing `mul` to `contract` and `matmul` to `product`. This is part of the plan laid out in #285.