### PR TITLE
Try to fix documentation building for tags

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.documenter }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,4 +20,5 @@ jobs:
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.documenter }}
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
Documenter has not been building/deploying the docs for the latest tags (as of now it hasn't built any since v1.1.10). I believe it is caused by this problem: https://github.com/JuliaDocs/Documenter.jl/issues/1177 since we are only using the `GITHUB_TOKEN` for authentication. 

I'm trying to follow the documenter docs here: https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#GitHub-Actions to use SSH authentication for both Documenter and TagBot.