### PR TITLE
Add normalization step after truncation in DMRG

### DIFF
--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -187,7 +187,11 @@ end
       @printf("After sweep %d energy=%.12f maxlinkdim=%d time=%.3f\n",
               sw, energy, maxlinkdim(psi), sw_time)
     end
-    checkdone!(obs; outputlevel = outputlevel) && break
+    isdone = checkdone!(obs;energy=energy,
+                            psi=psi,
+                            sweep=sw,
+                            outputlevel=outputlevel) 
+    isdone && break
   end
   return (energy, psi)
 end

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -163,6 +163,7 @@ end
                                          cutoff = cutoff(sweeps, sw),
                                          eigen_perturbation = drho,
                                          ortho = ortho,
+                                         normalize=true,
                                          which_decomp = which_decomp)
 end
 

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -295,6 +295,7 @@ function replacebond!(M::MPS,
                       kwargs...)
   ortho = get(kwargs, :ortho, "left")
   which_decomp = get(kwargs, :which_decomp, "automatic")
+  normalize = get(kwargs,:normalize,false)
 
   # Deprecated keywords
   if haskey(kwargs, :dir)
@@ -310,9 +311,11 @@ function replacebond!(M::MPS,
   if ortho == "left"
     leftlim(M) == b-1 && setleftlim!(M, leftlim(M)+1)
     rightlim(M) == b+1 && setrightlim!(M, rightlim(M)+1)
+    normalize && (M[b+1] /= norm(M[b+1]))
   elseif ortho == "right"
     leftlim(M) == b && setleftlim!(M, leftlim(M)-1)
     rightlim(M) == b+2 && setrightlim!(M, rightlim(M)-1)
+    normalize && (M[b] /= norm(M[b]))
   else
     error("In replacebond!, got ortho = $ortho, only currently supports `left` and `right`.")
   end

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -311,11 +311,11 @@ function replacebond!(M::MPS,
   if ortho == "left"
     leftlim(M) == b-1 && setleftlim!(M, leftlim(M)+1)
     rightlim(M) == b+1 && setrightlim!(M, rightlim(M)+1)
-    normalize && (M[b+1] /= norm(M[b+1]))
+    normalize && (M[b+1] ./= norm(M[b+1]))
   elseif ortho == "right"
     leftlim(M) == b && setleftlim!(M, leftlim(M)-1)
     rightlim(M) == b+2 && setrightlim!(M, rightlim(M)-1)
-    normalize && (M[b] /= norm(M[b]))
+    normalize && (M[b] ./= norm(M[b]))
   else
     error("In replacebond!, got ortho = $ortho, only currently supports `left` and `right`.")
   end


### PR DESCRIPTION
Fixes an error in `dmrg` where the wavefunction can lose normalization due to truncation. Adds the `normalize::Bool` keyword arg to `replacebond!` which can be used by other algorithms such as time evolution. Also passes more keyword args to the observer checkdone! method for future observer customizations.