### PR TITLE
Fix some issues with precompile_itensors.jl code

### DIFF
--- a/src/packagecompile/precompile_itensors.jl
+++ b/src/packagecompile/precompile_itensors.jl
@@ -35,8 +35,7 @@ for j=1:N-1
     ampo .+= (0.5,"S-",j,"S+",j+1)
 end
 H = MPO(ampo,sites)
-state = [isodd(n) ? "Up" : "Dn" for n=1:N]
-psi0 = randomMPS(sites,state,2)
+psi0 = randomMPS(sites,[isodd(n) ? "Up" : "Dn" for n=1:N],2)
 sweeps = Sweeps(1)
 maxdim!(sweeps, 10)
 cutoff!(sweeps, 1E-13)

--- a/src/packagecompile/precompile_itensors.jl
+++ b/src/packagecompile/precompile_itensors.jl
@@ -13,9 +13,9 @@ N = 6
 sites = siteinds("S=1",N)
 ampo = AutoMPO()
 for j=1:N-1
-    ampo .+= ("Sz",j,"Sz",j+1)
-    ampo .+= (0.5,"S+",j,"S-",j+1)
-    ampo .+= (0.5,"S-",j,"S+",j+1)
+    ampo .+= "Sz",j,"Sz",j+1
+    ampo .+= 0.5,"S+",j,"S-",j+1
+    ampo .+= 0.5,"S-",j,"S+",j+1
 end
 H = MPO(ampo,sites)
 psi0 = randomMPS(sites,2)
@@ -24,7 +24,10 @@ maxdim!(sweeps, 10)
 cutoff!(sweeps, 1E-13)
 energy, psi = dmrg(H,psi0, sweeps)
 
-sites = siteinds("S=1", N; conserve_qns = true)
+sites = siteinds("S=1", N; conserve_qns=true)
+if !hasqns(sites[1])
+  throw(ErrorException("Index does not have QNs in part of precompile script"))
+end
 ampo = AutoMPO()
 for j=1:N-1
     ampo .+= ("Sz",j,"Sz",j+1)

--- a/src/packagecompile/precompile_itensors.jl
+++ b/src/packagecompile/precompile_itensors.jl
@@ -9,7 +9,7 @@ using ITensors
 #                           test"),
 #                  "runtests.jl"))
 
-N = 10
+N = 6
 sites = siteinds("S=1",N)
 ampo = AutoMPO()
 for j=1:N-1
@@ -18,13 +18,13 @@ for j=1:N-1
     ampo .+= (0.5,"S-",j,"S+",j+1)
 end
 H = MPO(ampo,sites)
-psi0 = randomMPS(sites,10)
-sweeps = Sweeps(5)
-maxdim!(sweeps, 10,20,100,100,200)
-cutoff!(sweeps, 1E-11)
+psi0 = randomMPS(sites,2)
+sweeps = Sweeps(1)
+maxdim!(sweeps, 10)
+cutoff!(sweeps, 1E-13)
 energy, psi = dmrg(H,psi0, sweeps)
 
-sites = siteinds("S=1", N; conserveqns = true)
+sites = siteinds("S=1", N; conserve_qns = true)
 ampo = AutoMPO()
 for j=1:N-1
     ampo .+= ("Sz",j,"Sz",j+1)
@@ -32,8 +32,9 @@ for j=1:N-1
     ampo .+= (0.5,"S-",j,"S+",j+1)
 end
 H = MPO(ampo,sites)
-psi0 = randomMPS(sites,10)
-sweeps = Sweeps(5)
-maxdim!(sweeps, 10,20,100,100,200)
-cutoff!(sweeps, 1E-11)
+state = [isodd(n) ? "Up" : "Dn" for n=1:N]
+psi0 = randomMPS(sites,state,2)
+sweeps = Sweeps(1)
+maxdim!(sweeps, 10)
+cutoff!(sweeps, 1E-13)
 energy, psi = dmrg(H,psi0, sweeps)

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -20,6 +20,14 @@ using ITensors,
     end
   end
 
+  @testset "Package Compile Code" begin
+    @test_nowarn begin 
+      @capture_out begin
+        include("../src/packagecompile/precompile_itensors.jl")
+      end 
+    end
+  end
+
 end
 
 nothing


### PR DESCRIPTION
The ITensors.compile() command was failing due to some incorrect code usage in the QN part of the precompile_itensors.jl file. This PR updates that code to restore ITensors.compile() to working.
