### PR TITLE
Add swapsites keyword argument to replacebond

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -184,6 +184,7 @@ export
   linkind,
   productMPS,
   randomMPS,
+  replacebond,
   replacebond!,
   sample,
   sample!,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -190,6 +190,7 @@ export
   sample!,
   siteind,
   siteinds,
+  swapbondsites,
   totalqn,
 
 # mps/observer.jl

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -393,6 +393,16 @@ function replacebond(M0::MPS, b::Int, phi::ITensor;
 end
 
 """
+    swapbondsites(ψ::MPS, b::Int; kwargs...)
+
+Swap the sites `b` and `b+1`.
+"""
+function swapbondsites(ψ::MPS, b::Int; kwargs...)
+  kwargs = setindex(values(kwargs), true, :swapsites)
+  return replacebond(ψ, b, ψ[b] * ψ[b+1]; kwargs...)
+end
+
+"""
     sample!(m::MPS)
 
 Given a normalized MPS m, returns a `Vector{Int}`

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -424,8 +424,7 @@ end
     N = 5
     sites = siteinds("S=1/2", N)
     ψ0 = randomMPS(sites)
-    b = 3
-    ψ = replacebond(ψ0, b, ψ0[b] * ψ0[b+1];
+    ψ = replacebond(ψ0, 3, ψ0[3] * ψ0[4];
                     swapsites = true,
                     cutoff = 1e-15)
     @test siteind(ψ, 1) == siteind(ψ0, 1)
@@ -433,6 +432,16 @@ end
     @test siteind(ψ, 4) == siteind(ψ0, 3)
     @test siteind(ψ, 3) == siteind(ψ0, 4)
     @test siteind(ψ, 5) == siteind(ψ0, 5)
+    @test prod(ψ) ≈ prod(ψ0)
+    @test maxlinkdim(ψ) == 1
+
+    ψ = swapbondsites(ψ0, 4;
+                      cutoff = 1e-15)
+    @test siteind(ψ, 1) == siteind(ψ0, 1)
+    @test siteind(ψ, 2) == siteind(ψ0, 2)
+    @test siteind(ψ, 3) == siteind(ψ0, 3)
+    @test siteind(ψ, 5) == siteind(ψ0, 4)
+    @test siteind(ψ, 4) == siteind(ψ0, 5)
     @test prod(ψ) ≈ prod(ψ0)
     @test maxlinkdim(ψ) == 1
   end

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -420,6 +420,23 @@ end
     @test flux(M) == QN("Sz",-4)
   end
 
+  @testset "swapsites" begin
+    N = 5
+    sites = siteinds("S=1/2", N)
+    ψ0 = randomMPS(sites)
+    b = 3
+    ψ = replacebond(ψ0, b, ψ0[b] * ψ0[b+1];
+                    swapsites = true,
+                    cutoff = 1e-15)
+    @test siteind(ψ, 1) == siteind(ψ0, 1)
+    @test siteind(ψ, 2) == siteind(ψ0, 2)
+    @test siteind(ψ, 4) == siteind(ψ0, 3)
+    @test siteind(ψ, 3) == siteind(ψ0, 4)
+    @test siteind(ψ, 5) == siteind(ψ0, 5)
+    @test prod(ψ) ≈ prod(ψ0)
+    @test maxlinkdim(ψ) == 1
+  end
+
 end
 
 nothing


### PR DESCRIPTION
This adds a `swapsites` keyword argument to `replacebond!`. When this is turned on, it would replace bond 3 of an MPS:
```
   s3  s4
   |   |
--A3---A4--
```
with the the following:
```
   s3  s4            s4   s3
   |   |             |    |
--( phi ) --   ->  --A3'--A4'--
```
so it acts like a swap gate, but just does it by inputting the appropriate indices into `factorize`.

The motivation is that this makes defining an operation for swapping sites of an MPS very simple (just a wrapper around `replacebond!` with `swapsites=true`, where `phi = A3 * A4`).

I also added a `replacebond` function that wraps `replacebond!` but returns a new MPS.

@emstoudenmire, I don't recall the C++ having this option, let me know if this kind of interface makes sense to you. We could also consider adding a function `swapbondsites(M::MPS, b::Int)`:
```julia
function swapbondsites(M::MPS, b::Int;
                       ortho::String = "left",
                       cutoff::Real = 1e-15)
  return replacebond(M, b, M[b] * M[b+1];
                     ortho = ortho,
                     swapsites = true,
                     cutoff = cutoff)
end
```
since that is quite useful for gate evolution applications. We would have to distinguish that functionality from something like `swapsiteinds(M::MPS, n1::Int, n2::Int)` (which doesn't exist right now, but might) which instead of doing a swap gate, actually did a `swapinds`.