### PR TITLE
QN randomMPS

### DIFF
--- a/examples/dmrg/2ddmrg.jl
+++ b/examples/dmrg/2ddmrg.jl
@@ -6,7 +6,7 @@ let
 
   N = Nx*Ny
 
-  sites = siteinds("S=1/2",N)
+  sites = siteinds("S=1/2",N;conserve_qns=true)
 
   # Turning on QN conservation can 
   # give large speedups for DMRG:
@@ -20,16 +20,20 @@ let
     ampo += (0.5,"S-",b.s1,"S+",b.s2)
     ampo += ("Sz",b.s1,"Sz",b.s2)
   end
-  H = toMPO(ampo,sites)
+  H = MPO(ampo,sites)
 
   state = [isodd(n) ? "Up" : "Dn" for n=1:N]
-  psi0 = productMPS(sites,state)
+  # Initialize wavefunction to a random MPS
+  # of bond-dimension 10 with same quantum
+  # numbers as `state`
+  psi0 = randomMPS(sites,state,20)
 
   sweeps = Sweeps(10)
-  maxdim!(sweeps,10,20,100,100,200,400,800)
+  maxdim!(sweeps,20,60,100,100,200,400,800)
   cutoff!(sweeps,1E-8)
   @show sweeps
 
   energy,psi = dmrg(H,psi0,sweeps)
 
+  return
 end

--- a/examples/dmrg/exthubbard.jl
+++ b/examples/dmrg/exthubbard.jl
@@ -52,7 +52,10 @@ let
       p -= 1
     end
   end
-  psi0 = productMPS(sites,state)
+  # Initialize wavefunction to be bond 
+  # dimension 10 random MPS with number
+  # of particles the same as `state`
+  psi0 = randomMPS(sites,state,10)
 
   # Check total number of particles:
   @show flux(psi0)

--- a/examples/dmrg/qn_1d_heisenberg.jl
+++ b/examples/dmrg/qn_1d_heisenberg.jl
@@ -17,7 +17,7 @@ let
   psi0 = MPS(N)
 
   state = [isodd(n) ? "Up" : "Dn" for n in 1:N] 
-  psi0 = productMPS(sites,state)
+  psi0 = randomMPS(sites,state,10)
 
   # Plan to do 5 DMRG sweeps:
   sweeps = Sweeps(5)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -64,6 +64,22 @@ with element type Float64.
 """
 MPS(sites) = MPS(Float64, sites)
 
+function randomU(s1,s2)
+  if !hasqns(s1) && !hasqns(s2)
+    mdim = dim(s1)*dim(s2)
+    RM = randn(mdim,mdim)
+    Q,_ = NDTensors.qr_positive(RM)
+    G = itensor(Q,dag(s1),dag(s2),s1',s2')
+  else
+    M = randomITensor(QN(),s1',s2',dag(s1),dag(s2))
+    U,S,V = svd(M,(s1',s2'))
+    u = commonind(U,S)
+    v = commonind(S,V)
+    G = (U*delta(dag(u),v))*V
+  end
+  return G
+end
+
 function randomizeMPS!(M::MPS, sites, linkdim=1)
   N = length(sites)
   c = div(N,2)
@@ -77,10 +93,7 @@ function randomizeMPS!(M::MPS, sites, linkdim=1)
     for b=brange
       s1 = sites[b]
       s2 = sites[b+db]
-      mdim = dim(s1)*dim(s2)
-      RM = randn(mdim,mdim)
-      Q,_ = NDTensors.qr_positive(RM)
-      G = itensor(Q,dag(s1),dag(s2),s1',s2')
+      G = randomU(s1,s2)
       T = noprime(G*M[b]*M[b+db])
       rinds = uniqueinds(M[b],M[b+db])
       U,S,V = svd(T,rinds;maxdim=linkdim)
@@ -98,7 +111,6 @@ function randomizeMPS!(M::MPS, sites, linkdim=1)
     error("MPS center bond dim less than requested")
   end
 end
-
 
 function randomCircuitMPS(sites,linkdim::Int;kwargs...)::MPS
   N = length(sites)
@@ -139,27 +151,14 @@ end
 Construct a random MPS with link dimension `linkdim` of 
 type `T`.
 """
