### PR TITLE
Fix contraction logic bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["mfishman <mfishman@caltech.edu>"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
@@ -17,7 +17,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 julia = "1.4"
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
-NDTensors = "0.1.9"
+NDTensors = "0.1.10"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"
 

--- a/test/decomp.jl
+++ b/test/decomp.jl
@@ -82,6 +82,10 @@ using ITensors,
     @test entropy(Spectrum([0.5; 0.5], 0.0)) == log(2)
     @test entropy(Spectrum([1.0], 0.0)) == 0.0 
     @test entropy(Spectrum([0.0], 0.0)) == 0.0 
+
+    @test isnothing(eigs(Spectrum(nothing, 1.0)))
+    @test_throws ErrorException entropy(Spectrum(nothing, 1.0))
+    @test truncerror(Spectrum(nothing, 1.0)) == 1.0
   end
 end
 


### PR DESCRIPTION
This bumps the version to NDTensor v0.1.10, which:
 - Fixes some bugs in the contraction logic which showed up for more complicated in-place contractions. Tests are added for those cases.
 - Extends the Spectrum definition to allow `nothing` for the eigenvalues in the Spectrum object, to help with cases like QR where the eigenvalues are not efficient to compute (as discussed in #427).
 - Speeds up very small out-of-place tensor contractions a little bit (maybe 10-20%) by improving the code for contracting the labels.