### PR TITLE
Compile QN DMRG

### DIFF
--- a/src/packagecompile/compile.jl
+++ b/src/packagecompile/compile.jl
@@ -1,59 +1,61 @@
 
-"""
-    ITensors.compile(; path = "~/.julia/sysimages",
-                       filename = "sys_itensors.so")
+const default_compile_dir = joinpath(ENV["HOME"],
+                                     ".julia",
+                                     "sysimages")
 
-Compile ITensors.jl with [PackageCompiler](https://julialang.github.io/PackageCompiler.jl/dev/).
+const default_compile_filename = "sys_itensors.so"
 
-This will take some time, perhaps a few minutes. This will create the file `sys_itensors.so`, by default in the directory `~/.julia/sysimages/`. This is a version of Julia that is compiled with ITensors. After running this command, if you start Julia with:
-```
-~ julia --sysimage ~/.julia/sysimages/sys_itensors.so
-```
-and you should see the startup time and JIT compilation time are substantially improved when you are using ITensors.
+const default_compile_path = joinpath(default_compile_dir,
+                                      default_compile_filename)
 
-You can create an alias like:
-```
-~ alias julia_itensors="julia --sysimage ~/.julia/sysimages/sys_itensors.so"
-```
-(which you can put in your `~/.bashrc`, `~/.zshrc`, etc.). Then you can start Julia with a version of ITensors installed with the command:
-```
-~ julia_itensors
-```
 
-Note that if you update ITensors to a new version, for example with `Pkg.update("ITensors")`, you will need to run this command again to recompile the new version of ITensors.
-"""
-function compile(; path::AbstractString = joinpath(ENV["HOME"],
-                                                   ".julia",
-                                                   "sysimages"),
-                   filename::AbstractString = "sys_itensors.so")
-  if !isdir(path)
-    println("""The directory "$path" doesn't exist yet, creating it now.""")
+function compile_note(; dir = default_compile_dir,
+                        filename = default_compile_filename)
+  path = joinpath(dir, filename)
+  return """
+  You will be able to start Julia with a compiled version of ITensors using:
+  ```
+  ~ julia --sysimage $path
+  ```
+  and you should see that the startup times and JIT compilation times are substantially improved when you are using ITensors.
+
+  In unix, you can create an alias with the Bash command:
+  ```
+  ~ alias julia_itensors="julia --sysimage $path -e 'using ITensors' -i"
+  ```
+  which you can put in your `~/.bashrc`, `~/.zshrc`, etc. This also executes `using ITensors` so that ITensors is loaded and ready to use, you can leave off ` -e 'using ITensors' -i` if you don't want that. Then you can start Julia with a version of ITensors installed with the command:
+  ```
+  ~ julia_itensors
+  ```
+
+  Note that if you update ITensors to a new version, for example with `using Pkg; Pkg.update("ITensors")`, you will need to run the `ITensors.compile()` command again to recompile the new version of ITensors.
+  """
+end
+
+function compile(; dir::AbstractString = default_compile_dir,
+                   filename::AbstractString = default_compile_filename)
+  if !isdir(dir)
+    println("""The directory "$dir" doesn't exist yet, creating it now.""")
     println()
-    mkdir(path)
+    mkdir(dir)
   end
-  path_filename = joinpath(path, filename)
-  println("""Creating the system image containing the compiled version of ITensors at "$path_filename". This may take a few minutes.""")
+  path = joinpath(dir, filename)
+  println("""Creating the system image "$path" containing the compiled version of ITensors. This may take a few minutes.""")
   create_sysimage(:ITensors;
-                  sysimage_path = path_filename,
+                  sysimage_path = path,
                   precompile_execution_file = joinpath(@__DIR__,
                                                        "precompile_itensors.jl"))
-  println("""
-
-          The system image containing the compiled version of ITensors is located at "$path_filename". This is a version of Julia that is compiled with ITensors.
-
-          You can now start Julia with:
-          ```
-          ~ julia --sysimage $path_filename
-          ```
-          and you should see that the startup times and JIT compilation times are substantially improved when you are using ITensors.
-
-          You can create an alias like:
-          ```
-          ~ alias julia_itensors="julia --sysimage $path_filename"
-          ```
-          (which you can put in your `~/.bashrc`, `~/.zshrc`, etc.). Then you can start Julia with a version of ITensors installed with the command:
-          ```
-          ~ julia_itensors
-          ```
-          """)
+  println(compile_note(; dir = dir, filename = filename))
+  return path
 end
