### PR TITLE
Fix QN Combiner constructor for IndexSet

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -488,12 +488,12 @@ isindequal(iv1::IndexValOrPairIndexInt,
 
 plev(iv::IndexValOrPairIndexInt) = plev(ind(iv))
 
-prime(iv::IndexValOrPairIndexInt,
+prime(iv::IndexVal,
       inc::Integer = 1) = IndexVal(prime(ind(iv), inc), val(iv))
 
-dag(iv::IndexValOrPairIndexInt) = IndexVal(dag(ind(iv)), val(iv))
+dag(iv::IndexVal) = IndexVal(dag(ind(iv)), val(iv))
 
-Base.adjoint(iv::IndexValOrPairIndexInt) = IndexVal(prime(ind(iv)), val(iv))
+Base.adjoint(iv::IndexVal) = IndexVal(prime(ind(iv)), val(iv))
 
 #
 # Printing, reading, and writing

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -17,6 +17,12 @@ struct IndexSet{N, IndexT <: Index, DataT <: Tuple}
   IndexSet{Any}() = new{Any, Union{}, Tuple{}}()
 end
 
+# Definition to help with generic code
+const Indices{N, IndexT} = Union{IndexSet{N,
+                                          IndexT,
+                                          NTuple{N, IndexT}},
+                                 NTuple{N, IndexT}}
+
 function IndexSet{N, IndexT}(inds) where {N, IndexT}
   data = NTuple{N, IndexT}(inds)
   return IndexSet{N, IndexT, typeof(data)}(data)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -148,9 +148,8 @@ storage and indices as the ITensor.
 NDTensors.tensor(A::ITensor) = tensor(store(A),inds(A))
 
 """
-    ITensor([::Type{ElT} = Float64, ]inds::IndexSet) where {ElT <: Number}
-
-    ITensor([::Type{ElT} = Float64, ]inds::Index...) where {ElT <: Number}
+    ITensor([::Type{ElT} = Float64, ]inds)
+    ITensor([::Type{ElT} = Float64, ]inds::Index...)
 
 Construct an ITensor filled with zeros having indices `inds` and element type `ElT`. If the element type is not specified, it defaults to `Float64`.
 
@@ -176,9 +175,8 @@ ITensor(inds::Index...) = ITensor(Float64, IndexSet(inds...))
 ITensor() = ITensor(Float64, IndexSet())
 
 """
-    ITensor([::Type{ElT} = Float64, ]::UndefInitializer, inds::IndexSet) where {ElT <: Number}
-
-    ITensor([::Type{ElT} = Float64, ]::UndefInitializer, inds::Index...) where {ElT <: Number}
+    ITensor([::Type{ElT} = Float64, ]::UndefInitializer, inds)
+    ITensor([::Type{ElT} = Float64, ]::UndefInitializer, inds::Index...)
 
 Construct an ITensor filled with undefined elements having indices `inds` and element type `ElT`. If the element type is not specified, it defaults to `Float64`.
 
@@ -203,8 +201,7 @@ ITensor(::UndefInitializer,
         inds::Index...) = ITensor(Float64, undef, IndexSet(inds...))
 
 """
-    ITensor(x::Number, inds::IndexSet)
-
+    ITensor(x::Number, inds)
     ITensor(x::Number, inds::Index...)
 
 Construct an ITensor with all elements set to `float(x)` and indices `inds`.
@@ -224,9 +221,8 @@ ITensor(x::Number,
 #
 
 """
-    emptyITensor([::Type{ElT} = Float64, ]inds::IndexSet) where {ElT <: Number}
-
-    emptyITensor([::Type{ElT} = Float64, ]inds::Index...) where {ElT <: Number}
+    emptyITensor([::Type{ElT} = Float64, ]inds)
+    emptyITensor([::Type{ElT} = Float64, ]inds::Index...)
 
 Construct an ITensor with storage type `NDTensors.Empty`, indices `inds`, and element type `ElT`. If the element type is not specified, it defaults to `Float64`.
 """
@@ -252,7 +248,7 @@ end
 emptyITensor() = emptyITensor(Float64)
 
 """
-    emptyITensor(::Type{ElT} = Float64, ::Type{Any}) where {ElT <: Number}
+    emptyITensor([::Type{ElT} = Float64, ]::Type{Any})
 
 Construct an ITensor with empty storage and `Any` number of indices.
 """
@@ -267,7 +263,7 @@ emptyITensor(::Type{Any}) = emptyITensor(Float64, Any)
 #
 
 """
-    itensor(A::Array, inds::IndexSet)
+    itensor(A::Array, inds)
     itensor(A::Array, inds::Index...)
 
 Construct an ITensor from an Array `A` and indices `inds`.
@@ -285,7 +281,7 @@ itensor(A::Array{<:Number},
         inds::Index...) = itensor(A, IndexSet(inds...))
 
 """
-    ITensor(A::Array, inds::IndexSet)
+    ITensor(A::Array, inds)
     ITensor(A::Array, inds::Index...)
 
 Construct an ITensor from an Array `A` and indices `inds`.
@@ -306,8 +302,8 @@ ITensor(A::Array, inds::Index...) = ITensor(A, IndexSet(inds...))
 #
 
 """
-    diagITensor(::Type{ElT}, is::IndexSet)
-    diagITensor(::Type{ElT}, is::Index...)
+    diagITensor([::Type{ElT} = Float64, ]inds)
+    diagITensor([::Type{ElT} = Float64, ]inds::Index...)
 
 Make a sparse ITensor of element type `ElT` with only elements
 along the diagonal stored. Defaults to having `zero(T)` along 
@@ -324,9 +320,13 @@ diagITensor(::Type{ElT},
             inds::Index...) where {ElT} = diagITensor(ElT,
                                                       IndexSet(inds...))
 
+diagITensor(is::Indices) = diagITensor(Float64, is)
+
+diagITensor(inds::Index...) = diagITensor(Float64, IndexSet(inds...))
+
 """
-    diagITensor(v::Vector{T}, is::IndexSet)
-    diagITensor(v::Vector{T}, is::Index...)
+    diagITensor(v::Vector{T}, inds)
+    diagITensor(v::Vector{T}, inds::Index...)
 
 Make a sparse ITensor with non-zero elements only along the diagonal. 
 The diagonal elements will be set to the values stored in `v` and 
@@ -336,29 +336,17 @@ The storage will have type `NDTensors.Diag`.
 function diagITensor(v::Vector{<:Number},
                      is::Indices)
   length(v) ≠ mindim(is) && error("Length of vector for diagonal must equal minimum of the dimension of the input indices")
-  return itensor(Diag(float(v)),is)
+  return itensor(Diag(float(v)), is)
 end
 
 function diagITensor(v::Vector{<:Number},
                      is::Index...)
-  return diagITensor(v,IndexSet(is...))
+  return diagITensor(v, IndexSet(is...))
 end
 
 """
-    diagITensor(is::IndexSet)
-    diagITensor(is::Index...)
-
-Make a sparse ITensor of element type Float64 with non-zero elements 
-only along the diagonal. Defaults to storing zeros along the diagonal.
-The storage will have `NDTensors.Diag` type.
-"""
-diagITensor(is::Indices) = diagITensor(Float64,is)
-
-diagITensor(inds::Index...) = diagITensor(IndexSet(inds...))
-
-"""
-    diagITensor(x::Number, is::IndexSet)
-    diagITensor(x::Number, is::Index...)
+    diagITensor(x::Number, inds)
+    diagITensor(x::Number, inds::Index...)
 
 Make a sparse ITensor with non-zero elements only along the diagonal. 
 The diagonal elements will be set to the value `float(x)` and
@@ -376,8 +364,8 @@ function diagITensor(x::Number,
 end
 
 """
-    delta(::Type{ElT <: Number}, inds::IndexSet)
-    delta(::Type{ElT <: Number}, inds::Index...)
+    delta([::Type{ElT} = Float64, ]inds)
+    delta([::Type{ElT} = Float64, ]inds::Index...)
 
 Make a uniform diagonal ITensor with all diagonal elements
 `one(ElT)`. Only a single diagonal element is stored.
@@ -394,18 +382,9 @@ function delta(::Type{T},
   return delta(T, IndexSet(is...))
 end
 
-"""
-    delta(inds::IndexSet)
-    delta(inds::Index...)
-
-Make a uniform diagonal ITensor with all diagonal elements
-`one(Float64)`. Only a single diagonal element is stored.
-
-This function has an alias `δ`.
-"""
 delta(is::Indices) = delta(Float64, is)
 
-delta(is::Index...) = delta(IndexSet(is...))
+delta(is::Index...) = delta(Float64, IndexSet(is...))
 
 const δ = delta
 
@@ -444,32 +423,34 @@ Base.complex(T::ITensor) = itensor(complex(tensor(T)))
 Base.eltype(T::ITensor) = eltype(tensor(T))
 
 """
-    order(A::ITensor) = ndims(A)
+    order(A::ITensor)
+    ndims(A::ITensor)
 
 The number of indices, `length(inds(A))`.
 """
 order(T::ITensor) = ndims(T)
 
-Base.ndims(T::ITensor) = length(inds(T))
+Base.ndims(::ITensor{N}) = N
 
 """
-    dim(A::ITensor) = length(A)
+    dim(A::ITensor)
 
-The total number of entries, `prod(size(A))`.
+The total dimension of the space the tensor lives in, `prod(dims(A))`.
 """
 NDTensors.dim(T::ITensor) = dim(inds(T))
 
 """
-    dims(A::ITensor) = size(A)
+    dims(A::ITensor)
+    size(A::ITensor)
 
-Tuple containing `size(A,d) == dim(inds(A)[d]) for d in 1:ndims(A)`.
+Tuple containing `dim(inds(A)[d]) for d in 1:ndims(A)`.
 """
 NDTensors.dims(T::ITensor) = dims(inds(T))
 
-Base.size(A::ITensor) = dims(inds(A))
+Base.size(T::ITensor) = dims(T)
 
 Base.size(A::ITensor,
-          d::Int) = dim(inds(A),d)
+          d::Int) = dim(inds(A), d)
 
 Base.copy(T::ITensor) = itensor(copy(tensor(T)))
 
@@ -920,7 +901,7 @@ function Random.randn!(T::ITensor)
 end
 
 """
-    randomITensor([::Type{ElT <: Number} = Float64, ]inds::IndexSet)
+    randomITensor([::Type{ElT <: Number} = Float64, ]inds)
 
     randomITensor([::Type{ElT <: Number} = Float64, ]inds::Index...)
 
@@ -1086,7 +1067,7 @@ end
 LinearAlgebra.dot(A::ITensor, B::ITensor) = (dag(A)*B)[]
 
 """
-    exp(A::ITensor, Lis::IndexSet; hermitian = false)
+    exp(A::ITensor, Lis; hermitian = false)
 
 Compute the exponential of the tensor `A` by treating it as a matrix ``A_{lr}`` with
 the left index `l` running over all indices in `Lis` and `r` running over all

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -430,7 +430,7 @@ The number of indices, `length(inds(A))`.
 """
 order(T::ITensor) = ndims(T)
 
-Base.ndims(::ITensor{N}) = N
+Base.ndims(::ITensor{N}) where {N} = N
 
 """
     dim(A::ITensor)

--- a/src/qn/qnindexset.jl
+++ b/src/qn/qnindexset.jl
@@ -1,5 +1,8 @@
 
-const QNIndexSet{N} = IndexSet{N,QNIndex}
+const QNIndexSet{N} = IndexSet{N, QNIndex, NTuple{N, QNIndex}}
+
+const QNIndices{N} = Union{QNIndexSet{N},
+                           NTuple{N, QNIndex}}
 
 # Get a list of the non-zero blocks given a desired flux
 # TODO: make a fillqns(inds::IndexSet) function that makes all indices

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -1,8 +1,7 @@
 
 """
-    ITensor([::Type{ElT} = Float64, ]flux::QN, inds::IndexSet) where {ElT <: Number}
-
-    ITensor([::Type{ElT} = Float64, ]flux::QN, inds::Index...) where {ElT <: Number}
+    ITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds)
+    ITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds::Index...)
 
 Construct an ITensor with BlockSparse storage filled with `zero(ElT)` where the nonzero blocks are determined by `flux`.
 
@@ -41,9 +40,8 @@ end
 ITensor(inds::QNIndex...) = ITensor(Float64, QN(), IndexSet(inds...))
 
 """
-    emptyITensor([::Type{ElT} = Float64, ]inds::QNIndexSet) where {ElT <: Number}
-
-    emptyITensor([::Type{ElT} = Float64, ]inds::QNIndex...) where {ElT <: Number}
+    emptyITensor([::Type{ElT} = Float64, ]inds::QNIndexSet)
+    emptyITensor([::Type{ElT} = Float64, ]inds::QNIndex...)
 
 Construct an ITensor with `NDTensors.BlockSparse` storage of element type `ElT` with the no blocks.
 
@@ -59,9 +57,8 @@ end
 emptyITensor(inds::QNIndices) = emptyITensor(Float64, inds)
 
 """
-    randomITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds::IndexSet) where {ElT <: Number}
-
-    randomITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds::Index...) where {ElT <: Number}
+    randomITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds)
+    randomITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds::Index...)
 
 Construct an ITensor with `NDTensors.BlockSparse` storage filled with random elements of type `ElT` where the nonzero blocks are determined by `flux`.
 
