### PR TITLE
Fix uncombining combiner bug when combined Index is not first index

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["mfishman <mfishman@caltech.edu>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
@@ -17,7 +17,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 julia = "1.4"
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
-NDTensors = "0.1.3"
+NDTensors = "0.1.5"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"
 

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -578,6 +578,16 @@ Random.seed!(1234)
     @test TT ≈ T
   end
 
+  @testset "Combiner bug #395" begin
+    i1 = Index([QN(0)=>1,QN(1)=>2],"i1")
+    i2 = Index([QN(0)=>1,QN(1)=>2],"i2")
+    A = randomITensor(QN(),i1,i2,dag(i1)', dag(i2)')
+    CL = combiner(i1,i2)
+    CR = combiner(dag(i1)',dag(i2)')
+    AC = A * CR * CL
+    @test AC * dag(CR) * dag(CL) ≈ A
+  end
+
   @testset "Contract to scalar" begin
     i = Index([QN(0)=>1,QN(1)=>1],"i")
     A = randomITensor(QN(0),i,dag(i'))


### PR DESCRIPTION
This bumps the version of NDTensors, which includes a bug fix for a certain case of uncombining when the index to be uncombined is not the first index in the IndexSet.