### PR TITLE
Customization of siteinds and siteind

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -262,4 +262,6 @@ export
 
 # qn/qnindex.jl
   flux,
-  hasqns
+  hasqns,
+  nblocks,
+  qn

--- a/src/physics/site_types/electron.jl
+++ b/src/physics/site_types/electron.jl
@@ -1,8 +1,6 @@
 
-const ElectronSite = SiteType"Electron"
 
-function siteinds(::ElectronSite, 
-                  N::Int; kwargs...)
+function space(::SiteType"Electron"; kwargs...)
   conserve_qns = get(kwargs,:conserve_qns,false)
   conserve_sz = get(kwargs,:conserve_sz,conserve_qns)
   conserve_nf = get(kwargs,:conserve_nf,conserve_qns)
@@ -12,28 +10,28 @@ function siteinds(::ElectronSite,
     up = QN(("Nf",1,-1),("Sz",+1)) => 1
     dn = QN(("Nf",1,-1),("Sz",-1)) => 1
     ud = QN(("Nf",2,-1),("Sz", 0)) => 1
-    return [Index(em,up,dn,ud;tags="Site,Electron,n=$n") for n=1:N]
+    return [em,up,dn,ud]
   elseif conserve_nf
     zer = QN("Nf",0,-1) => 1
     one = QN("Nf",1,-1) => 2
     two = QN("Nf",2,-1) => 1
-    return [Index(zer,one,two;tags="Site,Electron,n=$n") for n=1:N]
+    return [zer,one,two]
   elseif conserve_sz
     em = QN(("Sz", 0),("Pf",0,-2)) => 1
     up = QN(("Sz",+1),("Pf",1,-2)) => 1
     dn = QN(("Sz",-1),("Pf",1,-2)) => 1
     ud = QN(("Sz", 0),("Pf",0,-2)) => 1
-    return [Index(em,up,dn,ud;tags="Site,Electron,n=$n") for n=1:N]
+    return [em,up,dn,ud]
   elseif conserve_parity
     zer = QN("Pf",0,-2) => 1
     one = QN("Pf",1,-2) => 2
     two = QN("Pf",0,-2) => 1
-    return [Index(zer,one,two;tags="Site,Electron,n=$n") for n=1:N]
+    return [zer,one,two]
   end
-  return [Index(4,"Site,Electron,n=$n") for n=1:N]
+  return 4
 end
 
-function state(::ElectronSite,
+function state(::SiteType"Electron",
                st::AbstractString)
   if st == "Emp" || st == "0"
     return 1
@@ -48,7 +46,7 @@ function state(::ElectronSite,
   return 0
 end
 
-function op(::ElectronSite,
+function op(::SiteType"Electron",
             s::Index,
             opname::AbstractString)::ITensor
   Emp   = s(1)
@@ -144,12 +142,12 @@ function op(::ElectronSite,
     pUD[UpDn] = 1.0
     return pUD
   else
-    throw(ArgumentError("Operator name $opname not recognized for ElectronSite"))
+    throw(ArgumentError("Operator name $opname not recognized for \"Electron\" site"))
   end
   return Op
 end
 
-function has_fermion_string(::ElectronSite,
+function has_fermion_string(::SiteType"Electron",
             s::Index,
             opname::AbstractString)::Bool
   if opname=="Cup" || opname=="Cdagup" || opname=="Cdn" || opname=="Cdagdn"

--- a/src/physics/site_types/fermion.jl
+++ b/src/physics/site_types/fermion.jl
@@ -1,24 +1,21 @@
 
-const FermionSite = SiteType"Fermion"
-
-function siteinds(::FermionSite, 
-                  N::Int; kwargs...)
+function space(::SiteType"Fermion"; kwargs...)
   conserve_qns = get(kwargs,:conserve_qns,false)
   conserve_nf = get(kwargs,:conserve_nf,conserve_qns)
   conserve_parity = get(kwargs,:conserve_parity,conserve_qns)
   if conserve_nf
     zer = QN("Nf",0,-1) => 1
     one = QN("Nf",1,-1) => 1
-    return [Index(zer,one;tags="Site,Fermion,n=$n") for n=1:N]
+    return [zer,one]
   elseif conserve_parity
     zer = QN("Pf",0,-2) => 1
     one = QN("Pf",1,-2) => 1
-    return [Index(zer,one;tags="Site,Fermion,n=$n") for n=1:N]
+    return [zer,one]
   end
-  return [Index(2,"Site,Fermion,n=$n") for n=1:N]
+  return 2
 end
 
-function state(::FermionSite,
+function state(::SiteType"Fermion",
                st::AbstractString)
   if st == "Emp" || st == "0"
     return 1
@@ -29,7 +26,7 @@ function state(::FermionSite,
   return 0
 end
 
-function op(::FermionSite,
+function op(::SiteType"Fermion",
             s::Index,
             opname::AbstractString)::ITensor
   Emp   = s(1)
@@ -57,12 +54,12 @@ function op(::FermionSite,
     pOcc[Occ] = 1.0
     return pOcc
   else
-    throw(ArgumentError("Operator name $opname not recognized for FermionSite"))
+    throw(ArgumentError("Operator name $opname not recognized for \"Fermion\" site"))
   end
   return Op
 end
 
-function has_fermion_string(::FermionSite,
+function has_fermion_string(::SiteType"Fermion",
             s::Index,
             opname::AbstractString)::Bool
   if opname=="C" || opname=="Cdag"

--- a/src/physics/site_types/spinhalf.jl
+++ b/src/physics/site_types/spinhalf.jl
@@ -1,16 +1,14 @@
 
-function siteinds(::SiteType"S=1/2",
-                  N::Int; kwargs...)
+function space(::SiteType"S=1/2"; kwargs...)
   conserve_qns = get(kwargs,:conserve_qns,false)
   conserve_sz = get(kwargs,:conserve_sz,conserve_qns)
   if conserve_sz
-    return [Index(QN("Sz",+1)=>1,QN("Sz",-1)=>1;tags="Site,S=1/2,n=$n") for n=1:N]
+    return [QN("Sz",+1)=>1,QN("Sz",-1)=>1]
   end
-  return [Index(2,"Site,S=1/2,n=$n") for n=1:N]
+  return 2
 end
 
-siteinds(::SiteType"SpinHalf",
-         N::Int; kwargs...) = siteinds(SiteType("S=1/2"),N;kwargs...)
+space(::SiteType"SpinHalf"; kwargs...) = space(SiteType("S=1/2");kwargs...)
 
 function state(::SiteType"S=1/2",
                st::AbstractString)

--- a/src/physics/site_types/spinone.jl
+++ b/src/physics/site_types/spinone.jl
@@ -1,19 +1,14 @@
 
-function siteinds(::SiteType"S=1",
-                  N::Int; kwargs...)
+function space(::SiteType"S=1"; kwargs...)
   conserve_qns = get(kwargs,:conserve_qns,false)
   conserve_sz = get(kwargs,:conserve_sz,conserve_qns)
   if conserve_sz
-    up = QN("Sz",+2) => 1
-    z0 = QN("Sz", 0) => 1
-    dn = QN("Sz",-2) => 1
-    return [Index(up,z0,dn;tags="Site,S=1,n=$n") for n=1:N]
+    return [QN("Sz",+2)=>1,QN("Sz",0)=>1,QN("Sz",-2)=>1]
   end
-  return [Index(3,"Site,S=1,n=$n") for n=1:N]
+  return 3
 end
 
-siteinds(::SiteType"SpinOne",
-         N::Int; kwargs...) = siteinds(SiteType("S=1"),N;kwargs...)
+space(::SiteType"SpinOne"; kwargs...) = space(SiteType("S=1");kwargs...)
 
 function state(::SiteType"S=1",
                st::AbstractString)
@@ -24,7 +19,7 @@ function state(::SiteType"S=1",
   elseif st == "Dn" || st == "↓"
     return 3
   end
-  throw(ArgumentError("State string \"$st\" not recognized for SpinOne site"))
+  throw(ArgumentError("State string \"$st\" not recognized for \"S=1\" site"))
   return 0
 end
 

--- a/src/physics/site_types/tj.jl
+++ b/src/physics/site_types/tj.jl
@@ -1,8 +1,5 @@
 
-const tJSite = SiteType"tJ"
-
-function siteinds(::tJSite,
-                  N::Int; kwargs...)
+function space(::SiteType"tJ"; kwargs...)
   conserve_qns = get(kwargs,:conserve_qns,false)
   conserve_sz = get(kwargs,:conserve_sz,conserve_qns)
   conserve_nf = get(kwargs,:conserve_nf,conserve_qns)
@@ -11,25 +8,25 @@ function siteinds(::tJSite,
     em = QN(("Nf",0,-1),("Sz", 0)) => 1
     up = QN(("Nf",1,-1),("Sz",+1)) => 1
     dn = QN(("Nf",1,-1),("Sz",-1)) => 1
-    return [Index(em,up,dn;tags="Site,tJ,n=$n") for n=1:N]
+    return [em,up,dn]
   elseif conserve_nf
     zer = QN("Nf",0,-1) => 1
     one = QN("Nf",1,-1) => 2
-    return [Index(zer,one;tags="Site,tJ,n=$n") for n=1:N]
+    return [zer,one]
   elseif conserve_sz
     em = QN(("Sz", 0),("Pf",0,-2)) => 1
     up = QN(("Sz",+1),("Pf",1,-2)) => 1
     dn = QN(("Sz",-1),("Pf",1,-2)) => 1
-    return [Index(em,up,dn;tags="Site,tJ,n=$n") for n=1:N]
+    return [em,up,dn]
   elseif conserve_parity
     zer = QN("Pf",0,-2) => 1
     one = QN("Pf",1,-2) => 2
-    return [Index(zer,one;tags="Site,tJ,n=$n") for n=1:N]
+    return [zer,one]
   end
-  return [Index(3,"Site,tJ,n=$n") for n=1:N]
+  return 3
 end
 
-function state(::tJSite,
+function state(::SiteType"tJ",
                st::AbstractString)
   if st == "0" || st == "Emp"
     return 1
@@ -42,7 +39,7 @@ function state(::tJSite,
   return 0
 end
 
-function op(::tJSite,
+function op(::SiteType"tJ",
             s::Index,
             opname::AbstractString)::ITensor
   Emp = s(1)
@@ -103,12 +100,12 @@ function op(::tJSite,
     pD[Dn] = 1.
     return pD
   else
-    throw(ArgumentError("Operator name '$opname' not recognized for tJSite"))
+    throw(ArgumentError("Operator name '$opname' not recognized for \"tJ\" site"))
   end
   return Op
 end
 
-function has_fermion_string(::tJSite,
+function has_fermion_string(::SiteType"tJ",
             s::Index,
             opname::AbstractString)::Bool
   if opname=="Cup" || opname=="Cdagup" || opname=="Cdn" || opname=="Cdagdn"

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -239,20 +239,19 @@ end
 #
 #---------------------------------------
 
-function siteind(st::SiteType,n;kwargs...) 
-  t = String(tag(st))
+function siteind(st::SiteType; kwargs...) 
   if applicable(space,st)
     sp = space(st;kwargs...)
-    return Index(sp,"Site,$t,n=$n")
+    return Index(sp,"Site,$(tag(st))")
   end
   throw(ArgumentError("Overload of \"siteind\" or \"space\" functions not found for Index tag: $t"))
 end
 
-function siteind(tag::String,
-                 n::Integer; kwargs...)
-  st = SiteType(tag)
-  return siteind(st,n;kwargs...)
-end
+siteind(st::SiteType, n; kwargs...) = addtags(siteind(st;kwargs...),"n=$n")
+
+siteind(tag::String; kwargs...) = siteind(SiteType(tag);kwargs...)
+
+siteind(tag::String,n; kwargs...) = siteind(SiteType(tag),n;kwargs...)
 
 # Special case of `siteind` where integer (dim) provided
 # instead of a tag string

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -27,6 +27,7 @@ end
 
 SiteType(s::AbstractString) = SiteType{Tag(s)}()
 SiteType(t::Tag) = SiteType{t}()
+tag(::SiteType{T}) where {T} = T
 
 macro SiteType_str(s)
   SiteType{Tag(s)}
@@ -67,6 +68,7 @@ end
 
 OpName(s::AbstractString) = OpName{SmallString(s)}()
 OpName(s::SmallString) = OpName{s}()
+name(::OpName{N}) where {N} = N
 
 macro OpName_str(s)
   OpName{SmallString(s)}

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -241,12 +241,12 @@ end
 
 space(st::SiteType; kwargs...) = throw(MethodError("Overload of \"space\",\"siteind\", or \"siteinds\" functions not found for Index tag: $(tag(st))"))
 
-function siteind(st::SiteType; kwargs...) 
+function siteind(st::SiteType; add_tags="", kwargs...) 
   sp = space(st;kwargs...)
-  return Index(sp,"Site,$(tag(st))")
+  return Index(sp,"Site,$(tag(st)),$add_tags")
 end
 
-siteind(st::SiteType, n; kwargs...) = addtags(siteind(st;kwargs...),"n=$n")
+siteind(st::SiteType, n; kwargs...) = addtags(siteind(st; kwargs...),"n=$n")
 
 siteind(tag::String; kwargs...) = siteind(SiteType(tag);kwargs...)
 

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -241,9 +241,9 @@ end
 
 space(st::SiteType; kwargs...) = throw(MethodError("Overload of \"space\",\"siteind\", or \"siteinds\" functions not found for Index tag: $(tag(st))"))
 
-function siteind(st::SiteType; add_tags="", kwargs...) 
+function siteind(st::SiteType; addtags="", kwargs...) 
   sp = space(st;kwargs...)
-  return Index(sp,"Site,$(tag(st)),$add_tags")
+  return Index(sp,"Site,$(tag(st)),$addtags")
 end
 
 siteind(st::SiteType, n; kwargs...) = addtags(siteind(st; kwargs...),"n=$n")

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -276,6 +276,11 @@ function siteinds(tag::String,
   return [siteind(st,j; kwargs...) for j=1:N]
 end
 
+function siteinds(f::Function,
+                  N::Integer; kwargs...)
+  [siteind(f(n),n; kwargs...) for n=1:N]
+end
+
 # Special case of `siteinds` where integer (dim)
 # provided instead of a tag string
 function siteinds(d::Integer,

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -239,12 +239,11 @@ end
 #
 #---------------------------------------
 
+space(st::SiteType; kwargs...) = throw(MethodError("Overload of \"space\",\"siteind\", or \"siteinds\" functions not found for Index tag: $(tag(st))"))
+
 function siteind(st::SiteType; kwargs...) 
-  if applicable(space,st)
-    sp = space(st;kwargs...)
-    return Index(sp,"Site,$(tag(st))")
-  end
-  throw(ArgumentError("Overload of \"siteind\" or \"space\" functions not found for Index tag: $(tag(st))"))
+  sp = space(st;kwargs...)
+  return Index(sp,"Site,$(tag(st))")
 end
 
 siteind(st::SiteType, n; kwargs...) = addtags(siteind(st;kwargs...),"n=$n")
@@ -262,7 +261,6 @@ siteind(d::Integer,n::Integer; kwargs...) = Index(d,"Site,n=$n")
 # siteinds system
 #
 #---------------------------------------
-
 
 siteinds(::SiteType, N; kwargs...) = nothing
 

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -244,7 +244,7 @@ function siteind(st::SiteType; kwargs...)
     sp = space(st;kwargs...)
     return Index(sp,"Site,$(tag(st))")
   end
-  throw(ArgumentError("Overload of \"siteind\" or \"space\" functions not found for Index tag: $t"))
+  throw(ArgumentError("Overload of \"siteind\" or \"space\" functions not found for Index tag: $(tag(st))"))
 end
 
 siteind(st::SiteType, n; kwargs...) = addtags(siteind(st;kwargs...),"n=$n")

--- a/test/phys_site_types.jl
+++ b/test/phys_site_types.jl
@@ -6,6 +6,18 @@ using ITensors,
   N = 10
 
   @testset "Spin Half sites" begin
+
+    s = siteind("S=1/2")
+    @test hastags(s,"S=1/2,Site")
+    @test dim(s) == 2
+
+    s = siteind("S=1/2";conserve_qns=true)
+    @test hastags(s,"S=1/2,Site")
+    @test dim(s) == 2
+    @test nblocks(s) == 2
+    @test qn(s,1) == QN("Sz",+1)
+    @test qn(s,2) == QN("Sz",-1)
+
     s = siteinds("S=1/2",N)
 
     @test state(s[1],"Up") == s[1](1)
@@ -165,41 +177,6 @@ using ITensors,
     @test Sm3 ≈ [0.0 0. 0; 0 0 0; 0 1.0 0]
   end
 
-end
-
-
-@testset "Custom Site Tag Type" begin
-
-  function ITensors.op!(Op::ITensor,
-                        ::SiteType"MySite",
-                        ::OpName"MyOp",
-                        s::Index)
-    Op[s(1),s'(1)] = 11
-    Op[s(1),s'(2)] = 12
-    Op[s(2),s'(1)] = 21
-    Op[s(2),s'(2)] = 22
-  end
-
-  function ITensors.state(::SiteType"MySite",
-                          statename::AbstractString)
-    if statename == "One"
-      return 1
-    elseif statename == "Two"
-      return 2
-    end
-  end
-
-  i = Index(2,"MySite")
-
-  expectedOp = ITensor(i,i')
-  expectedOp[i(1),i'(1)] = 11
-  expectedOp[i(1),i'(2)] = 12
-  expectedOp[i(2),i'(1)] = 21
-  expectedOp[i(2),i'(2)] = 22
-  @test op("MyOp",i) ≈ expectedOp
-
-  @test state(i,"One") == i(1)
-  @test state(i,"Two") == i(2)
 end
 
 nothing

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -177,6 +177,14 @@ using ITensors,
     end
   end
 
+  @testset "siteinds add_tags keyword argument" begin
+    N = 4
+    s = siteinds("S=1/2",N,add_tags="T")
+    for n=1:N
+      @test hastags(s[n],"Site,S=1/2,n=$n,T")
+    end
+  end
+
   @testset "Error for undefined tag in siteinds,space system" begin
     @test_throws MethodError siteinds("Missing",10)
     @test_throws MethodError siteind("Missing",3)

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -177,9 +177,9 @@ using ITensors,
     end
   end
 
-  @testset "siteinds add_tags keyword argument" begin
+  @testset "siteinds addtags keyword argument" begin
     N = 4
-    s = siteinds("S=1/2",N,add_tags="T")
+    s = siteinds("S=1/2",N,addtags="T")
     for n=1:N
       @test hastags(s[n],"Site,S=1/2,n=$n,T")
     end

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -125,8 +125,7 @@ using ITensors,
   end
 
   @testset "siteinds defined by space overload" begin
-    function ITensors.space(::SiteType"Test4"; kwargs...) 
-      conserve_qns = get(kwargs,:conserve_qns,false)
+    function ITensors.space(::SiteType"Test4"; conserve_qns=false)
       if conserve_qns
         return [QN("T",0)=>2, QN("T",1)=>1, QN("T",2)=>1]
       end

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -164,6 +164,12 @@ using ITensors,
     end
   end
 
+  @testset "Error for undefined tag in siteinds,space system" begin
+    @test_throws MethodError siteinds("Missing",10)
+    @test_throws MethodError siteind("Missing",3)
+    @test_throws MethodError siteind("Missing")
+  end
+
 end
 
 nothing

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -96,6 +96,71 @@ using ITensors,
     @test Sp[s'(3),s(4)] ≈ sqrt(3)
   end
 
+  @testset "siteind defined by space overload" begin
+    ITensors.space(::SiteType"Test1") = 4
+    s = siteind("Test1",3)
+    @test dim(s) == 4
+    @test hastags(s,"Site,Test1,n=3")
+  end
+
+  @testset "siteind defined by siteind overload" begin
+    ITensors.siteind(::SiteType"Test2",n) = Index(4,"Test2,n=$n")
+    s = siteind("Test2",3)
+    @test dim(s) == 4
+    @test hastags(s,"Test2,n=3")
+  end
+
+  @testset "siteind defined by space overload with QN" begin
+    function ITensors.space(::SiteType"Test3") 
+      return [QN("T",0)=>2, QN("T",1)=>1, QN("T",2)=>1]
+    end
+    s = siteind("Test3",3)
+    @test dim(s) == 4
+    @test hasqns(s)
+    @test hastags(s,"Site,Test3,n=3")
+  end
+
+  @testset "siteinds defined by space overload" begin
+    function ITensors.space(::SiteType"Test4"; kwargs...) 
+      conserve_qns = get(kwargs,:conserve_qns,false)
+      if conserve_qns
+        return [QN("T",0)=>2, QN("T",1)=>1, QN("T",2)=>1]
+      end
+      return 4
+    end
+
+    # Without QNs
+    s = siteinds("Test4",6)
+    @test length(s) == 6
+    @test dim(s[1]) == 4
+    for n=1:length(s)
+      @test hastags(s[n],"Site,Test4,n=$n")
+      @test !hasqns(s[n])
+    end
+
+    # With QNs
+    s = siteinds("Test4",6;conserve_qns=true)
+    @test length(s) == 6
+    @test dim(s[1]) == 4
+    for n=1:length(s)
+      @test hastags(s[n],"Site,Test4,n=$n")
+      @test hasqns(s[n])
+    end
+
+  end
+
+  @testset "siteinds defined by siteinds overload" begin
+    function ITensors.siteinds(::SiteType"Test5",N; kwargs...) 
+      return [Index(4,"Test5,n=$n") for n=1:N]
+    end
+    s = siteinds("Test5",8)
+    @test length(s) == 8
+    @test dim(s[1]) == 4
+    for n=1:length(s)
+      @test hastags(s[n],"Test5,n=$n")
+    end
+  end
+
 end
 
 nothing

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -101,10 +101,14 @@ using ITensors,
     s = siteind("Test1",3)
     @test dim(s) == 4
     @test hastags(s,"Site,Test1,n=3")
+
+    s = siteind("Test1")
+    @test dim(s) == 4
+    @test hastags(s,"Site,Test1")
   end
 
   @testset "siteind defined by siteind overload" begin
-    ITensors.siteind(::SiteType"Test2",n) = Index(4,"Test2,n=$n")
+    ITensors.siteind(::SiteType"Test2") = Index(4,"Test2")
     s = siteind("Test2",3)
     @test dim(s) == 4
     @test hastags(s,"Test2,n=3")

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -164,6 +164,19 @@ using ITensors,
     end
   end
 
+  @testset "Version of siteinds taking function argument" begin
+    N = 10
+    s = siteinds(n->(n==1||n==N) ? "S=1/2" : "S=1",N)
+    for n in (1,N)
+      @test dim(s[n]) == 2
+      @test hastags(s[n],"Site,S=1/2,n=$n")
+    end
+    for n=2:N-1
+      @test dim(s[n]) == 3
+      @test hastags(s[n],"Site,S=1,n=$n")
+    end
+  end
+
   @testset "Error for undefined tag in siteinds,space system" begin
     @test_throws MethodError siteinds("Missing",10)
     @test_throws MethodError siteind("Missing",3)


### PR DESCRIPTION

This PR expands the customizability of the `siteinds` function in a  
backwards compatible way, by reimplementing it in terms of functions named
`siteind` which just make one site index, which itself calls by default another
function called `space` that just returns the space of a site index.

One advantage of having the function `siteind` is it makes it easy to make
site arrays which are mixtures of multiple site types.

This design gives the user multiple points of customization of how site indices 
get created. From lowest to highest level:
- create an overload of `space(::SiteType"Tag"; kwargs...)`
- create an overload of `siteind(::SiteType"Tag"; kwargs...)`
- create an overload of `siteind(::SiteType"Tag", n::Int; kwargs...)`
- create an overload of `siteinds(::SiteType"Tag", N::Int; kwargs...)`

This system works well, and the only drawbacks I can see are:
1. It might be a tad slower than before, especially in the QN case since the QN spaces get constructed N times rather than just once. But I don't think `siteinds` is a bottleneck in any case we know of.
2. If a user overloads `siteind(::SiteType"Tag",n)` but not `siteind(::SiteType"Tag")` or `space(::SiteType"Tag")`, then calling `siteind("Tag")` will result in an error. The solution is just to define one of those other functions but it could be a bit confusing to someone encountering this situation.


Commits included:
- Add functions for retrieving tag and name back from SiteType and OpName instances
- Initial draft of new siteinds and siteind system
- Unit tests for custom siteind and siteinds
- Compress code a bit and remove int argument from lowest-level siteind function
- Fix error message
- Upgrade spinhalf.jl and spinone.jl to use space
- Slight rewrite of test code
- Update all site types to use space function
- Add nblocks and qn to exports
- Test siteind function for "S=1/2" tag
