### PR TITLE
Allow user control of combined Index direction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+ITensors v0.1.6 Release Notes
+==============================
+
+* Allow user to control Arrow direction of combined Index in combiner (PR #417)
+* Fix eigen for case when left/right indices had mixed Arrow directions (PR #417)
+* Add exp for QN ITensor (PR #402)
+* Add Advanced Usage Guide to docs (PR #387)
+
 ITensors v0.1.5 Release Notes
 ==============================
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["mfishman <mfishman@caltech.edu>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
@@ -17,7 +17,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 julia = "1.4"
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
-NDTensors = "0.1.5"
+NDTensors = "0.1.6"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"
 

--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -179,8 +179,12 @@ function LinearAlgebra.eigen(A::ITensor{N},
   Lis = IndexSet(Linds...)
   Ris = IndexSet(Rinds...)
 
-  Lis = setdirs(Lis, dirs(A, Lis))
-  Ris = setdirs(Ris, dirs(A, Ris))
+  # Ensure the indices have the correct directions,
+  # QNs, etc.
+  # First grab the indices in A, then permute them
+  # correctly.
+  Lis = permute(commoninds(A, Lis), Lis)
+  Ris = permute(commoninds(A, Ris), Ris)
 
   for (l, r) in zip(Lis, Ris)
     if space(l) != space(r)
@@ -193,8 +197,8 @@ function LinearAlgebra.eigen(A::ITensor{N},
     end
   end
 
-  CL = combiner(Lis...; tags = "CMB,left")
-  CR = combiner(Ris...; tags = "CMB,right")
+  CL = combiner(Lis...; dir = Out, tags = "CMB,left")
+  CR = combiner(Ris...; dir = In, tags = "CMB,right")
 
   AC = A * CR * CL
 

--- a/src/index.jl
+++ b/src/index.jl
@@ -377,9 +377,12 @@ function Base.iterate(i::Index, state::Int = 1)
 end
 
 # This is a trivial definition for use in NDTensors
-NDTensors.outer(i::Index; tags = "",
-                          plev = 0) = sim(i; tags = tags,
-                                             plev = plev)
+NDTensors.outer(i::Index; tags = tags(i),
+                          plev = plev(i),
+                          dir = dir(i)) = 
+  sim(i; tags = tags,
+         plev = plev,
+         dir = dir)
 
 # This is for use in NDTensors
 function NDTensors.outer(i1::Index, i2::Index; tags = "")

--- a/src/index.jl
+++ b/src/index.jl
@@ -377,9 +377,10 @@ function Base.iterate(i::Index, state::Int = 1)
 end
 
 # This is a trivial definition for use in NDTensors
-NDTensors.outer(i::Index; tags = tags(i),
-                          plev = plev(i),
-                          dir = dir(i)) = 
+NDTensors.outer(i::Index;
+                dir = dir(i),
+                tags = "",
+                plev::Int = 0) =
   sim(i; tags = tags,
          plev = plev,
          dir = dir)

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -785,6 +785,11 @@ swapind(is::IndexSet, i1::Index, i2::Index) = swapinds(is, (i1,), (i2,))
 
 removeqns(is::IndexSet) = is
 
+function permute(is1::IndexSet{N}, is2::IndexSet{N}) where {N}
+  perm = NDTensors.getperm(is1, is2)
+  return NDTensors.permute(is1, perm)
+end
+
 #
 # Helper functions for contracting ITensors
 #
@@ -967,10 +972,19 @@ end
     dirs(is::IndexSet, inds)
 
 Return a tuple of the directions of the indices `inds` in 
-the IndexSet `is`.
+the IndexSet `is`, in the order they are found in `inds`.
 """
 function dirs(is1::IndexSet, inds)
   return ntuple(i -> dir(is1, inds[i]), Val(length(inds)))
+end
+
+"""
+    dirs(is::IndexSet)
+
+Return a tuple of the directions of the indices `is`.
+"""
+function dirs(is::IndexSet{N}) where {N}
+  return ntuple(i -> dir(is[i]), Val(N))
 end
 
 hasqns(is::IndexSet) = any(hasqns,is)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1135,7 +1135,6 @@ end
 function LinearAlgebra.exp(A::ITensor;
                            kwargs...)
   Ris = inds(A; plev = 0)
-  @show Ris
   Lis = Ris'
   return exp(A, Lis, Ris; kwargs...)
 end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1087,7 +1087,9 @@ length in the dense case), and appear in `A` with opposite directions.
 When `ishermitian=true` the exponential of `Hermitian(A_{lr})` is
 computed internally.
 """
-function LinearAlgebra.exp(A::ITensor{N}, Linds, Rinds; kwargs...) where N
+function LinearAlgebra.exp(A::ITensor{N},
+                           Linds,
+                           Rinds; kwargs...) where N
   ishermitian=get(kwargs,:ishermitian,false)
 
   @debug begin
@@ -1105,8 +1107,12 @@ function LinearAlgebra.exp(A::ITensor{N}, Linds, Rinds; kwargs...) where N
   Lis = IndexSet(Linds...)
   Ris = IndexSet(Rinds...)
 
-  Lis = setdirs(Lis, dirs(A, Lis))
-  Ris = setdirs(Ris, dirs(A, Ris))
+  # Ensure the indices have the correct directions,
+  # QNs, etc.
+  # First grab the indices in A, then permute them
+  # correctly.
+  Lis = permute(commoninds(A, Lis), Lis)
+  Ris = permute(commoninds(A, Ris), Ris)
 
   for (l, r) in zip(Lis, Ris)
     if space(l) != space(r)
@@ -1119,18 +1125,18 @@ function LinearAlgebra.exp(A::ITensor{N}, Linds, Rinds; kwargs...) where N
     end
   end
 
-  CL = combiner(Lis...)
-  CR = combiner(Ris...)
+  CL = combiner(Lis...; dir = Out)
+  CR = combiner(Ris...; dir = In)
   AC = A * CR * CL
   expAT = ishermitian ? exp(Hermitian(tensor(AC))) : exp(tensor(AC))
-  return itensor(expAT)*dag(CR)*dag(CL)
+  return itensor(expAT) * dag(CR) * dag(CL)
 end
 
 function LinearAlgebra.exp(A::ITensor;
-                             kwargs...)
+                           kwargs...)
   Ris = inds(A; plev = 0)
+  @show Ris
   Lis = Ris'
-
   return exp(A, Lis, Ris; kwargs...)
 end
 

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -211,19 +211,33 @@ function NDTensors.outer(i1::QNIndex, i2::QNIndex;
                          dir = nothing,
                          tags = "",
                          plev::Int = 0)
-    if isnothing(dir)
-      if ITensors.dir(i1) == ITensors.dir(i2)
-        dir = ITensors.dir(i1)
-      else
-        dir = Out
-      end
+  if isnothing(dir)
+    if ITensors.dir(i1) == ITensors.dir(i2)
+      dir = ITensors.dir(i1)
+    else
+      dir = Out
     end
-    newspace = dir * ((ITensors.dir(i1) * space(i1)) ⊗
-                      (ITensors.dir(i2) * space(i2)))
-    return Index(newspace;
-                 dir = dir,
-                 tags = tags,
-                 plev = plev)
+  end
+  newspace = dir * ((ITensors.dir(i1) * space(i1)) ⊗
+                    (ITensors.dir(i2) * space(i2)))
+  return Index(newspace;
+               dir = dir,
+               tags = tags,
+               plev = plev)
+end
+
+function NDTensors.outer(i::QNIndex;
+                         dir = nothing,
+                         tags = "",
+                         plev::Int = 0)
+  if isnothing(dir)
+    dir = ITensors.dir(i)
+  end
+  newspace = dir * (ITensors.dir(i) * space(i))
+  return Index(newspace;
+               dir = dir,
+               tags = tags,
+               plev = plev)
 end
 
 function Base.isless(qnb1::QNBlock, qnb2::QNBlock)

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -208,16 +208,22 @@ function NDTensors.outer(qn1::QNBlocks, qn2::QNBlocks)
 end
 
 function NDTensors.outer(i1::QNIndex, i2::QNIndex;
-                         tags="", plev=0)
-  if dir(i1) == dir(i2)
-    return Index(space(i1)⊗space(i2); dir=dir(i1),
-                                      tags=tags,
-                                      plev=plev)
-  else
-    return Index((dir(i1)*space(i1))⊗(dir(i2)*space(i2)); dir=Out,
-                                                          tags=tags,
-                                                          plev=plev)
-  end
+                         dir = nothing,
+                         tags = "",
+                         plev::Int = 0)
+    if isnothing(dir)
+      if ITensors.dir(i1) == ITensors.dir(i2)
+        dir = ITensors.dir(i1)
+      else
+        dir = Out
+      end
+    end
+    newspace = dir * ((ITensors.dir(i1) * space(i1)) ⊗
+                      (ITensors.dir(i2) * space(i2)))
+    return Index(newspace;
+                 dir = dir,
+                 tags = tags,
+                 plev = plev)
 end
 
 function Base.isless(qnb1::QNBlock, qnb2::QNBlock)

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -291,7 +291,7 @@ end
 
 removeqns(i::QNIndex) = Index(id(i),
                               dim(i),
-                              dir(i),
+                              Neither,
                               tags(i),
                               plev(i))
 

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -96,18 +96,16 @@ function randomITensor(::Type{ElT},
   return randomITensor(ElT, QN(), IndexSet(inds...))
 end
 
-randomITensor(inds::QNIndices) = randomITensor(Float64, QN(), inds)
+randomITensor(inds::QNIndices) =
+  randomITensor(Float64, QN(), inds)
 
-randomITensor(inds::QNIndex...) = randomITensor(Float64, QN(), IndexSet(inds...))
+randomITensor(inds::QNIndex...) =
+  randomITensor(Float64, QN(), IndexSet(inds...))
 
 function combiner(inds::QNIndices; kwargs...)
   # TODO: support combining multiple set of indices
   tags = get(kwargs, :tags, "CMB,Link")
   new_ind = ⊗(inds...; kwargs...)
-  if all(i->dir(i)!=Out,inds) && all(i->dir(i)!=In,inds)
-    new_ind = dag(new_ind)
-    new_ind = replaceqns(new_ind,-qnblocks(new_ind))
-  end
   new_ind = settags(new_ind,tags)
   comb_ind,perm,comb = combineblocks(new_ind)
   return itensor(Combiner(perm,comb),

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -103,7 +103,7 @@ randomITensor(inds::QNIndex...) = randomITensor(Float64, QN(), IndexSet(inds...)
 function combiner(inds::QNIndices; kwargs...)
   # TODO: support combining multiple set of indices
   tags = get(kwargs, :tags, "CMB,Link")
-  new_ind = ⊗(inds...)
+  new_ind = ⊗(inds...; kwargs...)
   if all(i->dir(i)!=Out,inds) && all(i->dir(i)!=In,inds)
     new_ind = dag(new_ind)
     new_ind = replaceqns(new_ind,-qnblocks(new_ind))

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -279,6 +279,25 @@ Random.seed!(1234)
       @test norm(A-Ap) ≈ 0.0
     end
 
+    @testset "Combine set direction" begin
+      i1 = Index([QN(0)=>2,QN(1)=>3],"i1")
+      A = randomITensor(i1',dag(i1))
+      @test isnothing(ITensors.checkflux(A))
+      C = combiner(dag(i1); dir = ITensors.Out)
+      c = combinedind(C)
+      @test dir(c) == ITensors.Out
+      AC = A * C
+      @test nnz(AC) == nnz(A)
+      @test nnzblocks(AC) == nnzblocks(A)
+      @test isnothing(ITensors.checkflux(AC))
+      Ap = AC*dag(C)
+      @test nnz(Ap) == nnz(A)
+      @test nnzblocks(Ap) == nnzblocks(A)
+      @test hassameinds(Ap, A)
+      @test isnothing(ITensors.checkflux(AC))
+      @test A ≈ Ap
+    end
+
     @testset "Order 2 (IndexSet constructor)" begin
       i1 = Index([QN(0,2)=>2,QN(1,2)=>2],"i1")
       A = randomITensor(QN(),i1,dag(i1'))

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -758,6 +758,16 @@ Random.seed!(1234)
       @test norm(A - Ut * D * dag(U)) ≉ 0.0 atol=1e-12
     end
 
+    @testset "eigen mixed arrows" begin
+      i1 = Index([QN(0)=>1,QN(1)=>2],"i1")
+      i2 = Index([QN(0)=>1,QN(1)=>2],"i2")
+      A = randomITensor(i1, i2, dag(i1)', dag(i2)')
+      F = eigen(A, (i1, i1'), (i2', i2))
+      D, U = F
+      Ut = F.Vt
+      @test norm(A * U - Ut * D) ≈ 0.0 atol=1e-12
+    end
+
   end
 
   @testset "svd" for ElT ∈ (Float64, ComplexF64)
@@ -1284,34 +1294,46 @@ Random.seed!(1234)
 end
 
 @testset "exponentiate" begin
-  i1 = Index([QN(0)=>1,QN(1)=>2],"i1")
-  i2 = Index([QN(0)=>1,QN(1)=>2],"i2")
-  A = randomITensor(QN(),i1,i2,dag(i1)', dag(i2)')
-  Aexp = exp(A)
-  Amat = Array(A, i1,i2, i1', i2')
-  Amatexp = reshape(exp(reshape(Amat,9,9)),3,3,3,3)
-  @test isapprox(norm(Array(Aexp,i1,i2,i1',i2') - Amatexp),0.0, atol=1e-14)
-  @test flux(Aexp) == QN()
-  @test length(setdiff(inds(Aexp),inds(A)))==0
 
-  @test isapprox(norm(exp(A, (i1,i2), (i1',i2')) - Aexp),0.0, atol=5e-14)
+  @testset "Simple arrows" begin
+    i1 = Index([QN(0)=>1,QN(1)=>2],"i1")
+    i2 = Index([QN(0)=>1,QN(1)=>2],"i2")
+    A = randomITensor(QN(),i1,i2,dag(i1)', dag(i2)')
+    Aexp = exp(A)
+    Amat = Array(A, i1,i2, i1', i2')
+    Amatexp = reshape(exp(reshape(Amat,9,9)),3,3,3,3)
+    @test isapprox(norm(Array(Aexp,i1,i2,i1',i2') - Amatexp),0.0, atol=1e-14)
+    @test flux(Aexp) == QN()
+    @test length(setdiff(inds(Aexp),inds(A)))==0
 
-  # test the case where indices are permuted
-  A = randomITensor(QN(),i1,dag(i1)', dag(i2)',i2)
-  Aexp = exp(A, (i1,i2), (i1',i2'))
-  Amat = Array(A, i1,i2,i1', i2')
-  Amatexp = reshape(exp(reshape(Amat,9,9)),3,3,3,3)
-  @test isapprox(norm(Array(Aexp,i1,i2,i1',i2') - Amatexp),0.0,atol=1e-14)
+    @test isapprox(norm(exp(A, (i1,i2), (i1',i2')) - Aexp),0.0, atol=5e-14)
 
-  # test exponentiation in the Hermitian case
-  i1 = Index([QN(0)=>2,QN(1)=>2,QN(2)=>3],"i1")
-  A = randomITensor(QN(),i1,dag(i1)')
-  Ad = dag(swapinds(A,IndexSet(i1),IndexSet(dag(i1)')))
-  Ah = A+Ad + 1e-10*randomITensor(QN(),i1,dag(i1)')
-  Amat = Array(Ah ,i1', i1)
-  Aexp = exp(Ah; ishermitian=true)
-  Amatexp= exp(Hermitian(Amat))
-  @test isapprox(norm(Array(Aexp,i1,i1')-Amatexp),0.0,atol=5e-14)
+    # test the case where indices are permuted
+    A = randomITensor(QN(),i1,dag(i1)', dag(i2)',i2)
+    Aexp = exp(A, (i1,i2), (i1',i2'))
+    Amat = Array(A, i1,i2,i1', i2')
+    Amatexp = reshape(exp(reshape(Amat,9,9)),3,3,3,3)
+    @test isapprox(norm(Array(Aexp,i1,i2,i1',i2') - Amatexp),0.0,atol=1e-14)
+
+    # test exponentiation in the Hermitian case
+    i1 = Index([QN(0)=>2,QN(1)=>2,QN(2)=>3],"i1")
+    A = randomITensor(QN(),i1,dag(i1)')
+    Ad = dag(swapinds(A,IndexSet(i1),IndexSet(dag(i1)')))
+    Ah = A+Ad + 1e-10*randomITensor(QN(),i1,dag(i1)')
+    Amat = Array(Ah ,i1', i1)
+    Aexp = exp(Ah; ishermitian=true)
+    Amatexp= exp(LinearAlgebra.Hermitian(Amat))
+    @test isapprox(norm(Array(Aexp,i1,i1')-Amatexp),0.0,atol=5e-14)
+  end
+
+  @testset "Mixed arrows" begin
+    i1 = Index([QN(0)=>1,QN(1)=>2],"i1")
+    i2 = Index([QN(0)=>1,QN(1)=>2],"i2")
+    A = randomITensor(i1, i2, dag(i1)', dag(i2)')
+    expA = exp(A, (i1, i1'), (i2', i2))
+    @test exp(dense(A), (i1, i1'), (i2', i2)) ≈ dense(expA)
+  end
+
 end
 
 end


### PR DESCRIPTION
This adds a `dir` keyword argument to `combiner` to control the direction of the combined Index.

This fixes #405, and also addresses an issue brought up in #402 where when the QN ITensor had mixed arrow directions in the left/right indices, when the ITensor was turned into a matrix the combined indices were both `Out` and the resulting matrix was not block diagonal (an assumption made internally in NDTensors).