### PR TITLE
Remove In,Out,Neither from exports to prevent conflicts. Fixes #356

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -11,11 +11,6 @@ export
   entropy,
   truncerror,
 
-# arrow.jl
-  In,
-  Neither,
-  Out,
-
 # decomp.jl
   eigen,
   factorize,

--- a/test/qnindex.jl
+++ b/test/qnindex.jl
@@ -1,6 +1,8 @@
 using ITensors,
       Test
 
+import ITensors: In, Out, Neither
+
 @testset "QN Index" begin
 
   @testset "hasqns function" begin


### PR DESCRIPTION
Fixes issue #356, regarding exporting In, Out, and Neither.