@@ -122,8 +119,7 @@ end
 #
 
 """
-    diagITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]is::IndexSet)
-
+    diagITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]is)
     diagITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]is::Index...)
 
 Make an ITensor with storage type `NDTensors.DiagBlockSparse` with elements `zero(ElT)`. The ITensor only has diagonal blocks consistent with the specified `flux`.
@@ -162,8 +158,7 @@ function diagITensor(inds::QNIndices)
 end
 
 """
-    delta([::Type{ElT} = Float64, ][flux::QN = QN(), ]is::IndexSet)
-
+    delta([::Type{ElT} = Float64, ][flux::QN = QN(), ]is)
     delta([::Type{ElT} = Float64, ][flux::QN = QN(), ]is::Index...)
 
 Make an ITensor with storage type `NDTensors.DiagBlockSparse` with uniform elements `one(ElT)`. The ITensor only has diagonal blocks consistent with the specified `flux`.

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -11,7 +11,7 @@ If `ElT` is not specified it defaults to `Float64`.
 function ITensor(::Type{ElT},
                  flux::QN,
                  inds::Indices) where {ElT <: Number}
-  blocks = nzblocks(flux, inds)
+  blocks = nzblocks(flux, IndexSet(inds))
   T = BlockSparseTensor(ElT, blocks, inds)
   return itensor(T)
 end
