### PR TITLE
Performance regression in ITensor broadcasting operations

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -257,7 +257,7 @@ function Base.copyto!(T::ITensor,
     else
       bc_bc_bc = find_type(Broadcasted, bc_bc.args)
       if isnothing(α)
-        α = find_type(Number, bc_bc_bc.args)
+      #  α = find_type(Number, bc_bc_bc.args)
         B = find_type(ITensor, bc_bc_bc.args)
       else
         A, B = bc_bc_bc.args

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -257,12 +257,12 @@ function Base.copyto!(T::ITensor,
     else
       bc_bc_bc = find_type(Broadcasted, bc_bc.args)
       if isnothing(α)
-      #  α = find_type(Number, bc_bc_bc.args)
+        β = find_type(Number, bc_bc_bc.args)
         B = find_type(ITensor, bc_bc_bc.args)
       else
         A, B = bc_bc_bc.args
       end
-      mul!(T, A, B, α, 1)
+      mul!(T, A, B, β, 1)
     end
   else
     error("When adding two ITensors in-place, one must be the same as the output ITensor")

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1169,15 +1169,9 @@ end
 w .+= a .* v
 ```
 """
-function LinearAlgebra.axpy!(a::Number,
-                             v::ITensor,
-                             w::ITensor)
-  return map!((r, t) -> r + a * t, w, w, v)
-end
-
-#LinearAlgebra.axpy!(a::Number,
-#                    v::ITensor,
-#                    w::ITensor) = (w .+= a .* v)
+LinearAlgebra.axpy!(a::Number,
+                    v::ITensor,
+                    w::ITensor) = (w .+= a .* v)
 
 """
 axpby!(a,v,b,w)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1169,9 +1169,15 @@ end
 w .+= a .* v
 ```
 """
-LinearAlgebra.axpy!(a::Number,
-                    v::ITensor,
-                    w::ITensor) = (w .+= a .* v)
+function LinearAlgebra.axpy!(a::Number,
+                             v::ITensor,
+                             w::ITensor)
+  return map!((r, t) -> r + a * t, w, w, v)
+end
+
+#LinearAlgebra.axpy!(a::Number,
+#                    v::ITensor,
+#                    w::ITensor) = (w .+= a .* v)
 
 """
 axpby!(a,v,b,w)


### PR DESCRIPTION
There is a very strange performance regression with ITensor broadcasting operations. You can see it in the following example:
```julia
julia> i = Index(100);

julia> @btime axpy!(2, A, B) setup = (B = randomITensor(i, i'); A = randomITensor(i', i));
  498.087 μs (49533 allocations: 775.45 KiB)

julia> @btime map!((y, x) -> 2 * x + y, B, B, A) setup = (B = randomITensor(i, i'); A = randomITensor(i', i))
  9.657 μs (31 allocations: 1.83 KiB)
```
`axpy!(a, x, y)` is just defined [here](https://github.com/ITensor/ITensors.jl/blob/master/src/itensor.jl#L1172) in terms of the broadcast call `y .+= a .* x`, so that is testing the broadcasting performance.

The strange part about this is that the broadcast call `y .+= a .* x` is _itself_ defined in terms of the `map!` call above, as you can see [here](https://github.com/ITensor/ITensors.jl/blob/master/src/broadcast.jl#L256). It is therefore a complete mystery to me why the performance above is so different.

This regression is currently causing a huge slowdown in `dmrg`, for example running `examples/1d_Heisenberg_dmrg.jl`:
```
After sweep 1 energy=-138.837128197001 maxlinkdim=10 time=0.500
After sweep 2 energy=-138.937288615100 maxlinkdim=20 time=0.997
After sweep 3 energy=-138.940084627227 maxlinkdim=100 time=7.992
After sweep 4 energy=-138.940086090413 maxlinkdim=100 time=21.790
After sweep 5 energy=-138.940086113354 maxlinkdim=122 time=28.010
```
which is clearly quite slow.

The "fix" in this PR is to call `map!` directly in `axpy!`, instead of indirectly through the slow broadcast call (which, again, is defined in terms of `map!` anyway...). That improves the `dmrg` performance back to what we would expect:
```
After sweep 1 energy=-138.832801271759 maxlinkdim=10 time=0.216
After sweep 2 energy=-138.937263887382 maxlinkdim=20 time=0.297
After sweep 3 energy=-138.940084729709 maxlinkdim=100 time=1.676
After sweep 4 energy=-138.940086098620 maxlinkdim=100 time=4.005
After sweep 5 energy=-138.940086121925 maxlinkdim=122 time=5.478
```

It is a pretty dissatisfying "fix", and the broadcast call is still slow. I haven't benchmarked other broadcast calls, it would be interesting to see if this is a general problem and figure out how to make the broadcast call fast again.