### PR TITLE
Fix the correct QNs for the indices introduced in eigen

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1222,6 +1222,37 @@ NDTensors.blockoffsets(T::ITensor) = blockoffsets(tensor(T))
 
 flux(T::ITensor, args...) = flux(inds(T), args...)
 
+"""
+    flux(T::ITensor)
+
+Returns the flux of the ITensor.
+
+If the ITensor is empty or it has no QNs, returns `nothing`.
+"""
+function flux(T::ITensor)
+  (!hasqns(T) || isempty(T)) && return nothing
+  @debug checkflux(T)
+  bofs = blockoffsets(T)
+  block1 = nzblock(bofs, 1)
+  return flux(T, block1)
+end
+
+function checkflux(T::ITensor, flux_check)
+  for b in nzblocks(T)
+    fluxTb = flux(T, b)
+    if fluxTb != flux_check
+      error("Block $b has flux $fluxTb that is inconsistent with the desired flux $flux_check")
+    end
+  end
+  return nothing
+end
+
+function checkflux(T::ITensor)
+  b1 = first(nzblocks(T))
+  fluxTb1 = flux(T, b1)
+  return checkflux(T, fluxTb1)
+end
+
 function NDTensors.addblock!(T::ITensor,
                              args...)
   (!isnothing(flux(T)) && flux(T) ≠ flux(T, args...)) && 
@@ -1239,20 +1270,6 @@ Returns `true` if the ITensor contains no elements.
 An ITensor with `Empty` storage always returns `true`.
 """
 Base.isempty(T::ITensor) = isempty(tensor(T))
-
-"""
-    flux(T::ITensor)
-
-Returns the flux of the ITensor.
-
-If the ITensor is empty or it has no QNs, returns `nothing`.
-"""
-function flux(T::ITensor)
-  (!hasqns(T) || isempty(T)) && return nothing
-  bofs = blockoffsets(T)
-  block1 = nzblock(bofs, 1)
-  return flux(T, block1)
-end
 
 
 #######################################################################

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -564,6 +564,13 @@ end
 
 totalqn(M::AbstractMPS) = flux(M)
 
+function checkflux(M::AbstractMPS)
+  for m in M
+    checkflux(m)
+  end
+  return nothing
+end
+
 @doc """
     orthogonalize!(M::MPS, j::Int; kwargs...)
 

--- a/src/mps/projmpo.jl
+++ b/src/mps/projmpo.jl
@@ -236,3 +236,12 @@ function noiseterm(P::ProjMPO,
   return nt
 end
 
+function checkflux(P::ProjMPO)
+  checkflux(P.H)
+  for n in length(P.LR)
+    if isassigned(P.LR, n)
+      checkflux(P.LR[n])
+    end
+  end
+end
+

--- a/src/qn/qnindexset.jl
+++ b/src/qn/qnindexset.jl
@@ -32,3 +32,11 @@ end
 
 removeqns(is::QNIndexSet) = map(i -> removeqns(i), is)
 
+function Base.show(io::IO, is::QNIndexSet)
+  print(io,"IndexSet{$(length(is))} ")
+  for i in is
+    print(io, i)
+    println(io)
+  end
+end
+

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -213,6 +213,45 @@ using ITensors, Test, Random
     energy, psi = dmrg(H, psi0, sweeps; outputlevel = 0)
     @test (-6.5 < energy < -6.4)
   end
+
+  @testset "Hubbard model" begin
+    N = 10
+    Npart = 8
+    t1 = 1.0
+    U  = 1.0
+    V1 = 0.5
+    sites = siteinds("Electron",N; conserve_qns=true)
+    ampo = AutoMPO()
+    for i=1:N
+      ampo += (U,"Nupdn",i)
+    end
+    for b=1:N-1
+      ampo += (-t1,"Cdagup",b,"Cup",b+1)
+      ampo += (-t1,"Cdagup",b+1,"Cup",b)
+      ampo += (-t1,"Cdagdn",b,"Cdn",b+1)
+      ampo += (-t1,"Cdagdn",b+1,"Cdn",b)
+      ampo += (V1,"Ntot",b,"Ntot",b+1)
+    end
+    H = MPO(ampo,sites)
+    sweeps = Sweeps(6)
+    maxdim!(sweeps,50,100,200,400,800,800)
+    cutoff!(sweeps,1E-10)
+    state = ["Up",
+             "Dn",
+             "Dn",
+             "Up",
+             "Emp",
+             "Up",
+             "Up",
+             "Emp",
+             "Dn",
+             "Dn"
+            ]
+    psi0 = randomMPS(sites,state,10)
+    energy,psi = dmrg(H,psi0,sweeps; outputlevel = 0)
+    @test (-8.02 < energy < -8.01)
+  end
+
 end
 
 nothing


### PR DESCRIPTION
This fixes a bug brought up by Steve White where sometimes the new Index introduced by eigen had the wrong flux, causing errors later on related to some blocks having the wrong flux.

The fix is just to manually set the correct QNs of the new Index, based on the constraint that `flux(V) == QN()` and `flux(D) == QN()`.