### PR TITLE
Fix missing return statement in QNVal constructor

### DIFF
--- a/src/qn/qn.jl
+++ b/src/qn/qn.jl
@@ -7,7 +7,7 @@ struct QNVal
   function QNVal(name,v::Int,m::Int=1)
     am = abs(m)
     if am > 1
-      new(SmallString(name),mod(v,am),m)
+      return new(SmallString(name),mod(v,am),m)
     end
     new(SmallString(name),v,m)
   end
@@ -25,9 +25,9 @@ isfermionic(qv::QNVal) = modulus(qv) < 0
 Base.:<(qv1::QNVal,qv2::QNVal) = (name(qv1) < name(qv2))
 
 function qn_mod(val::Int,modulus::Int)
-  modulus = abs(modulus)
-  (modulus == 0 || modulus == 1) && return val
-  return mod(val,modulus)
+  amod = abs(modulus)
+  amod <= 1 && return val
+  return mod(val,amod)
 end
 
 function Base.:-(qv::QNVal)


### PR DESCRIPTION
A user was reporting a surprising issue with a code that did a replaceinds! on a QNITensor. Even though replaceinds! is smart enough to handle arrows automatically, there was an error. The issue stemmed from a mod-3 QN which was having negative values which shouldn't happen by design. The error was that the QNVal constructor should have had a `return` keyword on a certain line which was missing and causing silent errors in some cases. Fixes #430
