### PR TITLE
Simplification of noiseterm interface

### DIFF
--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -155,7 +155,7 @@ end
       drho = nothing
       if noise(sweeps, sw) > 0.0
         # Use noise term when determining new MPS basis
-        drho = noise(sweeps, sw) * noiseterm(PH, phi, b, ortho)
+        drho = noise(sweeps, sw) * noiseterm(PH,phi,ortho)
       end
 
 @timeit_debug GLOBAL_TIMER "replacebond!" begin

--- a/src/mps/projmpo.jl
+++ b/src/mps/projmpo.jl
@@ -130,15 +130,14 @@ end
 # Return a "noise term" as in Phys. Rev. B 72, 180403
 function noiseterm(pm::ProjMPO,
                    phi::ITensor,
-                   b::Int,
                    ortho::String)
   if ortho == "left"
-    nt = pm.H[b]*phi
+    nt = pm.H[pm.lpos+1]*phi
     if !isnothing(lproj(pm))
       nt *= lproj(pm)
     end
   elseif ortho == "right"
-    nt = phi*pm.H[b+1]
+    nt = phi*pm.H[pm.rpos-1]
     if !isnothing(rproj(pm))
       nt *= rproj(pm)
     end

--- a/src/mps/projmpo_mps.jl
+++ b/src/mps/projmpo_mps.jl
@@ -46,5 +46,4 @@ end
 
 noiseterm(P::ProjMPO_MPS,
           phi::ITensor,
-          b::Int,
-          dir::String) = noiseterm(P.PH,phi,b,dir)
+          dir::String) = noiseterm(P.PH,phi,dir)

--- a/src/mps/projmposum.jl
+++ b/src/mps/projmposum.jl
@@ -40,11 +40,10 @@ end
 
 function noiseterm(P::ProjMPOSum,
                    phi::ITensor,
-                   b::Int,
                    dir::String)
-  nt = noiseterm(P.pm[1],phi,b,dir)
+  nt = noiseterm(P.pm[1],phi,dir)
   for n=2:length(P.pm)
-    nt += noiseterm(P.pm[n],phi,b,dir)
+    nt += noiseterm(P.pm[n],phi,dir)
   end
   return nt
 end


### PR DESCRIPTION
Remove redundant `b::Int` argument to the function `noiseterm`, because `b` is already known to ProjMPO through the internal `lpos` and `rpos` values it stores.