### PR TITLE
DMRG outputlevel

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -252,11 +252,11 @@ end
 # output
 
 sweeps = Sweeps
-1 cutoff=1.0E-10, maxdim=10, mindim=1
-2 cutoff=1.0E-10, maxdim=20, mindim=1
-3 cutoff=1.0E-10, maxdim=100, mindim=1
-4 cutoff=1.0E-10, maxdim=100, mindim=1
-5 cutoff=1.0E-10, maxdim=200, mindim=1
+1 cutoff=1.0E-10, maxdim=10, mindim=1, noise=0.0E+00
+2 cutoff=1.0E-10, maxdim=20, mindim=1, noise=0.0E+00
+3 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
+4 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
+5 cutoff=1.0E-10, maxdim=200, mindim=1, noise=0.0E+00
 
 After sweep 1 energy=-137.845841178879 maxlinkdim=9 time=8.538
 After sweep 2 energy=-138.935378608196 maxlinkdim=20 time=0.316

--- a/examples/dmrg/dmrg_with_observer.jl
+++ b/examples/dmrg/dmrg_with_observer.jl
@@ -38,7 +38,7 @@ let
   1E-7 tolerance
   =#
   let
-    Sz_observer = DMRGObserver(["Sz"],sites,1E-7)
+    Sz_observer = DMRGObserver(["Sz"],sites,energy_tol=1E-7)
 
     # we will now run DMRG calculation for different values
     # of the transverse field and check how local observables
@@ -58,7 +58,7 @@ let
   let
     println("\nRunning DMRG for TFIM with h=0.5 (critical point)")
     println("================================")
-    Sz_observer= DMRGObserver(["Sz"],sites,1E-7)
+    Sz_observer= DMRGObserver(["Sz"],sites,energy_tol=1E-7)
     H = tfimMPO(sites,0.5)
     energy, psi = dmrg(H,psi0,sweeps,observer=Sz_observer)
 
@@ -70,7 +70,7 @@ let
   let
     println("\nRunning DMRG for TFIM with h=5.")
     println("================================")
-    Sz_Sx_observer= DMRGObserver(["Sz","Sx"],sites,1E-7)
+    Sz_Sx_observer= DMRGObserver(["Sz","Sx"],sites,energy_tol=1E-7)
     H = tfimMPO(sites,5.0)
     energy, psi = dmrg(H,psi0,sweeps,observer=Sz_Sx_observer)
 

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -82,10 +82,10 @@ function measure!(obs::DMRGObserver;
 end
 
 function checkdone!(o::DMRGObserver; kwargs...)
-  quiet = get(kwargs,:quiet,false)
+  outputlevel = get(kwargs,:outputlevel,false)
   if (length(energies(o)) > o.minsweeps &&
       abs(energies(o)[end] - energies(o)[end-1]) < o.etol)
-    !quiet && println("Energy difference less than $(o.etol), stopping DMRG")
+    outputlevel > 0 && println("Energy difference less than $(o.etol), stopping DMRG")
     return true
   end
   return false

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -4,11 +4,23 @@ abstract type AbstractObserver end
 measure!(o::AbstractObserver; kwargs...) = nothing
 checkdone!(o::AbstractObserver; kwargs...) = false
 
+"""
+NoObserver is a trivial implementation of an
+observer type which can be used as a default
+argument for DMRG routines taking an AbstractObserver
+"""
 struct NoObserver <: AbstractObserver
 end
 
 const DMRGMeasurement = Vector{Vector{Float64}}
 
+"""
+DMRGObserver is an implementation of an
+observer object (<:AbstractObserver) which
+implements custom measurements and allows
+the `dmrg` function to return early if an
+energy convergence criterion is met.
+"""
 struct DMRGObserver <: AbstractObserver
   ops::Vector{String}
   sites::Vector{<:Index}
@@ -18,17 +30,17 @@ struct DMRGObserver <: AbstractObserver
   etol::Float64
   minsweeps::Int64
 
-  function DMRGObserver(etol::Real=0, 
-                        minsweeps::Int=2) 
-    new([],[],Dict{String,DMRGMeasurement}(),[],[],etol,minsweeps)
+  function DMRGObserver(energy_tol=0.0, 
+                        minsweeps=2) 
+    new([],[],Dict{String,DMRGMeasurement}(),[],[],energy_tol,minsweeps)
   end
 
   function DMRGObserver(ops::Vector{String}, 
-                        sites::Vector{<:Index},
-                        etol::Real=0,
-                        minsweeps::Int=2)
+                        sites::Vector{<:Index};
+                        energy_tol=0.0,
+                        minsweeps=2)
     measurements = Dict(o => DMRGMeasurement() for o in ops)
-    return new(ops,sites,measurements,[],[],etol,minsweeps)
+    return new(ops,sites,measurements,[],[],energy_tol,minsweeps)
   end
 end
 
@@ -38,7 +50,7 @@ sites(obs::DMRGObserver) = obs.sites
 ops(obs::DMRGObserver) = obs.ops
 truncerrors(obs::DMRGObserver) = obs.truncerrs
 