+
+@doc """
+    ITensors.compile(; dir = "$default_compile_dir",
+                       filename = "$default_compile_filename")
+
+Compile ITensors.jl with [PackageCompiler](https://julialang.github.io/PackageCompiler.jl/dev/). This will take some time, perhaps a few minutes.
+
+This will create a system image containing the compiled version of ITensors located at `dir/filename`, by default `$default_compile_path`.
+
+$(compile_note())
+""" compile

--- a/src/packagecompile/compile.jl
+++ b/src/packagecompile/compile.jl
@@ -1,16 +1,16 @@
 
-const default_compile_dir = joinpath(ENV["HOME"],
-                                     ".julia",
-                                     "sysimages")
+default_compile_dir() = joinpath(homedir(),
+                                 ".julia",
+                                 "sysimages")
 
-const default_compile_filename = "sys_itensors.so"
+default_compile_filename() = "sys_itensors.so"
 
-const default_compile_path = joinpath(default_compile_dir,
-                                      default_compile_filename)
+default_compile_path() = joinpath(default_compile_dir(),
+                                  default_compile_filename())
 
 
-function compile_note(; dir = default_compile_dir,
-                        filename = default_compile_filename)
+function compile_note(; dir = default_compile_dir(),
+                        filename = default_compile_filename())
   path = joinpath(dir, filename)
   return """
   You will be able to start Julia with a compiled version of ITensors using:
@@ -32,8 +32,8 @@ function compile_note(; dir = default_compile_dir,
   """
 end
 
-function compile(; dir::AbstractString = default_compile_dir,
-                   filename::AbstractString = default_compile_filename)
+function compile(; dir::AbstractString = default_compile_dir(),
+                 filename::AbstractString = default_compile_filename())
   if !isdir(dir)
     println("""The directory "$dir" doesn't exist yet, creating it now.""")
     println()
@@ -50,12 +50,12 @@ function compile(; dir::AbstractString = default_compile_dir,
 end
 
 @doc """
-    ITensors.compile(; dir = "$default_compile_dir",
-                       filename = "$default_compile_filename")
+    ITensors.compile(; dir = "$(default_compile_dir())",
+                       filename = "$(default_compile_filename())")
 
 Compile ITensors.jl with [PackageCompiler](https://julialang.github.io/PackageCompiler.jl/dev/). This will take some time, perhaps a few minutes.
 
-This will create a system image containing the compiled version of ITensors located at `dir/filename`, by default `$default_compile_path`.
+This will create a system image containing the compiled version of ITensors located at `dir/filename`, by default `$(default_compile_path())`.
 
 $(compile_note())
 """ compile

--- a/src/packagecompile/precompile_itensors.jl
+++ b/src/packagecompile/precompile_itensors.jl
@@ -1,6 +1,30 @@
 using ITensors
-N = 100
+
+# TODO: this uses all of the tests to make
+# precompile statements, but takes a long time
+# (e.g. 700 seconds).
+# Try again with later versions of PackageCompiler
+#
+# include(joinpath(joinpath(dirname(dirname(@__DIR__)), 
+#                           test"),
+#                  "runtests.jl"))
+
+N = 10
 sites = siteinds("S=1",N)
+ampo = AutoMPO()
+for j=1:N-1
+    ampo .+= ("Sz",j,"Sz",j+1)
+    ampo .+= (0.5,"S+",j,"S-",j+1)
+    ampo .+= (0.5,"S-",j,"S+",j+1)
+end
+H = MPO(ampo,sites)
+psi0 = randomMPS(sites,10)
+sweeps = Sweeps(5)
+maxdim!(sweeps, 10,20,100,100,200)
+cutoff!(sweeps, 1E-11)
+energy, psi = dmrg(H,psi0, sweeps)
+
+sites = siteinds("S=1", N; conserveqns = true)
 ampo = AutoMPO()
 for j=1:N-1
     ampo .+= ("Sz",j,"Sz",j+1)


### PR DESCRIPTION
With this added, on my laptop, compilation took about 3 minutes, so not too bad.

This also improves the docstring and output message of the `ITensors.compile()` command.

I tried using the tests to generate precompilation commands for PackageCompiler, but the compilation time increased to over 10 minutes, so that is not a good idea right now. I left the command to do that in `precompile_itensors.jl` and we can revisit it later.