### PR TITLE
Replace fastsvd keyword argument in svd with alg

### DIFF
--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -32,11 +32,13 @@ computed from the dense svds of seperate blocks.
 """
 function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
                            kwargs...) where {ElT}
+  alg::String = get(kwargs, :alg, "recursive")
+
   truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
 
-  Us = Vector{BlockSparseMatrix{ElT}}(undef,nnzblocks(T))
-  Ss = Vector{DiagBlockSparseMatrix{real(ElT)}}(undef,nnzblocks(T))
-  Vs = Vector{BlockSparseMatrix{ElT}}(undef,nnzblocks(T))
+  Us = Vector{BlockSparseMatrix{ElT}}(undef, nnzblocks(T))
+  Ss = Vector{DiagBlockSparseMatrix{real(ElT)}}(undef, nnzblocks(T))
+  Vs = Vector{BlockSparseMatrix{ElT}}(undef, nnzblocks(T))
 
   # Sorted eigenvalues
   d = Vector{real(ElT)}()
@@ -44,11 +46,11 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
   for n in 1:nnzblocks(T)
     b = nzblock(T, n)
     blockT = blockview(T, n)
-    Ub,Sb,Vb = svd(blockT)
+    Ub, Sb, Vb = svd(blockT; alg = alg)
     Us[n] = Ub
     Ss[n] = Sb
     Vs[n] = Vb
-    append!(d,vector(diag(Sb)))
+    append!(d, vector(diag(Sb)))
   end
 
   # Square the singular values to get

--- a/NDTensors/src/svd.jl
+++ b/NDTensors/src/svd.jl
@@ -60,8 +60,9 @@ function svd_recursive(M::AbstractMatrix;
 end
 
 # TODO: maybe move to another location?
+# Include options for other svd algorithms
 function polar(M::AbstractMatrix)
-  U,S,V = svd(M) # calls LinearAlgebra.svd()
-  return U*V',V*Diagonal(S)*V'
+  U,S,V = svd(M) # calls LinearAlgebra.svd(_)
+  return U*V', V*Diagonal(S)*V'
 end
 

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -11,7 +11,9 @@ end
 Construct an IndexSet of order N and element type IndexT
 from a collection of indices (any collection that is convertable to a Tuple).
 """
-IndexSet{N,IndexT}(inds::Index...) where {N,IndexT} = IndexSet{N,IndexT}(inds)
+function IndexSet{N,IndexT}(inds::Index...) where {N,IndexT}
+  return IndexSet{N,IndexT}(inds)
+end
 
 """
     IndexSet{N}(inds)
@@ -115,7 +117,10 @@ NDTensors.ValLength(::Type{<:IndexSet{N}}) where {N} = Val{N}
 NDTensors.ValLength(::IndexSet{N}) where {N} = Val(N)
 
 # Convert to an Index if there is only one
-Index(is::IndexSet) = length(is)==1 ? is[1] : error("Number of Index in IndexSet ≠ 1")
+function Index(is::IndexSet)
+  length(is) != 1 && error("Number of Index in IndexSet ≠ 1")
+  return is[1]
+end
 
 """
     getindex(is::IndexSet, n::Int)
@@ -341,7 +346,7 @@ IndexSet equality (order dependent). For order
 independent equality use `issetequal` or
 `hassameinds`.
 """
-function Base.:(==)(A::IndexSet,B::IndexSet)
+function Base.:(==)(A::IndexSet, B::IndexSet)
   length(A) ≠ length(B) && return false
   for (a,b) in zip(A,B)
     a ≠ b && return false
@@ -400,13 +405,9 @@ Checks if the Index matches the provided conditions.
 """
 indmatch(i::Index; kwargs...) = fmatch(; kwargs...)(i)
 
-const IndexCollection{IndexT<:Index} = Union{IndexSet{<:Any,IndexT},
-                                             Tuple{Vararg{IndexT}},
-                                             Vector{IndexT},
-                                             SVector{<:Any,IndexT},
-                                             MVector{<:Any,IndexT}}
-
-function Base.setdiff(f::Function, A, Bs...)
+function Base.setdiff(f::Function,
+                      A::IndexSet,
+                      Bs::IndexSet...)
   R = eltype(A)[]
   for a ∈ A
     f(a) && all(B -> a ∉ B, Bs) && push!(R, a)