-function measureLocalOps!(obs::DMRGObserver,
+function measurelocalops!(obs::DMRGObserver,
                           wf::ITensor,
                           i::Int)
   for o in ops(obs)
@@ -59,7 +71,7 @@ function measure!(obs::DMRGObserver;
   if half_sweep==2
     N = length(psi)
 
-    if b==N-1
+    if b==(N-1)
       for o in ops(obs)
         push!(measurements(obs)[o],zeros(N))
       end
@@ -71,11 +83,11 @@ function measure!(obs::DMRGObserver;
     # We want to measure at n=b+1 because there the tensor has been
     # already fully updated (by the right and left pass of the sweep).
     wf = psi[b]*psi[b+1]
-    measureLocalOps!(obs,wf,b+1)
+    measurelocalops!(obs,wf,b+1)
 
     if b==1
       push!(energies(obs), energy)
-      measureLocalOps!(obs,wf,b)
+      measurelocalops!(obs,wf,b)
     end
     truncerr > truncerrors(obs)[end] && (truncerrors(obs)[end] = truncerr)
   end

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -23,7 +23,7 @@ using ITensors, Test, Random
     noise!(sweeps,1E-10)
     str = split(sprint(show, sweeps), '\n')
     @test length(str) > 1
-    energy,psi = dmrg(H, psi, sweeps; quiet=true)
+    energy,psi = dmrg(H, psi, sweeps; outputlevel=0)
     @test energy < -12.0
   end
 
@@ -44,7 +44,7 @@ using ITensors, Test, Random
     maxdim!(sweeps,10,20)
     cutoff!(sweeps,1E-12)
     noise!(sweeps,1E-10)
-    energy,psi = dmrg(H,psi0,sweeps,quiet=true)
+    energy,psi = dmrg(H,psi0,sweeps,outputlevel=0)
 
     # Exact energy for transverse field Ising model
     # with open boundary conditions at criticality
@@ -71,7 +71,7 @@ using ITensors, Test, Random
 
     observer = DMRGObserver(["Sz","Sx"], sites)
 
-    E,psi = dmrg(H,psi0,sweeps,observer=observer,quiet=true)
+    E,psi = dmrg(H,psi0,sweeps,observer=observer,outputlevel=0)
     @test length(measurements(observer)["Sz"])==3
     @test length(measurements(observer)["Sx"])==3
     @test all(length.(measurements(observer)["Sz"]) .== N)
@@ -110,7 +110,7 @@ using ITensors, Test, Random
     mindim!(sweeps,1,10,10)
     cutoff!(sweeps,1E-11)
     noise!(sweeps,1E-10)
-    energy,psi = dmrg([HZ,HXY], psi, sweeps; quiet=true)
+    energy,psi = dmrg([HZ,HXY], psi, sweeps; outputlevel=0)
     @test energy < -12.0
   end
 
@@ -137,11 +137,11 @@ using ITensors, Test, Random
     cutoff!(sweeps, 1E-11)
     noise!(sweeps,1E-10)
 
-    energy0, psi0 = dmrg(H,psi0i, sweeps; quiet=true)
+    energy0, psi0 = dmrg(H,psi0i, sweeps; outputlevel=0)
     @test energy0 < -11.5
 
     psi1i = randomMPS(sites,10)
-    energy1,psi1 = dmrg(H,[psi0],psi1i,sweeps;quiet=true,weight=weight)
+    energy1,psi1 = dmrg(H,[psi0],psi1i,sweeps;outputlevel=0,weight=weight)
 
     @test energy1 > energy0
     @test energy1 < -11.1
@@ -180,7 +180,7 @@ using ITensors, Test, Random
     cutoff!(sweeps, 1E-8)
     noise!(sweeps,1E-10)
 
-    energy,psi = dmrg(H,psi0,sweeps;quiet=true)
+    energy,psi = dmrg(H,psi0,sweeps;outputlevel=0)
     @test (-6.5 < energy < -6.4)
   end
 end

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -132,8 +132,8 @@ using ITensors, Test, Random
 
     psi0i = randomMPS(sites,10)
 
-    sweeps = Sweeps(6)
-    maxdim!(sweeps, 10,20,100,100,200)
+    sweeps = Sweeps(4)
+    maxdim!(sweeps, 10,20,100,100)
     cutoff!(sweeps, 1E-11)
     noise!(sweeps,1E-10)
 

--- a/test/readme.jl
+++ b/test/readme.jl
@@ -92,13 +92,15 @@ using ITensors,
     sweeps = Sweeps(2)
     maxdim!(sweeps, 10,20,100,100,200)
     cutoff!(sweeps, 1E-10)
-    #@show sweeps
+    @show sweeps
 
     # Run the DMRG algorithm, returning energy
     # (dominant eigenvalue) and optimized MPS
-    energy, psi = dmrg(H,psi0, sweeps,quiet=true)
+    energy, psi = dmrg(H,psi0, sweeps)
     #println("Final energy = $energy")
   end
 
 
 end
+
+nothing


### PR DESCRIPTION
Enhancement to the `dmrg` functions which replaces the quiet::Bool keyword with outputlevel::Int. Setting the output level to 0 means no output; 1 means only per-sweep output; 2 shows every step. The DMRGObserver type also makes limited use of the outputlevel, which gets passed through the keyword args. Addresses issue #267 

This PR includes a few other small tweaks and fixes:
- fix output in README doctest regarding showing noise level in sweeps
- change energy tolerance arg of DMRGObserver constructor to be a keyword arg