### PR TITLE
Update state system to use StateName

### DIFF
--- a/src/physics/site_types/electron.jl
+++ b/src/physics/site_types/electron.jl
@@ -35,10 +35,10 @@ state(::SiteType"Electron",::StateName"Emp")  = 1
 state(::SiteType"Electron",::StateName"Up")   = 2
 state(::SiteType"Electron",::StateName"Dn")   = 3
 state(::SiteType"Electron",::StateName"UpDn") = 4
-state(::SiteType"Electron",::StateName"0")    = 1
-state(::SiteType"Electron",::StateName"↑")    = 2
-state(::SiteType"Electron",::StateName"↓")    = 3
-state(::SiteType"Electron",::StateName"↑↓")   = 4
+state(st::SiteType"Electron",::StateName"0")    = state(st,StateName("Emp"))
+state(st::SiteType"Electron",::StateName"↑")    = state(st,StateName("Up"))
+state(st::SiteType"Electron",::StateName"↓")    = state(st,StateName("Dn"))
+state(st::SiteType"Electron",::StateName"↑↓")   = state(st,StateName("UpDn"))
 
 function op(::SiteType"Electron",
             s::Index,

--- a/src/physics/site_types/electron.jl
+++ b/src/physics/site_types/electron.jl
@@ -31,20 +31,14 @@ function space(::SiteType"Electron"; kwargs...)
   return 4
 end
 
-function state(::SiteType"Electron",
-               st::AbstractString)
-  if st == "Emp" || st == "0"
-    return 1
-  elseif st == "Up" || st == "↑"
-    return 2
-  elseif st == "Dn" || st == "↓"
-    return 3
-  elseif st == "UpDn" || st == "↑↓"
-    return 4
-  end
-  throw(ArgumentError("State string \"$st\" not recognized for Electron site"))
-  return 0
-end
+state(::SiteType"Electron",::StateName"Emp")  = 1
+state(::SiteType"Electron",::StateName"Up")   = 2
+state(::SiteType"Electron",::StateName"Dn")   = 3
+state(::SiteType"Electron",::StateName"UpDn") = 4
+state(::SiteType"Electron",::StateName"0")    = 1
+state(::SiteType"Electron",::StateName"↑")    = 2
+state(::SiteType"Electron",::StateName"↓")    = 3
+state(::SiteType"Electron",::StateName"↑↓")   = 4
 
 function op(::SiteType"Electron",
             s::Index,

--- a/src/physics/site_types/electron.jl
+++ b/src/physics/site_types/electron.jl
@@ -141,11 +141,7 @@ function op(::SiteType"Electron",
   return Op
 end
 
-function has_fermion_string(::SiteType"Electron",
-            s::Index,
-            opname::AbstractString)::Bool
-  if opname=="Cup" || opname=="Cdagup" || opname=="Cdn" || opname=="Cdagdn"
-    return true
-  end
-  return false
-end
+has_fermion_string(::SiteType"Electron",::OpName"Cup") = true
+has_fermion_string(::SiteType"Electron",::OpName"Cdagup") = true
+has_fermion_string(::SiteType"Electron",::OpName"Cdn") = true
+has_fermion_string(::SiteType"Electron",::OpName"Cdagdn") = true

--- a/src/physics/site_types/fermion.jl
+++ b/src/physics/site_types/fermion.jl
@@ -15,16 +15,10 @@ function space(::SiteType"Fermion"; kwargs...)
   return 2
 end
 
-function state(::SiteType"Fermion",
-               st::AbstractString)
-  if st == "Emp" || st == "0"
-    return 1
-  elseif st == "Occ" || st == "1"
-    return 2
-  end
-  throw(ArgumentError("State string \"$st\" not recognized for Fermion site"))
-  return 0
-end
+state(::SiteType"Fermion",::StateName"Emp")  = 1
+state(::SiteType"Fermion",::StateName"Occ")  = 2
+state(::SiteType"Fermion",::StateName"0")  = 1
+state(::SiteType"Fermion",::StateName"1")  = 2
 
 function op(::SiteType"Fermion",
             s::Index,

--- a/src/physics/site_types/fermion.jl
+++ b/src/physics/site_types/fermion.jl
@@ -53,11 +53,6 @@ function op(::SiteType"Fermion",
   return Op
 end
 
-function has_fermion_string(::SiteType"Fermion",
-            s::Index,
-            opname::AbstractString)::Bool
-  if opname=="C" || opname=="Cdag"
-    return true
-  end
-  return false
-end
+
+has_fermion_string(::SiteType"Fermion",::OpName"C") = true
+has_fermion_string(::SiteType"Fermion",::OpName"Cdag") = true

--- a/src/physics/site_types/fermion.jl
+++ b/src/physics/site_types/fermion.jl
@@ -17,8 +17,8 @@ end
 
 state(::SiteType"Fermion",::StateName"Emp")  = 1
 state(::SiteType"Fermion",::StateName"Occ")  = 2
-state(::SiteType"Fermion",::StateName"0")  = 1
-state(::SiteType"Fermion",::StateName"1")  = 2
+state(st::SiteType"Fermion",::StateName"0") = state(st,StateName("Emp"))
+state(st::SiteType"Fermion",::StateName"1") = state(st,StateName("Occ"))
 
 function op(::SiteType"Fermion",
             s::Index,

--- a/src/physics/site_types/spinhalf.jl
+++ b/src/physics/site_types/spinhalf.jl
@@ -11,8 +11,8 @@ end
 
 state(::SiteType"S=1/2",::StateName"Up") = 1
 state(::SiteType"S=1/2",::StateName"Dn") = 2
-state(::SiteType"S=1/2",::StateName"↑") = 1
-state(::SiteType"S=1/2",::StateName"↓") = 2
+state(st::SiteType"S=1/2",::StateName"↑") = state(st,StateName("Up"))
+state(st::SiteType"S=1/2",::StateName"↓") = state(st,StateName("Dn"))
 
 function op!(Op::ITensor,
              ::SiteType"S=1/2",

--- a/src/physics/site_types/spinhalf.jl
+++ b/src/physics/site_types/spinhalf.jl
@@ -8,21 +8,11 @@ function space(::SiteType"S=1/2"; kwargs...)
   return 2
 end
 
-space(::SiteType"SpinHalf"; kwargs...) = space(SiteType("S=1/2");kwargs...)
 
-function state(::SiteType"S=1/2",
-               st::AbstractString)
-  if st == "Up" || st == "↑"
-    return 1
-  elseif st == "Dn" || st == "↓"
-    return 2
-  end
-  throw(ArgumentError("State string \"$st\" not recognized for \"S=1/2\" site"))
-  return 0
-end
-
-state(::SiteType"SpinHalf",
-      st::AbstractString) = state(SiteType("S=1/2"),st)
+state(::SiteType"S=1/2",::StateName"Up") = 1
+state(::SiteType"S=1/2",::StateName"Dn") = 2
+state(::SiteType"S=1/2",::StateName"↑") = 1
+state(::SiteType"S=1/2",::StateName"↓") = 2
 
 function op!(Op::ITensor,
              ::SiteType"S=1/2",
@@ -103,6 +93,12 @@ end
 
 op!(Op::ITensor,t::SiteType"S=1/2",
     ::OpName"S²",s::Index) = op!(Op,t,OpName("S2"),s)
+
+
+# Support the tag "SpinHalf" as equivalent to "S=1/2"
+
+space(::SiteType"SpinHalf"; kwargs...) = space(SiteType("S=1/2");kwargs...)
+state(::SiteType"SpinHalf",n::StateName) = state(SiteType("S=1/2"),n)
 
 op!(Op::ITensor,
     ::SiteType"SpinHalf",

--- a/src/physics/site_types/spinone.jl
+++ b/src/physics/site_types/spinone.jl
@@ -11,9 +11,9 @@ end
 state(::SiteType"S=1",::StateName"Up") = 1
 state(::SiteType"S=1",::StateName"Z0") = 2
 state(::SiteType"S=1",::StateName"Dn") = 3
-state(::SiteType"S=1",::StateName"↑") = 1
-state(::SiteType"S=1",::StateName"0") = 2
-state(::SiteType"S=1",::StateName"↓") = 3
+state(st::SiteType"S=1",::StateName"↑") = state(st,StateName("Up"))
+state(st::SiteType"S=1",::StateName"0") = state(st,StateName("Z0"))
+state(st::SiteType"S=1",::StateName"↓") = state(st,StateName("Dn"))
 
 
 function op!(Op::ITensor,

--- a/src/physics/site_types/spinone.jl
+++ b/src/physics/site_types/spinone.jl
@@ -8,22 +8,13 @@ function space(::SiteType"S=1"; kwargs...)
   return 3
 end
 
-space(::SiteType"SpinOne"; kwargs...) = space(SiteType("S=1");kwargs...)
+state(::SiteType"S=1",::StateName"Up") = 1
+state(::SiteType"S=1",::StateName"Z0") = 2
+state(::SiteType"S=1",::StateName"Dn") = 3
+state(::SiteType"S=1",::StateName"↑") = 1
+state(::SiteType"S=1",::StateName"0") = 2
+state(::SiteType"S=1",::StateName"↓") = 3
 
-function state(::SiteType"S=1",
-               st::AbstractString)
-  if st == "Up" || st == "↑"
-    return 1
-  elseif st == "Z0" || st == "0"
-    return 2
-  elseif st == "Dn" || st == "↓"
-    return 3
-  end
-  throw(ArgumentError("State string \"$st\" not recognized for \"S=1\" site"))
-  return 0
-end
-
-state(::SiteType"SpinOne",st::AbstractString) = state(SiteType("S=1"),st)
 
 function op!(Op::ITensor,
              ::SiteType"S=1",
@@ -131,6 +122,9 @@ function op!(Op::ITensor,
   Op[s'=>1,s=>3] = -0.5
   Op[s'=>3,s=>3] = +0.5
 end
+
+space(::SiteType"SpinOne"; kwargs...) = space(SiteType("S=1");kwargs...)
+state(::SiteType"SpinOne",st::AbstractString) = state(SiteType("S=1"),st)
 
 op!(Op::ITensor,
     ::SiteType"SpinOne",

--- a/src/physics/site_types/tj.jl
+++ b/src/physics/site_types/tj.jl
@@ -26,18 +26,12 @@ function space(::SiteType"tJ"; kwargs...)
   return 3
 end
 
-function state(::SiteType"tJ",
-               st::AbstractString)
-  if st == "0" || st == "Emp"
-    return 1
-  elseif st == "Up" || st == "↑"
-    return 2
-  elseif st == "Dn" || st == "↓"
-    return 3
-  end
-  throw(ArgumentError("State string \"$st\" not recognized for tJ site"))
-  return 0
-end
+state(::SiteType"tJ",::StateName"Emp")  = 1
+state(::SiteType"tJ",::StateName"Up")   = 2
+state(::SiteType"tJ",::StateName"Dn")   = 3
+state(::SiteType"tJ",::StateName"0")    = 1
+state(::SiteType"tJ",::StateName"↑")    = 2
+state(::SiteType"tJ",::StateName"↓")    = 3
 
 function op(::SiteType"tJ",
             s::Index,

--- a/src/physics/site_types/tj.jl
+++ b/src/physics/site_types/tj.jl
@@ -29,9 +29,9 @@ end
 state(::SiteType"tJ",::StateName"Emp")  = 1
 state(::SiteType"tJ",::StateName"Up")   = 2
 state(::SiteType"tJ",::StateName"Dn")   = 3
-state(::SiteType"tJ",::StateName"0")    = 1
-state(::SiteType"tJ",::StateName"↑")    = 2
-state(::SiteType"tJ",::StateName"↓")    = 3
+state(st::SiteType"tJ",::StateName"0")    = state(st,StateName("Emp"))
+state(st::SiteType"tJ",::StateName"↑")    = state(st,StateName("Up"))
+state(st::SiteType"tJ",::StateName"↓")    = state(st,StateName("Dn"))
 
 function op(::SiteType"tJ",
             s::Index,
@@ -81,18 +81,6 @@ function op(::SiteType"tJ",
     Op[UpP, Dn] = 1.
   elseif opname == "S⁻" || opname == "Sminus"
     Op[DnP, Up] = 1.
-  elseif opname == "Emp" || opname == "0"
-    pEmp = emptyITensor(s)
-    pEmp[Emp] = 1.
-    return pEmp
-  elseif opname == "Up" || opname == "↑"
-    pU = emptyITensor(s)
-    pU[Up] = 1.
-    return pU
-  elseif opname == "Dn" || opname == "↓"
-    pD = emptyITensor(s)
-    pD[Dn] = 1.
-    return pD
   else
     throw(ArgumentError("Operator name '$opname' not recognized for \"tJ\" site"))
   end

--- a/src/physics/site_types/tj.jl
+++ b/src/physics/site_types/tj.jl
@@ -99,11 +99,7 @@ function op(::SiteType"tJ",
   return Op
 end
 
-function has_fermion_string(::SiteType"tJ",
-            s::Index,
-            opname::AbstractString)::Bool
-  if opname=="Cup" || opname=="Cdagup" || opname=="Cdn" || opname=="Cdagdn"
-    return true
-  end
-  return false
-end
+has_fermion_string(::SiteType"tJ",::OpName"Cup") = true
+has_fermion_string(::SiteType"tJ",::OpName"Cdagup") = true
+has_fermion_string(::SiteType"tJ",::OpName"Cdn") = true
+has_fermion_string(::SiteType"tJ",::OpName"Cdagdn") = true

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -307,24 +307,18 @@ end
 #
 #---------------------------------------
 
+has_fermion_string(::SiteType,::OpName) = nothing
+
 function has_fermion_string(s::Index,
                             opname::AbstractString;
                             kwargs...)::Bool
   opname = strip(opname)
-  use_tag = 0
-  nfound = 0
-  for n=1:length(tags(s))
-    SType = SiteType{tags(s)[n]}
-    if hasmethod(has_fermion_string,Tuple{SType,Index,AbstractString})
-      use_tag = n
-      nfound += 1
-    end
+  Ntags = length(tags(s))
+  stypes  = [SiteType(tags(s)[n]) for n in 1:Ntags]
+  opn = OpName(SmallString(opname))
+  for st in stypes
+    res = has_fermion_string(st,opn)
+    !isnothing(res) && return res
   end
-  if nfound == 0
-    return false
-  elseif nfound > 1
-    throw(ArgumentError("Multiple tags from $(tags(s)) overload the function \"has_fermion_string\""))
-  end
-  st = SiteType(tags(s)[use_tag])
-  return has_fermion_string(st,s,opname;kwargs...)
+  return false
 end

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -204,34 +204,47 @@ op(s::Vector{<:Index},
 #
 #---------------------------------------
 
-state(s::Index,n::Integer) = s[n]
+@eval struct StateName{Name}
+  (f::Type{<:StateName})() = $(Expr(:new, :f))
+end
+
+StateName(s::AbstractString) = StateName{SmallString(s)}()
+StateName(s::SmallString) = StateName{s}()
+name(::StateName{N}) where {N} = N
+
+macro StateName_str(s)
+  StateName{SmallString(s)}
+end
+
+state(::SiteType,::StateName) = nothing
+state(::SiteType,::AbstractString) = nothing
 
 function state(s::Index,
-               str::String)::IndexVal
-  use_tag = 0
-  nfound = 0
-  for n=1:length(tags(s))
-    SType = SiteType{tags(s)[n]}
-    if hasmethod(state,Tuple{SType,AbstractString})
-      use_tag = n
-      nfound += 1
-    end
+               name::AbstractString)::IndexVal
+  Ntags = max(1,length(tags(s))) # use max here in case of no tags
+                                 # because there may still be a
+                                 # generic case such as name=="Id"
+  stypes  = [SiteType(tags(s)[n]) for n in 1:Ntags]
+  sname = StateName(SmallString(name))
+
+  # Try calling state(::SiteType"Tag",::StateName"Name")
+  for st in stypes
+    res = state(st,sname)
+    !isnothing(res) && return s(res)
   end
-  if nfound == 0
-    throw(ArgumentError("Overload of \"state\" function not found for Index tags $(tags(s))"))
-  elseif nfound > 1
-    throw(ArgumentError("Multiple tags from $(tags(s)) overload the function \"state\""))
+
+  # Try calling state(::SiteType"Tag","Name")
+  for st in stypes
+    res = state(st,name)
+    !isnothing(res) && return s(res)
   end
-  st = SiteType(tags(s)[use_tag])
-  sn = state(st,str)
-  return s[sn]
+
+  throw(ArgumentError("Overload of \"state\" function not found for Index tags $(tags(s))"))
 end
 
-function state(sset::Vector{<:Index},
-               j::Integer,
-               st)::IndexVal
-  return state(sset[j],st)
-end
+state(s::Index,n::Integer) = s[n]
+
+state(sset::Vector{<:Index},j::Integer,st) = state(sset[j],st)
 
 #---------------------------------------
 #

--- a/test/phys_site_types.jl
+++ b/test/phys_site_types.jl
@@ -74,107 +74,123 @@ using ITensors,
   end
 
   @testset "Fermion sites" begin
-    s = siteinds("Fermion",N)
+    s = siteind("Fermion")
 
-    @test state(s[1],"0")   == s[1](1)
-    @test state(s[1],"1")   == s[1](2)
-    @test_throws ArgumentError state(s[1],"Fake")
+    @test state(s,"0")   == s(1)
+    @test state(s,"1")   == s(2)
+    @test_throws ArgumentError state(s,"Fake")
 
-    N5 = op(s,"N",5)
-    @test hasinds(N5,s[5]',s[5])
+    N = op(s,"N")
+    @test hasinds(N,s',s)
      
-    @test_throws ArgumentError op(s, "Fake", 2)
-    N3 = Array(op(s,"N",3),s[3]',s[3]) 
-    @test N3 ≈ [0. 0; 0 1]
-    C3 = Array(op(s,"C",3),s[3]',s[3]) 
-    @test C3 ≈ [0. 1; 0 0]
-    Cdag3 = Array(op(s,"Cdag",3),s[3]',s[3]) 
-    @test Cdag3 ≈ [0. 0; 1 0]
-    F3 = Array(op(s,"F",3),s[3]',s[3]) 
-    @test F3 ≈ [1. 0; 0 -1]
+    @test_throws ArgumentError op(s, "Fake")
+    N = Array(op(s,"N"),s',s) 
+    @test N ≈ [0. 0; 0 1]
+    C = Array(op(s,"C"),s',s) 
+    @test C ≈ [0. 1; 0 0]
+    Cdag = Array(op(s,"Cdag"),s',s) 
+    @test Cdag ≈ [0. 0; 1 0]
+    F = Array(op(s,"F"),s',s) 
+    @test F ≈ [1. 0; 0 -1]
+
+    @test has_fermion_string(s,"C")
+    @test has_fermion_string(s,"Cdag")
+    @test !has_fermion_string(s,"N")
   end
 
   @testset "Electron sites" begin
-    s = siteinds("Electron",N)
+    s = siteind("Electron")
 
-    @test state(s[1],"0")    == s[1](1)
-    @test state(s[1],"Up")   == s[1](2)
-    @test state(s[1],"Dn")   == s[1](3)
-    @test state(s[1],"UpDn") == s[1](4)
-    @test_throws ArgumentError state(s[1],"Fake")
+    @test state(s,"0")    == s(1)
+    @test state(s,"Up")   == s(2)
+    @test state(s,"Dn")   == s(3)
+    @test state(s,"UpDn") == s(4)
+    @test_throws ArgumentError state(s,"Fake")
 
-    Nup5 = op(s,"Nup",5)
-    @test hasinds(Nup5,s[5]',s[5])
+    Nup = op(s,"Nup")
+    @test hasinds(Nup,s',s)
      
-    @test_throws ArgumentError op(s, "Fake", 2)
-    Nup3 = Array(op(s,"Nup",3),s[3]',s[3]) 
-    @test Nup3 ≈ [0. 0 0 0; 0 1 0 0; 0 0 0 0; 0 0 0 1]
-    Ndn3 = Array(op(s,"Ndn",3),s[3]',s[3]) 
-    @test Ndn3 ≈ [0. 0 0 0; 0 0 0 0; 0 0 1 0; 0 0 0 1]
-    Ntot3 = Array(op(s,"Ntot",3),s[3]',s[3]) 
-    @test Ntot3 ≈ [0. 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 2]
-    Cup3 = Array(op(s,"Cup",3),s[3]',s[3]) 
-    @test Cup3 ≈ [0. 1 0 0; 0 0 0 0; 0 0 0 1; 0 0 0 0]
-    Cdagup3 = Array(op(s,"Cdagup",3),s[3]',s[3]) 
-    @test Cdagup3 ≈ [0. 0 0 0; 1 0 0 0; 0 0 0 0; 0 0 1 0]
-    Cdn3 = Array(op(s,"Cdn",3),s[3]',s[3]) 
-    @test Cdn3 ≈ [0. 0 1 0; 0 0 0 -1; 0 0 0 0; 0 0 0 0]
-    Cdagdn3 = Array(op(s,"Cdagdn",3),s[3]',s[3]) 
-    @test Cdagdn3 ≈ [0. 0 0 0; 0 0 0 0; 1 0 0 0; 0 -1 0 0]
-    F3 = Array(op(s,"F",3),s[3]',s[3]) 
-    @test F3 ≈ [1. 0 0 0; 0 -1 0 0; 0 0 -1 0; 0 0 0 1]
-    Fup3 = Array(op(s,"Fup",3),s[3]',s[3]) 
-    @test Fup3 ≈ [1. 0 0 0; 0 -1 0 0; 0 0 1 0; 0 0 0 -1]
-    Fdn3 = Array(op(s,"Fdn",3),s[3]',s[3]) 
+    @test_throws ArgumentError op(s, "Fake")
+    Nup = Array(op(s,"Nup"),s',s) 
+    @test Nup ≈ [0. 0 0 0; 0 1 0 0; 0 0 0 0; 0 0 0 1]
+    Ndn = Array(op(s,"Ndn"),s',s) 
+    @test Ndn ≈ [0. 0 0 0; 0 0 0 0; 0 0 1 0; 0 0 0 1]
+    Ntot = Array(op(s,"Ntot"),s',s) 
+    @test Ntot ≈ [0. 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 2]
+    Cup = Array(op(s,"Cup"),s',s) 
+    @test Cup ≈ [0. 1 0 0; 0 0 0 0; 0 0 0 1; 0 0 0 0]
+    Cdagup = Array(op(s,"Cdagup"),s',s) 
+    @test Cdagup ≈ [0. 0 0 0; 1 0 0 0; 0 0 0 0; 0 0 1 0]
+    Cdn = Array(op(s,"Cdn"),s',s) 
+    @test Cdn ≈ [0. 0 1 0; 0 0 0 -1; 0 0 0 0; 0 0 0 0]
+    Cdagdn = Array(op(s,"Cdagdn"),s',s) 
+    @test Cdagdn ≈ [0. 0 0 0; 0 0 0 0; 1 0 0 0; 0 -1 0 0]
+    F = Array(op(s,"F"),s',s) 
+    @test F ≈ [1. 0 0 0; 0 -1 0 0; 0 0 -1 0; 0 0 0 1]
+    Fup = Array(op(s,"Fup"),s',s) 
+    @test Fup ≈ [1. 0 0 0; 0 -1 0 0; 0 0 1 0; 0 0 0 -1]
+    Fdn3 = Array(op(s,"Fdn"),s',s) 
     @test Fdn3 ≈ [1. 0 0 0; 0 1 0 0; 0 0 -1 0; 0 0 0 -1]
-    Sz3 = Array(op(s,"Sz",3),s[3]',s[3]) 
+    Sz3 = Array(op(s,"Sz"),s',s) 
     @test Sz3 ≈ [0. 0 0 0; 0 0.5 0 0; 0 0 -0.5 0; 0 0 0 0]
-    Sx3 = Array(op(s,"Sx",3),s[3]',s[3]) 
+    Sx3 = Array(op(s,"Sx"),s',s) 
     @test Sx3 ≈ [0. 0 0 0; 0 0 0.5 0; 0 0.5 0 0; 0 0 0 0]
-    Sp3 = Array(op(s,"S+",3),s[3]',s[3]) 
+    Sp3 = Array(op(s,"S+"),s',s) 
     @test Sp3 ≈ [0. 0 0 0; 0 0 1 0; 0 0 0 0; 0 0 0 0]
-    Sm3 = Array(op(s,"S-",3),s[3]',s[3]) 
+    Sm3 = Array(op(s,"S-"),s',s) 
     @test Sm3 ≈ [0. 0 0 0; 0 0 0 0; 0 1 0 0; 0 0 0 0]
+
+    @test has_fermion_string(s,"Cup")
+    @test has_fermion_string(s,"Cdagup")
+    @test has_fermion_string(s,"Cdn")
+    @test has_fermion_string(s,"Cdagdn")
+    @test !has_fermion_string(s,"N")
   end
 
   @testset "tJ sites" begin
-    s = siteinds("tJ",N)
+    s = siteind("tJ")
 
-    @test state(s[1],"0")    == s[1](1)
-    @test state(s[1],"Up")   == s[1](2)
-    @test state(s[1],"Dn")   == s[1](3)
-    @test_throws ArgumentError state(s[1],"Fake")
+    @test state(s,"0")    == s(1)
+    @test state(s,"Up")   == s(2)
+    @test state(s,"Dn")   == s(3)
+    @test_throws ArgumentError state(s,"Fake")
 
-    @test_throws ArgumentError op(s, "Fake", 2)
-    Nup_2 = op(s,"Nup",2)
-    @test Nup_2[2,2] ≈ 1.0
-    Ndn_2 = op(s,"Ndn",2)
-    @test Ndn_2[3,3] ≈ 1.0
-    Ntot_2 = op(s,"Ntot",2)
-    @test Ntot_2[2,2] ≈ 1.0
-    @test Ntot_2[3,3] ≈ 1.0
-    Cup3 = Array(op(s,"Cup",3),s[3]',s[3]) 
-    @test Cup3 ≈ [0. 1 0; 0 0 0; 0 0 0]
-    Cdup3 = Array(op(s,"Cdagup",3),s[3]',s[3]) 
-    @test Cdup3 ≈ [0 0 0; 1. 0 0; 0 0 0]
-    Cdn3 = Array(op(s,"Cdn",3),s[3]',s[3]) 
-    @test Cdn3 ≈ [0. 0. 1; 0 0 0; 0 0 0]
-    Cddn3 = Array(op(s,"Cdagdn",3),s[3]',s[3]) 
-    @test Cddn3 ≈ [0 0 0; 0. 0 0; 1 0 0]
-    FP3 = Array(op(s,"FP",3),s[3]',s[3]) 
-    @test FP3 ≈ [1.0 0. 0; 0 -1.0 0; 0 0 -1.0]
-    Fup3 = Array(op(s,"Fup",3),s[3]',s[3]) 
-    @test Fup3 ≈ [1.0 0. 0; 0 -1.0 0; 0 0 1.0]
-    Fdn3 = Array(op(s,"Fdn",3),s[3]',s[3]) 
-    @test Fdn3 ≈ [1.0 0. 0; 0 1.0 0; 0 0 -1.0]
-    Sz3 = Array(op(s,"Sz",3),s[3]',s[3]) 
-    @test Sz3 ≈ [0.0 0. 0; 0 0.5 0; 0 0 -0.5]
-    Sx3 = Array(op(s,"Sx",3),s[3]',s[3]) 
-    @test Sx3 ≈ [0.0 0. 0; 0 0 1; 0 1 0]
-    Sp3 = Array(op(s,"Splus",3),s[3]',s[3]) 
-    @test Sp3 ≈ [0.0 0. 0; 0 0 1.0; 0 0 0]
-    Sm3 = Array(op(s,"Sminus",3),s[3]',s[3]) 
-    @test Sm3 ≈ [0.0 0. 0; 0 0 0; 0 1.0 0]
+    @test_throws ArgumentError op(s, "Fake")
+    Nup = op(s,"Nup")
+    @test Nup[2,2] ≈ 1.0
+    Ndn = op(s,"Ndn")
+    @test Ndn[3,3] ≈ 1.0
+    Ntot = op(s,"Ntot")
+    @test Ntot[2,2] ≈ 1.0
+    @test Ntot[3,3] ≈ 1.0
+    Cup = Array(op(s,"Cup"),s',s) 
+    @test Cup ≈ [0. 1 0; 0 0 0; 0 0 0]
+    Cdup = Array(op(s,"Cdagup"),s',s) 
+    @test Cdup ≈ [0 0 0; 1. 0 0; 0 0 0]
+    Cdn = Array(op(s,"Cdn"),s',s) 
+    @test Cdn ≈ [0. 0. 1; 0 0 0; 0 0 0]
+    Cddn = Array(op(s,"Cdagdn"),s',s) 
+    @test Cddn ≈ [0 0 0; 0. 0 0; 1 0 0]
+    FP = Array(op(s,"FP"),s',s) 
+    @test FP ≈ [1.0 0. 0; 0 -1.0 0; 0 0 -1.0]
+    Fup = Array(op(s,"Fup"),s',s) 
+    @test Fup ≈ [1.0 0. 0; 0 -1.0 0; 0 0 1.0]
+    Fdn = Array(op(s,"Fdn"),s',s) 
+    @test Fdn ≈ [1.0 0. 0; 0 1.0 0; 0 0 -1.0]
+    Sz = Array(op(s,"Sz"),s',s) 
+    @test Sz ≈ [0.0 0. 0; 0 0.5 0; 0 0 -0.5]
+    Sx = Array(op(s,"Sx"),s',s) 
+    @test Sx ≈ [0.0 0. 0; 0 0 1; 0 1 0]
+    Sp = Array(op(s,"Splus"),s',s) 
+    @test Sp ≈ [0.0 0. 0; 0 0 1.0; 0 0 0]
+    Sm = Array(op(s,"Sminus"),s',s) 
+    @test Sm ≈ [0.0 0. 0; 0 0 0; 0 1.0 0]
+
+    @test has_fermion_string(s,"Cup")
+    @test has_fermion_string(s,"Cdagup")
+    @test has_fermion_string(s,"Cdn")
+    @test has_fermion_string(s,"Cdagdn")
+    @test !has_fermion_string(s,"N")
   end
 
 end


### PR DESCRIPTION
This PR updates the `state(::SiteType,...)` system to use a new type `StateName"Name"`
to allow the system to be user-extensible and offer automatic error handling, etc. 
It falls back to the older system for backwards compatibility.

This PR also updates the `has_fermion_string` system used by AutoMPO to use `OpName`
for similar reasons.

- Redesign of `state` system to use StateName type
- Update physics site types to use StateName overloads
- Update has_fermion_string system to use OpName
