### PR TITLE
Generalize to n-site DMRG for any integer n >= 2

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -694,7 +694,7 @@ the tensors in the network. The name
 `totalqn` is an alias for `flux`.
 """
 function flux(M::AbstractMPS)::QN
-  hasqns(M) || error("MPS or MPO does not conserve QNs")
+  hasqns(M) || return nothing
   q = QN()
   for j=M.llim+1:M.rlim-1
     q += flux(M[j])

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -693,7 +693,7 @@ the flux is the sum of fluxes of each of
 the tensors in the network. The name
 `totalqn` is an alias for `flux`.
 """
-function flux(M::AbstractMPS)::QN
+function flux(M::AbstractMPS)
   hasqns(M) || return nothing
   q = QN()
   for j=M.llim+1:M.rlim-1

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -693,8 +693,8 @@ the flux is the sum of fluxes of each of
 the tensors in the network. The name
 `totalqn` is an alias for `flux`.
 """
-function flux(M::AbstractMPS)
-  hasqns(M) || return nothing
+function flux(M::AbstractMPS)::QN
+  hasqns(M) || error("MPS or MPO does not conserve QNs")
   q = QN()
   for j=M.llim+1:M.rlim-1
     q += flux(M[j])

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -80,7 +80,7 @@ function dmrg(H::MPO,
               kwargs...)
   weight = get(kwargs,:weight,1.0)
   ncenter::Int = get(kwargs, :ncenter, 2)
-  PMM = ProjMPO_MPS(H,Ms;weight=weight)
+  PMM = ProjMPO_MPS(H,Ms;weight=weight,nsite=ncenter)
   return dmrg(PMM,psi0,sweeps;kwargs...)
 end
 

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -415,6 +415,7 @@ end
 
 """
     replacebond(M::MPS, b::Int, phi::ITensor; kwargs...)
+
 Like `replacebond!`, but returns the new MPS.
 """
 function replacebond(M0::MPS, b::Int, phi::ITensor;
@@ -426,6 +427,7 @@ end
 
 """
     swapbondsites(ψ::MPS, b::Int; kwargs...)
+    
 Swap the sites `b` and `b+1`.
 """
 function swapbondsites(ψ::MPS, b::Int; kwargs...)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -355,6 +355,9 @@ function replacebond!(M::MPS,
           Note that the options are now the same as factorize, so use `left` instead of `fromleft` and `right` instead of `fromright`.""")
   end
 
+  if ncenter < 2
+    error("""ncenter must be at least 2.""")
+  end
   if swapsites && ncenter != 2
     error("""swapsites only compatible with 2-site DMRG, i.e. ncenter=2.""")
   end

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -366,13 +366,13 @@ function replacebond!(M::MPS,
   push!(phi_new, copy(phi))
   temp = ITensor[] # will store site tensors before we put them back into M
   for j=0:ncenter-3
-    indsMb = inds(M[b])
+    indsMb = inds(M[b+j])
     if swapsites
       sb = siteind(M, b)
       sbp1 = siteind(M, b+1)
       indsMb = replaceind(indsMb, sb, sbp1)
     end
-    index_set = j==0 ? inds(M[b+j]) : push(indsMb, commonind(temp[j], phi_new[j+1]))
+    index_set = j==0 ? indsMb : push(indsMb, commonind(temp[j], phi_new[j+1]))
     L,R,spec = factorize(phi_new[j+1], index_set; which_decomp = which_decomp,
                                        tags = tags(linkind(M,b+j)),
                                        kwargs...)
@@ -381,19 +381,19 @@ function replacebond!(M::MPS,
   end
   # j = ncenter-2 case isolated from loop so that spec is defined at the end
   j = ncenter-2
-  indsMb = inds(M[b])
+  indsMb = inds(M[b+j])
   if swapsites
     sb = siteind(M, b)
     sbp1 = siteind(M, b+1)
     indsMb = replaceind(indsMb, sb, sbp1)
   end
-  index_set = j==0 ? inds(M[b+j]) : push(indsMb, commonind(temp[j], phi_new[j+1]))
+  index_set = j==0 ? indsMb : push(indsMb, commonind(temp[j], phi_new[j+1]))
   L,R,spec = factorize(phi_new[j+1], index_set; which_decomp = which_decomp,
                                        tags = tags(linkind(M,b+j)),
                                        kwargs...)
   push!(temp, L)
   push!(temp, R)
-  
+
   # copy tensors from temp into M
   for j = 0:ncenter-1
     M[b+j] = copy(temp[j+1])
@@ -427,7 +427,7 @@ end
 
 """
     swapbondsites(ψ::MPS, b::Int; kwargs...)
-    
+
 Swap the sites `b` and `b+1`.
 """
 function swapbondsites(ψ::MPS, b::Int; kwargs...)

--- a/src/mps/projmpo.jl
+++ b/src/mps/projmpo.jl
@@ -26,6 +26,8 @@ mutable struct ProjMPO
   LR::Vector{ITensor}
   ProjMPO(H::MPO) = new(0,length(H)+1,2,H,
                         Vector{ITensor}(undef, length(H)))
+  ProjMPO(H::MPO, nsite::Int) = new(0,length(H)+1,nsite,H,
+                        Vector{ITensor}(undef, length(H)))                      
 end
 
 """

--- a/src/mps/projmpo_mps.jl
+++ b/src/mps/projmpo_mps.jl
@@ -3,10 +3,15 @@ mutable struct ProjMPO_MPS
   PH::ProjMPO
   pm::Vector{ProjMPS}
   weight::Float64
+  nsite::Int # default value = 2
+  ProjMPO_MPS(PH::ProjMPO, pm::Vector{ProjMPS}, weight::Float64, nsite::Int) = new(PH, pm, weight, nsite)
+  ProjMPO_MPS(PH::ProjMPO, pm::Vector{ProjMPS}, weight::Float64) = new(PH, pm, weight, 2)
 end
 
-function ProjMPO_MPS(H::MPO,mpsv::Vector{MPS};weight=1.0) 
-  return ProjMPO_MPS(ProjMPO(H),[ProjMPS(m) for m in mpsv],weight)
+function ProjMPO_MPS(H::MPO,mpsv::Vector{MPS};kwargs...) 
+  weight = get(kwargs, :weight, 1.0)
+  nsite = get(kwargs, :nsite, 2)
+  return ProjMPO_MPS(ProjMPO(H, nsite), [ProjMPS(nsite, m) for m in mpsv], weight, nsite)
 end
 
 


### PR DESCRIPTION
The current implementation of DMRG in ITensors.jl is restricted to 2-site DMRG, meaning that each optimization step handles two adjacent sites. This commit generalizes DMRG to n-site DMRG for any integer n >= 2. The sweeps are still conducted in the same way as before, i.e. progressing forward one site at a time and then backward one site at a time. For example, if one is carrying out n-site DMRG on an N-site chain, then the first optimization covers sites 1 through n, the second optimization covers sites 2 through n+1, and so on, until the (N-n+1)th optimization covers sites n-N+1 through N. Then you do all of those again in reverse order, and that completes one sweep.