### PR TITLE
Add pair syntax to mapprime, replacetags, and replaceinds

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -306,7 +306,8 @@ specified tags added to the existing ones.
 The `ts` argument can be a comma-separated 
 string of tags or a TagSet.
 """
-addtags(i::Index, ts) = settags(i, addtags(tags(i), ts))
+addtags(i::Index, ts) =
+  settags(i, addtags(tags(i), ts))
 
 """
     removetags(i::Index, ts)
@@ -315,20 +316,36 @@ Return a copy of Index `i` with the
 specified tags removed. The `ts` argument
 can be a comma-separated string of tags or a TagSet.
 """
-removetags(i::Index, ts) = settags(i, removetags(tags(i), ts))
+removetags(i::Index, ts) =
+  settags(i, removetags(tags(i), ts))
 
 """
     replacetags(i::Index, tsold, tsnew)
+
+    replacetags(i::Index, tsold => tsnew)
 
 If the tag set of `i` contains the tags specified by `tsold`,
 replaces these with the tags specified by `tsnew`, preserving
 any other tags. The arguments `tsold` and `tsnew` can be
 comma-separated strings of tags, or TagSet objects.
+
+# Examples
+```jldoctest; filter=r"id=[0-9]{1,3}"
+julia> i = Index(2; tags = "l,x", plev = 1)
+(dim=2|id=83|"l,x")'
+
+julia> replacetags(i, "l", "m")
+(dim=2|id=83|"m,x")'
+
+julia> replacetags(i, "l" => "m")
+(dim=2|id=83|"m,x")'
+```
 """
-replacetags(i::Index,
-            tsold,
-            tsnew) = settags(i,
-                             replacetags(tags(i), tsold, tsnew))
+replacetags(i::Index, tsold, tsnew) =
+  settags(i, replacetags(tags(i), tsold, tsnew))
+
+replacetags(i::Index, rep_ts::Pair) =
+  replacetags(i, rep_ts...)
 
 """
     prime(i::Index, plinc::Int = 1)

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -406,7 +406,10 @@ fmatch(id::IDType) = hasid(id)
 
 fmatch(n::Not) = !fmatch(parent(n))
 
