### PR TITLE
Fix a bug in broadcast and in-place contraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["mfishman <mfishman@caltech.edu>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
@@ -17,7 +17,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 julia = "1.4"
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
-NDTensors = "0.1.8"
+NDTensors = "0.1.9"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -253,7 +253,7 @@ function Base.copyto!(T::ITensor,
     α = find_type(Number, bc_bc.args)
     A = find_type(ITensor, bc_bc.args)
     if !isnothing(α) && !isnothing(A)
-      map!((r, t) -> r + α * t, T, T, A)
+      map!((r, t) -> r + bc_bc.f(t, α), T, T, A)
     else
       bc_bc_bc = find_type(Broadcasted, bc_bc.args)
       if isnothing(α)
@@ -284,7 +284,7 @@ function Base.copyto!(T::ITensor,
     α = find_type(Number, bc_bc.args)
     A = find_type(ITensor, bc_bc.args)
     if !isnothing(α) && !isnothing(A)
-      map!((r, t) -> r - α * t, T, T, A)
+      map!((r, t) -> r - bc_bc.f(t, α), T, T, A)
     else
       bc_bc_bc = find_type(Broadcasted, bc_bc.args)
       if isnothing(α)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -64,6 +64,28 @@ using ITensors,
     @test_throws ErrorException Bc .= α ./ A
   end
 
+  @testset "Add and divide (in-place)" begin
+    Bc = copy(B)
+    Bc .+= A ./ α
+    @test Bc[1,1] == B[1,1] + A[1,1] / α
+    @test Bc[2,1] == B[2,1] + A[1,2] / α
+    @test Bc[1,2] == B[1,2] + A[2,1] / α
+    @test Bc[2,2] == B[2,2] + A[2,2] / α
+    # Should error
+    @test_broken Bc .+= α ./ A
+  end
+
+  @testset "Subtract and divide (in-place)" begin
+    Bc = copy(B)
+    Bc .-= A ./ α
+    @test Bc[1,1] == B[1,1] - A[1,1] / α
+    @test Bc[2,1] == B[2,1] - A[1,2] / α
+    @test Bc[1,2] == B[1,2] - A[2,1] / α
+    @test Bc[2,2] == B[2,2] - A[2,2] / α
+    # Should error
+    @test_broken Bc .-= α ./ A
+  end
+
   @testset "Scalar multiplication (out-of-place)" begin
     Bc = α .* A
     @test Bc[1,1] == α * A[1,1]

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -259,6 +259,55 @@ end
   β = 3
   R = mul!(copy(C), A, B, α, β)
   @test α*A*B+β*C ≈ R
+
+  @testset "In-place bug" begin
+    l1 = Index(3, "l=1")
+    l2 = Index(3, "l=2")
+    s = Index(2, "s")
+
+    A = randomITensor(s', s)
+    B = randomITensor(l1, s, l2)
+
+    C = randomITensor(l1, s', l2)
+
+    C .= A .* B
+
+    @test C ≈ A * B
+  end
+
+  @testset "In-place outer bug" begin
+    l1 = Index(3, "l=1")
+    s = Index(2, "s")
+
+    A = randomITensor(l1)
+    B = randomITensor(s)
+    C = randomITensor(s, l1)
+
+    C .= A .* B
+
+    @test C ≈ A * B
+  end
+
+  @testset "In-place contractions" begin
+    i1 = Index(2, "i1")
+    i2 = Index(2, "i2")
+    i3 = Index(2, "i3")
+    i4 = Index(2, "i4")
+    i5 = Index(2, "i5")
+    i6 = Index(2, "i6")
+    j1 = Index(2, "j1")
+    j2 = Index(2, "j2")
+    j3 = Index(2, "j3")
+
+    #A = randomITensor(s', s)
+    #B = randomITensor(l1, s, l2)
+
+    #C = randomITensor(l1, s', l2)
+
+    C .= A .* B
+    @test C ≈ A * B
+  end
+
 end
 
 @testset "exponentiate" begin


### PR DESCRIPTION
This fixes some bugs in broadcasting and in-place contraction.

The broadcasting issue was that `A .+= B ./ x` and `A .-= B ./ x` were giving the wrong result (they were doing `.*` before, using some generic code). Also, some `A .= B .* C` contractions were hitting bugs in the contraction logic in NDTensors, which are fixed now in the latest version.

There is still a bug in broadcasting that `A .+= x ./ B` and `A .-= x ./ B` is allowed, even though it is not well defined (for scalar `x`). That will be fixed in a future PR.