@@ -415,16 +416,18 @@ function Base.setdiff(f::Function, A, Bs...)
 end
 
 """
-    setdiff(A,B...)
+    setdiff(A::IndexSet, Bs::IndexSet...)
 
-Output the IndexSet with Indices in Ais but not in
-the IndexSets Bis.
+Output the IndexSet with Indices in `A` but not in
+the IndexSets `Bs`.
 """
-Base.setdiff(A::IndexCollection,
-             Bs::IndexCollection...;
+Base.setdiff(A::IndexSet,
+             Bs::IndexSet...;
              kwargs...) = setdiff(fmatch(; kwargs...), A, Bs...)
 
-function firstsetdiff(f::Function, A, Bs...)
+function firstsetdiff(f::Function,
+                      A::IndexSet,
+                      Bs::IndexSet...)
   for a in A
     f(a) && all(B -> a ∉ B, Bs) && return a
   end
@@ -432,18 +435,22 @@ function firstsetdiff(f::Function, A, Bs...)
 end
 
 """
-    firstsetdiff(A,B)
+    firstsetdiff(A::IndexSet, Bs::IndexSet...)
 
-Output the Index in Ais but not in the IndexSets Bis.
+Output the first Index in `A` that is not in the IndexSets `Bs`.
 Otherwise, return a default constructed Index.
-
-In the future, this may throw an error if more than 
-one Index is found.
 """
-firstsetdiff(A, Bs...;
+firstsetdiff(A::IndexSet,
+             Bs::IndexSet...;
              kwargs...) = firstsetdiff(fmatch(; kwargs...), A, Bs...)
 
-function Base.intersect(f::Function, A, B)
+"""
+    intersect(f::Function, A::IndexSet, B::IndexSet)
+
+Output the IndexSet in the intersection of `A` and `B`,
+optionally filtering by the function `f`.
+"""
+function Base.intersect(f::Function, A::IndexSet, B::IndexSet)
   R = eltype(A)[]
   for a in A
     f(a) && a ∈ B && push!(R,a)
@@ -452,15 +459,16 @@ function Base.intersect(f::Function, A, B)
 end
 
 """
-    intersect(A,B)
+    intersect(A::IndexSet, B::IndexSet; kwargs...)
 
-Output the IndexSet in the intersection of A and B
+Output the IndexSet in the intersection of `A` and `B`,
+optionally filtering by tags, prime level, etc.
 """
-Base.intersect(A::IndexCollection,
-               B::IndexCollection;
+Base.intersect(A::IndexSet,
+               B::IndexSet;
                kwargs...) = intersect(fmatch(; kwargs...), A, B)
 
-function firstintersect(f::Function, A, B)
+function firstintersect(f::Function, A::IndexSet, B::IndexSet)
   for a in A
     f(a) && a ∈ B && return a
   end
@@ -468,59 +476,82 @@ function firstintersect(f::Function, A, B)
 end
 
 """
-    firstintersect(Ais,Bis)
+    firstintersect(A::IndexSet, B::IndexSet; kwargs...)
 
-Output the Index common to Ais and Bis.
+Output the Index common to `A` and `B`, optionally
+filtering by tags, prime level, etc.
 If more than one Index is found, throw an error.
 Otherwise, return a default constructed Index.
 """
-firstintersect(A, B;
+firstintersect(A::IndexSet,
+               B::IndexSet;
                kwargs...) = firstintersect(fmatch(; kwargs...), A, B)
 
 """
-    filter(f::Function,inds::IndexSet)
+    filter(f::Function, inds::IndexSet)
 
 Filter the IndexSet by the given function (output a new
 IndexSet with indices `i` for which `f(i)` returns true).
-"""
-Base.filter(f::Function, is::IndexSet) = IndexSet(filter(f,Tuple(is)))
 
-Base.filter(is::IndexCollection,
+Note that this function is not type stable, since the number
+of output indices is not known at compile time.
+"""
+Base.filter(f::Function,
+            is::IndexSet) = IndexSet(filter(f, Tuple(is)))
+
+Base.filter(is::IndexSet,
             args...; kwargs...) = filter(fmatch(args...;
-                                                kwargs...),is)
+                                                kwargs...), is)
 
 # To fix ambiguity error with Base function
-Base.filter(is::IndexCollection,
-            tags::String; kwargs...) = filter(fmatch(tags; kwargs...),is)
+Base.filter(is::IndexSet,
+            tags::String;
+            kwargs...) = filter(fmatch(tags; kwargs...),is)
 
 """
-Like first, but if the length is 0 return nothing
+    getfirst(is::IndexSet)
+
+Return the first Index in the IndexSet. If the IndexSet
+is empty, return `nothing`.
 """
-function getfirst(is)
+function getfirst(is::IndexSet)
   length(is) == 0 && return nothing
   return first(is)
 end
 
 """
-Get the first value matching the pattern function,
-return nothing if not found.
+    getfirst(f::Function, is::IndexSet)
+
+Get the first Index matching the pattern function,
+return `nothing` if not found.
 """
-function getfirst(f::Function, is)
+function getfirst(f::Function, is::IndexSet)
   for i in is
     f(i) && return i
   end
   return nothing
 end
 
-getfirst(is,
+getfirst(is::IndexSet,
          args...; kwargs...) = getfirst(fmatch(args...;
                                                kwargs...),is)
 
-Base.findall(is::IndexCollection,
+Base.findall(is::IndexSet,
              args...; kwargs...) = findall(fmatch(args...;
                                                   kwargs...), is)
 
-Base.findfirst(is::IndexCollection,
+"""
+    indexin(ais::IndexSet, bis::IndexSet)
+
+For collections of Indices, returns the first location in 
+`bis` for each value in `ais`, as a Tuple.
+"""
+function Base.indexin(ais::IndexSet,
+                      bis::IndexSet)
+  return ntuple(i -> findfirst(bis, ais[i]), Val(length(ais)))
+end
+
+Base.findfirst(is::IndexSet,
                args...; kwargs...) = findfirst(fmatch(args...;
                                                       kwargs...), is)
 
@@ -543,7 +574,7 @@ function prime(f::Function,
 end
 
 """
-    prime(A, plinc, ...)
+    prime(A::IndexSet, plinc, ...)
 
 Increase the prime level of the indices by the specified amount.
 Filter which indices are primed using keyword arguments
@@ -714,11 +745,13 @@ function replaceind(is::IndexSet, i1::Index, i2::Index)
   return setindex(is, i2, pos)
 end
 
-function replaceinds(is::IndexSet, is1, is2)
-  poss = findall(is,is1)
-  for (j,pos) ∈ enumerate(poss)
+function replaceinds(is::IndexSet, inds1, inds2)
+  is1 = IndexSet(inds1)
+  poss = indexin(is1, is)
+  for (j, pos) in enumerate(poss)
     i1 = is[pos]
-    i2 = is2[j]
+    i2 = inds2[j]
+    space(i1) != space(i2) && error("Indices must have the same spaces to be replaced")
     i2 = setdir(i2, dir(i1))
     is = setindex(is, i2, pos)
   end

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -154,7 +154,7 @@ using ITensors, Test, Random
     t1 = 1.0
     t2 = 0.5
     V = 0.2
-    s = siteinds("Fermion",N;conserve_qns=true)
+    s = siteinds("Fermion", N; conserve_qns = true)
 
     state = fill(1,N)
     state[1] = 2
@@ -165,22 +165,22 @@ using ITensors, Test, Random
 
     ampo = AutoMPO()
     for j=1:N-1
-      ampo += (-t1,"Cdag",j,  "C",j+1)
-      ampo += (-t1,"Cdag",j+1,"C",j)
-      ampo += (V,"N",j,"N",j+1)
+      ampo += (-t1, "Cdag", j,   "C", j+1)
+      ampo += (-t1, "Cdag", j+1, "C", j)
+      ampo += (  V, "N",    j,   "N", j+1)
     end
     for j=1:N-2
-      ampo += (-t2,"Cdag",j,  "C",j+2)
-      ampo += (-t2,"Cdag",j+2,"C",j)
+      ampo += (-t2, "Cdag", j,   "C", j+2)
+      ampo += (-t2, "Cdag", j+2, "C", j)
     end
-    H = MPO(ampo,s)
+    H = MPO(ampo, s)
 
     sweeps = Sweeps(5)
-    maxdim!(sweeps, 10,20,100,100,200)
+    maxdim!(sweeps, 10, 20, 100, 100, 200)
     cutoff!(sweeps, 1E-8)
-    noise!(sweeps,1E-10)
+    noise!(sweeps, 1E-10)
 
-    energy,psi = dmrg(H,psi0,sweeps;outputlevel=0)
+    energy, psi = dmrg(H, psi0, sweeps; outputlevel = 0)
     @test (-6.5 < energy < -6.4)
   end
 end

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -40,35 +40,37 @@ using ITensors,
 
     @test maxdim(I) == max(idim,jdim,kdim)
   end
+
   @testset "Set operations" begin
-    I1 = IndexSet(i,j,k)
-    I2 = IndexSet(k,l)
-    I3 = IndexSet(j,l)
-    @test hassameinds(I1,(k,j,i))
-    @test firstsetdiff(I1,I2,I3) == i
-    @test isnothing(firstsetdiff(I1,IndexSet(k, j, i)))
-    @test setdiff(I1,I2) == [i,j]
-    @test hassameinds(setdiff(I1,I2),IndexSet(i,j))
-    @test hassameinds(setdiff(I1,I2),(j,i))
+    I1 = IndexSet(i, j, k)
+    I2 = IndexSet(k, l)
+    I3 = IndexSet(j, l)
+    @test hassameinds(I1, (k, j, i))
+    @test firstsetdiff(I1, I2, I3) == i
+    @test isnothing(firstsetdiff(I1, IndexSet(k, j, i)))
+    @test setdiff(I1, I2) == [i, j]
+    @test hassameinds(setdiff(I1, I2), IndexSet(i, j))
+    @test hassameinds(setdiff(I1, I2), (j, i))
     @test I1 ∩ I2 == [k]
-    @test hassameinds(I1 ∩ I2,IndexSet(k))
-    @test firstintersect(I1,I2) == k
-    @test isnothing(firstintersect(I1,IndexSet(l)))
-    @test intersect(I1,(j,l)) == [j]
-    @test hassameinds(intersect(I1,(j,l)),IndexSet(j))
-    @test firstintersect(I1,(j,l)) == j
-    @test intersect(I1,(j,k)) == [j,k]
-    @test hassameinds(intersect(I1,(j,k)),IndexSet(j,k))
-    @test hassameinds(intersect(I1,(j,k,l)),(j,k))
-    @test filter(I1,"i") == IndexSet(i)
-    @test hassameinds(filter(I1,"i"),IndexSet(i))
-    @test getfirst(I1,"j") == j
-    @test isnothing(getfirst(I1,"l"))
-    @test findfirst(I1,i) == 1
-    @test findfirst(I1,j) == 2
-    @test findfirst(I1,k) == 3
-    @test isnothing(findfirst(I1,Index(2)))
+    @test hassameinds(I1 ∩ I2, IndexSet(k))
+    @test firstintersect(I1, I2) == k
+    @test isnothing(firstintersect(I1, IndexSet(l)))
+    @test intersect(I1, (j, l)) == [j]
+    @test hassameinds(intersect(I1, (j, l)), IndexSet(j))
+    @test firstintersect(I1, IndexSet(j, l)) == j
+    @test intersect(I1, (j, k)) == [j, k]
+    @test hassameinds(intersect(I1, (j, k)), IndexSet(j, k))
+    @test hassameinds(intersect(I1, (j, k, l)), (j, k))
+    @test filter(I1, "i") == IndexSet(i)
+    @test hassameinds(filter(I1, "i"), IndexSet(i))
+    @test getfirst(I1, "j") == j
+    @test isnothing(getfirst(I1, "l"))
+    @test findfirst(I1, i) == 1
+    @test findfirst(I1, j) == 2
+    @test findfirst(I1, k) == 3
+    @test isnothing(findfirst(I1, Index(2)))
   end
+
   @testset "intersect index ordering" begin
     I = IndexSet(i,k,j)
     J = IndexSet(j,l,i)

--- a/test/itensor_dense.jl
+++ b/test/itensor_dense.jl
@@ -520,6 +520,7 @@ end
     @test ind(A1, 1) == s1
     @test ind(A1, 2) == l
   end
+
   @testset "replaceind and replaceinds" begin
     rA1 = replaceind(A1,s1,s2)
     @test hasinds(rA1,s2,l,l')
@@ -534,6 +535,19 @@ end
 
     replaceinds!(A2,(s2,l'),(s1,l))
     @test hasinds(A2,s1,l,l'')
+  end
+
+  @testset "replaceinds fixed errors" begin
+    l = Index(3; tags="l")
+    s = Index(2; tags="s")
+    l̃, s̃ = sim(l), sim(s)
+    A = randomITensor(s, l)
+    Ã = replaceinds(A, (l, s), (l̃, s̃))
+    @test ind(A, 1) == s
+    @test ind(A, 2) == l
+    @test ind(Ã, 1) == s̃
+    @test ind(Ã, 2) == l̃
+    @test_throws ErrorException replaceinds(A, (l, s), (s̃, l̃))
   end
 
 end #End "ITensor other index operations"
@@ -649,6 +663,28 @@ end
       @test V*dag(prime(V,v))≈δ(SType,v,v') atol=1e-14
     end
 
+    @testset "Test SVD of an ITensor with different algorithms" begin
+      U, S, V, spec, u, v = svd(A, j, l; alg = "recursive")
+      @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
+      @test A ≈ U * S * V
+      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-14
+      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-14
+
+      U, S, V, spec, u, v = svd(A, j,l; alg = "divide_and_conquer")
+      @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
+      @test A ≈ U * S * V
+      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-14
+      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-14
+
+      U, S, V, spec, u, v = svd(A, j,l; alg = "qr_iteration")
+      @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
+      @test A ≈ U * S * V
+      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-14
+      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-14
+
+      @test_throws ErrorException svd(A, j,l; alg = "bad_alg")
+    end
+
     @testset "Test SVD of a DenseTensor internally" begin
       Lis = commoninds(A,IndexSet(j,l))
       Ris = uniqueinds(A,Lis)
@@ -744,6 +780,17 @@ end
         @test A ≈ L*R
         @test L*dag(prime(L, l)) ≉ δ(SType, l, l')
         @test R*dag(prime(R, l)) ≉ δ(SType, l, l')
+      end
+
+      @testset "factorize when ITensor has primed indices" begin
+        A = randomITensor(i, i')
+        L, R = factorize(A, i)
+        l = commonind(L, R)
+        @test A ≈ L * R
+        @test L * dag(prime(L, l)) ≈ δ(SType, l, l')
+        @test R * dag(prime(R, l)) ≉ δ(SType, l, l')
+
+        @test_throws ErrorException factorize(A, i; svd_alg = "bad_alg")
       end
 
     end

--- a/test/readme.jl
+++ b/test/readme.jl
@@ -92,11 +92,10 @@ using ITensors,
     sweeps = Sweeps(2)
     maxdim!(sweeps, 10,20,100,100,200)
     cutoff!(sweeps, 1E-10)
-    @show sweeps
 
     # Run the DMRG algorithm, returning energy
     # (dominant eigenvalue) and optimized MPS
-    energy, psi = dmrg(H,psi0, sweeps; outputlevel=0)
+    energy, psi = dmrg(H,psi0, sweeps; outputlevel = 0)
     #println("Final energy = $energy")
   end
 


### PR DESCRIPTION
This replaces the `fastsvd` keyword argument in `svd` with the `alg` keyword argument. The `alg` keyword argument has the options `"recursive"`, `"divide_and_conquer"`, and `"qr_iteration"` (the first is ITensor's custom svd, and the last two use LAPACK's gesdd and gesvd functions respectively).

Additionally, this adds the `svd_alg` keyword argument to `factorize`, with the same options.