### PR TITLE
Split make.jl into multiple scripts for deployment and local building of docs, with and without doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,5 @@
 include("settings.jl")
 
-makedocs(sitename = sitename;
-         modules = modules,
-         pages = pages,
-         format = Documenter.HTML(prettyurls = false),
-         doctest = true,
-         checkdocs = :none)
+makedocs(sitename = sitename; settings...)
 
 deploydocs(repo = "github.com/ITensor/ITensors.jl.git")

--- a/docs/make_local_notest.jl
+++ b/docs/make_local_notest.jl
@@ -4,7 +4,5 @@ makedocs(sitename = sitename;
          modules = modules,
          pages = pages,
          format = Documenter.HTML(prettyurls = false),
-         doctest = true,
+         doctest = false,
          checkdocs = :none)
-
-deploydocs(repo = "github.com/ITensor/ITensors.jl.git")

--- a/docs/make_local_notest.jl
+++ b/docs/make_local_notest.jl
@@ -1,8 +1,5 @@
 include("settings.jl")
 
-makedocs(sitename = sitename;
-         modules = modules,
-         pages = pages,
-         format = Documenter.HTML(prettyurls = false),
-         doctest = false,
-         checkdocs = :none)
+settings[:doctest] = false
+
+makedocs(sitename = sitename; settings...)

--- a/docs/make_local_test.jl
+++ b/docs/make_local_test.jl
@@ -1,8 +1,3 @@
 include("settings.jl")
 
-makedocs(sitename = sitename;
-         modules = modules,
-         pages = pages,
-         format = Documenter.HTML(prettyurls = false),
-         doctest = true,
-         checkdocs = :none)
+makedocs(sitename = sitename; settings...)

--- a/docs/make_local_test.jl
+++ b/docs/make_local_test.jl
@@ -6,5 +6,3 @@ makedocs(sitename = sitename;
          format = Documenter.HTML(prettyurls = false),
          doctest = true,
          checkdocs = :none)
-
-deploydocs(repo = "github.com/ITensor/ITensors.jl.git")

--- a/docs/settings.jl
+++ b/docs/settings.jl
@@ -1,0 +1,21 @@
+using Documenter, ITensors
+
+DocMeta.setdocmeta!(ITensors,
+                    :DocTestSetup,
+                    :(using ITensors);
+                    recursive=true)
+
+sitename = "ITensors.jl"
+modules = [ITensors]
+
+pages = [
+        "Introduction" => "index.md",
+        "Index" => "IndexType.md",
+        "IndexVal" => "IndexValType.md",
+        "IndexSet" => "IndexSetType.md",
+        "ITensor" => "ITensorType.md",
+        "MPS and MPO" => "MPSandMPO.md",
+        "DMRG" => "DMRG.md",
+        "AutoMPO" => "AutoMPO.md",
+        "ProjMPO" => "ProjMPO.md",
+         ]

--- a/docs/settings.jl
+++ b/docs/settings.jl
@@ -6,16 +6,21 @@ DocMeta.setdocmeta!(ITensors,
                     recursive=true)
 
 sitename = "ITensors.jl"
-modules = [ITensors]
 
-pages = [
-        "Introduction" => "index.md",
-        "Index" => "IndexType.md",
-        "IndexVal" => "IndexValType.md",
-        "IndexSet" => "IndexSetType.md",
-        "ITensor" => "ITensorType.md",
-        "MPS and MPO" => "MPSandMPO.md",
-        "DMRG" => "DMRG.md",
-        "AutoMPO" => "AutoMPO.md",
-        "ProjMPO" => "ProjMPO.md",
-         ]
+settings = Dict(
+  :modules => [ITensors],
+  :pages => [
+          "Introduction" => "index.md",
+          "Index" => "IndexType.md",
+          "IndexVal" => "IndexValType.md",
+          "IndexSet" => "IndexSetType.md",
+          "ITensor" => "ITensorType.md",
+          "MPS and MPO" => "MPSandMPO.md",
+          "DMRG" => "DMRG.md",
+          "AutoMPO" => "AutoMPO.md",
+          "ProjMPO" => "ProjMPO.md",
+           ],
+  :format => Documenter.HTML(prettyurls = false),
+  :doctest => true,
+  :checkdocs => :none,
+ )


### PR DESCRIPTION
This PR moves the ITensor-specific Documenter configuration into a file docs/settings.jl. It also introduces new scripts make_local_test.jl and make_local_notest.jl for building docs locally without deployment and also without running (time consuming) doc tests in the case of make_local_notest.jl.
