### PR TITLE
Add BenchmarkCI support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,21 @@
+name: Run benchmarks
+
+on:
+  pull_request:
+
+jobs:
+  Benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1.4
+      - name: Install dependencies
+        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1.2"'
+      - name: Run benchmarks
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
+      - name: Post results
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/build/
 precompile/tmp
 .DS_Store
 benchmark/*.json
+.benchmarkci

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"


### PR DESCRIPTION
This (hopefully) adds support for running the benchmarks defined in `benchmark/benchmarks.jl` at every commit, using [BenchmarkCI.jl](https://github.com/tkf/BenchmarkCI.jl).

It is set up to compare against the latest master branch.