@@ -133,7 +133,7 @@ If the element type is not specified, it defaults to `Float64`. If theflux is no
 function diagITensor(::Type{ElT},
                      flux::QN,
                      is::Indices) where {ElT <: Number}
-  blocks = nzdiagblocks(flux, is)
+  blocks = nzdiagblocks(flux, IndexSet(is))
   T = DiagBlockSparseTensor(ElT, blocks, is)
   return itensor(T)
 end
@@ -173,7 +173,7 @@ If the element type is not specified, it defaults to `Float64`. If theflux is no
 function delta(::Type{ElT},
                flux::QN,
                inds::Indices) where {ElT <: Number}
-  blocks = nzdiagblocks(flux, inds)
+  blocks = nzdiagblocks(flux, IndexSet(inds))
   T = DiagBlockSparseTensor(one(ElT), blocks, inds)
   return itensor(T)
 end

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -10,7 +10,7 @@ If `ElT` is not specified it defaults to `Float64`.
 """
 function ITensor(::Type{ElT},
                  flux::QN,
-                 inds::IndexSet) where {ElT <: Number}
+                 inds::Indices) where {ElT <: Number}
   blocks = nzblocks(flux, inds)
   T = BlockSparseTensor(ElT, blocks, inds)
   return itensor(T)
@@ -22,22 +22,23 @@ function ITensor(::Type{ElT},
   return ITensor(ElT, flux, IndexSet(inds...))
 end
 
-ITensor(flux::QN, inds::IndexSet) = ITensor(Float64, flux, inds)
+ITensor(flux::QN, inds::Indices) = ITensor(Float64, flux, inds)
 
 ITensor(flux::QN,
         inds::Index...) = ITensor(Float64, flux, IndexSet(inds...))
 
-# TODO: make this default to QN()
-ITensor(::Type{<:Number},
-        inds::QNIndexSet) = error("Must specify flux")
-
-ITensor(inds::QNIndexSet) = ITensor(Float64, inds)
-
-function ITensor(::Type{ElT}, inds::QNIndex...) where {ElT<:Number} 
-  return ITensor(ElT, IndexSet(inds...))
+function ITensor(::Type{ElT},
+                 inds::QNIndices) where {ElT <: Number}
+  return ITensor(ElT, QN(), inds)
 end
 
-ITensor(inds::QNIndex...) = ITensor(Float64, IndexSet(inds...))
+ITensor(inds::QNIndices) = ITensor(Float64, QN(), inds)
+
+function ITensor(::Type{ElT}, inds::QNIndex...) where {ElT<:Number} 
+  return ITensor(ElT, QN(), IndexSet(inds...))
+end
+
+ITensor(inds::QNIndex...) = ITensor(Float64, QN(), IndexSet(inds...))
 
 """
     emptyITensor([::Type{ElT} = Float64, ]inds::QNIndexSet) where {ElT <: Number}