-function randomMPS(::Type{T}, sites, linkdim=1) where {T<:Number}
-
-  if linkdim > 1 && !hasqns(sites[1])
-    # For non-QN-conserving MPS, instantiate
-    # the random MPS directly as a circuit:
-    return randomCircuitMPS(sites,linkdim)
+function randomMPS(::Type{T}, sites, linkdim::Int=1) where {T<:Number}
+  if hasqns(sites[1])
+    error("initial state required to use randomMPS with QNs")
   end
 
-  M = MPS(T, sites)
-  for i in eachindex(sites)
-    randn!(M[i])
-    normalize!(M[i])
-  end
-
-  setleftlim!(M, 0)
-  setrightlim!(M, 2)
-
-  if linkdim > 1
-    randomizeMPS!(M, sites, linkdim)
-  end
-  return M
+  # For non-QN-conserving MPS, instantiate
+  # the random MPS directly as a circuit:
+  return randomCircuitMPS(sites,linkdim)
 end
 
 """
@@ -168,7 +167,22 @@ end
 Construct a random MPS with link dimension `linkdim` of 
 type `Float64`.
 """
-randomMPS(sites, linkdim=1) = randomMPS(Float64, sites, linkdim)
+randomMPS(sites, linkdim::Int=1) = randomMPS(Float64, sites, linkdim)
+
+"""
+    randomMPS(sites,state; linkdim=1)
+
+Construct a real, random MPS with link dimension `linkdim`,
+made by randomizing an initial product state specified by
+`state`.
+"""
+function randomMPS(sites,state,linkdim::Int=1)::MPS
+  M = productMPS(sites,state)
+  if linkdim > 1
+    randomizeMPS!(M,sites,linkdim)
+  end
+  return M
+end
 
 """
     productMPS(::Type{T<:Number}, ivals::Vector{<:IndexVal})

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -59,8 +59,10 @@ using ITensors, Test, Random
     psi0 = randomMPS(sites)
 
     ampo = AutoMPO()
+    for j = 1:N-1
+      add!(ampo,-1.0,"Sz",j,"Sz",j+1)
+    end
     for j = 1:N
-      j < N && add!(ampo,-1.0,"Sz",j,"Sz",j+1)
       add!(ampo,-0.2,"Sx",j)
     end
     H = MPO(ampo,sites)
@@ -79,7 +81,7 @@ using ITensors, Test, Random
     @test length(energies(observer))==3
     @test length(truncerrors(observer))==3
     @test energies(observer)[end]==E
-    @test all(truncerrors(observer) .< 1E-11)
+    @test all(truncerrors(observer) .< 1E-9)
 
     orthogonalize!(psi,1)
     m = scalar(dag(psi[1])*noprime(op(sites, "Sz", 1)*psi[1]))

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -74,7 +74,6 @@ include("util.jl")
 
     @test hasind(phi[4],sites[4])
     @test norm(phi[4])≈1.0
-
   end
 
   @testset "inner different MPS" begin
@@ -316,8 +315,7 @@ end
 
     @test norm(M[1]) ≈ 1.0
 
-    c = div(N,2)
-    @test dim(linkind(M,c)) == chi
+    @test maxlinkdim(M) == chi
 
     # Test for right-orthogonality
     R = M[N]*prime(M[N],"Link")

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -328,6 +328,33 @@ end
     end
   end
 
+  @testset "randomMPS from initial state (QN case)" begin
+    N = 20
+    chi = 8
+    sites = siteinds("S=1/2",N;conserve_qns=true)
+
+    # Make flux-zero random MPS
+    state = [isodd(n) ? 1 : 2 for n=1:N]
+    M = randomMPS(sites,state,chi)
+    @test flux(M) == QN("Sz",0)
+
+    @test ITensors.leftlim(M) == 0
+    @test ITensors.rightlim(M) == 2
+
+    @test norm(M[1]) ≈ 1.0
+    @test inner(M,M) ≈ 1.0
+
+    @test maxlinkdim(M) == chi
+
+    # Test making random MPS with different flux
+    state[1] = 2
+    M = randomMPS(sites,state,chi)
+    @test flux(M) == QN("Sz",-2)
+    state[3] = 2
+    M = randomMPS(sites,state,chi)
+    @test flux(M) == QN("Sz",-4)
+  end
+
 end
 
 nothing


### PR DESCRIPTION
Version of randomMPS which takes a `state` vector, allowing it to be used for making random, QN-conserving MPS. This will be helpful for testing other code involving QN MPS, for initializing algorithms like DMRG, and in the future hopefully as a tool for improving other algorithms such as fitting methods or TDVP.