### PR TITLE
New eigen interface

### DIFF
--- a/NDTensors/src/blocksparse/diagblocksparse.jl
+++ b/NDTensors/src/blocksparse/diagblocksparse.jl
@@ -139,9 +139,11 @@ function Base.promote_rule(::Type{<:UniformDiagBlockSparse{ElT1,VecT1}},
 end
 
 function Base.promote_rule(::Type{BlockSparseT1},
-                           ::Type{<:NonuniformDiagBlockSparse{ElT2,VecT2}}) where {BlockSparseT1<:BlockSparse,
-                                                                                   ElT2<:Number,VecT2<:AbstractVector}
-  return promote_type(BlockSparseT1,BlockSparse{ElT2,VecT2})
+                           ::Type{<:NonuniformDiagBlockSparse{ElT2,VecT2,N2}}) where {BlockSparseT1<:BlockSparse,
+                                                                                      ElT2<:Number,
+                                                                                      VecT2<:AbstractVector,
+                                                                                      N2}
+  return promote_type(BlockSparseT1,BlockSparse{ElT2,VecT2,N2})
 end
 
 function Base.promote_rule(::Type{BlockSparseT1},

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -21,7 +21,7 @@ function _truncated_blockdim(S::DiagMatrix,
 end
 
 """
-svd(T::BlockSparseTensor{<:Number,2}; kwargs...)
+    svd(T::BlockSparseTensor{<:Number,2}; kwargs...)
 
 svd of an order-2 BlockSparseTensor.
 
@@ -148,46 +148,57 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT};
     nzblocksV[n] = blockV
   end
 
-  U = BlockSparseTensor(undef,nzblocksU,indsU)
-  V = BlockSparseTensor(undef,nzblocksV,indsV)
-  S = DiagBlockSparseTensor(undef,nzblocksS,indsS)
+  U = BlockSparseTensor(undef, nzblocksU, indsU)
+  V = BlockSparseTensor(undef, nzblocksV, indsV)
+  S = DiagBlockSparseTensor(undef, nzblocksS, indsS)
 
   for n in 1:nnzblocksT
-    Ub,Sb,Vb = Us[n],Ss[n],Vs[n]
+    Ub, Sb, Vb = Us[n], Ss[n], Vs[n]
 
     blockU = nzblocksU[n]
     blockV = nzblocksV[n]
     blockS = nzblocksS[n]
 
-    blockview(U,blockU) .= Ub
-    blockview(V,blockV) .= Vb
+    blockview(U, blockU) .= Ub
+    blockview(V, blockV) .= Vb
 
-    blockviewS = blockview(S,blockS)
+    blockviewS = blockview(S, blockS)
     for i in 1:diaglength(Sb)
-      setdiagindex!(blockviewS,getdiagindex(Sb,i),i)
+      setdiagindex!(blockviewS, getdiagindex(Sb, i), i)
     end
   end
 
   return U,S,V,Spectrum(d,truncerr)
 end
 
-function LinearAlgebra.eigen(T::Hermitian{ElT,<:BlockSparseMatrix{ElT}};
+_eigen_eltypes(T::Hermitian{ElT,<:BlockSparseMatrix{ElT}}) where {ElT} = real(ElT), ElT
+
+_eigen_eltypes(T::BlockSparseMatrix{ElT}) where {ElT} = complex(ElT), complex(ElT)
+
+function LinearAlgebra.eigen(T::Union{Hermitian{ElT,<:BlockSparseMatrix{ElT}},
+                                      BlockSparseMatrix{ElT}};
                              kwargs...) where {ElT<:Union{Real,Complex}}
   truncate = haskey(kwargs,:maxdim) || haskey(kwargs,:cutoff)
 
-  Us = Vector{BlockSparseMatrix{ElT}}(undef,nnzblocks(T))
-  Ds = Vector{DiagBlockSparseMatrix{real(ElT)}}(undef,nnzblocks(T))
+  ElD, ElV = _eigen_eltypes(T)
 
   # Sorted eigenvalues
   d = Vector{real(ElT)}()
 
-  for n in 1:nnzblocks(T)
+  b = nzblock(T, 1)
+  all(==(b[1]), b) || error("Eigen currently only supports block diagonal matrices.")
+  blockT = blockview(T, 1)
+  Db, Vb = eigen(blockT)
+  Ds = [Db]
+  Vs = [Vb]
+  for n in 2:nnzblocks(T)
     b = nzblock(T, n)
+    all(==(b[1]), b) || error("Eigen currently only supports block diagonal matrices.")
     blockT = blockview(T, n)
-    Ub,Db = eigen(blockT)
-    Us[n] = Ub
-    Ds[n] = Db
-    append!(d,vector(diag(Db)))
+    Db, Vb = eigen(blockT)
+    push!(Ds, Db)
+    push!(Vs, Vb)
+    append!(d, abs.(vector(diag(Db))))
   end
 
   dropblocks = Int[]
@@ -202,11 +213,11 @@ function LinearAlgebra.eigen(T::Hermitian{ElT,<:BlockSparseMatrix{ElT}};
         Dtrunc = tensor(Diag(store(Ds[n])[1:blockdim]),
                         (blockdim,blockdim))
         Ds[n] = Dtrunc
-        Us[n] = copy(Us[n][1:dim(Us[n],1),1:blockdim])
+        Vs[n] = copy(Vs[n][1:dim(Vs[n],1),1:blockdim])
       end
     end
     deleteat!(Ds,dropblocks)
-    deleteat!(Us,dropblocks)
+    deleteat!(Vs,dropblocks)
   else
     truncerr = 0.0
   end
@@ -214,180 +225,64 @@ function LinearAlgebra.eigen(T::Hermitian{ElT,<:BlockSparseMatrix{ElT}};
   # Get the list of blocks of T
   # that are not dropped
   nzblocksT = nzblocks(T)
-  deleteat!(nzblocksT,dropblocks)
+  deleteat!(nzblocksT, dropblocks)
 
   # The number of blocks of T remaining
-  nnzblocksT = nnzblocks(T)-length(dropblocks)
+  nnzblocksT = nnzblocks(T) - length(dropblocks)
 
   #
-  # Put the blocks into U,D
+  # Put the blocks into D, V
   #
 
-  nb1_lt_nb2 = (nblocks(T)[1] < nblocks(T)[2] || (nblocks(T)[1] == nblocks(T)[2] && dim(T,1) < dim(T,2)))
+  i1, i2 = inds(T)
+  l = sim(i1)
 
-  if nb1_lt_nb2
-    uind = sim(ind(T,1))
-  else
-    uind = sim(ind(T,2))
+  deleteat!(l, dropblocks)
+
+  # l may have too many blocks
+  if nblocks(l) > nnzblocksT
+    resize!(l, nnzblocksT)
   end
 
-  deleteat!(uind,dropblocks)
-
-  # uind may have too many blocks
-  if nblocks(uind) > nnzblocksT
-    resize!(uind,nnzblocksT)
-  end
-
+  # Truncation may have changed
+  # some block sizes
   for n in 1:nnzblocksT
-    setblockdim!(uind,minimum(dims(Ds[n])),n)
+    setblockdim!(l, minimum(dims(Ds[n])), n)
   end
 
-  if dir(uind) != dir(inds(T)[1])
-    uind = dag(uind)
-  end
-  indsU = setindex(inds(T),dag(uind),2)
+  r = dag(sim(l))
 
-  vind = sim(uind)
-  if dir(vind) != dir(inds(T)[2])
-    vind = dag(vind)
-  end
-  indsV = setindex(inds(T),dag(vind),1)
-  indsV = permute(indsV,(2,1))
+  indsD = (l, r)
+  indsV = (dag(i2), r)
 
-  indsD = setindex(inds(T),uind,1)
-  indsD = setindex(indsD,vind,2)
-
-  nzblocksU = Vector{Block{2}}(undef,nnzblocksT)
-  nzblocksD = Vector{Block{2}}(undef,nnzblocksT)
-
+  nzblocksD = Vector{Block{2}}(undef, nnzblocksT)
+  nzblocksV = Vector{Block{2}}(undef, nnzblocksT)
   for n in 1:nnzblocksT
     blockT = nzblocksT[n]
 
-    blockU = (blockT[1],n)
-    nzblocksU[n] = blockU
-
-    blockD = (n,n)
+    blockD = (n, n)
     nzblocksD[n] = blockD
+
+    blockV = (blockT[1], n)
+    nzblocksV[n] = blockV
   end
 
-  U = BlockSparseTensor(ElT,undef,nzblocksU,indsU)
-  D = DiagBlockSparseTensor(ElT,undef,nzblocksD,indsD)
+  D = DiagBlockSparseTensor(ElD, undef, nzblocksD, indsD)
+  V = BlockSparseTensor(ElV, undef, nzblocksV, indsV)
 
   for n in 1:nnzblocksT
-    Ub,Db = Us[n],Ds[n]
+    Db, Vb = Ds[n], Vs[n]
 
-    blockU = nzblocksU[n]
     blockD = nzblocksD[n]
-
-    blockview(U,blockU) .= Ub
-
     blockviewD = blockview(D,blockD)
     for i in 1:diaglength(Db)
-      setdiagindex!(blockviewD,getdiagindex(Db,i),i)
+      setdiagindex!(blockviewD, getdiagindex(Db, i), i)
     end
+
+    blockV = nzblocksV[n]
+    blockview(V, blockV) .= Vb
   end
 
-  return U,D,Spectrum(d,truncerr)
-end
-
-function LinearAlgebra.eigen(T::BlockSparseMatrix{ElT};
-                             kwargs...) where {ElT}
-  truncate = haskey(kwargs,:maxdim) || haskey(kwargs,:cutoff)
-
-  if truncate
-    error("Truncation is not currently supported by non-Hermitian eigendecomposition")
-  end
-
-  Us = Vector{BlockSparseMatrix{complex(ElT)}}(undef,nnzblocks(T))
-  Ds = Vector{DiagBlockSparseMatrix{complex(ElT)}}(undef,nnzblocks(T))
-
-  # Sorted eigenvalues
-  d = Vector{real(ElT)}()
-
-  for n in 1:nnzblocks(T)
-    b = nzblock(T, n)
-    blockT = blockview(T, n)
-    Ub,Db = eigen(blockT)
-    Us[n] = complex(Ub)
-    Ds[n] = complex(Db)
-    append!(d,abs.(vector(diag(Db))))
-  end
-  sort!(d; rev=true)
-  truncerr = 0.0
-
-  # Get the list of blocks of T
-  # that are not dropped
-  nzblocksT = nzblocks(T)
-
-  # The number of blocks of T remaining
-  nnzblocksT = nnzblocks(T)
-
-  #
-  # Put the blocks into U,D
-  #
-
-  nb1_lt_nb2 = (nblocks(T)[1] < nblocks(T)[2] || (nblocks(T)[1] == nblocks(T)[2] && dim(T,1) < dim(T,2)))
-
-  if nb1_lt_nb2
-    uind = sim(ind(T,1))
-  else
-    uind = sim(ind(T,2))
-  end
-
-  # uind may have too many blocks
-  if nblocks(uind) > nnzblocksT
-    resize!(uind,nnzblocksT)
-  end
-
-  for n in 1:nnzblocksT
-    setblockdim!(uind,minimum(dims(Ds[n])),n)
-  end
-
-  if dir(uind) != dir(inds(T)[1])
-    uind = dag(uind)
-  end
-  indsU = setindex(inds(T),dag(uind),2)
-
-  vind = sim(uind)
-  if dir(vind) != dir(inds(T)[2])
-    vind = dag(vind)
-  end
-  indsV = setindex(inds(T),dag(vind),1)
-  indsV = permute(indsV,(2,1))
-
-  indsD = setindex(inds(T),uind,1)
-  indsD = setindex(indsD,vind,2)
-
-  nzblocksU = Vector{Block{2}}(undef,nnzblocksT)
-  nzblocksD = Vector{Block{2}}(undef,nnzblocksT)
-
-  for n in 1:nnzblocksT
-    blockT = nzblocksT[n]
-
-    blockU = (blockT[1],n)
-    nzblocksU[n] = blockU
-
-    blockD = (n,n)
-    nzblocksD[n] = blockD
-  end
-
-  U = BlockSparseTensor(complex(ElT),undef,nzblocksU,indsU)
-  D = DiagBlockSparseTensor(complex(ElT),undef,nzblocksD,indsD)
-
-  for n in 1:nnzblocksT
-    Ub,Db = Us[n],Ds[n]
-
-    blockU = nzblocksU[n]
-    blockD = nzblocksD[n]
-
-    blockview(U,blockU) .= Ub
-
-    blockviewD = blockview(D,blockD)
-    for i in 1:diaglength(Db)
-      setdiagindex!(blockviewD,getdiagindex(Db,i),i)
-    end
-  end
-
-  return U,D,Spectrum(d,truncerr)
+  return D, V, Spectrum(d, truncerr)
 end
 

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -191,6 +191,7 @@ function LinearAlgebra.eigen(T::Union{Hermitian{ElT,<:BlockSparseMatrix{ElT}},
   Db, Vb = eigen(blockT)
   Ds = [Db]
   Vs = [Vb]
+  append!(d, abs.(vector(diag(Db))))
   for n in 2:nnzblocks(T)
     b = nzblock(T, n)
     all(==(b[1]), b) || error("Eigen currently only supports block diagonal matrices.")
@@ -203,6 +204,7 @@ function LinearAlgebra.eigen(T::Union{Hermitian{ElT,<:BlockSparseMatrix{ElT}},
 
   dropblocks = Int[]
   sort!(d; rev=true, by=abs)
+
   if truncate
     truncerr,docut = truncate!(d; kwargs...)
     for n in 1:nnzblocks(T)

--- a/NDTensors/src/dims.jl
+++ b/NDTensors/src/dims.jl
@@ -50,3 +50,6 @@ dir(::Int) = 0
 # This is to help with ITensor compatibility
 dag(i::Int) = i
 
+# This is to help with ITensor compatibility
+sim(i::Int) = i
+

--- a/docs/src/ITensorType.md
+++ b/docs/src/ITensorType.md
@@ -64,6 +64,8 @@ swaptags(::ITensor, ::Any...)
 ```@docs
 replaceind(::ITensor, ::Any...)
 replaceinds(::ITensor, ::Any...)
+swapind(::ITensor, ::Any...)
+swapinds(::ITensor, ::Any...)
 ```
 
 ## Math operations

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -69,6 +69,8 @@ export
   replaceind,
   replaceinds,
   setindex,
+  swapind,
+  swapinds,
   swapprime,
   swaptags,
 

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -925,11 +925,39 @@ function getindices(is::IndexSet, I...)
 end
 
 NDTensors.getindices(is::IndexSet,
-                   I...) = getindices(is, I...)
+                     I...) = getindices(is, I...)
 
 #
 # QN functions
 #
+
+"""
+    setdirs(is::IndexSet, dirs::Arrow...)
+
+Return a new IndexSet with indices `setdir(is[i], dirs[i])`.
+"""
+function setdirs(is::IndexSet{N}, dirs) where {N}
+  return IndexSet(ntuple(i -> setdir(is[i], dirs[i]), Val(N)))
+end
+
+"""
+    dir(is::IndexSet, i::Index)
+
+Return the direction of the Index `i` in the IndexSet `is`.
+"""
+function dir(is1::IndexSet, i::Index)
+  return dir(getfirst(is1, i))
+end
+
+"""
+    dirs(is::IndexSet, inds)
+
+Return a tuple of the directions of the indices `inds` in 
+the IndexSet `is`.
+"""
+function dirs(is1::IndexSet, inds)
+  return ntuple(i -> dir(is1, inds[i]), Val(length(inds)))
+end
 
 hasqns(is::IndexSet) = any(hasqns,is)
 

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -735,14 +735,6 @@ swaptags(is::IndexSet,
          kwargs...) = swaptags(fmatch(args...; kwargs...),
                                is, tags1, tags2)
 
-function replaceind(is::IndexSet, i1::Index, i2::Index)
-  space(i1) != space(i2) && error("Indices must have the same spaces to be replaced")
-  pos = findfirst(is, i1)
-  isnothing(pos) && error("Index not found")
-  i2 = setdir(i2, dir(is[pos]))
-  return setindex(is, i2, pos)
-end
-
 function replaceinds(is::IndexSet, inds1, inds2)
   is1 = IndexSet(inds1)
   poss = indexin(is1, is)
@@ -755,6 +747,23 @@ function replaceinds(is::IndexSet, inds1, inds2)
   end
   return is
 end
+
+replaceind(is::IndexSet, i1::Index, i2::Index) = replaceinds(is, (i1,), (i2,))
+
+function swapinds(is::IndexSet, inds1, inds2)
+  is1 = IndexSet(inds1)
+  is2 = IndexSet(inds2)
+
+  # Temporary indices for swapping
+  is2_sim = sim(is2)
+
+  is = replaceinds(is, is1, is2_sim)
+  is = replaceinds(is, is2, is1)
+  is = replaceinds(is, is2_sim, is2)
+  return is
+end
+
+swapind(is::IndexSet, i1::Index, i2::Index) = swapinds(is, (i1,), (i2,))
 
 NDTensors.dense(::Type{<:IndexSet}) = IndexSet
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -670,7 +670,9 @@ for fname in (:prime,
               :settags,
               :swaptags,
               :replaceind,
-              :replaceinds)
+              :replaceinds,
+              :swapind,
+              :swapinds)
   @eval begin
     $fname(f::Function,
            A::ITensor,
@@ -829,6 +831,28 @@ The indices must have the same space (i.e. the same dimension and QNs, if applic
 
 The storage of the ITensor is not modified or copied (the output ITensor is a view of the input ITensor).
 """ replaceinds(::ITensor, ::Any...)
+
+@doc """
+    swapind(A::ITensor, i1::Index, i2::Index) -> ITensor
+
+    swapind!(A::ITensor, i1::Index, i2::Index)
+
+Swap the Index `i1` with the Index `i2` in the ITensor.
+
+The indices must have the same space (i.e. the same dimension and QNs, if applicable).
+""" swapind(::ITensor, ::Any...)
+
+@doc """
+    swapinds(A::ITensor, inds1, inds2) -> ITensor
+
+    swapinds!(A::ITensor, inds1, inds2)
+
+Swap the Index `inds1[n]` with the Index `inds2[n]` in the ITensor, where `n` runs from `1` to `length(inds1) == length(inds2)`.
+
+The indices must have the same space (i.e. the same dimension and QNs, if applicable).
+
+The storage of the ITensor is not modified or copied (the output ITensor is a view of the input ITensor).
+""" swapinds(::ITensor, ::Any...)
 
 """
     adjoint(A::ITensor)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -656,7 +656,7 @@ firstind(A...; kwargs...) = getfirst(itensor2inds.(A)...;
                                      kwargs...)
 
 NDTensors.inds(A...; kwargs...) = filter(itensor2inds.(A)...;
-                                       kwargs...)
+                                         kwargs...)
 
 # in-place versions of priming and tagging
 for fname in (:prime,
@@ -860,6 +860,8 @@ The storage of the ITensor is not modified or copied (the output ITensor is a vi
 For `A'` notation to prime an ITensor by 1.
 """
 Base.adjoint(A::ITensor) = prime(A)
+
+dirs(A::ITensor, is) = dirs(inds(A), is)
 
 function Base.:(==)(A::ITensor, B::ITensor)
   return norm(A - B) == zero(promote_type(eltype(A),eltype(B)))

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -158,13 +158,13 @@ end
       end
 
 @timeit_debug GLOBAL_TIMER "replacebond!" begin
-        spec = replacebond!(psi, b, phi; maxdim = maxdim(sweeps, sw),
-                                         mindim = mindim(sweeps, sw),
-                                         cutoff = cutoff(sweeps, sw),
-                                         eigen_perturbation = drho,
-                                         ortho = ortho,
-                                         normalize = true,
-                                         which_decomp = which_decomp)
+      spec = replacebond!(psi, b, phi; maxdim = maxdim(sweeps, sw),
+                                       mindim = mindim(sweeps, sw),
+                                       cutoff = cutoff(sweeps, sw),
+                                       eigen_perturbation = drho,
+                                       ortho = ortho,
+                                       normalize = true,
+                                       which_decomp = which_decomp)
 end
 
       if outputlevel >= 2

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -295,14 +295,15 @@ function _contract_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
   s̃ = unique_siteind(simA_c, psi_c, n)
   Lis = IndexSet(s)
   Ris = IndexSet(s̃)
-  FU, D = eigen(ρ, Lis, Ris; ishermitian=true, 
-                             tags=ts, 
-                             kwargs...)
-  l_renorm = commonind(FU, D)
-  simFU_c = replaceinds(prime(dag(FU), l_renorm), Lis, Ris)
-  psi_out[n] = FU
-  R = R * dag(FU) * psi[n-1] * A[n-1]
-  simR_c = simR_c * dag(simFU_c) * psi_c[n-1] * simA_c[n-1]
+  F = eigen(ρ, Lis, Ris; ishermitian=true, 
+                         tags=ts, 
+                         kwargs...)
+  U, D = F
+  Ut = F.Ut
+  l_renorm = commonind(U, D)
+  psi_out[n] = U
+  R = R * dag(U) * psi[n-1] * A[n-1]
+  simR_c = simR_c * Ut * psi_c[n-1] * simA_c[n-1]
   for j in reverse(2:n-1)
     s = unique_siteind(A, psi, j)
     s̃ = unique_siteind(simA_c, psi_c, j)
@@ -311,14 +312,15 @@ function _contract_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
     ts = isnothing(l) ? "" : tags(l)
     Lis = IndexSet(s, l_renorm)
     Ris = IndexSet(s̃, l_renorm')
-    FU, D = eigen(ρ, Lis, Ris; ishermitian=true,
-                                tags=ts, 
-                                kwargs...)
-    l_renorm = commonind(FU, D)
-    simFU_c = replaceinds(prime(dag(FU), l_renorm), Lis, Ris)
-    psi_out[j] = FU
-    R = R * dag(FU) * psi[j-1] * A[j-1]
-    simR_c = simR_c * dag(simFU_c) * psi_c[j-1] * simA_c[j-1]
+    F = eigen(ρ, Lis, Ris; ishermitian=true,
+                           tags=ts, 
+                           kwargs...)
+    U, D = F
+    Ut = F.Ut
+    l_renorm = commonind(U, D)
+    psi_out[j] = U
+    R = R * dag(U) * psi[j-1] * A[j-1]
+    simR_c = simR_c * Ut * psi_c[j-1] * simA_c[j-1]
   end
   if normalize
     R ./= norm(R)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -298,7 +298,7 @@ function _contract_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
   F = eigen(ρ, Lis, Ris; ishermitian=true, 
                          tags=ts, 
                          kwargs...)
-  U, D = F
+  D, U = F
   Ut = F.Ut
   l_renorm = commonind(U, D)
   psi_out[n] = U
@@ -315,7 +315,7 @@ function _contract_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
     F = eigen(ρ, Lis, Ris; ishermitian=true,
                            tags=ts, 
                            kwargs...)
-    U, D = F
+    D, U = F
     Ut = F.Ut
     l_renorm = commonind(U, D)
     psi_out[j] = U

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -298,12 +298,11 @@ function _contract_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
   F = eigen(ρ, Lis, Ris; ishermitian=true, 
                          tags=ts, 
                          kwargs...)
-  D, U = F
-  Ut = F.Ut
-  l_renorm = commonind(U, D)
-  psi_out[n] = U
-  R = R * dag(U) * psi[n-1] * A[n-1]
-  simR_c = simR_c * Ut * psi_c[n-1] * simA_c[n-1]
+  D, U, Ut = F.D, F.V, F.Vt
+  l_renorm, r_renorm = F.l, F.r
+  psi_out[n] = Ut
+  R = R * dag(Ut) * psi[n-1] * A[n-1]
+  simR_c = simR_c * U * psi_c[n-1] * simA_c[n-1]
   for j in reverse(2:n-1)
     s = unique_siteind(A, psi, j)
     s̃ = unique_siteind(simA_c, psi_c, j)
@@ -311,16 +310,15 @@ function _contract_densitymatrix(A::MPO, psi::MPS; kwargs...)::MPS
     l = linkind(psi, j-1)
     ts = isnothing(l) ? "" : tags(l)
     Lis = IndexSet(s, l_renorm)
-    Ris = IndexSet(s̃, l_renorm')
+    Ris = IndexSet(s̃, r_renorm)
     F = eigen(ρ, Lis, Ris; ishermitian=true,
                            tags=ts, 
                            kwargs...)
-    D, U = F
-    Ut = F.Ut
-    l_renorm = commonind(U, D)
-    psi_out[j] = U
-    R = R * dag(U) * psi[j-1] * A[j-1]
-    simR_c = simR_c * Ut * psi_c[j-1] * simA_c[j-1]
+    D, U, Ut = F.D, F.V, F.Vt
+    l_renorm, r_renorm = F.l, F.r
+    psi_out[j] = Ut
+    R = R * dag(Ut) * psi[j-1] * A[j-1]
+    simR_c = simR_c * U * psi_c[j-1] * simA_c[j-1]
   end
   if normalize
     R ./= norm(R)

--- a/test/ctmrg.jl
+++ b/test/ctmrg.jl
@@ -24,12 +24,10 @@ function ctmrg(T::ITensor,
     lr = firstind(Clu⁽¹⁾,"link,right")
     sr = firstind(Clu⁽¹⁾,"site,right")
 
-    Ud,Cdr = eigen(Clu⁽¹⁾, (ld, sd), (lr, sr); ishermitian = true,
+    Cdr,Ur = eigen(Clu⁽¹⁾, (ld, sd), (lr, sr); ishermitian = true,
                                                maxdim = χmax,
                                                lefttags = "link,down,renorm",
-                                               leftplev = 0,
-                                               righttags = "link,right,renorm",
-                                               rightplev = 0)
+                                               righttags = "link,right,renorm")
 
     ## The renormalized CTM is the diagonal matrix of eigenvalues
     Clu = replacetags(Cdr,"renorm","orig")
@@ -38,6 +36,7 @@ function ctmrg(T::ITensor,
     Clu = Clu/norm(Clu)
 
     ## Calculate the renormalized half row transfer matrix (HRTM)
+    Ud = replacetags(Ur,"right","down")
     Uu = replacetags(Ud,"down","up")
 
     Al = Al*Uu*T*Ud

--- a/test/decomp.jl
+++ b/test/decomp.jl
@@ -52,7 +52,7 @@ using ITensors,
     eigA = eigen(A)
     Dt, Ut = eigen(NDTensors.tensor(A))
     eigArr = eigen(array(A))
-    @test diag(array(eigA.D), 0) == eigArr.values
+    @test diag(array(eigA.D), 0) ≈ eigArr.values
     @test diag(array(Dt), 0) == eigArr.values
   end
 

--- a/test/decomp.jl
+++ b/test/decomp.jl
@@ -50,7 +50,7 @@ using ITensors,
     j = Index(2,"j")
     A = randomITensor(i,i')
     eigA = eigen(A)
-    Ut, Dt = eigen(NDTensors.tensor(A))
+    Dt, Ut = eigen(NDTensors.tensor(A))
     eigArr = eigen(array(A))
     @test diag(array(eigA.D), 0) == eigArr.values
     @test diag(array(Dt), 0) == eigArr.values

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -734,15 +734,12 @@ end
 
     @testset "Test Hermitian eigendecomposition of an ITensor" begin
       is = IndexSet(i,j)
-      T = randomITensor(is..., prime(is)...)
+      T = randomITensor(SType, is..., prime(is)...)
       T = T + swapprime(dag(T), 0, 1)
-
-      @show inds(T)
-
-      D, U, spec, u = eigen(T; ishermitian=true)
+      D, U, spec, l, r = eigen(T; ishermitian=true)
       @test T ≈ prime(U) * D * dag(U) atol=1e-13
-      UUᴴ =  U * prime(dag(U), u)
-      @test UUᴴ ≈ δ(u, u')
+      UUᴴ =  U * prime(dag(U), r)
+      @test UUᴴ ≈ δ(r, r')
     end
 
     @testset "Test factorize of an ITensor" begin

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -736,10 +736,13 @@ end
       is = IndexSet(i,j)
       T = randomITensor(is..., prime(is)...)
       T = T + swapprime(dag(T), 0, 1)
-      U,D,spec,u = eigen(T; ishermitian=true)
-      @test T ≈ U*D*prime(dag(U)) atol=1e-13
-      UUᴴ =  U*prime(dag(U),u)
-      @test UUᴴ ≈ δ(u,u')
+
+      @show inds(T)
+
+      D, U, spec, u = eigen(T; ishermitian=true)
+      @test T ≈ prime(U) * D * dag(U) atol=1e-13
+      UUᴴ =  U * prime(dag(U), u)
+      @test UUᴴ ≈ δ(u, u')
     end
 
     @testset "Test factorize of an ITensor" begin
@@ -792,7 +795,7 @@ end
     @testset "Test error for empty inputs" begin
       @test_throws ErrorException svd(A)
       @test_throws ErrorException svd(A, inds(A))
-      @test_throws ErrorException eigen(A, inds(A))
+      @test_throws ErrorException eigen(A, inds(A), inds(A))
       @test_throws ErrorException factorize(A)
       @test_throws ErrorException factorize(A, inds(A))
     end

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -3,8 +3,7 @@ using ITensors,
 
 include("util.jl")
 
-function basicRandomMPO(N::Int, sites;dim=4)
-  #sites = [Index(2,"Site") for n=1:N]
+function basicRandomMPO(N::Int, sites; dim=4)
   M = MPO(sites)
   links = [Index(dim,"n=$(n-1),Link") for n=1:N+1]
   for n=1:N
@@ -17,7 +16,7 @@ end
 
 @testset "MPO Basics" begin
   N = 6
-  sites = [Index(2,"Site") for n=1:N]
+  sites = [Index(2,"Site,n=$n") for n=1:N]
   @test length(MPO()) == 0
   O = MPO(sites)
   @test length(O) == N
@@ -152,7 +151,7 @@ end
     K   = randomMPO(sites)
     @test maxlinkdim(K) == 1
     psi = randomMPS(sites)
-    psi_out = contract(K, psi,maxdim=1)
+    psi_out = contract(K, psi; maxdim=1)
     @test inner(phi,psi_out) ≈ inner(phi,K,psi)
     @test_throws ArgumentError contract(K, psi, method="fakemethod")
 

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -548,7 +548,11 @@ Random.seed!(1234)
       A = randomITensor(QN(),i,j,dag(k),dag(l))
       A = A*prime(dag(A),(i,j))
 
-      U,D = eigen(A; ishermitian=true, tags="x")
+      F = eigen(A; ishermitian=true, tags="x")
+
+      U, D = F
+      Ut = F.Ut
+
 
       @test store(U) isa NDTensors.BlockSparse
       @test store(D) isa NDTensors.DiagBlockSparse
@@ -564,8 +568,9 @@ Random.seed!(1234)
       @test hassameinds(U,(i,j,u))
       @test hassameinds(D,(u,up))
 
-      @test norm(A-U*D*dag(U)') ≈ 0.0 atol=1e-11
-      @test norm(A*U'-U*D) ≈ 0.0 atol=1e-11
+      @test norm(A - U * D * dag(U)') ≈ 0.0 atol=1e-11
+      @test norm(A * U' - U * D) ≈ 0.0 atol=1e-11
+      @test norm(A * Ut - U * D) ≈ 0.0 atol=1e-11
     end
 
     @testset "eigen hermitian (truncate)" begin
@@ -582,15 +587,18 @@ Random.seed!(1234)
       A = A/norm(A)
 
       cutoff = 1e-5
-      U,D,spec = eigen(A; ishermitian=true,
-                          tags="x",
-                          cutoff=cutoff)
+      F = eigen(A; ishermitian=true,
+                   tags="x",
+                   cutoff=cutoff)
+
+      U, D, spec = F
+      Ut = F.Ut
 
       @test store(U) isa NDTensors.BlockSparse
       @test store(D) isa NDTensors.DiagBlockSparse
 
-      u = commonind(D,U)
-      up = uniqueind(D,U)
+      u = commonind(D, U)
+      up = uniqueind(D, U)
 
       @test hastags(u,"x")
       @test plev(u) == 0
@@ -610,9 +618,10 @@ Random.seed!(1234)
         @test flux(D,b)==QN(0)
       end
 
-      Ap = U*D*dag(U)'
+      Ap = U * D * dag(U)'
 
       @test norm(Ap-A) ≤ 1e-2
+      @test norm(U * D * dag(Ut) - A) ≤ 1e-2
       @test minimum(dims(D)) == length(spec.eigs)
       @test minimum(dims(D)) < dim(i)*dim(j)
 
@@ -628,7 +637,10 @@ Random.seed!(1234)
 
       A = randomITensor(QN(),i,j,dag(i'),dag(j'))
 
-      U,D = eigen(A; tags="x")
+      F = eigen(A; tags="x")
+
+      U, D = F
+      Ut = F.Ut
 
       @test store(U) isa NDTensors.BlockSparse
       @test store(D) isa NDTensors.DiagBlockSparse
@@ -641,8 +653,44 @@ Random.seed!(1234)
       @test hastags(up,"x")
       @test plev(up) == 1
 
-      @test norm(A-U*D*dag(U)') ≉ 0.0 atol=1e-12
-      @test norm(A*U'-U*D) ≈ 0.0 atol=1e-12
+      @test norm(A - U * D * dag(U)') ≉ 0.0 atol=1e-12
+      @test norm(A - U * D * dag(Ut)) ≉ 0.0 atol=1e-12
+      @test norm(A * Ut - U * D) ≈ 0.0 atol=1e-12
+    end
+
+    @testset "eigen non-hermitian (general inds)" begin
+      i = Index(QN(0) => 2,
+                QN(1) => 3,
+                QN(2) => 4; tags="i")
+      j = settags(i, "j")
+      ĩ, j̃ = sim(i), sim(j)
+
+      A = randomITensor(QN(), i, j, dag(ĩ),dag(j̃))
+
+      F = eigen(A, (i, j), (ĩ, j̃); lefttags = "x", righttags = "y")
+
+      U, D = F
+      Ut = F.Ut
+
+      @test store(U) isa NDTensors.BlockSparse
+      @test store(D) isa NDTensors.DiagBlockSparse
+
+      u = commonind(D, U)
+      ut = uniqueind(D, U)
+
+      @test F.u == u
+      @test F.ut == ut
+
+      @test hastags(u, "x")
+      @test plev(u) == 0
+      @test hastags(ut, "y")
+      @test plev(ut) == 0
+
+      @test hassameinds(U, (i, j, u))
+      @test hassameinds(Ut, (ĩ, j̃, ut))
+
+      @test norm(A - U * D * dag(Ut)) ≉ 0.0 atol=1e-12
+      @test norm(A * Ut - U * D) ≈ 0.0 atol=1e-12
     end
 
   end

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -550,8 +550,8 @@ Random.seed!(1234)
 
       F = eigen(A; ishermitian=true, tags="x")
 
-      U, D = F
-      Ut = F.Ut
+      D, U = F
+      Ut = F.Vt
 
 
       @test store(U) isa NDTensors.BlockSparse
@@ -565,12 +565,13 @@ Random.seed!(1234)
       @test hastags(up,"x")
       @test plev(up) == 1
 
-      @test hassameinds(U,(i,j,u))
-      @test hassameinds(D,(u,up))
+      @test hassameinds(U, (i,j,u))
+      @test hassameinds(D, (u,up))
 
-      @test norm(A - U * D * dag(U)') ≈ 0.0 atol=1e-11
-      @test norm(A * U' - U * D) ≈ 0.0 atol=1e-11
-      @test norm(A * Ut - U * D) ≈ 0.0 atol=1e-11
+      @test norm(A - dag(U) * D * U') ≈ 0.0 atol=1e-11
+      @test norm(A - dag(U) * D * Ut) ≈ 0.0 atol=1e-11
+      @test norm(A * U - U' * D) ≈ 0.0 atol=1e-11
+      @test norm(A * U - Ut * D) ≈ 0.0 atol=1e-11
     end
 
     @testset "eigen hermitian (truncate)" begin
@@ -591,8 +592,8 @@ Random.seed!(1234)
                    tags="x",
                    cutoff=cutoff)
 
-      U, D, spec = F
-      Ut = F.Ut
+      D, U, spec = F
+      Ut = F.Vt
 
       @test store(U) isa NDTensors.BlockSparse
       @test store(D) isa NDTensors.DiagBlockSparse
@@ -618,10 +619,10 @@ Random.seed!(1234)
         @test flux(D,b)==QN(0)
       end
 
-      Ap = U * D * dag(U)'
+      Ap = dag(U) * D * U'
 
       @test norm(Ap-A) ≤ 1e-2
-      @test norm(U * D * dag(Ut) - A) ≤ 1e-2
+      @test norm(dag(U) * D * Ut - A) ≤ 1e-2
       @test minimum(dims(D)) == length(spec.eigs)
       @test minimum(dims(D)) < dim(i)*dim(j)
 
@@ -639,8 +640,8 @@ Random.seed!(1234)
 
       F = eigen(A; tags="x")
 
-      U, D = F
-      Ut = F.Ut
+      D, U = F
+      Ut = F.Vt
 
       @test store(U) isa NDTensors.BlockSparse
       @test store(D) isa NDTensors.DiagBlockSparse
@@ -653,9 +654,10 @@ Random.seed!(1234)
       @test hastags(up,"x")
       @test plev(up) == 1
 
-      @test norm(A - U * D * dag(U)') ≉ 0.0 atol=1e-12
-      @test norm(A - U * D * dag(Ut)) ≉ 0.0 atol=1e-12
-      @test norm(A * Ut - U * D) ≈ 0.0 atol=1e-12
+      @test norm(A - U' * D * dag(U)) ≉ 0.0 atol=1e-12
+      @test norm(A - Ut * D * dag(U)) ≉ 0.0 atol=1e-12
+      @test norm(A * U - U' * D) ≈ 0.0 atol=1e-12
+      @test norm(A * U - Ut * D) ≈ 0.0 atol=1e-12
     end
 
     @testset "eigen non-hermitian (general inds)" begin
@@ -669,28 +671,28 @@ Random.seed!(1234)
 
       F = eigen(A, (i, j), (ĩ, j̃); lefttags = "x", righttags = "y")
 
-      U, D = F
-      Ut = F.Ut
+      D, U = F
+      Ut = F.Vt
 
       @test store(U) isa NDTensors.BlockSparse
       @test store(D) isa NDTensors.DiagBlockSparse
 
-      u = commonind(D, U)
-      ut = uniqueind(D, U)
+      l = uniqueind(D, U)
+      r = commonind(D, U)
 
-      @test F.u == u
-      @test F.ut == ut
+      @test F.l == l
+      @test F.r == r
 
-      @test hastags(u, "x")
-      @test plev(u) == 0
-      @test hastags(ut, "y")
-      @test plev(ut) == 0
+      @test hastags(l, "x")
+      @test plev(l) == 0
+      @test hastags(r, "y")
+      @test plev(r) == 0
 
-      @test hassameinds(U, (i, j, u))
-      @test hassameinds(Ut, (ĩ, j̃, ut))
+      @test hassameinds(U, (ĩ, j̃, r))
+      @test hassameinds(Ut, (i, j, l))
 
-      @test norm(A - U * D * dag(Ut)) ≉ 0.0 atol=1e-12
-      @test norm(A * Ut - U * D) ≈ 0.0 atol=1e-12
+      @test norm(A * U - Ut * D) ≈ 0.0 atol=1e-12
+      @test norm(A - Ut * D * dag(U)) ≉ 0.0 atol=1e-12
     end
 
   end


### PR DESCRIPTION
This addresses #331.

~~The version proposed here is non-breaking. The api is the following:~~
```julia
i = Index(QN(0) => 2,
          QN(1) => 3,
          QN(2) => 4; tags="i")
j = settags(i, "j")
it, jt = sim(i), sim(j)
A = randomITensor(QN(), i, j, dag(it), dag(jt))
F = eigen(A, (i, j), (it, jt); lefttags = "x", righttags = "y")
U, D, spec = F
Ut = F.Ut
@show norm(A * Ut - U * D)
```
~~Here, the ITensor `Ut` that has the correct indices to contract with `A` can only by extracted from the `TruncEigen` object `F`, not through iteration.~~

~~We could consider returning it at the end of the iteration, or somewhere else (like after `D` and before `spec`). I guess the question is if people are more likely to use `Ut` or `spec`.~~

See later comments for the updated syntax.
