### PR TITLE
Speed up op a bit

### DIFF
--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -123,7 +123,7 @@ function op(name::AbstractString,
   Ntags = max(1,length(tags(s))) # use max here in case of no tags
                                  # because there may still be a
                                  # generic case such as name=="Id"
-  stypes  = ntuple(n->SiteType(tags(s)[n]),Ntags)
+  stypes  = [SiteType(tags(s)[n]) for n in Ntags]
   opn = OpName(SmallString(name))
 
   #

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -123,7 +123,7 @@ function op(name::AbstractString,
   Ntags = max(1,length(tags(s))) # use max here in case of no tags
                                  # because there may still be a
                                  # generic case such as name=="Id"
-  stypes  = [SiteType(tags(s)[n]) for n in Ntags]
+  stypes  = [SiteType(tags(s)[n]) for n in 1:Ntags]
   opn = OpName(SmallString(name))
 
   #


### PR DESCRIPTION
This stores the `SiteType`s made within `op` in a Vector instead of a Tuple, which is more appropriate since the number of SiteTypes/Tags is a dynamic value. This leads to:
```julia
julia> s = Index(2, "A,B,C,S=1/2")
(dim=2|id=499|"A,B,C,S=1/2")

julia> @btime op("Id", $s);
  1.634 μs (27 allocations: 2.17 KiB)
```
instead of the following on master:
```julia
julia> @btime op("Id", $s);
  2.352 μs (29 allocations: 2.17 KiB)
```

For a custom `op` overload it is even more pronounced:
```julia
julia> ITensors.op(::SiteType"S=1/2", ::OpName"Sz", s::Index) = itensor([1.0 0.0; 0.0 -1.0], s', s)

julia> @btime op("Sz", $s);
  893.650 ns (16 allocations: 1008 bytes)
```
compared to master:
```julia
julia> @btime op("Sz", $s);
  1.742 μs (20 allocations: 1.20 KiB)
```