### PR TITLE
HDF5 Support for QNITensors, QNIndex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 julia = "1.4"
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
-NDTensors = "0.1.10"
+NDTensors = "0.1.11"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"
 

--- a/src/index.jl
+++ b/src/index.jl
@@ -555,6 +555,14 @@ function HDF5.write(parent::Union{HDF5File, HDF5Group},
   write(g, "dir", Int(dir(I)))
   write(g, "tags", tags(I))
   write(g, "plev", plev(I))
+  if typeof(space(I)) == Int
+    attrs(g)["space_type"] = "Int"
+  elseif typeof(space(I)) == QNBlocks
+    attrs(g)["space_type"] = "QNBlocks"
+    write(g,"space",space(I))
+  else
+    error("Index space type not recognized")
+  end
 end
 
 function HDF5.read(parent::Union{HDF5File,HDF5Group},
@@ -569,6 +577,15 @@ function HDF5.read(parent::Union{HDF5File,HDF5Group},
   dir = Arrow(read(g,"dir"))
   tags = read(g,"tags",TagSet)
   plev = read(g,"plev")
-  return Index(id,dim,dir,tags,plev)
+  space_type = "Int"
+  if exists(attrs(g),"space_type")
+    space_type = read(attrs(g)["space_type"])
+  end
+  if space_type == "Int"
+    space = dim
+  elseif space_type == "QNBlocks"
+    space = read(g,"space",QNBlocks)
+  end
+  return Index(id,space,dir,tags,plev)
 end
 

--- a/src/qn/qn.jl
+++ b/src/qn/qn.jl
@@ -374,6 +374,34 @@ function Base.show(io::IO,q::QN)
   print(io,")")
 end
 
+function HDF5.write(parent::Union{HDF5File, HDF5Group},
+                    gname::AbstractString,
+                    q::QN)
+  g = g_create(parent, gname)
+  attrs(g)["type"] = "QN"
+  attrs(g)["version"] = 1
+  names = [String(name(q[n])) for n=1:maxQNs]
+  vals = [val(q[n]) for n=1:maxQNs]
+  mods = [modulus(q[n]) for n=1:maxQNs]
+  write(g,"names",names)
+  write(g,"vals",vals)
+  write(g,"mods",mods)
+end
+
+function HDF5.read(parent::Union{HDF5File,HDF5Group},
+                   name::AbstractString,
+                   ::Type{QN})
+  g = g_open(parent,name)
+  if read(attrs(g)["type"]) != "QN"
+    error("HDF5 group or file does not contain QN data")
+  end
+  names = read(g,"names")
+  vals = read(g,"vals")
+  mods = read(g,"mods")
+  mqn = ntuple(n->QNVal(names[n],vals[n],mods[n]),maxQNs)
+  return QN(mqn)
+end
+
 import .NDTensors.store
 @deprecate store(qn::QN) data(qn)
 

--- a/test/qn.jl
+++ b/test/qn.jl
@@ -135,6 +135,12 @@ import ITensors: nactive
     @test hash(QN(("Sz",1),("N",2))) == hash(QN(("N",2),("Sz",1)))
   end
 
+  @testset "Negative value for mod > 1" begin
+    @test QN("T",-1,3) == QN("T",2,3)
+    @test QN("T",-2,3) == QN("T",1,3)
+    @test QN("T",-3,3) == QN("T",0,3)
+  end
+
 end
 
 nothing

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -60,7 +60,7 @@ include("util.jl")
     @test ris == is
   end
 
-  @testset "ITensor" begin
+  @testset "Dense ITensor" begin
 
     # default constructed case
     T = ITensor()
@@ -97,6 +97,43 @@ include("util.jl")
     rT = read(fi,"complexT",ITensor)
     close(fi)
     @test norm(rT-T)/norm(T) < 1E-10
+  end
+
+  @testset "QN ITensor" begin
+
+    i = Index(QN("A",-1)=>3,
+              QN("A", 0)=>4,
+              QN("A",+1)=>3;tags="i")
+    j = Index(QN("A",-2)=>2,
+              QN("A", 0)=>3,
+              QN("A",+2)=>2;tags="j")
+    k = Index(QN("A",-1)=>1,
+              QN("A", 0)=>1,
+              QN("A",+1)=>1;tags="k")
+
+    # real case
+    T = randomITensor(QN("A",1),i,j,k)
+
+    fo = h5open("data.h5","w")
+    write(fo,"T",T)
+    close(fo)
+
+    fi = h5open("data.h5","r")
+    rT = read(fi,"T",ITensor)
+    close(fi)
+    @test rT ≈ T
+
+    # complex case
+    T = randomITensor(ComplexF64,i,j,k)
+
+    fo = h5open("data.h5","w")
+    write(fo,"complexT",T)
+    close(fo)
+
+    fi = h5open("data.h5","r")
+    rT = read(fi,"complexT",ITensor)
+    close(fi)
+    @test rT ≈ T
   end
 
   @testset "MPO/MPS" begin

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -3,6 +3,8 @@ using ITensors,
       HDF5,
       Test
 
+include("util.jl")
+
 @testset "HDF5 Read and Write" begin
 
   i = Index(2,"i")


### PR DESCRIPTION
- Add include to readwrite.jl
- Add HDF5 support for QN objects
- Add HDF5 support for QNBlocks
- Add HDF5 support for QNIndex
- Unit tests for HDF5 readwrite of QNITensors
- Bonus regression test of a previous bug fix
- Require NDTensors 0.1.11
