### PR TITLE
Add inds keyword argument to IndexSet prime, tag, set, filter functions

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -417,10 +417,14 @@ An internal function that returns a function
 that accepts an Index that checks if the
 Index matches the provided conditions.
 """
-function fmatch(; tags=nothing,
-                  plev=nothing,
-                  id=nothing)
-  return i -> fmatch(plev)(i) && fmatch(id)(i) && fmatch(tags)(i)
+function fmatch(; inds = nothing,
+                  tags = nothing,
+                  plev = nothing,
+                  id = nothing)
+  return i -> fmatch(inds)(i) &&
+              fmatch(plev)(i) &&
+              fmatch(id)(i) &&
+              fmatch(tags)(i)
 end
 
 """

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -62,6 +62,13 @@ using ITensors,
     @test hassameinds(intersect(I1, (j, k)), IndexSet(j, k))
     @test hassameinds(intersect(I1, (j, k, l)), (j, k))
     @test filter(I1, "i") == IndexSet(i)
+    @test filter(I1; tags = "i") == IndexSet(i)
+    @test filter(I1; inds = j) == IndexSet(j)
+    @test filter(I1; tags = "i", inds = j) == IndexSet()
+    @test filter(I1; plev = 1, inds = j) == IndexSet()
+    @test filter(I1; plev = 0, inds = k) == IndexSet(k)
+    @test filter(I1; plev = 0) == IndexSet(i, j, k)
+    @test filter(I1; inds = l) == IndexSet()
     @test hassameinds(filter(I1, "i"), IndexSet(i))
     @test getfirst(I1, "j") == j
     @test isnothing(getfirst(I1, "l"))
@@ -110,6 +117,12 @@ using ITensors,
     J = prime(I, j)
     @test i ∈ J
     @test j' ∈ J
+    J = prime(I; inds = j)
+    @test i ∈ J
+    @test j' ∈ J
+    J = prime(I; inds = not(j))
+    @test i' ∈ J
+    @test j ∈ J
   end
   @testset "noprime" begin
     I = IndexSet(i'', j')


### PR DESCRIPTION
This adds notation like `prime(A; inds = (i, j))` to prime the indices `(i, j)` in `A`.