### PR TITLE
implement exponentiation for ITensors with QNs

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1072,26 +1072,67 @@ end
 LinearAlgebra.dot(A::ITensor, B::ITensor) = (dag(A)*B)[]
 
 """
-    exp(A::ITensor, Linds, Rinds = prime(dag(IndexSet(Linds))); ishermitian = false)
+    exp(A::ITensor, Linds=Rinds', Rinds=inds(A,plev=0); ishermitian = false)
 
 Compute the exponential of the tensor `A` by treating it as a matrix ``A_{lr}`` with
 the left index `l` running over all indices in `Linds` and `r` running over all
-indices in `Rinds`. Must have `dim(Linds) == dim(inds(A))/dim(Linds)` for the exponentiation to
-be defined.
+indices in `Rinds`.
+
+Only accepts index lists `Linds`,`Rinds` such that: (1) `length(Linds) +
+length(Rinds) == length(inds(A))` (2) `length(Linds) == length(Rinds)` (3) For
+each pair of indices `(Linds[n],Rinds[n])`, `Linds[n]` and `Rinds[n]` represent
+the same Hilbert space (the same QN structure in the QN case, or just the same
+length in the dense case), and appear in `A` with opposite directions.
+
 When `ishermitian=true` the exponential of `Hermitian(A_{lr})` is
 computed internally.
 """
-function LinearAlgebra.exp(A::ITensor,
-                           Linds,
-                           Rinds = prime(dag(IndexSet(Linds)));
-                           ishermitian = false)
-  CL = combiner(Linds...)
-  CR = combiner(Rinds...)
+function LinearAlgebra.exp(A::ITensor{N}, Linds, Rinds; kwargs...) where N
+  ishermitian=get(kwargs,:ishermitian,false)
+
+  @debug begin
+    if hasqns(A)
+      @assert flux(A) == QN()
+    end
+  end
+
+  NL = length(Linds)
+  NR = length(Rinds)
+  NL != NR && error("Must have equal number of left and right indices")
+  N != NL + NR && error("Number of left and right indices must add up to total number of indices")
+
+  # Linds, Rinds may not have the correct directions
+  Lis = IndexSet(Linds...)
+  Ris = IndexSet(Rinds...)
+
+  Lis = setdirs(Lis, dirs(A, Lis))
+  Ris = setdirs(Ris, dirs(A, Ris))
+
+  for (l, r) in zip(Lis, Ris)
+    if space(l) != space(r)
+      error("In exp, indices must come in pairs with equal spaces.")
+    end
+    if hasqns(A)
+      if dir(l) == dir(r)
+        error("In exp, indices must come in pairs with opposite directions")
+      end
+    end
+  end
+
+  CL = combiner(Lis...)
+  CR = combiner(Ris...)
   AC = A * CR * CL
   expAT = ishermitian ? exp(Hermitian(tensor(AC))) : exp(tensor(AC))
   return itensor(expAT)*dag(CR)*dag(CL)
 end
 
