### PR TITLE
Introduce removeqns function

### DIFF
--- a/NDTensors/src/blocksparse/blockdims.jl
+++ b/NDTensors/src/blocksparse/blockdims.jl
@@ -24,14 +24,6 @@ Base.ndims(ds::Type{<:BlockDims{N}}) where {N} = N
 similar_type(::Type{<:BlockDims},
              ::Type{Val{N}}) where {N} = BlockDims{N}
 
-"""
-dense(::BlockDims) -> Dims
-
-Make the "dense" version of the block indices.
-"""
-dense(ds::BlockDims) = dims(ds)
-dense(::Type{<:BlockDims{N}}) where {N} = Dims{N}
-
 Base.copy(ds::BlockDims) = ds
 
 """

--- a/NDTensors/src/blocksparse/blocksparsetensor.jl
+++ b/NDTensors/src/blocksparse/blocksparsetensor.jl
@@ -293,7 +293,7 @@ end
 
 # convert to Dense
 function dense(T::TensorT) where {TensorT<:BlockSparseTensor}
-  R = zeros(dense(TensorT),dense(inds(T)))
+  R = zeros(dense(TensorT), inds(T))
   for (block,offset) in blockoffsets(T)
     # TODO: make sure this assignment is efficient
     R[blockindices(T,block)] = blockview(T,block)

--- a/NDTensors/src/tensor.jl
+++ b/NDTensors/src/tensor.jl
@@ -195,7 +195,7 @@ end
 # Convert the tensor type to the closest dense
 # type
 function dense(::Type{<:Tensor{ElT,NT,StoreT,IndsT}}) where {ElT,NT,StoreT,IndsT}
-  return Tensor{ElT,NT,dense(StoreT),dense(IndsT)}
+  return Tensor{ElT,NT,dense(StoreT),IndsT}
 end
 
 dense(T::Tensor) = tensor(dense(store(T)), inds(T))

--- a/src/index.jl
+++ b/src/index.jl
@@ -396,6 +396,13 @@ Checks of the Index has QNs or not.
 """
 hasqns(::Index) = false
 
+"""
+    removeqns(::Index)
+
+Removes the QNs from the Index, if it has any.
+"""
+removeqns(i::Index) = i
+
 #
 # IndexVal
 #

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -756,11 +756,7 @@ end
 
 swapind(is::IndexSet, i1::Index, i2::Index) = swapinds(is, (i1,), (i2,))
 
-NDTensors.dense(::Type{<:IndexSet}) = IndexSet
-
-NDTensors.dense(is::IndexSet) = IndexSet(dense(is...))
-
-NDTensors.dense(inds::Index...) = inds
+removeqns(is::IndexSet) = is
 
 #
 # Helper functions for contracting ITensors

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -398,11 +398,15 @@ end
 """
     dense(T::ITensor)
 
-Make a new ITensor where the storage is the dense version,
+Make a new ITensor where the storage is the closest Dense storage,
 avoiding allocating new data if possible.
-For example, an ITensor with Diag storage will become Dense storage.
+For example, an ITensor with Diag storage will become Dense storage,
+filled with zeros except for the diagonal values.
 """
-NDTensors.dense(T::ITensor) = itensor(dense(tensor(T)))
+function NDTensors.dense(A::ITensor)
+  T = dense(tensor(A))
+  return itensor(store(T), removeqns(inds(A)))
+end
 
 """
     complex(T::ITensor)

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -289,10 +289,11 @@ function combineblocks(i::QNIndex)
   return iR,perm,comb
 end
 
-# TODO: should this be removeblocks/removeqns?
-NDTensors.dense(inds::QNIndex...) = dense.(inds)
-
-NDTensors.dense(i::QNIndex) = Index(id(i),dim(i),dir(i),tags(i),plev(i))
+removeqns(i::QNIndex) = Index(id(i),
+                              dim(i),
+                              dir(i),
+                              tags(i),
+                              plev(i))
 
 function Base.show(io::IO,
                    i::QNIndex)

--- a/src/qn/qnindexset.jl
+++ b/src/qn/qnindexset.jl
@@ -27,3 +27,5 @@ function nzdiagblocks(qn::QN,
   return blocks
 end
 
+removeqns(is::QNIndexSet) = map(i -> removeqns(i), is)
+


### PR DESCRIPTION
This introduces the `removeqns` function, so far just for `Index` and `IndexSet`. It replaces the use of `dense(::Index)` and `dense(::IndexSet)` for removing the QNS, which I think was a bad name for that functionality.

We still need to add `removeqns(::ITensor)`, but right now that functionality is not available for certain storage types (for example we don't have `DiagBlockSparse -> BlockSparse`).