### PR TITLE
small fix for productMPS with ComplexF64 eltype 

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -222,7 +222,7 @@ function productMPS(::Type{T},
   M = MPS(N)
 
   if N==1
-    M[1] = emptyITensor(ind(ivals[1]))
+    M[1] = emptyITensor(T,ind(ivals[1]))
     M[1][ivals[1]] = one(T)
     return M
   end
@@ -232,7 +232,7 @@ function productMPS(::Type{T},
   else
     links = [Index(1,"Link,l=$n") for n=1:N]
   end
-  M[1] = emptyITensor(ind(ivals[1]), links[1])
+  M[1] = emptyITensor(T,ind(ivals[1]), links[1])
   M[1][ivals[1],links[1](1)] = one(T)
   for n=2:N-1
     s = ind(ivals[n])

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -78,6 +78,14 @@ include("util.jl")
         sign = isodd(j) ? +1.0 : -1.0
         @test (psi[j]*op(sites,"Sz",j)*dag(prime(psi[j],"Site")))[] ≈ sign/2
       end
+
+      @testset "ComplexF64 eltype" begin
+        sites  = siteinds("S=1/2",N)
+        psi = productMPS(ComplexF64,sites,fill(1,N))
+        for j=1:N
+          @test eltype(psi[j]) <: ComplexF64
+        end
+      end
     end
 
     @testset "N=1 case" begin


### PR DESCRIPTION
tiny fix to `productMPS(::T,args...)` to make sure that the first tensor has the requested `eltype`.
I also added a small test.