### PR TITLE
Fix AutoMPO dim bug

### DIFF
--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -47,7 +47,7 @@ end
 # MPOTerm                 # 
 ###########################
 
-struct MPOTerm
+mutable struct MPOTerm
   coef::ComplexF64
   ops::OpTerm
 end
@@ -842,8 +842,7 @@ function sorteachterm(ampo::AutoMPO, sites)
     perm = Vector{Int}(undef,Nt)
     sortperm!(perm,t.ops, alg=InsertionSort, lt=isless_site)
 
-    #t.ops = t.ops[perm]
-    t = MPOTerm(coef(t),ops(t)[perm])
+    t.ops = t.ops[perm]
 
     # Identify fermionic operators,
     # zeroing perm for bosonic operators,
@@ -855,7 +854,7 @@ function sorteachterm(ampo::AutoMPO, sites)
         # Put Jordan-Wigner string emanating
         # from fermionic operators to the right
         # (Remaining F operators will be put in by svdMPO)
-        t.ops[n].name = "$(t.ops[n].name)*F"
+        t.ops[n] = SiteOp("$(name(t.ops[n]))*F",site(t.ops[n]))
       end
       if fermionic
         parity = -parity
@@ -873,8 +872,7 @@ function sorteachterm(ampo::AutoMPO, sites)
     # Account for anti-commuting, fermionic operators 
     # during above sort; put resulting sign into coef
 
-    t = MPOTerm(parity_sign(perm)*coef(t),ops(t))
-    #t.coef *= parity_sign(perm)
+    t.coef *= parity_sign(perm)
   end
   return ampo
 end

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -7,7 +7,7 @@
 # SiteOp                  # 
 ###########################
 
-mutable struct SiteOp
+struct SiteOp
   name::String
   site::Int
 end

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -11,9 +11,13 @@ struct SiteOp
   name::String
   site::Int
 end
+
 name(s::SiteOp) = s.name
 site(s::SiteOp) = s.site
+
 Base.show(io::IO,s::SiteOp) = print(io,"\"$(name(s))\"($(site(s)))")
+
+Base.:(==)(s1::SiteOp,s2::SiteOp) = (s1.site==s2.site && s1.name==s2.name)
 
 function Base.isless(s1::SiteOp,s2::SiteOp)::Bool
   if site(s1) < site(s2)

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -43,7 +43,7 @@ end
 # MPOTerm                 # 
 ###########################
 
-mutable struct MPOTerm
+struct MPOTerm
   coef::ComplexF64
   ops::OpTerm
 end
@@ -837,7 +837,9 @@ function sorteachterm(ampo::AutoMPO, sites)
     # and keep the permutation used, perm, for analysis below
     perm = Vector{Int}(undef,Nt)
     sortperm!(perm,t.ops, alg=InsertionSort, lt=isless_site)
-    t.ops = t.ops[perm]
+
+    #t.ops = t.ops[perm]
+    t = MPOTerm(coef(t),ops(t)[perm])
 
     # Identify fermionic operators,
     # zeroing perm for bosonic operators,
@@ -866,7 +868,9 @@ function sorteachterm(ampo::AutoMPO, sites)
     filter!(!iszero,perm)
     # Account for anti-commuting, fermionic operators 
     # during above sort; put resulting sign into coef
-    t.coef *= parity_sign(perm)
+
+    t = MPOTerm(parity_sign(perm)*coef(t),ops(t))
+    #t.coef *= parity_sign(perm)
   end
   return ampo
 end


### PR DESCRIPTION
Fixes #407, which was a bug with AutoMPO resulting in very large
bond dimensions in certain simple cases. The origin of the bug
turned out to be that the predefined `==` operator for structs in
Julia does the thing one would expect for immutable structs, but
not immutable ones. So the fix is the explicitly define `==` for
the SiteOp struct.

- Make MPOTerm mutable again to keep fermion code simple
- Define == for SiteOp, fixing issue 407
- Change MPOTerm to immutable
- Change SiteOp to be immutable