-fmatch(::Nothing) = _ -> true
+# Function that always returns true
+ftrue() = true
+
+fmatch(::Nothing) = ftrue
 
 """
     ITensors.fmatch(; tags=nothing,
@@ -689,6 +692,25 @@ mapprime(is::IndexSet,
          args...; kwargs...) = mapprime(fmatch(args...; kwargs...),
                                         is, pl1, pl2)
 
+function _mapprime(i::Index,
+                   rep_pls::Pair{Int, Int}...)
+  for (pl1, pl2) in rep_pls
+    hasplev(i, pl1) && return setprime(i, pl2)
+  end
+  return i
+end
+
+function mapprime(f::Function,
+                  is::IndexSet,
+                  rep_pls::Pair{Int, Int}...)
+  return map(i -> f(i) ? _mapprime(i, rep_pls...) : i, is)
+end
+
+mapprime(is::IndexSet,
+         rep_pls::Pair{Int, Int}...;
+         kwargs...) = mapprime(fmatch(; kwargs...),
+                               is, rep_pls...)
+
 function addtags(f::Function,
                  is::IndexSet,
                  args...)
@@ -724,11 +746,15 @@ removetags(is::IndexSet,
            kwargs...) = removetags(fmatch(args...; kwargs...),
                                    is, tags)
 
-function replacetags(f::Function,
-                     is::IndexSet,
-                     args...)
-  return map(i -> f(i) ? replacetags(i, args...) : i, is)
-end
+replacetags(f::Function,
+            is::IndexSet,
+            args...) =
+  map(i -> f(i) ? replacetags(i, args...) : i, is)
+
+replacetags(f::Function,
+            is::IndexSet,
+            rep_ts::Pair) =
+  map(i -> f(i) ? replacetags(i, rep_ts) : i, is)
 
 replacetags(is::IndexSet,
             tags1,
@@ -736,6 +762,11 @@ replacetags(is::IndexSet,
             args...;
             kwargs...) = replacetags(fmatch(args...; kwargs...),
                                      is, tags1, tags2)
+
+replacetags(is::IndexSet,
+            rep_ts::Pair;
+            kwargs...) = replacetags(fmatch(; kwargs...),
+                                     is, rep_ts)
 
 function _swaptags(f::Function,
                    i::Index,
@@ -766,10 +797,14 @@ swaptags(is::IndexSet,
          kwargs...) = swaptags(fmatch(args...; kwargs...),
                                is, tags1, tags2)
 
+replaceinds(is::IndexSet, rep_inds::Pair{ <: Index, <: Index}...) =
+  replaceinds(is, zip(rep_inds...)...)
+
 function replaceinds(is::IndexSet, inds1, inds2)
   is1 = IndexSet(inds1)
   poss = indexin(is1, is)
   for (j, pos) in enumerate(poss)
+    isnothing(pos) && continue
     i1 = is[pos]
     i2 = inds2[j]
     space(i1) != space(i2) && error("Indices must have the same spaces to be replaced")
@@ -780,6 +815,8 @@ function replaceinds(is::IndexSet, inds1, inds2)
 end
 
 replaceind(is::IndexSet, i1::Index, i2::Index) = replaceinds(is, (i1,), (i2,))
+
+replaceind(is::IndexSet, rep_i::Pair{ <: Index, <: Index}) = replaceinds(is, rep_i)
 
 function swapinds(is::IndexSet, inds1, inds2)
   return replaceinds(is, (inds1..., inds2...), (inds2..., inds1...))

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -573,11 +573,17 @@ end
     @test hasinds(A2r,s2,ltmp',l'')
   end
   @testset "replacetags(::ITensor,::String,::String)" begin
-    s2tmp = replacetags(s2,"Site","Temp")
-    ltmp = replacetags(l,"Link","Temp")
+    s2tmp = replacetags(s2, "Site", "Temp")
 
-    A2r = replacetags(A2,"Site","Temp")
+    @test s2tmp == replacetags(s2, "Site" => "Temp")
+
+    ltmp = replacetags(l, "Link", "Temp")
+
+    A2r = replacetags(A2, "Site", "Temp")
     @test hasinds(A2r,s2tmp,l',l'')
+
+    A2r = replacetags(A2, "Site" => "Temp")
+    @test hasinds(A2r, s2tmp, l', l'')
 
     A2r = replacetags(A2,"Link","Temp")
     @test hasinds(A2r,s2,ltmp',ltmp'')
@@ -599,10 +605,20 @@ end
     @test hasinds(mapprime(A2,1,7),s2,l^7,l'')
     @test hasinds(mapprime(A2,0,1),s2',l',l'')
   end
-  @testset "setprime" begin
-    @test hasinds(setprime(A2,2,s2),s2'',l',l'')
-    @test hasinds(setprime(A2,0,l''),s2,l',l)
+
+  @testset "replaceprime" begin
+    @test hasinds(mapprime(A2, 1 => 7), s2, l^7, l'')
+    @test hasinds(mapprime(A2, 0 => 1), s2', l', l'')
+    @test hasinds(mapprime(A2, 1 => 7, 0 => 1), s2', l^7, l'')
+    @test hasinds(mapprime(A2, 1 => 2, 2 => 1), s2, l'', l')
+    @test hasinds(mapprime(A2, 1 => 0, 0 => 1), s2', l, l'')
   end
+
+  @testset "setprime" begin
+    @test hasinds(setprime(A2,2,s2), s2'', l', l'')
+    @test hasinds(setprime(A2,0,l''), s2, l', l)
+  end
+
   @testset "swapprime" begin
     @test hasinds(swapprime(A2,1,3),l''',s2,l'')
   end
@@ -610,11 +626,11 @@ end
 
 @testset "ITensor other index operations" begin
 
-  s1 = Index(2,"Site,s=1")
-  s2 = Index(2,"Site,s=2")
-  l = Index(3,"Link")
-  A1 = randomITensor(s1,l,l')
-  A2 = randomITensor(s2,l',l'')
+  s1 = Index(2, "Site,s=1")
+  s2 = Index(2, "Site,s=2")
+  l = Index(3, "Link")
+  A1 = randomITensor(s1, l, l')
+  A2 = randomITensor(s2, l', l'')
 
   @testset "ind(::ITensor)" begin
     @test ind(A1, 1) == s1
@@ -622,19 +638,34 @@ end
   end
 
   @testset "replaceind and replaceinds" begin
-    rA1 = replaceind(A1,s1,s2)
-    @test hasinds(rA1,s2,l,l')
-    @test hasinds(A1,s1,l,l')
+    rA1 = replaceind(A1, s1, s2)
+    @test hasinds(rA1, s2, l, l')
+    @test hasinds(A1, s1, l, l')
 
-    replaceind!(A1,s1,s2)
-    @test hasinds(A1,s2,l,l')
+    # Pair notation (like Julia's replace function)
+    rA1 = replaceind(A1, s1 => s2)
+    @test hasinds(rA1, s2, l, l')
+    @test hasinds(A1, s1, l, l')
 
-    rA2 = replaceinds(A2,(s2,l'),(s1,l))
-    @test hasinds(rA2,s1,l,l'')
-    @test hasinds(A2,s2,l',l'')
+    replaceind!(A1, s1, s2)
+    @test hasinds(A1, s2, l, l')
 
-    replaceinds!(A2,(s2,l'),(s1,l))
-    @test hasinds(A2,s1,l,l'')
+    rA2 = replaceinds(A2, (s2, l'), (s1, l))
+    @test hasinds(rA2, s1, l, l'')
+    @test hasinds(A2, s2, l', l'')
+
+    # Pair notation (like Julia's replace function)
+    rA2 = replaceinds(A2, s2 => s1, l' => l)
+    @test hassameinds(rA2, (s1, l, l''))
+    @test hassameinds(A2, (s2, l', l''))
+
+    # Test ignoring indices that don't exist
+    rA2 = replaceinds(A2, s1 => l, l' => l)
+    @test hassameinds(rA2, (s2, l, l''))
+    @test hassameinds(A2, (s2, l', l''))
+
+    replaceinds!(A2, (s2, l'), (s1, l))
+    @test hasinds(A2, s1, l, l'')
   end
 
   @testset "replaceinds fixed errors" begin

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -587,6 +587,11 @@ end
 
     A2r = replacetags(A2,"Link","Temp")
     @test hasinds(A2r,s2,ltmp',ltmp'')
+
+    A2r = replacetags(A2, "Site" => "Link", "Link" => "Site")
+    @test hasinds(A2r, replacetags(s2, "Site" => "Link"),
+                       replacetags(l', "Link" => "Site"),
+                       replacetags(l'', "Link" => "Site"))
   end
   @testset "prime(::ITensor,::String)" begin
     A2p = prime(A2)


### PR DESCRIPTION
This implements #451. It adds `Pair` syntax to `mapprime`, `replacetags`, and `replaceinds`. For example:
```julia
i = Index(2, "i")
j = Index(2, "j")
A = randomITensor(i, j')
mapprime(A, 0 => 1)
replacetags(A, "i" => "k")
replaceinds(A, i => i')
```
What is cool about this syntax (and adding support for multiple inputs) is that it adds an alternative syntax for `swapprime`, `swaptags`, and `swapinds`, i.e.:
```julia
mapprime(A, 0 => 1, 1 => 0) == swapprime(A, 0, 1)
replacetags(A, "i" => "j", "j" => "i") == swaptags(A, "i", "j")
replaceinds(A, i => j', j' => i) == swapinds(A, i, j')
```