+function LinearAlgebra.exp(A::ITensor;
+                             kwargs...)
+  Ris = inds(A; plev = 0)
+  Lis = Ris'
+
+  return exp(A, Lis, Ris; kwargs...)
+end
 
 """
     product(A::ITensor, B::ITensor)

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -1287,30 +1287,31 @@ end
   i1 = Index([QN(0)=>1,QN(1)=>2],"i1")
   i2 = Index([QN(0)=>1,QN(1)=>2],"i2")
   A = randomITensor(QN(),i1,i2,dag(i1)', dag(i2)')
-  Aexp = exp(A,IndexSet(i1,i2))
-  Amat = Array(A, i1,i2, dag(i1)', dag(i2)')
+  Aexp = exp(A)
+  Amat = Array(A, i1,i2, i1', i2')
   Amatexp = reshape(exp(reshape(Amat,9,9)),3,3,3,3)
-  @test isapprox(norm(Array(Aexp,i1,i2,dag(i1)',dag(i2)') - Amatexp),0.0, atol=1e-14)
+  @test isapprox(norm(Array(Aexp,i1,i2,i1',i2') - Amatexp),0.0, atol=1e-14)
   @test flux(Aexp) == QN()
   @test length(setdiff(inds(Aexp),inds(A)))==0
 
+  @test isapprox(norm(exp(A, (i1,i2), (i1',i2')) - Aexp),0.0, atol=5e-14)
+
   # test the case where indices are permuted
   A = randomITensor(QN(),i1,dag(i1)', dag(i2)',i2)
-  Aexp = exp(A,IndexSet(i1,i2))
-  Amat = Array(A, i1,i2,dag(i1)', dag(i2)')
+  Aexp = exp(A, (i1,i2), (i1',i2'))
+  Amat = Array(A, i1,i2,i1', i2')
   Amatexp = reshape(exp(reshape(Amat,9,9)),3,3,3,3)
-  @test isapprox(norm(Array(Aexp,i1,i2,dag(i1)',dag(i2)') - Amatexp),0.0,atol=1e-14)
+  @test isapprox(norm(Array(Aexp,i1,i2,i1',i2') - Amatexp),0.0,atol=1e-14)
 
   # test exponentiation in the Hermitian case
   i1 = Index([QN(0)=>2,QN(1)=>2,QN(2)=>3],"i1")
   A = randomITensor(QN(),i1,dag(i1)')
   Ad = dag(swapinds(A,IndexSet(i1),IndexSet(dag(i1)')))
   Ah = A+Ad + 1e-10*randomITensor(QN(),i1,dag(i1)')
-  Amat = Array(Ah ,i1,dag(i1)')
-  Aexp = exp(Ah,IndexSet(i1), ishermitian=true)
+  Amat = Array(Ah ,i1', i1)
+  Aexp = exp(Ah; ishermitian=true)
   Amatexp= exp(Hermitian(Amat))
-  @test isapprox(norm(Array(Aexp,i1,dag(i1)')-Amatexp),0.0,atol=5e-14)
-
+  @test isapprox(norm(Array(Aexp,i1,i1')-Amatexp),0.0,atol=5e-14)
 end
 
 end

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -1283,6 +1283,36 @@ Random.seed!(1234)
 
 end
 
+@testset "exponentiate" begin
+  i1 = Index([QN(0)=>1,QN(1)=>2],"i1")
+  i2 = Index([QN(0)=>1,QN(1)=>2],"i2")
+  A = randomITensor(QN(),i1,i2,dag(i1)', dag(i2)')
+  Aexp = exp(A,IndexSet(i1,i2))
+  Amat = Array(A, i1,i2, dag(i1)', dag(i2)')
+  Amatexp = reshape(exp(reshape(Amat,9,9)),3,3,3,3)
+  @test isapprox(norm(Array(Aexp,i1,i2,dag(i1)',dag(i2)') - Amatexp),0.0, atol=1e-14)
+  @test flux(Aexp) == QN()
+  @test length(setdiff(inds(Aexp),inds(A)))==0
+
+  # test the case where indices are permuted
+  A = randomITensor(QN(),i1,dag(i1)', dag(i2)',i2)
+  Aexp = exp(A,IndexSet(i1,i2))
+  Amat = Array(A, i1,i2,dag(i1)', dag(i2)')
+  Amatexp = reshape(exp(reshape(Amat,9,9)),3,3,3,3)
+  @test isapprox(norm(Array(Aexp,i1,i2,dag(i1)',dag(i2)') - Amatexp),0.0,atol=1e-14)
+
+  # test exponentiation in the Hermitian case
+  i1 = Index([QN(0)=>2,QN(1)=>2,QN(2)=>3],"i1")
+  A = randomITensor(QN(),i1,dag(i1)')
+  Ad = dag(swapinds(A,IndexSet(i1),IndexSet(dag(i1)')))
+  Ah = A+Ad + 1e-10*randomITensor(QN(),i1,dag(i1)')
+  Amat = Array(Ah ,i1,dag(i1)')
+  Aexp = exp(Ah,IndexSet(i1), ishermitian=true)
+  Amatexp= exp(Hermitian(Amat))
+  @test isapprox(norm(Array(Aexp,i1,dag(i1)')-Amatexp),0.0,atol=5e-14)
+
+end
+
 end
 
 nothing


### PR DESCRIPTION
One thing about this implementation that I'm not sure about- 
currently it will not support the scenario :
``` julia 
i1 = Index([QN(0)=>1,QN(1)=>2],"i1")
i2 = Index([QN(0)=>1,QN(1)=>2],"i2")
A = randomITensor(QN(),i1,i2,dag(i1)', dag(i2)')
Lis = IndexSet(i1,dag(i1)')
Ris = IndexSet(i2,dag(i2)')
exp(A,Lis,Ris )
```
Because the order 2 block-sparse tensor with combined indices `AC= A*combiner(Lis...)*combiner(Ris...)` will not be block diagonal. 

But since `AC` still has zero flux it is my understanding (which might be incorrect) that it should be possible to exponentiate it block by block, preserving the block structure, and the reason it is not represented as a block diagonal tensor is because both indices  of `AC` have an  (arbitrary?) `OUT` direction.

It is very possible that this scenario has no use-case, but it just made me wonder whether I made some mistake in the implementation and it should be also supported.
