### PR TITLE
Add multi-site op support

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -125,6 +125,8 @@ Obtain the TagSet of an Index.
 """
 tags(i::Index) = i.tags
 
+commontags(is::Index...) = commontags(tags.(is)...)
+
 """
     plev(i::Index)
 

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -59,7 +59,7 @@ mult(t1::OpTerm,t2::OpTerm) = isempty(t2) ? t1 : vcat(t1,t2)
 function isfermionic(t::OpTerm,sites)::Bool
   p = +1
   for op in t
-    if has_fermion_string(sites[site(op)],name(op))
+    if has_fermion_string(name(op), sites[site(op)])
       p *= -1
     end
   end
@@ -879,7 +879,8 @@ function sorteachterm!(ampo::AutoMPO, sites)
     # and inserting string "F" operators
     parity = +1
     for n=Nt:-1:1
-      fermionic = has_fermion_string(sites[site(t.ops[n])],name(t.ops[n]))
+      fermionic = has_fermion_string(name(t.ops[n]),
+                                     sites[site(t.ops[n])])
       if parity == -1
         # Put Jordan-Wigner string emanating
         # from fermionic operators to the right

--- a/src/physics/site_types/electron.jl
+++ b/src/physics/site_types/electron.jl
@@ -141,7 +141,7 @@ function op(::SiteType"Electron",
   return Op
 end
 
-has_fermion_string(::SiteType"Electron",::OpName"Cup") = true
-has_fermion_string(::SiteType"Electron",::OpName"Cdagup") = true
-has_fermion_string(::SiteType"Electron",::OpName"Cdn") = true
-has_fermion_string(::SiteType"Electron",::OpName"Cdagdn") = true
+has_fermion_string(::OpName"Cup", ::SiteType"Electron") = true
+has_fermion_string(::OpName"Cdagup", ::SiteType"Electron") = true
+has_fermion_string(::OpName"Cdn", ::SiteType"Electron") = true
+has_fermion_string(::OpName"Cdagdn", ::SiteType"Electron") = true

--- a/src/physics/site_types/fermion.jl
+++ b/src/physics/site_types/fermion.jl
@@ -54,5 +54,9 @@ function op(::SiteType"Fermion",
 end
 
 
-has_fermion_string(::SiteType"Fermion",::OpName"C") = true
-has_fermion_string(::SiteType"Fermion",::OpName"Cdag") = true
+has_fermion_string(::OpName"C",
+                   ::SiteType"Fermion") = true
+
+has_fermion_string(::OpName"Cdag",
+                   ::SiteType"Fermion") = true
+

--- a/src/physics/site_types/generic_sites.jl
+++ b/src/physics/site_types/generic_sites.jl
@@ -1,8 +1,8 @@
 
-function op(::SiteType,
-            ::OpName"Id",
+function op(::OpName"Id",
+            ::SiteType,
             s::Index)
-  Op = emptyITensor(s',dag(s))
+  Op = emptyITensor(s', dag(s))
   for n=1:dim(s)
     Op[n,n] = 1.0
   end

--- a/src/physics/site_types/spinhalf.jl
+++ b/src/physics/site_types/spinhalf.jl
@@ -1,107 +1,131 @@
 
-function space(::SiteType"S=1/2"; kwargs...)
-  conserve_qns = get(kwargs,:conserve_qns,false)
-  conserve_sz = get(kwargs,:conserve_sz,conserve_qns)
+function space(::SiteType"S=1/2";
+               conserve_qns = false,
+               conserve_sz = conserve_qns)
   if conserve_sz
     return [QN("Sz",+1)=>1,QN("Sz",-1)=>1]
   end
   return 2
 end
 
+state(::SiteType"S=1/2", ::StateName"Up") = 1
+state(::SiteType"S=1/2", ::StateName"Dn") = 2
 
-state(::SiteType"S=1/2",::StateName"Up") = 1
-state(::SiteType"S=1/2",::StateName"Dn") = 2
-state(st::SiteType"S=1/2",::StateName"↑") = state(st,StateName("Up"))
-state(st::SiteType"S=1/2",::StateName"↓") = state(st,StateName("Dn"))
+state(st::SiteType"S=1/2", ::StateName"↑") =
+  state(st, StateName("Up"))
+state(st::SiteType"S=1/2", ::StateName"↓") =
+  state(st, StateName("Dn"))
 
 function op!(Op::ITensor,
-             ::SiteType"S=1/2",
              ::OpName"Sz",
+             ::SiteType"S=1/2",
              s::Index)
   Op[s'=>1, s=>1] = 0.5
   Op[s'=>2, s=>2] = -0.5
 end
 
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"Sᶻ",s::Index) = op!(Op,t,OpName("Sz"),s)
+op!(Op::ITensor,
+    ::OpName"Sᶻ",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("Sz"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1/2",
              ::OpName"S+",
+             ::SiteType"S=1/2",
              s::Index)
   Op[s'=>1, s=>2] = 1.0
 end
 
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"S⁺",s::Index) = op!(Op,t,OpName("S+"),s)
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"Splus",s::Index) = op!(Op,t,OpName("S+"),s)
+op!(Op::ITensor,
+    ::OpName"S⁺",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("S+"), t, s)
+
+op!(Op::ITensor,
+    ::OpName"Splus",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("S+"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1/2",
              ::OpName"S-",
+             ::SiteType"S=1/2",
              s::Index)
   Op[s'=>2, s=>1] = 1.0
 end
 
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"S⁻",s::Index) = op!(Op,t,OpName("S-"),s)
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"Sminus",s::Index) = op!(Op,t,OpName("S-"),s)
+op!(Op::ITensor,
+    ::OpName"S⁻",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("S-"), t, s)
+
+op!(Op::ITensor,
+    ::OpName"Sminus",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("S-"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1/2",
              ::OpName"Sx",
+             ::SiteType"S=1/2",
              s::Index)
   Op[s'=>1, s=>2] = 0.5
   Op[s'=>2, s=>1] = 0.5
 end
 
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"Sˣ",s::Index) = op!(Op,t,OpName("Sx"),s)
+op!(Op::ITensor,
+    ::OpName"Sˣ",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("Sx"),t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1/2",
              ::OpName"iSy",
+             ::SiteType"S=1/2",
              s::Index)
   Op[s'=>1, s=>2] = +0.5
   Op[s'=>2, s=>1] = -0.5
 end
 
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"iSʸ",s::Index) = op!(Op,t,OpName("iSy"),s)
+op!(Op::ITensor,
+    ::OpName"iSʸ",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("iSy"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1/2",
              ::OpName"Sy",
+             ::SiteType"S=1/2",
              s::Index)
   complex!(Op)
   Op[s'=>1, s=>2] = -0.5im
   Op[s'=>2, s=>1] = 0.5im
 end
 
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"Sʸ",s::Index) = op!(Op,t,OpName("Sy"),s)
+op!(Op::ITensor,
+    ::OpName"Sʸ",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("Sy"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1/2",
              ::OpName"S2",
+             ::SiteType"S=1/2",
              s::Index)
   Op[s'=>1, s=>1] = 0.75
   Op[s'=>2, s=>2] = 0.75
 end
 
-op!(Op::ITensor,t::SiteType"S=1/2",
-    ::OpName"S²",s::Index) = op!(Op,t,OpName("S2"),s)
+op!(Op::ITensor,
+    ::OpName"S²",
+    t::SiteType"S=1/2",
+    s::Index) = op!(Op, OpName("S2"), t, s)
 
 
 # Support the tag "SpinHalf" as equivalent to "S=1/2"
 
-space(::SiteType"SpinHalf"; kwargs...) = space(SiteType("S=1/2");kwargs...)
-state(::SiteType"SpinHalf",n::StateName) = state(SiteType("S=1/2"),n)
+space(::SiteType"SpinHalf"; kwargs...) =
+  space(SiteType("S=1/2"); kwargs...)
+state(::SiteType"SpinHalf", n::StateName) =
+  state(SiteType("S=1/2"), n)
 
 op!(Op::ITensor,
-    ::SiteType"SpinHalf",
     o::OpName,
-    s::Index) = op!(Op,SiteType("S=1/2"),o,s)
+    ::SiteType"SpinHalf",
+    s::Index) = op!(Op, o, SiteType("S=1/2"), s)
 

--- a/src/physics/site_types/spinone.jl
+++ b/src/physics/site_types/spinone.jl
@@ -1,7 +1,7 @@
 
-function space(::SiteType"S=1"; kwargs...)
-  conserve_qns = get(kwargs,:conserve_qns,false)
-  conserve_sz = get(kwargs,:conserve_sz,conserve_qns)
+function space(::SiteType"S=1";
+               conserve_qns = false,
+               conserve_sz = conserve_qns)
   if conserve_sz
     return [QN("Sz",+2)=>1,QN("Sz",0)=>1,QN("Sz",-2)=>1]
   end
@@ -11,51 +11,64 @@ end
 state(::SiteType"S=1",::StateName"Up") = 1
 state(::SiteType"S=1",::StateName"Z0") = 2
 state(::SiteType"S=1",::StateName"Dn") = 3
+
 state(st::SiteType"S=1",::StateName"↑") = state(st,StateName("Up"))
 state(st::SiteType"S=1",::StateName"0") = state(st,StateName("Z0"))
 state(st::SiteType"S=1",::StateName"↓") = state(st,StateName("Dn"))
 
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"Sz",
+             ::SiteType"S=1",
              s::Index)
   Op[s'=>1,s=>1] = +1.0
   Op[s'=>3,s=>3] = -1.0
 end
 
-op!(Op::ITensor,t::SiteType"S=1",
-    ::OpName"Sᶻ",s::Index) = op!(Op,t,OpName("Sz"),s)
+op!(Op::ITensor,
+    ::OpName"Sᶻ",
+    t::SiteType"S=1",
+    s::Index) = op!(Op, OpName("Sz"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"S+",
+             ::SiteType"S=1",
              s::Index)
   Op[s'=>2,s=>3] = sqrt(2)
   Op[s'=>1,s=>2] = sqrt(2)
 end
 
-op!(Op::ITensor,t::SiteType"S=1",
-    ::OpName"S⁺",s::Index) = op!(Op,t,OpName("S+"),s)
-op!(Op::ITensor,t::SiteType"S=1",
-    ::OpName"Splus",s::Index) = op!(Op,t,OpName("S+"),s)
+op!(Op::ITensor,
+    ::OpName"S⁺",
+    t::SiteType"S=1",
+    s::Index) = op!(Op, OpName("S+"), t, s)
+
+op!(Op::ITensor,
+    ::OpName"Splus",
+    t::SiteType"S=1",
+    s::Index) = op!(Op, OpName("S+"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"S-",
+             ::SiteType"S=1",
              s::Index)
   Op[s'=>3,s=>2] = sqrt(2)
   Op[s'=>2,s=>1] = sqrt(2)
 end
 
-op!(Op::ITensor,t::SiteType"S=1",
-    ::OpName"S⁻",s::Index) = op!(Op,t,OpName("S-"),s)
-op!(Op::ITensor,t::SiteType"S=1",
-    ::OpName"Sminus",s::Index) = op!(Op,t,OpName("S-"),s)
+op!(Op::ITensor,
+    ::OpName"S⁻",
+    t::SiteType"S=1",
+    s::Index) = op!(Op, OpName("S-"), t, s)
+
+op!(Op::ITensor,
+    ::OpName"Sminus",
+    t::SiteType"S=1",
+    s::Index) = op!(Op, OpName("S-"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"Sx",
+             ::SiteType"S=1",
              s::Index)
   Op[s'=>2,s=>1] = 1/sqrt(2)
   Op[s'=>1,s=>2] = 1/sqrt(2)
@@ -63,12 +76,14 @@ function op!(Op::ITensor,
   Op[s'=>2,s=>3] = 1/sqrt(2)
 end
 
-op!(Op::ITensor,t::SiteType"S=1",
-    ::OpName"Sˣ",s::Index) = op!(Op,t,OpName("Sx"),s)
+op!(Op::ITensor,
+    ::OpName"Sˣ",
+    t::SiteType"S=1",
+    s::Index) = op!(Op, OpName("Sx"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"iSy",
+             ::SiteType"S=1",
              s::Index)
   Op[s'=>2,s=>1] = -1/sqrt(2)
   Op[s'=>1,s=>2] = +1/sqrt(2)
@@ -76,12 +91,14 @@ function op!(Op::ITensor,
   Op[s'=>2,s=>3] = +1/sqrt(2)
 end
 
-op!(Op::ITensor,t::SiteType"S=1",
-    ::OpName"iSʸ",s::Index) = op!(Op,t,OpName("iSy"),s)
+op!(Op::ITensor,
+    ::OpName"iSʸ",
+    t::SiteType"S=1",
+    s::Index) = op!(Op, OpName("iSy"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"Sy",
+             ::SiteType"S=1",
              s::Index)
   complex!(Op)
   Op[s'=>2,s=>1] = -1im/sqrt(2)
@@ -90,20 +107,22 @@ function op!(Op::ITensor,
   Op[s'=>2,s=>3] = +1im/sqrt(2)
 end
 
-op!(Op::ITensor,t::SiteType"S=1",
-    ::OpName"Sʸ",s::Index) = op!(Op,t,OpName("Sy"),s)
+op!(Op::ITensor,
+    ::OpName"Sʸ",
+    t::SiteType"S=1",
+    s::Index) = op!(Op, OpName("Sy"), t, s)
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"Sz2",
+             ::SiteType"S=1",
              s::Index)
   Op[s'=>1,s=>1] = +1.0
   Op[s'=>3,s=>3] = +1.0
 end
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"Sx2",
+             ::SiteType"S=1",
              s::Index)
   Op[s'=>1,s=>1] = 0.5
   Op[s'=>3,s=>1] = 0.5
@@ -113,8 +132,8 @@ function op!(Op::ITensor,
 end
 
 function op!(Op::ITensor,
-             ::SiteType"S=1",
              ::OpName"Sy2",
+             ::SiteType"S=1",
              s::Index)
   Op[s'=>1,s=>1] = +0.5
   Op[s'=>3,s=>1] = -0.5
@@ -123,10 +142,13 @@ function op!(Op::ITensor,
   Op[s'=>3,s=>3] = +0.5
 end
 
-space(::SiteType"SpinOne"; kwargs...) = space(SiteType("S=1");kwargs...)
-state(::SiteType"SpinOne",st::AbstractString) = state(SiteType("S=1"),st)
+space(::SiteType"SpinOne"; kwargs...) =
+  space(SiteType("S=1");kwargs...)
+
+state(::SiteType"SpinOne",
+      st::AbstractString) = state(SiteType("S=1"), st)
 
 op!(Op::ITensor,
-    ::SiteType"SpinOne",
     o::OpName,
-    s::Index) = op!(Op,SiteType("S=1"),o,s)
+    ::SiteType"SpinOne",
+    s::Index) = op!(Op, o, SiteType("S=1"), s)

--- a/src/physics/site_types/tj.jl
+++ b/src/physics/site_types/tj.jl
@@ -87,7 +87,7 @@ function op(::SiteType"tJ",
   return Op
 end
 
-has_fermion_string(::SiteType"tJ",::OpName"Cup") = true
-has_fermion_string(::SiteType"tJ",::OpName"Cdagup") = true
-has_fermion_string(::SiteType"tJ",::OpName"Cdn") = true
-has_fermion_string(::SiteType"tJ",::OpName"Cdagdn") = true
+has_fermion_string(::OpName"Cup", ::SiteType"tJ") = true
+has_fermion_string(::OpName"Cdagup", ::SiteType"tJ") = true
+has_fermion_string(::OpName"Cdn", ::SiteType"tJ") = true
+has_fermion_string(::OpName"Cdagdn", ::SiteType"tJ") = true

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -228,7 +228,7 @@ end
 
 function commontags(ts1::TagSet, ts2::TagSet,
                     ts3::TagSet, ts::TagSet...)
-  error("commontags(::TagSet...) not implemented yet")
+  return commontags(commontags(ts1, ts2), ts3, ts...)
 end
 
 function Base.show(io::IO, T::TagSet)

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -215,7 +215,6 @@ end
 commontags(ts::TagSet) = ts
 
 function commontags(ts1::TagSet, ts2::TagSet)
-  #error("commontags(::TagSet, ::TagSet) not implemented yet")
   ts3 = TagSet()
   N1 = length(ts1)
   for n1 in 1:N1

--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -11,13 +11,19 @@ struct TagSet
   data::TagSetStorage
   length::Int
   function TagSet() 
-    ts = TagSetStorage(ntuple(_ -> IntTag(0),Val(4)))
-    new(ts,0)
+    ts = TagSetStorage(ntuple(_ -> IntTag(0), Val(4)))
+    new(ts, 0)
   end
-  TagSet(tags::TagSetStorage,len::Int) = new(tags,len)
+  TagSet(tags::TagSetStorage, len::Int) = new(tags, len)
 end
 
 TagSet(ts::TagSet) = ts
+
+function TagSet(t::Tag)
+  ts = MTagSetStorage(ntuple(_ -> IntTag(0), Val(maxTags)))
+  ts[1] = IntSmallString(t)
+  return TagSet(TagSetStorage(ts), 1)
+end
 
 not(ts::Union{AbstractString,TagSet}) = Not(TagSet(ts))
 
@@ -201,6 +207,29 @@ function tagstring(T::TagSet)
   end
   res *= "$(Tag(T[N]))"
   return res
+end
+
+# TODO: add iteration
+#Base.iterate(ts::TagSet, args...) = iterate(data(ts), args...)
+
+commontags(ts::TagSet) = ts
+
+function commontags(ts1::TagSet, ts2::TagSet)
+  #error("commontags(::TagSet, ::TagSet) not implemented yet")
+  ts3 = TagSet()
+  N1 = length(ts1)
+  for n1 in 1:N1
+    t1 = ts1[n1]
+    if hastag(ts2, t1)
+      ts3 = addtags(ts3, t1)
+    end
+  end
+  return ts3
+end
+
+function commontags(ts1::TagSet, ts2::TagSet,
+                    ts3::TagSet, ts::TagSet...)
+  error("commontags(::TagSet...) not implemented yet")
 end
 
 function Base.show(io::IO, T::TagSet)

--- a/test/phys_site_types.jl
+++ b/test/phys_site_types.jl
@@ -93,9 +93,9 @@ using ITensors,
     F = Array(op(s,"F"),s',s) 
     @test F ≈ [1. 0; 0 -1]
 
-    @test has_fermion_string(s,"C")
-    @test has_fermion_string(s,"Cdag")
-    @test !has_fermion_string(s,"N")
+    @test has_fermion_string("C", s)
+    @test has_fermion_string("Cdag", s)
+    @test !has_fermion_string("N", s)
   end
 
   @testset "Electron sites" begin
@@ -140,11 +140,11 @@ using ITensors,
     Sm3 = Array(op(s,"S-"),s',s) 
     @test Sm3 ≈ [0. 0 0 0; 0 0 0 0; 0 1 0 0; 0 0 0 0]
 
-    @test has_fermion_string(s,"Cup")
-    @test has_fermion_string(s,"Cdagup")
-    @test has_fermion_string(s,"Cdn")
-    @test has_fermion_string(s,"Cdagdn")
-    @test !has_fermion_string(s,"N")
+    @test has_fermion_string("Cup", s)
+    @test has_fermion_string("Cdagup", s)
+    @test has_fermion_string("Cdn", s)
+    @test has_fermion_string("Cdagdn", s)
+    @test !has_fermion_string("N", s)
   end
 
   @testset "tJ sites" begin
@@ -186,11 +186,11 @@ using ITensors,
     Sm = Array(op(s,"Sminus"),s',s) 
     @test Sm ≈ [0.0 0. 0; 0 0 0; 0 1.0 0]
 
-    @test has_fermion_string(s,"Cup")
-    @test has_fermion_string(s,"Cdagup")
-    @test has_fermion_string(s,"Cdn")
-    @test has_fermion_string(s,"Cdagdn")
-    @test !has_fermion_string(s,"N")
+    @test has_fermion_string("Cup", s)
+    @test has_fermion_string("Cdagup", s)
+    @test has_fermion_string("Cdn", s)
+    @test has_fermion_string("Cdagdn", s)
+    @test !has_fermion_string("N", s)
   end
 
 end

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -94,6 +94,21 @@ using ITensors,
     @test_throws ErrorException op("β", s2, s1)
   end
 
+  @testset "op with more than two indices" begin
+    ITensors.space(SiteType"qubit") = 2
+
+    ITensors.op(::OpName"rand",
+                ::SiteType"qubit",
+                s::Index...) =
+      randomITensor(prime.(s)..., dag.(s)...)
+
+    s = siteinds("qubit", 4)
+    o = op("rand", s...)
+    @test norm(o) > 0
+    @test order(o) == 8
+    @test hassameinds(o, (prime.(s)..., s...))
+  end
+
   @testset "Custom SiteType using op!" begin
     # Use "_Custom_" tag even though this example
     # is for S=3/2, because we might define the 

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -95,7 +95,7 @@ using ITensors,
   end
 
   @testset "op with more than two indices" begin
-    ITensors.space(SiteType"qubit") = 2
+    ITensors.space(::SiteType"qubit") = 2
 
     ITensors.op(::OpName"rand",
                 ::SiteType"qubit",

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -54,19 +54,44 @@ using ITensors,
       return Op
     end
 
-    s = Index(4, "_Custom_")
+    function ITensors.op(::SiteType"_Custom1",
+                         ::SiteType"_Custom2",
+                         ::OpName"β",
+                         s1::Index,
+                         s2::Index)
+      Op = emptyITensor(s1', s2',
+                        dag(s1), dag(s2))
+      Op[s1'=>1, s2'=>2, s1=>1, s2=>2] = +5/2
+      Op[s1'=>2, s2'=>1, s1=>2, s2=>2] = +3/2
+      Op[s1'=>3, s2'=>3, s1=>3, s2=>4] = -3/2
+      Op[s1'=>4, s2'=>1, s1=>4, s2=>2] = -5/2
+      return Op
+    end
+
+    s = Index(4, "_Custom_, __x")
     Sz = op("Sz", s)
     @test Sz[s'=>1,s=>1] ≈ +3/2
     @test Sz[s'=>2,s=>2] ≈ +1/2
     @test Sz[s'=>3,s=>3] ≈ -1/2
     @test Sz[s'=>4,s=>4] ≈ -3/2
 
-    t = Index(4, "_Custom_")
+    t = Index(4, "_Custom_, __x")
     α = op("α", s, t)
     @test α[s'=>1, t'=>2, s=>1, t=>2] ≈ +3/2
     @test α[s'=>2, t'=>1, s=>2, t=>2] ≈ +1/2
     @test α[s'=>3, t'=>3, s=>3, t=>4] ≈ -1/2
     @test α[s'=>4, t'=>1, s=>4, t=>2] ≈ -3/2
+
+    s1 = Index(4, "_Custom1, __x")
+    @test_throws ErrorException op("α", s, s1)
+
+    s2 = Index(4, "_Custom2, __x")
+    β = op("β", s1, s2)
+    @test β[s1'=>1, s2'=>2, s1=>1, s2=>2] ≈ +5/2
+    @test β[s1'=>2, s2'=>1, s1=>2, s2=>2] ≈ +3/2
+    @test β[s1'=>3, s2'=>3, s1=>3, s2=>4] ≈ -3/2
+    @test β[s1'=>4, s2'=>1, s1=>4, s2=>2] ≈ -5/2
+    @test_throws ErrorException op("β", s2, s1)
   end
 
   @testset "Custom SiteType using op!" begin
@@ -83,7 +108,8 @@ using ITensors,
       Op[s'=>4,s=>4] = -3/2
     end
 
-    function ITensors.op!(::SiteType"_Custom_",
+    function ITensors.op!(Op::ITensor,
+                          ::SiteType"_Custom_",
                           ::OpName"α",
                           s1::Index,
                           s2::Index)
@@ -93,19 +119,42 @@ using ITensors,
       Op[s1'=>4, s2'=>1, s1=>4, s2=>2] = -3/2
     end
 
-    s = Index(4, "_Custom_")
+    function ITensors.op!(Op::ITensor,
+                          ::SiteType"_Custom1",
+                          ::SiteType"_Custom2",
+                          ::OpName"β",
+                          s1::Index,
+                          s2::Index)
+      Op[s1'=>1, s2'=>2, s1=>1, s2=>2] = +5/2
+      Op[s1'=>2, s2'=>1, s1=>2, s2=>2] = +3/2
+      Op[s1'=>3, s2'=>3, s1=>3, s2=>4] = -3/2
+      Op[s1'=>4, s2'=>1, s1=>4, s2=>2] = -5/2
+    end
+
+    s = Index(4, "_Custom_, __x")
     Sz = op("Sz", s)
     @test Sz[s'=>1, s=>1] ≈ +3/2
     @test Sz[s'=>2, s=>2] ≈ +1/2
     @test Sz[s'=>3, s=>3] ≈ -1/2
     @test Sz[s'=>4, s=>4] ≈ -3/2
 
-    t = Index(4, "_Custom_")
+    t = Index(4, "_Custom_, __x")
     α = op("α", s, t)
     @test α[s'=>1, t'=>2, s=>1, t=>2] ≈ +3/2
     @test α[s'=>2, t'=>1, s=>2, t=>2] ≈ +1/2
     @test α[s'=>3, t'=>3, s=>3, t=>4] ≈ -1/2
     @test α[s'=>4, t'=>1, s=>4, t=>2] ≈ -3/2
+
+    s1 = Index(4, "_Custom1, __x")
+    @test_throws ErrorException op("α", t, s1)
+
+    s2 = Index(4, "_Custom2, __x")
+    β = op("β", s1, s2)
+    @test β[s1'=>1, s2'=>2, s1=>1, s2=>2] ≈ +5/2
+    @test β[s1'=>2, s2'=>1, s1=>2, s2=>2] ≈ +3/2
+    @test β[s1'=>3, s2'=>3, s1=>3, s2=>4] ≈ -3/2
+    @test β[s1'=>4, s2'=>1, s1=>4, s2=>2] ≈ -5/2
+    @test_throws ErrorException op("β", s2, s1)
   end
 
   @testset "Custom SiteType using older op interface" begin

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -30,8 +30,8 @@ using ITensors,
     # Use "_Custom_" tag even though this example
     # is for S=3/2, because we might define the 
     # "S=3/2" TagType inside ITensors.jl later
-    function ITensors.op(::SiteType"_Custom_",
-                         ::OpName"Sz",
+    function ITensors.op(::OpName"Sz",
+                         ::SiteType"_Custom_",
                          s::Index)
       Op = emptyITensor(s',dag(s))
       Op[s'=>1,s=>1] = +3/2
@@ -41,8 +41,8 @@ using ITensors,
       return Op
     end
 
-    function ITensors.op(::SiteType"_Custom_",
-                         ::OpName"α",
+    function ITensors.op(::OpName"α",
+                         ::SiteType"_Custom_",
                          s1::Index,
                          s2::Index)
       Op = emptyITensor(s1', s2',
@@ -54,9 +54,9 @@ using ITensors,
       return Op
     end
 
-    function ITensors.op(::SiteType"_Custom1",
+    function ITensors.op(::OpName"β",
+                         ::SiteType"_Custom1",
                          ::SiteType"_Custom2",
-                         ::OpName"β",
                          s1::Index,
                          s2::Index)
       Op = emptyITensor(s1', s2',
@@ -99,8 +99,8 @@ using ITensors,
     # is for S=3/2, because we might define the 
     # "S=3/2" TagType inside ITensors.jl later
     function ITensors.op!(Op::ITensor,
-                          ::SiteType"_Custom_",
                           ::OpName"Sz",
+                          ::SiteType"_Custom_",
                           s::Index)
       Op[s'=>1,s=>1] = +3/2
       Op[s'=>2,s=>2] = +1/2
@@ -109,8 +109,8 @@ using ITensors,
     end
 
     function ITensors.op!(Op::ITensor,
-                          ::SiteType"_Custom_",
                           ::OpName"α",
+                          ::SiteType"_Custom_",
                           s1::Index,
                           s2::Index)
       Op[s1'=>1, s2'=>2, s1=>1, s2=>2] = +3/2
@@ -120,9 +120,9 @@ using ITensors,
     end
 
     function ITensors.op!(Op::ITensor,
+                          ::OpName"β",
                           ::SiteType"_Custom1",
                           ::SiteType"_Custom2",
-                          ::OpName"β",
                           s1::Index,
                           s2::Index)
       Op[s1'=>1, s2'=>2, s1=>1, s2=>2] = +5/2

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -41,12 +41,32 @@ using ITensors,
       return Op
     end
 
-    s = Index(4,"_Custom_")
-    Sz = op("Sz",s)
+    function ITensors.op(::SiteType"_Custom_",
+                         ::OpName"α",
+                         s1::Index,
+                         s2::Index)
+      Op = emptyITensor(s1', s2',
+                        dag(s1), dag(s2))
+      Op[s1'=>1, s2'=>2, s1=>1, s2=>2] = +3/2
+      Op[s1'=>2, s2'=>1, s1=>2, s2=>2] = +1/2
+      Op[s1'=>3, s2'=>3, s1=>3, s2=>4] = -1/2
+      Op[s1'=>4, s2'=>1, s1=>4, s2=>2] = -3/2
+      return Op
+    end
+
+    s = Index(4, "_Custom_")
+    Sz = op("Sz", s)
     @test Sz[s'=>1,s=>1] ≈ +3/2
     @test Sz[s'=>2,s=>2] ≈ +1/2
     @test Sz[s'=>3,s=>3] ≈ -1/2
     @test Sz[s'=>4,s=>4] ≈ -3/2
+
+    t = Index(4, "_Custom_")
+    α = op("α", s, t)
+    @test α[s'=>1, t'=>2, s=>1, t=>2] ≈ +3/2
+    @test α[s'=>2, t'=>1, s=>2, t=>2] ≈ +1/2
+    @test α[s'=>3, t'=>3, s=>3, t=>4] ≈ -1/2
+    @test α[s'=>4, t'=>1, s=>4, t=>2] ≈ -3/2
   end
 
   @testset "Custom SiteType using op!" begin
@@ -63,12 +83,29 @@ using ITensors,
       Op[s'=>4,s=>4] = -3/2
     end
 
-    s = Index(4,"_Custom_")
-    Sz = op("Sz",s)
-    @test Sz[s'=>1,s=>1] ≈ +3/2
-    @test Sz[s'=>2,s=>2] ≈ +1/2
-    @test Sz[s'=>3,s=>3] ≈ -1/2
-    @test Sz[s'=>4,s=>4] ≈ -3/2
+    function ITensors.op!(::SiteType"_Custom_",
+                          ::OpName"α",
+                          s1::Index,
+                          s2::Index)
+      Op[s1'=>1, s2'=>2, s1=>1, s2=>2] = +3/2
+      Op[s1'=>2, s2'=>1, s1=>2, s2=>2] = +1/2
+      Op[s1'=>3, s2'=>3, s1=>3, s2=>4] = -1/2
+      Op[s1'=>4, s2'=>1, s1=>4, s2=>2] = -3/2
+    end
+
+    s = Index(4, "_Custom_")
+    Sz = op("Sz", s)
+    @test Sz[s'=>1, s=>1] ≈ +3/2
+    @test Sz[s'=>2, s=>2] ≈ +1/2
+    @test Sz[s'=>3, s=>3] ≈ -1/2
+    @test Sz[s'=>4, s=>4] ≈ -3/2
+
+    t = Index(4, "_Custom_")
+    α = op("α", s, t)
+    @test α[s'=>1, t'=>2, s=>1, t=>2] ≈ +3/2
+    @test α[s'=>2, t'=>1, s=>2, t=>2] ≈ +1/2
+    @test α[s'=>3, t'=>3, s=>3, t=>4] ≈ -1/2
+    @test α[s'=>4, t'=>1, s=>4, t=>2] ≈ -3/2
   end
 
   @testset "Custom SiteType using older op interface" begin


### PR DESCRIPTION
This adds support for adding ops that have more than one site.

The current implementation is a bit too simplistic, because it just searches through the tags of the first input Index for an `op` overload. What we could do is first make a TagSet of the tags that are common between all of the input indices (through something like a `commontags(::Index...) -> TagSet` function), and then search for `op` overloads of just the common tags. This would catch issues like trying to make a multi-site `op` of mixed site types, which for now is not officially support.