@@ -51,12 +52,11 @@ If `ElT` is not specified it defaults to `Float64`.
 In the future, this will use the storage `NDTensors.EmptyBlockSparse`.
 """
 function emptyITensor(::Type{ElT},
-                      inds::QNIndexSet{N}) where {ElT <: Number,
-                                                  N} 
+                      inds::QNIndices) where {ElT <: Number}
   return itensor(EmptyBlockSparseTensor(ElT, inds))
 end
 
-emptyITensor(inds::QNIndexSet) = emptyITensor(Float64, inds)
+emptyITensor(inds::QNIndices) = emptyITensor(Float64, inds)
 
 """
     randomITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds::IndexSet) where {ElT <: Number}
@@ -69,7 +69,7 @@ If `ElT` is not specified it defaults to `Float64`. If the flux is not specified
 """
 function randomITensor(::Type{ElT},
                        flux::QN,
-                       inds::IndexSet) where {ElT<:Number}
+                       inds::Indices) where {ElT <: Number}
   T = ITensor(ElT, flux, inds)
   randn!(T)
   return T
@@ -82,12 +82,12 @@ function randomITensor(::Type{ElT},
 end
 
 function randomITensor(::Type{ElT},
-                       inds::QNIndexSet) where {ElT<:Number}
+                       inds::QNIndices) where {ElT<:Number}
   return randomITensor(ElT, QN(), inds)
 end
 
 randomITensor(flux::QN,
-              inds::IndexSet) = randomITensor(Float64, flux, inds)
+              inds::Indices) = randomITensor(Float64, flux, inds)
 
 randomITensor(flux::QN,
               inds::Index...) = randomITensor(Float64,
@@ -99,11 +99,11 @@ function randomITensor(::Type{ElT},
   return randomITensor(ElT, QN(), IndexSet(inds...))
 end
 
-randomITensor(inds::QNIndexSet) = randomITensor(Float64, QN(), inds)
+randomITensor(inds::QNIndices) = randomITensor(Float64, QN(), inds)
 
 randomITensor(inds::QNIndex...) = randomITensor(Float64, QN(), IndexSet(inds...))
 
-function combiner(inds::QNIndex...; kwargs...)
+function combiner(inds::QNIndices; kwargs...)
   # TODO: support combining multiple set of indices
   tags = get(kwargs, :tags, "CMB,Link")
   new_ind = ⊗(inds...)
@@ -116,9 +116,6 @@ function combiner(inds::QNIndex...; kwargs...)
   return itensor(Combiner(perm,comb),
                  IndexSet(comb_ind, dag.(inds)...))
 end
-
-combiner(inds::Tuple{Vararg{QNIndex}};
-         kwargs...) = combiner(inds...; kwargs...)
 
 #
 # DiagBlockSparse ITensor constructors
@@ -135,7 +132,7 @@ If the element type is not specified, it defaults to `Float64`. If theflux is no
 """
 function diagITensor(::Type{ElT},
                      flux::QN,
-                     is::IndexSet{N}) where {ElT <: Number, N}
+                     is::Indices) where {ElT <: Number}
   blocks = nzdiagblocks(flux, is)
   T = DiagBlockSparseTensor(ElT, blocks, is)
   return itensor(T)
