### PR TITLE
Add unit test for QN-conserving Heisenberg DMRG

### DIFF
--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -203,18 +203,9 @@ function LinearAlgebra.eigen(A::ITensor{N},
   DT, VT, spec = eigen(AT; kwargs...)
   D, VC = itensor(DT), itensor(VT)
 
-  l = uniqueind(D, VC)
-  r = commonind(D, VC)
-
   if hasqns(A)
-    # Fix the flux of D, VC
-    # and flux(D) == flux(A)
-    # such that flux(VC) == QN()
-    for b in nzblocks(VC)
-      i1, i2 = inds(VC)
-      newqn = -dir(i2) * qn(i1, b[1])
-      setblockqn!(i2, newqn, b[2])
-      setblockqn!(r, newqn, b[2])
+    for b in nzblocks(D)
+      @assert flux(D, b) == QN()
     end
   end
 


### PR DESCRIPTION
This PR concerns a recent issue where QN-conserving DMRG is failing in some cases, specifically for the S=1 Heisenberg model. I tried coming up with a more minimal example, but the minimal example succeeded; I could only reproduce the failure in the context of a full DMRG calculation, like the one in the updated test/dmrg.jl included in this PR.

The issue is happening in the call to `replacebond!` inside of DMRG. (See the typical error message below.)

One line of code that looks potentially concerning to me is line 227 or so of decomp.jl:
`r̃ = setprime(settags(l̃, righttags), rightplev)`
Maybe the argument to settags on the right should be r instead of l̃ ?

Here's the error I get:

  Indices must have the same spaces to be replaced
  Stacktrace:
   [1] error(::String) at ./error.jl:33
   [2] replaceinds(::IndexSet{2,Index{Array{Pair{QN,Int64},1}}}, ::Tuple{Index{Array{Pair{QN,Int64},1}},Index{Array{Pair{QN,Int64},1}}}, ::Tuple{Index{Array{Pair{QN,Int64},1}},Index{Array{Pair{QN,Int64},1}}}) at /Users/mstoudenmire/software/jitensor/src/indexset.jl:744
   [3] replaceinds!(::ITensor{2}, ::Tuple{Index{Array{Pair{QN,Int64},1}},Index{Array{Pair{QN,Int64},1}}}, ::Vararg{Tuple{Index{Array{Pair{QN,Int64},1}},Index{Array{Pair{QN,Int64},1}}},N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/mstoudenmire/software/jitensor/src/itensor.jl:701
   [4] replaceinds!(::ITensor{2}, ::Tuple{Index{Array{Pair{QN,Int64},1}},Index{Array{Pair{QN,Int64},1}}}, ::Tuple{Index{Array{Pair{QN,Int64},1}},Index{Array{Pair{QN,Int64},1}}}) at /Users/mstoudenmire/software/jitensor/src/itensor.jl:701
   [5] eigen(::ITensor{4}, ::IndexSet{2,Index{Array{Pair{QN,Int64},1}}}, ::IndexSet{2,Index{Array{Pair{QN,Int64},1}}}; kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{10,Symbol},NamedTuple{(:ishermitian, :which_decomp, :tags, :maxdim, :mindim, :cutoff, :eigen_perturbation, :ortho, :normalize, :svd_alg),Tuple{Bool,Nothing,TagSet,Int64,Int64,Float64,ITensor{4},String,Bool,String}}}) at /Users/mstoudenmire/software/jitensor/src/decomp.jl:229
   [6] factorize_eigen(::ITensor{3}, ::IndexSet{3,Index{Array{Pair{QN,Int64},1}}}; kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{9,Symbol},NamedTuple{(:which_decomp, :tags, :maxdim, :mindim, :cutoff, :eigen_perturbation, :ortho, :normalize, :svd_alg),Tuple{Nothing,TagSet,Int64,Int64,Float64,ITensor{4},String,Bool,String}}}) at /Users/mstoudenmire/software/jitensor/src/decomp.jl:321
   [7] factorize(::ITensor{3}, ::IndexSet{3,Index{Array{Pair{QN,Int64},1}}}; kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{9,Symbol},NamedTuple{(:which_decomp, :tags, :maxdim, :mindim, :cutoff, :eigen_perturbation, :ortho, :normalize, :svd_alg),Tuple{Nothing,TagSet,Int64,Int64,Float64,ITensor{4},String,Bool,String}}}) at /Users/mstoudenmire/software/jitensor/src/decomp.jl:387
   [8] replacebond!(::MPS, ::Int64, ::ITensor{3}; kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{8,Symbol},NamedTuple{(:maxdim, :mindim, :cutoff, :eigen_perturbation, :ortho, :normalize, :which_decomp, :svd_alg),Tuple{Int64,Int64,Float64,ITensor{4},String,Bool,Nothing,String}}}) at /Users/mstoudenmire/software/jitensor/src/mps/mps.jl:325
   [9] macro expansion at /Users/mstoudenmire/software/jitensor/src/mps/dmrg.jl:162 [inlined]




