### PR TITLE
Use Strided for permutedims

### DIFF
--- a/NDTensors/src/NDTensors.jl
+++ b/NDTensors/src/NDTensors.jl
@@ -4,6 +4,7 @@ using Random
 using LinearAlgebra
 using StaticArrays
 using HDF5
+using Strided
 
 #####################################
 # DenseTensor and DiagTensor

--- a/NDTensors/src/svd.jl
+++ b/NDTensors/src/svd.jl
@@ -19,7 +19,6 @@ function svd_recursive(M::AbstractMatrix;
                       thresh::Float64=1E-3,
                       north_pass::Int=2)
   Mr,Mc = size(M)
-
   if Mr > Mc
     V,S,U = svd_recursive(transpose(M))
     conj!(U)

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]

--- a/examples/dmrg/exthubbard.jl
+++ b/examples/dmrg/exthubbard.jl
@@ -67,8 +67,9 @@ let
   dnd = fill(0.0,N)
   for j=1:N
     orthogonalize!(psi,j)
-    upd[j] = scalar(dag(prime(psi[j],"Site"))*op(sites,"Nup",j)*psi[j])
-    dnd[j] = scalar(dag(prime(psi[j],"Site"))*op(sites,"Ndn",j)*psi[j])
+    psidag_j = dag(prime(psi[j], "Site"))
+    upd[j] = scalar(psidag_j * op(sites, "Nup", j) * psi[j])
+    dnd[j] = scalar(psidag_j * op(sites, "Ndn", j) * psi[j])
   end
 
   println("Up Density:")

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -87,6 +87,7 @@ function dmrg(PH,
               sweeps::Sweeps;
               kwargs...)
   which_decomp::Union{String, Nothing} = get(kwargs, :which_decomp, nothing)
+  svd_alg::String = get(kwargs, :svd_alg, "recursive")
   obs = get(kwargs, :observer, NoObserver())
   outputlevel::Int = get(kwargs, :outputlevel, 1)
 
@@ -164,7 +165,7 @@ end
                                          eigen_perturbation = drho,
                                          ortho = ortho,
                                          normalize = true,
-                                         which_decomp = which_decomp)
+                                         which_decomp = which_decomp,                                          svd_alg = svd_alg)
 end
 
       if outputlevel >= 2


### PR DESCRIPTION
Jutho has a nice package called [Strided.jl](https://github.com/Jutho/Strided.jl) which has a custom implementation of Julia's `permutedims` that acts lazily and can fuse with other operations with broadcasting. This pull request uses it as a drop-in replacement for `permutedims[!]` in NDTensors (including replacing our custom version that applies a function). 

Here are some results running `examples/dmrg/exthubbard.jl`. On master:
```
After sweep 1 energy=-15.684191171846 maxlinkdim=50 time=0.593
After sweep 2 energy=-17.211812572484 maxlinkdim=100 time=1.379
After sweep 3 energy=-17.429068161255 maxlinkdim=200 time=2.681
After sweep 4 energy=-17.435370008361 maxlinkdim=400 time=5.339
After sweep 5 energy=-17.435415463390 maxlinkdim=630 time=8.128
After sweep 6 energy=-17.435415758946 maxlinkdim=654 time=6.943
```
and on this branch:
```
After sweep 1 energy=-16.351502376855 maxlinkdim=50 time=0.739
After sweep 2 energy=-17.342280545549 maxlinkdim=100 time=1.504
After sweep 3 energy=-17.434333146203 maxlinkdim=200 time=2.607
After sweep 4 energy=-17.435410320715 maxlinkdim=400 time=4.993
After sweep 5 energy=-17.435415710430 maxlinkdim=603 time=6.444
After sweep 6 energy=-17.435415760166 maxlinkdim=618 time=6.199
```
Not a huge speedup over all, but of course `permutedims` wasn't dominating the `dmrg` cost so it is pretty good.

For reference, here is the same run in C++ ITensor v3:
```
    Largest link dim during sweep 1/6 was 50
    Energy after sweep 1/6 is -13.654587063495
    Sweep 1/6 CPU time = 0.361s (Wall time = 0.266s)

    Largest link dim during sweep 2/6 was 100
    Energy after sweep 2/6 is -16.892217260698
    Sweep 2/6 CPU time = 5.572s (Wall time = 1.003s)

    Largest link dim during sweep 3/6 was 200
    Energy after sweep 3/6 is -17.409957867258
    Sweep 3/6 CPU time = 11.16s (Wall time = 1.947s)

    Largest link dim during sweep 4/6 was 400
    Energy after sweep 4/6 is -17.435221134464
    Sweep 4/6 CPU time = 18.04s (Wall time = 3.160s)

    Largest link dim during sweep 5/6 was 713
    Energy after sweep 5/6 is -17.435414564047
    Sweep 5/6 CPU time = 35.16s (Wall time = 6.151s)

    Largest link dim during sweep 6/6 was 659
    Energy after sweep 6/6 is -17.435415752219
    Sweep 6/6 CPU time = 26.14s (Wall time = 4.591s)
```
so it is not too far off. All of these runs are with MKL, letting MKL choose the number of threads.

There are still some things to play with, for example Strided.jl supports multithreaded `permutedims`. On a first test adding more threads made things slower, perhaps because it was competing with MKL BLAS threads. I tried turning off MKL BLAS threads and I still didn't see Strided.jl's multithreading helping much.

I did some profiling of the `exthubbard.jl` `dmrg` run, and focused first on `permutedims` since I saw it show up heavily in the profile. There were a few other things that showed up a bit too much, for example some contraction logic and block contraction logic, which we should look into. Calls to `svd_recursive` also showed up, so I added an `svd_alg` keyword argument to `dmrg`. Using `svd_alg = "divide_and_conquer"`, here are the results:
```
After sweep 1 energy=-15.134829206976 maxlinkdim=50 time=0.589
After sweep 2 energy=-17.068192318420 maxlinkdim=100 time=1.409
After sweep 3 energy=-17.423436286897 maxlinkdim=200 time=2.571
After sweep 4 energy=-17.435342471525 maxlinkdim=400 time=4.436
After sweep 5 energy=-17.435415113102 maxlinkdim=653 time=6.820
After sweep 6 energy=-17.435415754267 maxlinkdim=657 time=5.609
```
so another modest speedup.