@@ -148,7 +145,7 @@ function diagITensor(::Type{ElT},
 end
 
 diagITensor(flux::QN,
-            is::IndexSet) = diagITensor(Float64, flux, is)
+            is::Indices) = diagITensor(Float64, flux, is)
 
 diagITensor(flux::QN,
             inds::Index...) = diagITensor(Float64,
@@ -156,11 +153,11 @@ diagITensor(flux::QN,
                                           IndexSet(inds...))
 
 function diagITensor(::Type{ElT},
-                     inds::QNIndexSet) where {ElT <: Number}
+                     inds::QNIndices) where {ElT <: Number}
   return diagITensor(ElT, QN(), inds)
 end
 
-function diagITensor(inds::QNIndexSet)
+function diagITensor(inds::QNIndices)
   return diagITensor(Float64, QN(), inds)
 end
 
@@ -175,7 +172,7 @@ If the element type is not specified, it defaults to `Float64`. If theflux is no
 """
 function delta(::Type{ElT},
                flux::QN,
-               inds::IndexSet) where {ElT <: Number}
+               inds::Indices) where {ElT <: Number}
   blocks = nzdiagblocks(flux, inds)
   T = DiagBlockSparseTensor(one(ElT), blocks, inds)
   return itensor(T)
@@ -188,15 +185,15 @@ function delta(::Type{ElT},
 end
 
 delta(flux::QN,
-      inds::IndexSet) = delta(Float64, flux, is)
+      inds::Indices) = delta(Float64, flux, is)
 
 delta(flux::QN,
       inds::Index...) = delta(Float64, flux, IndexSet(inds...))
 
 function delta(::Type{ElT},
-               inds::QNIndexSet) where {ElT <: Number}
+               inds::QNIndices) where {ElT <: Number}
   return delta(ElT, QN(), inds)
 end
 
-delta(inds::QNIndexSet) = delta(Float64, QN(), inds)
+delta(inds::QNIndices) = delta(Float64, QN(), inds)
 

--- a/test/index.jl
+++ b/test/index.jl
@@ -58,13 +58,13 @@ import ITensors: In, Out, Neither
     #@test i[:] == [i(1); i(2)]
     @test sprint(show, i(2)) == sprint(show, i)*"=>2"
 
-    @test dag(i(1)) != dag(i=>2)
-    @test dag(i(2)) == dag(i=>2)
+    @test dag(i(1)) != IndexVal(dag(i)=>2)
+    @test dag(i(2)) == IndexVal(dag(i)=>2)
     @test plev(i=>2) == 0
     @test plev(i'=>2) == 1
     @test prime(i(2)) == i'(2)
-    @test prime(i=>2) == i'(2)
-    @test (i=>1)' == i'(1)
+    @test IndexVal(prime(i)=>2) == i'(2)
+    @test IndexVal(i'=>1) == i'(1)
   end
   @testset "Iteration" begin
     i = Index(10)

--- a/test/qndiagitensor.jl
+++ b/test/qndiagitensor.jl
@@ -28,6 +28,17 @@ using ITensors,
     @test D[i(5),i'(5)] == 5
   end
 
+  @testset "diagITensor Tuple constructor" begin
+    i = Index(QN(0)=>2, QN(1)=>3; tags="i")
+
+    D = diagITensor((i, dag(i')))
+
+    for n in nnzblocks(D)
+      b = nzblock(D, n)
+      @test flux(D, b) == QN()
+    end
+  end
+
   @testset "delta" begin
     i = Index(QN(0)=>2,QN(1)=>3; tags="i")
     ĩ = sim(i; tags="i_sim")
@@ -47,6 +58,18 @@ using ITensors,
 
     @test norm(dense(NDTensors.tensor(A)) -
                dense(NDTensors.tensor(B))) ≈ 0
+  end
+
+  @testset "delta Tuple constructor" begin
+    i = Index(QN(0)=>2, QN(1)=>3; tags="i")
+    ĩ = sim(i; tags="i_sim")
+
+    δiĩ = δ((dag(i), ĩ))
+
+    for n in nnzblocks(δiĩ)
+      b = nzblock(δiĩ, n)
+      @test flux(δiĩ, b) == QN()
+    end
   end
 
 end

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -16,6 +16,36 @@ Random.seed!(1234)
     @test nnzblocks(A) == 2
   end
 
+  @testset "Constructor (from Tuple)" begin
+    i = Index([QN(0)=>1,QN(1)=>2],"i")
+    j = Index([QN(0)=>3,QN(1)=>4,QN(2)=>5],"j")
+
+    A = ITensor(QN(0), (i, dag(j)))
+
+    @test flux(A) == QN(0)
+    @test nnzblocks(A) == 2
+  end
+
+  @testset "Constructor (no flux specified)" begin
+    i = Index([QN(0)=>1, QN(1)=>2], "i")
+    j = Index([QN(0)=>3, QN(1)=>4, QN(2)=>5], "j")
+
+    A = ITensor(i, dag(j))
+
+    @test flux(A) == QN(0)
+    @test nnzblocks(A) == 2
+  end
+
+  @testset "Constructor (Tuple, no flux specified)" begin
+    i = Index([QN(0)=>1, QN(1)=>2], "i")
+    j = Index([QN(0)=>3, QN(1)=>4, QN(2)=>5], "j")
+
+    A = ITensor((i, dag(j)))
+
+    @test flux(A) == QN(0)
+    @test nnzblocks(A) == 2
+  end
+
   @testset "No indices getindex" begin
     T = ITensor(QN())
     @test order(T) == 0
@@ -249,9 +279,29 @@ Random.seed!(1234)
       @test norm(A-Ap) ≈ 0.0
     end
 
-    @testset "Order 2" begin
+    @testset "Order 2 (IndexSet constructor)" begin
       i1 = Index([QN(0,2)=>2,QN(1,2)=>2],"i1")
       A = randomITensor(QN(),i1,dag(i1'))
+
+      iss = [i1,
+             dag(i1'),
+             (i1,dag(i1')),
+             (dag(i1'),i1)]
+
+      for is in iss
+        C = combiner(IndexSet(is); tags="c")
+        AC = A*C
+        @test nnz(AC) == nnz(A)
+        Ap = AC*dag(C)
+        @test nnz(Ap) == nnz(A)
+        @test nnzblocks(Ap) == nnzblocks(A)
+        @test norm(A-Ap) ≈ 0.0
+      end
+    end
+
+    @testset "Order 2" begin
+      i1 = Index([QN(0,2)=>2,QN(1,2)=>2],"i1")
+      A = randomITensor(QN(), (i1, dag(i1')))
 
       iss = [i1,
              dag(i1'),


### PR DESCRIPTION
There was an issue with QN Combiner, where if you used `combiner(IndexSet(i, i'))` for a QN Index `i` (for example), it called the non-QN combiner constructor.

In the process, I was looking through ITensor constructors and realized some accepted only `IndexSet` or `Vararg{Index}`, and some also allowed `Tuple{Vararg{Index}}`. I changed it so that they could all accept `Tuple{Vararg{Index}}` (this is pretty standard throughout the rest of the library).

I also decided to remove functionality like `prime(::Pair{Index, Int})` for now. I had been torn about allowing that, since it seems like it would be ambiguous if it should return a `Pair{Index, Int}` or an `IndexVal`. If it seems useful we can bring it back later, I just wanted to be conservative right now.