### PR TITLE
Some improvements to printing of QN

### DIFF
--- a/src/qn/qn.jl
+++ b/src/qn/qn.jl
@@ -119,6 +119,13 @@ Base.lastindex(qn::QN) = length(qn)
 
 isactive(qn::QN) = isactive(qn[1])
 
+function nactive(q::QN)
+  for n=1:maxQNs
+    !isactive(q[n]) && (return n-1)
+  end
+  return maxQNs
+end
+
 function Base.iterate(qn::QN,state::Int=1)
   (state > length(qn)) && return nothing
   return (qn[state],state+1)
@@ -290,20 +297,19 @@ end
 
 function Base.show(io::IO,q::QN)
   print(io,"QN(")
-  for n=1:maxQNs
+  Na = nactive(q)
+  for n=1:Na
     v = q[n]
-    !isactive(v) && break
     n > 1 && print(io,",")
-    if name(v)==SmallString("")
-      print(io,"($(val(v))")
-    else
-      print(io,"(\"$(name(v))\",$(val(v))")
+    Na > 1 && print(io,"(")
+    if name(v) != SmallString("") 
+      print(io,"\"$(name(v))\",")
     end
+    print(io,"$(val(v))")
     if modulus(v) != 1
-      print(io,",$(modulus(v)))")
-    else
-      print(io,")")
+      print(io,",$(modulus(v))")
     end
+    Na > 1 && print(io,")")
   end
   print(io,")")
 end

--- a/test/qn.jl
+++ b/test/qn.jl
@@ -1,6 +1,8 @@
 using ITensors,
       Test
 
+import ITensors: nactive
+
 @testset "QN" begin
 
   @testset "QNVal Basics" begin
@@ -45,6 +47,7 @@ using ITensors,
     @test isactive(q[1])
     @test val(q,"P") == 1
     @test modulus(q,"P") == 2
+    @test nactive(q) == 1
 
     q = QN(("A",1),("B",2))
     @test isactive(q[1])
@@ -57,6 +60,14 @@ using ITensors,
     q = QN(("B",2),("A",1))
     @test val(q,"A") == 1
     @test val(q,"B") == 2
+    @test nactive(q) == 2
+
+    q = QN(("A",1),("B",2),("C",3),("D",4))
+    @test nactive(q) == 4
+
+    @test_throws BoundsError begin
+      q = QN(("A",1),("B",2),("C",3),("D",4),("E",5))
+    end
   end
 
   @testset "Comparison" begin


### PR DESCRIPTION
This PR just changes the printing of QNs with a single value to remove the extra set of parenthesis. It also introduces a new, internal function called `nactive` which can be used to compute how many values are in a QN.