### PR TITLE
throw error in case of order mismatch in ProjMPO-ITensor product

### DIFF
--- a/src/mps/projmpo.jl
+++ b/src/mps/projmpo.jl
@@ -69,7 +69,7 @@ as `v`. The operator overload `P(v)` is
 shorthand for `product(P,v)`.
 """
 function product(P::ProjMPO,
-                 v::ITensor)::ITensor
+                 v::ITensor{N})::ITensor{N} where N
   Hv = v
   if isnothing(lproj(P))
     if !isnothing(rproj(P))

--- a/src/mps/projmpo.jl
+++ b/src/mps/projmpo.jl
@@ -54,30 +54,8 @@ function rproj(P::ProjMPO)
   return P.LR[P.rpos]
 end
 
-function NDTensors.inds(P::ProjMPO)
-  Pinds = []
-  if isnothing(lproj(P))
-    if !isnothing(rproj(P))
-      push!(Pinds, inds(rproj(P))...)
-    else
-      throw("ProjMPO not initialized, call `position!` first.")
-    end
-  else
-    push!(Pinds,inds(lproj(P))...)
-    if !isnothing(rproj(P))
-      push!(Pinds,inds(rproj(P))...)
-    end
-  end
-  for j in P.rpos-1:-1:P.lpos+1
-    push!(Pinds,filter(x->hastags(x,"Site"), inds(P.H[j]))...)
-  end
-  return IndexSet(setdiff(IndexSet(Pinds...),
-                          IndexSet(filter(x->hastags(x,"Link"), IndexSet(inds(P.H[P.rpos-1])...,
-                                                                         inds(P.H[P.lpos+1])...)))))
-end
-
 """
-    product(P::ProjMPO,v::ITensor)
+    product(P::ProjMPO,v::ITensor{N})::ITensor{N}
 
     (P::ProjMPO)(v::ITensor)
 
@@ -114,8 +92,8 @@ function product(P::ProjMPO,
                  "this is probably due to an index mismatch.\nCommon reasons for this error: \n",
                  "(1) You are trying to multiply the ProjMPO with the $(nsite(P))-site wave-function at the wrong position.\n",
                  "(2) `orthognalize!` was called, changing the MPS without updating the ProjMPO.\n\n",
-                 "ProjMPO inds: $(inds(P)) \n\n",
-                 "ITensor inds: $(inds(v))"))
+                 "P*v inds: $(inds(Hv)) \n\n",
+                 "v inds: $(inds(v))"))
   end
   return noprime(Hv)
 end


### PR DESCRIPTION
This PR adds a check to `product(P::ProjMPO,wf::ITensor)` which will throw an informative error if the order of `P(wf)` doesn't match `wf`, as discussed in  https://github.com/ITensor/ITensors.jl/issues/389. 
I also implemented `NDTensors.inds(P::ProjMPO)`.

The error message (for the case `nsite(P)==2`) would look like this:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/1208196/82730466-3c924080-9d00-11ea-8d3c-2fe8d4617a04.png">

I should probably add some tests, but there was no `projmpo.jl` test file, should I create a new one or should the tests be in `dmrg.jl` test file?

Also there are some multi-line function calls there and I wasn't fully sure what formatting guidelines should be followed, so let me know if formatting is off (maybe worth adding some contributors guide section somewhere). 
