### PR TITLE
In-place permute! function for ITensor type

### DIFF
--- a/docs/src/ITensorType.md
+++ b/docs/src/ITensorType.md
@@ -107,5 +107,6 @@ factorize(::ITensor, ::Any...)
 
 ```@docs
 permute(::ITensor, ::Any)
+permute!(::ITensor, ::Any)
 ```
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -64,6 +64,7 @@ export
   maxdim,
   mindim,
   permute,
+  permute!,
   pop,
   popfirst,
   push,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1001,6 +1001,14 @@ permute(T::ITensor,
         inds::Index...) = permute(T,
                                   IndexSet(inds...))
 
+"""
+    permute!(T::ITensors, inds)
+    permute!(T::ITensors, inds::Index...)
+
+Modify the ITensor T to have indices permuted according
+to the input indices inds. The storage of the ITensor
+is permuted accordingly.
+"""
 function Base.permute!(T::ITensor{N},new_inds) where {N}
   Tp = permute(T,new_inds)
   T.store = Tp.store

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1001,6 +1001,17 @@ permute(T::ITensor,
         inds::Index...) = permute(T,
                                   IndexSet(inds...))
 
+function Base.permute!(T::ITensor{N},new_inds) where {N}
+  Tp = permute(T,new_inds)
+  T.store = Tp.store
+  T.inds = Tp.inds
+  return T
+end
+
+Base.permute!(T::ITensor,
+              inds::Index...) = permute!(T,IndexSet(inds...))
+
+
 Base.:*(T::ITensor, x::Number) = itensor(x*tensor(T))
 
 Base.:*(x::Number, T::ITensor) = T*x

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1011,8 +1011,8 @@ is permuted accordingly.
 """
 function Base.permute!(T::ITensor{N},new_inds) where {N}
   Tp = permute(T,new_inds)
-  T.store = Tp.store
-  T.inds = Tp.inds
+  setstore!(T,store(Tp))
+  setinds!(T,inds(Tp))
   return T
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -12,10 +12,10 @@ using ITensors,
   @testset "Copy" begin
     Bc = copy(B)
     Bc .= A
-    @test Bc[1,1] == A[1,1]
-    @test Bc[2,1] == A[1,2]
-    @test Bc[1,2] == A[2,1]
-    @test Bc[2,2] == A[2,2]
+    @test Bc[1,1] ≈ A[1,1]
+    @test Bc[2,1] ≈ A[1,2]
+    @test Bc[1,2] ≈ A[2,1]
+    @test Bc[2,2] ≈ A[2,2]
   end
 
   @testset "Fill" begin
@@ -30,75 +30,75 @@ using ITensors,
   @testset "Scaling" begin
     Bc = copy(B)
     Bc .*= α
-    @test Bc[1,1] == α * B[1,1]
-    @test Bc[2,1] == α * B[2,1]
-    @test Bc[1,2] == α * B[1,2]
-    @test Bc[2,2] == α * B[2,2]
+    @test Bc[1,1] ≈ α * B[1,1]
+    @test Bc[2,1] ≈ α * B[2,1]
+    @test Bc[1,2] ≈ α * B[1,2]
+    @test Bc[2,2] ≈ α * B[2,2]
   end
 
   @testset "Dividing" begin
     Bc = copy(B)
     Bc ./= α
-    @test Bc[1,1] == B[1,1] / α
-    @test Bc[2,1] == B[2,1] / α
-    @test Bc[1,2] == B[1,2] / α
-    @test Bc[2,2] == B[2,2] / α
+    @test Bc[1,1] ≈ B[1,1] / α
+    @test Bc[2,1] ≈ B[2,1] / α
+    @test Bc[1,2] ≈ B[1,2] / α
+    @test Bc[2,2] ≈ B[2,2] / α
   end
 
   @testset "Scalar multiplication (in-place)" begin
     Bc = copy(B)
     Bc .= α .* A
-    @test Bc[1,1] == α * A[1,1]
-    @test Bc[2,1] == α * A[1,2]
-    @test Bc[1,2] == α * A[2,1]
-    @test Bc[2,2] == α * A[2,2]
+    @test Bc[1,1] ≈ α * A[1,1]
+    @test Bc[2,1] ≈ α * A[1,2]
+    @test Bc[1,2] ≈ α * A[2,1]
+    @test Bc[2,2] ≈ α * A[2,2]
   end
 
   @testset "Dividing (in-place)" begin
     Bc = copy(B)
     Bc .= A ./ α
-    @test Bc[1,1] == A[1,1] / α
-    @test Bc[2,1] == A[1,2] / α
-    @test Bc[1,2] == A[2,1] / α
-    @test Bc[2,2] == A[2,2] / α
+    @test Bc[1,1] ≈ A[1,1] / α
+    @test Bc[2,1] ≈ A[1,2] / α
+    @test Bc[1,2] ≈ A[2,1] / α
+    @test Bc[2,2] ≈ A[2,2] / α
     @test_throws ErrorException Bc .= α ./ A
   end
 
   @testset "Scalar multiplication (out-of-place)" begin
     Bc = α .* A
-    @test Bc[1,1] == α * A[1,1]
-    @test Bc[2,1] == α * A[2,1]
-    @test Bc[1,2] == α * A[1,2]
-    @test Bc[2,2] == α * A[2,2]
+    @test Bc[1,1] ≈ α * A[1,1]
+    @test Bc[2,1] ≈ α * A[2,1]
+    @test Bc[1,2] ≈ α * A[1,2]
+    @test Bc[2,2] ≈ α * A[2,2]
   end
 
   @testset "Addition" begin
     Bc = copy(B)
     Bc .= A .+ Bc
-    @test Bc[1,1] == A[1,1] + B[1,1]
-    @test Bc[2,1] == A[1,2] + B[2,1]
-    @test Bc[1,2] == A[2,1] + B[1,2]
-    @test Bc[2,2] == A[2,2] + B[2,2]
+    @test Bc[1,1] ≈ A[1,1] + B[1,1]
+    @test Bc[2,1] ≈ A[1,2] + B[2,1]
+    @test Bc[1,2] ≈ A[2,1] + B[1,2]
+    @test Bc[2,2] ≈ A[2,2] + B[2,2]
   end
 
   @testset "Addition (with α)" begin
     Bc = copy(B)
     Bc .+= A .* α
 
-    @test Bc[1,1] == α * A[1,1] + B[1,1]
-    @test Bc[2,1] == α * A[1,2] + B[2,1]
-    @test Bc[1,2] == α * A[2,1] + B[1,2]
-    @test Bc[2,2] == α * A[2,2] + B[2,2]
+    @test Bc[1,1] ≈ α * A[1,1] + B[1,1]
+    @test Bc[2,1] ≈ α * A[1,2] + B[2,1]
+    @test Bc[1,2] ≈ α * A[2,1] + B[1,2]
+    @test Bc[2,2] ≈ α * A[2,2] + B[2,2]
   end
 
   @testset "Addition (with α and β)" begin
     Bc = copy(B)
     Bc .= α .* A .+ β .* Bc
 
-    @test Bc[1,1] == α * A[1,1] + β * B[1,1]
-    @test Bc[2,1] == α * A[1,2] + β * B[2,1]
-    @test Bc[1,2] == α * A[2,1] + β * B[1,2]
-    @test Bc[2,2] == α * A[2,2] + β * B[2,2]
+    @test Bc[1,1] ≈ α * A[1,1] + β * B[1,1]
+    @test Bc[2,1] ≈ α * A[1,2] + β * B[2,1]
+    @test Bc[1,2] ≈ α * A[2,1] + β * B[1,2]
+    @test Bc[2,2] ≈ α * A[2,2] + β * B[2,2]
   end
 
   @testset "Addition errors" begin
@@ -157,8 +157,8 @@ using ITensors,
     Bc2 = copy(B)
     Bc2 .+= sqrt.(absA)
 
-    @test Bc2[1,1] == B[1,1]+sqrt(absA[1,1])
-    @test Bc2[2,1] == B[2,1]+sqrt(absA[1,2])
+    @test Bc2[1,1] ≈ B[1,1]+sqrt(absA[1,1])
+    @test Bc2[2,1] ≈ B[2,1]+sqrt(absA[1,2])
   end
 
   @testset "Some other operations" begin
@@ -174,46 +174,46 @@ using ITensors,
     Bc = copy(B)
     Bc .= sqrt.(absA)
 
-    @test Bc[1] == sqrt(absA[1])
-    @test Bc[2] == sqrt(absA[2])
+    @test Bc[1] ≈ sqrt(absA[1])
+    @test Bc[2] ≈ sqrt(absA[2])
 
     Bc2 = copy(B)
     Bc2 .+= sqrt.(absA)
 
-    @test Bc2[1] == B[1]+sqrt(absA[1])
-    @test Bc2[2] == B[2]+sqrt(absA[2])
+    @test Bc2[1] ≈ B[1]+sqrt(absA[1])
+    @test Bc2[2] ≈ B[2]+sqrt(absA[2])
 
     Bc3 = copy(B)
     Bc3 .= sqrt.(absA) .+ sin.(Bc3)
 
-    @test Bc3[1] == sin(B[1])+sqrt(absA[1])
-    @test Bc3[2] == sin(B[2])+sqrt(absA[2])
+    @test Bc3[1] ≈ sin(B[1])+sqrt(absA[1])
+    @test Bc3[2] ≈ sin(B[2])+sqrt(absA[2])
 
     sqrtabsA = sqrt.(abs.(A))
 
-    @test sqrtabsA[1] == sqrt(abs(A[1]))
-    @test sqrtabsA[2] == sqrt(abs(A[2]))
+    @test sqrtabsA[1] ≈ sqrt(abs(A[1]))
+    @test sqrtabsA[2] ≈ sqrt(abs(A[2]))
 
     sqrtabsA = cos.(sin.(sqrt.(abs.(A))))
 
-    @test sqrtabsA[1] == cos(sin(sqrt(abs(A[1]))))
-    @test sqrtabsA[2] == cos(sin(sqrt(abs(A[2]))))
+    @test sqrtabsA[1] ≈ cos(sin(sqrt(abs(A[1]))))
+    @test sqrtabsA[2] ≈ cos(sin(sqrt(abs(A[2]))))
 
     # Not currently supported
     #Ap = A .+ 3
 
-    #@test Ap[1] == A[1] + 3
-    #@test Ap[2] == A[2] + 3
+    #@test Ap[1] ≈ A[1] + 3
+    #@test Ap[2] ≈ A[2] + 3
 
     Apow1 = A .^ 2.0
 
-    @test Apow1[1] == A[1]^2
-    @test Apow1[2] == A[2]^2
+    @test Apow1[1] ≈ A[1]^2
+    @test Apow1[2] ≈ A[2]^2
 
     Apow2 = A .^ 3
 
-    @test Apow2[1] == A[1]^3
-    @test Apow2[2] == A[2]^3
+    @test Apow2[1] ≈ A[1]^3
+    @test Apow2[2] ≈ A[2]^3
   end
 
 end

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -609,6 +609,19 @@ end
     for ii ∈ 1:dim(i), jj ∈ 1:dim(j), kk ∈ 1:dim(k)
       @test A[k=>kk,i=>ii,j=>jj]==permA[i=>ii,j=>jj,k=>kk]
     end
+
+    Aorig = deepcopy(A)
+    permute!(A,k,j,i)
+    @test k==inds(A)[1]
+    @test j==inds(A)[2]
+    @test i==inds(A)[3]
+    for ii ∈ 1:dim(i), jj ∈ 1:dim(j), kk ∈ 1:dim(k)
+      @test Aorig[k=>kk,i=>ii,j=>jj]==A[i=>ii,j=>jj,k=>kk]
+    end
+    for ii ∈ 1:dim(i), jj ∈ 1:dim(j), kk ∈ 1:dim(k)
+      @test Aorig[k=>kk,i=>ii,j=>jj]==A[i=>ii,j=>jj,k=>kk]
+    end
+
     # TODO: I think this was doing slicing, but what is the output
     # of slicing an ITensor?
     #@testset "getindex and setindex with vector of IndexVals" begin

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -610,7 +610,7 @@ end
       @test A[k=>kk,i=>ii,j=>jj]==permA[i=>ii,j=>jj,k=>kk]
     end
 
-    Aorig = deepcopy(A)
+    Aorig = copy(A)
     permute!(A,k,j,i)
     @test k==inds(A)[1]
     @test j==inds(A)[2]


### PR DESCRIPTION
It's convenient sometimes to have `permute!` for an ITensor versus only `permute`. So this pull request adds that function. The implementation simply calls `permute` and "steals" the store and inds references from the newly created ITensor. Perhaps there's a better way to do it?