### PR TITLE
Axes definition for ITensors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["mfishman <mfishman@caltech.edu>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
@@ -17,7 +17,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 julia = "1.4"
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
-NDTensors = "0.1.6"
+NDTensors = "0.1.7"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"
 

--- a/src/index.jl
+++ b/src/index.jl
@@ -140,7 +140,9 @@ then the prime levels are compared, and finally the
 tags are compared.
 """
 function Base.:(==)(i1::Index, i2::Index)
-  return id(i1) == id(i2) && tags(i1) == tags(i2) && plev(i1) == plev(i2)
+  return id(i1) == id(i2) &&
+         plev(i1) == plev(i2) &&
+         tags(i1) == tags(i2)
 end
 
 # This is so that when IndexSets are converted

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -440,12 +440,22 @@ The total dimension of the space the tensor lives in, `prod(dims(A))`.
 NDTensors.dim(T::ITensor) = dim(inds(T))
 
 """
+    dim(A::ITensor, n::Int)
+
+Get the nth dimension of the ITensors.
+"""
+NDTensors.dim(T::ITensor, n::Int) = dims(T)[n]
+
+"""
     dims(A::ITensor)
     size(A::ITensor)
 
 Tuple containing `dim(inds(A)[d]) for d in 1:ndims(A)`.
 """
-NDTensors.dims(T::ITensor) = dims(inds(T))
+(NDTensors.dims(T::ITensor{N})::NTuple{N,Int}) where {N} =
+  dims(inds(T))
+
+Base.axes(T::ITensor) = map(Base.OneTo, dims(T))
 
 Base.size(T::ITensor) = dims(T)
 

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -109,15 +109,14 @@ Base.length(T::TagSet) = T.length
 Base.getindex(T::TagSet,n::Int) = Tag(getindex(data(T),n))
 Base.copy(ts::TagSet) = TagSet(data(ts),length(ts))
 
-# Cast SVector of IntTag of length 4 to SVector of UInt128 of length 2
-# This is to make TagSet comparison a little bit faster
-function cast_to_uint128(a::TagSetStorage)
-  return unsafe_load(convert(Ptr{SVector{2,UInt128}},pointer_from_objref(MTagSetStorage(a))))
-end
-
 function Base.:(==)(ts1::TagSet,ts2::TagSet)
-  # Block the bits together to make the comparison faster
-  return cast_to_uint128(data(ts1)) == cast_to_uint128(data(ts2))
+  l1 = length(ts1)
+  l2 = length(ts2)
+  l1 != l2 && return false
+  for n in 1:l1
+    @inbounds ts1[n] != ts2[n] && return false
+  end
+  return true
 end
 
 function hastag(ts::TagSet, tag)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -105,7 +105,7 @@ using ITensors,
     C = randomITensor(i,i')
     @test_throws ErrorException C .= A .+ B
     @test_throws ErrorException C = A .+ B
-    @test_throws ErrorException C .= A .* B
+    @test_throws BoundsError C .= A .* B
   end
 
   @testset "Contraction" begin


### PR DESCRIPTION
This defines `axes` for ITensors, which is basically `(1:dim(A, 1), 1:dim(A, 2), ...)`. Broadcasting calls `axes`, but was using a general fallback method which was slow and added some overhead to all ITensor broadcasting calls (about 1 microsecond).

This also bumps the version of NDTensors to v0.1.7, which introduces a lot of optimizations for the contraction logic to minimize overhead for small ITensor contractions. I'll add some benchmarks, but initial tests show that for even very small tensor contractions (for example `(30 x 30) * (30 x 30)`), the overhead is now pretty small, something around 20%. Before this, the overhead was at least 100%.