### PR TITLE
Define `dag` for IndexVal and small printing tweak

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -451,6 +451,8 @@ plev(iv::IndexVal) = plev(ind(iv))
 prime(iv::IndexVal,
       inc::Integer = 1) = IndexVal(prime(ind(iv), inc), val(iv))
 
+dag(iv::IndexVal) = IndexVal(dag(ind(iv)),val(iv))
+
 Base.adjoint(iv::IndexVal) = IndexVal(prime(ind(iv)), val(iv))
 
 hasqns(::Index) = false
@@ -478,7 +480,7 @@ function Base.show(io::IO,
   end
 end
 
-Base.show(io::IO, iv::IndexVal) = print(io, ind(iv), "=$(val(iv))")
+Base.show(io::IO, iv::IndexVal) = print(io, ind(iv), "=>$(val(iv))")
 
 function readcpp(io::IO, ::Type{Index}; kwargs...)
   format = get(kwargs,:format,"v3")

--- a/src/index.jl
+++ b/src/index.jl
@@ -446,14 +446,14 @@ Base.:(==)(i::Index,
 Base.:(==)(iv::IndexValOrPairIndexInt,
            i::Index) = i == iv
 
-plev(iv::IndexVal) = plev(ind(iv))
+plev(iv::IndexValOrPairIndexInt) = plev(ind(iv))
 
-prime(iv::IndexVal,
+prime(iv::IndexValOrPairIndexInt,
       inc::Integer = 1) = IndexVal(prime(ind(iv), inc), val(iv))
 
-dag(iv::IndexVal) = IndexVal(dag(ind(iv)),val(iv))
+dag(iv::IndexValOrPairIndexInt) = IndexVal(dag(ind(iv)),val(iv))
 
-Base.adjoint(iv::IndexVal) = IndexVal(prime(ind(iv)), val(iv))
+Base.adjoint(iv::IndexValOrPairIndexInt) = IndexVal(prime(ind(iv)), val(iv))
 
 hasqns(::Index) = false
 

--- a/test/index.jl
+++ b/test/index.jl
@@ -65,7 +65,7 @@ import ITensors: In,Out,Neither
     @test val(i(2)') == 2
     @test plev(prime(i(2),4)) == 4
     #@test i[:] == [i(1); i(2)]
-    @test sprint(show, i(2)) == sprint(show, i)*"=2"
+    @test sprint(show, i(2)) == sprint(show, i)*"=>2"
 
     @test IndexVal() == IndexVal(Index(), 0)
   end

--- a/test/index.jl
+++ b/test/index.jl
@@ -68,6 +68,14 @@ import ITensors: In,Out,Neither
     @test sprint(show, i(2)) == sprint(show, i)*"=>2"
 
     @test IndexVal() == IndexVal(Index(), 0)
+
+    @test dag(i(1)) != dag(i=>2)
+    @test dag(i(2)) == dag(i=>2)
+    @test plev(i=>2) == 0
+    @test plev(i'=>2) == 1
+    @test prime(i(2)) == i'(2)
+    @test prime(i=>2) == i'(2)
+    @test (i=>1)' == i'(1)
   end
   @testset "Iteration" begin
     i = Index(10)


### PR DESCRIPTION
Defines dag(i(1)) to be the same as dag(i)(1).

Changes printing of IndexVals to use => notation (instead of = notation).

@mtfishman: would it be a good idea to define dag(::Pair{Index,Int}) too?