### PR TITLE
Export @TagType_str macro

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -237,7 +237,7 @@ export
 
 # physics/tag_types.jl
   TagType,
-  TagType_str,
+  @TagType_str,
   op,
   state,
   has_fermion_string,

--- a/test/tag_types.jl
+++ b/test/tag_types.jl
@@ -28,7 +28,10 @@ using ITensors,
 
   @testset "Custom TagType" begin
 
-    function ITensors.op(::TagType"S=3/2",
+    # Use "_Custom_" tag even though this example
+    # is for S=3/2, because we might define the 
+    # "S=3/2" TagType inside ITensors.jl later
+    function ITensors.op(::TagType"_Custom_",
                          s::Index,
                          opname::AbstractString)
       Op = ITensor(s',dag(s))
@@ -41,7 +44,7 @@ using ITensors,
       return Op
     end
 
-    s = Index(4,"S=3/2")
+    s = Index(4,"_Custom_")
     Sz = op(s,"Sz")
     @test Sz[s'=>1,s=>1] ≈ +3/2
     @test Sz[s'=>2,s=>2] ≈ +1/2

--- a/test/tag_types.jl
+++ b/test/tag_types.jl
@@ -1,7 +1,7 @@
 using ITensors,
       Test
 
-@testset "Site Types" begin
+@testset "Tag Types" begin
 
   N = 10
 
@@ -25,6 +25,30 @@ using ITensors,
     SySy = op(sites,"Sy * Sy",2)
     @test SySy ≈ product(Sy, Sy)
   end
+
+  @testset "Custom TagType" begin
+
+    function ITensors.op(::TagType"S=3/2",
+                         s::Index,
+                         opname::AbstractString)
+      Op = ITensor(s',dag(s))
+      if opname == "Sz"
+        Op[s'=>1,s=>1] = +3/2
+        Op[s'=>2,s=>2] = +1/2
+        Op[s'=>3,s=>3] = -1/2
+        Op[s'=>4,s=>4] = -3/2
+      end
+      return Op
+    end
+
+    s = Index(4,"S=3/2")
+    Sz = op(s,"Sz")
+    @test Sz[s'=>1,s=>1] ≈ +3/2
+    @test Sz[s'=>2,s=>2] ≈ +1/2
+    @test Sz[s'=>3,s=>3] ≈ -1/2
+    @test Sz[s'=>4,s=>4] ≈ -3/2
+  end
+
 end
 
 nothing


### PR DESCRIPTION
Currently, function definitions like
```julia
using ITensors

function ITensors.op(::TagType"S=3/2",
                     s::Index,
                     opname::AbstractString)
```
don't work because the `@TagType_str` macro is not being exported.
