### PR TITLE
Add Unicode support for SmallStrings/Tags

### DIFF
--- a/benchmark/bench_tagset.jl
+++ b/benchmark/bench_tagset.jl
@@ -1,0 +1,12 @@
+module BenchInplace
+
+using BenchmarkTools
+using ITensors
+
+suite = BenchmarkGroup()
+
+suite["tagset"] = @benchmarkable TagSet("abcdefgh,ijklmnop,qrstuvwx,ABCDEFGH")
+suite["tagset_unicode"] = @benchmarkable TagSet("αβγδϵζηθ,ijklmnop,qrstuvwx,ΑΒΓΔΕΖΗΘ")
+end
+
+BenchInplace.suite

--- a/src/smallstring.jl
+++ b/src/smallstring.jl
@@ -1,6 +1,6 @@
 
-const IntChar = UInt8
-const IntSmallString = UInt64
+const IntChar = UInt16
+const IntSmallString = UInt128
 const smallLength = 8
 const SmallStringStorage = SVector{smallLength,IntChar}
 const MSmallStringStorage = MVector{smallLength,IntChar}
@@ -89,7 +89,7 @@ function Base.String(s::SmallString)
     n += 1
   end
   len = n-1
-  return String(s.data[1:len])
+  return String(Char.(s.data[1:len]))
 end
 
 function Base.show(io::IO, s::SmallString)

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -69,8 +69,7 @@ function TagSet(str::AbstractString)
   ts = MTagSetStorage(ntuple(_ -> IntTag(0),Val(maxTags)))
   nchar = 0
   ntags = 0
-  for n = 1:length(str)
-    @inbounds current_char = str[n]
+  for current_char in str
     if current_char == ','
       if nchar != 0
         ntags = _addtag!(ts,ntags,cast_to_uint64(current_tag))


### PR DESCRIPTION
This adds Unicode support for SmallStrings/Tags. Here are some benchmarks for this branch:
```julia
julia> @btime TagSet("a")
  19.195 ns (1 allocation: 80 bytes)
"a"

julia> @btime TagSet("α")
  24.075 ns (1 allocation: 80 bytes)
"α"

julia> @btime TagSet("S+")
  21.121 ns (1 allocation: 80 bytes)
"S+"

julia> @btime TagSet("S⁺")
  26.263 ns (1 allocation: 80 bytes)
"S⁺"

julia> @btime TagSet("abcdefgh,ijklmnop,qrstuvwx,ABCDEFGH")
  145.278 ns (1 allocation: 80 bytes)
"ABCDEFGH,abcdefgh,ijklmnop,qrstuvwx"

julia> @btime TagSet("αβγδϵζηθ,ijklmnop,qrstuvwx,ΑΒΓΔΕΖΗΘ")
  242.012 ns (1 allocation: 80 bytes)
"ijklmnop,qrstuvwx,ΑΒΓΔΕΖΗΘ,αβγδϵζηθ"
```
and for the master branch:
```julia
julia> @btime TagSet("a")
  17.973 ns (1 allocation: 48 bytes)
"a"

julia> @btime TagSet("S+")
  19.842 ns (1 allocation: 48 bytes)
"S+"

julia> @btime TagSet("abcdefgh,ijklmnop,qrstuvwx,ABCDEFGH")
  103.082 ns (1 allocation: 48 bytes)
"ABCDEFGH,abcdefgh,ijklmnop,qrstuvwx"
```
which looks quite reasonable. I also added some benchmarks for constructing TagSets.