### PR TITLE
ITensor printing

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,11 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 julia = "1.4"
-NDTensors = "0.1.1"
+NDTensors = "0.1.2"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1284,15 +1284,19 @@ end
 function Base.summary(io::IO,
                       T::ITensor)
   print(io,"ITensor ord=$(order(T))")
-  for i = 1:order(T)
-    if hasqns(inds(T)[i])
-      startstr = (i==1) ? "\n" : ""
-      print(io,startstr,inds(T)[i])
-    else
-      print(io," ",inds(T)[i])
+  if hasqns(T)
+    println(io)
+    for i in 1:order(T)
+      print(io, inds(T)[i])
+      println(io)
     end
+  else
+    for i in 1:order(T)
+      print(io, " ", inds(T)[i])
+    end
+    println(io)
   end
-  print(io," \n",typeof(store(T)))
+  print(io, typeof(store(T)))
 end
 
 function Base.summary(io::IO,
@@ -1306,10 +1310,8 @@ end
 # that emphasizes the missing elements
 function Base.show(io::IO,
                    T::ITensor)
-  #summary(io,T)
   println(io,"ITensor ord=$(order(T))")
-  println(io)
-  Base.show(io,MIME"text/plain"(),tensor(T))
+  Base.show(io, MIME"text/plain"(), tensor(T))
 end
 
 function Base.show(io::IO,

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -299,7 +299,8 @@ function Base.show(io::IO,
   end
   println(io," <$(dir(i))>")
   for (n,qnblock) in enumerate(space(i))
-    println(io," $n: $qnblock")
+    print(io," $n: $qnblock")
+    n < length(space(i)) && println(io)
   end
 end
 


### PR DESCRIPTION
ITensor printing got a bit messy recently because of changes to Tensor printing in NDTensors. This bumps the compat version of NDTensors to v0.1.2 which has some improvements for that, and cleans up things a little on the ITensor side as well.

Here is the latest printing:
```julia
using ITensors

iqn = Index(QN(0) => 2, QN(1) => 2; tags = "i")
i = removeqns(iqn)

A = ITensor(i', dag(i))
D = diagITensor(i', dag(i))
Aqn = ITensor(iqn', dag(iqn))
Dqn = diagITensor(iqn', dag(iqn))

@show A;
println()
@show D;
println()
@show Aqn;
println()
@show Dqn;
```
gives:
```julia
A = ITensor ord=2
Dim 1: (dim=4|id=275|"i")'
Dim 2: (dim=4|id=275|"i")
NDTensors.Dense{Float64,Array{Float64,1}}
 4×4
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0

D = ITensor ord=2
Dim 1: (dim=4|id=275|"i")'
Dim 2: (dim=4|id=275|"i")
NDTensors.Diag{Float64,Array{Float64,1}}
 4×4
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0

Aqn = ITensor ord=2
Dim 1: (dim=4|id=275|"i")' <Out>
 1: QN(0) => 2
 2: QN(1) => 2
Dim 2: (dim=4|id=275|"i") <In>
 1: QN(0) => 2
 2: QN(1) => 2
NDTensors.BlockSparse{Float64,Array{Float64,1},2}
 4×4
Block: (1, 1)
 [1:2, 1:2]
 0.0  0.0
 0.0  0.0

Block: (2, 2)
 [3:4, 3:4]
 0.0  0.0
 0.0  0.0

Dqn = ITensor ord=2
Dim 1: (dim=4|id=275|"i")' <Out>
 1: QN(0) => 2
 2: QN(1) => 2
Dim 2: (dim=4|id=275|"i") <In>
 1: QN(0) => 2
 2: QN(1) => 2
NDTensors.DiagBlockSparse{Float64,Array{Float64,1},2}
 4×4
Block: (1, 1)
 [1:2, 1:2]
 0.0  0.0
 0.0  0.0

Block: (2, 2)
 [3:4, 3:4]
 0.0  0.0
 0.0  0.0
```