### PR TITLE
Make map for MPS reset the orthogonality limits

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -179,6 +179,7 @@ export
   # Methods
   error_contract,
   maxlinkdim,
+  orthogonalize,
   orthogonalize!,
   randomMPO,
   truncate!,

--- a/src/physics/site_types/spinhalf.jl
+++ b/src/physics/site_types/spinhalf.jl
@@ -121,11 +121,21 @@ op!(Op::ITensor,
 
 space(::SiteType"SpinHalf"; kwargs...) =
   space(SiteType("S=1/2"); kwargs...)
+
 state(::SiteType"SpinHalf", n::StateName) =
   state(SiteType("S=1/2"), n)
 
-op!(Op::ITensor,
-    o::OpName,
-    ::SiteType"SpinHalf",
-    s::Index) = op!(Op, o, SiteType("S=1/2"), s)
+op!(Op::ITensor, o::OpName, ::SiteType"SpinHalf", s::Index...) =
+  op!(Op, o, SiteType("S=1/2"), s...)
+
+# Support the tag "S=½" as equivalent to "S=1/2"
+
+space(::SiteType"S=½"; kwargs...) =
+  space(SiteType("S=1/2"); kwargs...)
+
+state(::SiteType"S=½", n::StateName) =
+  state(SiteType("S=1/2"), n)
+
+op!(Op::ITensor, o::OpName, ::SiteType"S=½", s::Index...) =
+  op!(Op, o, SiteType("S=1/2"), s...)
 

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -481,6 +481,40 @@ end
     @test maxlinkdim(ψ) == 1
   end
 
+  @testset "map!" begin
+    N = 5
+    s = siteinds("S=½", N)
+    M0 = productMPS(s, "↑")
+
+    # Test map! with limits getting set
+    M = orthogonalize(M0, 1)
+    @test ITensors.leftlim(M) == 0
+    @test ITensors.rightlim(M) == 2
+    map!(prime, M)
+    @test ITensors.leftlim(M) == 0
+    @test ITensors.rightlim(M) == N+1
+
+    # Test map! without limits getting set
+    M = orthogonalize(M0, 1)
+    map!(prime, M, set_limits = false)
+    @test ITensors.leftlim(M) == 0
+    @test ITensors.rightlim(M) == 2
+
+    # Test prime! with limits getting set
+    M = orthogonalize(M0, 1)
+    @test ITensors.leftlim(M) == 0
+    @test ITensors.rightlim(M) == 2
+    prime!(M, set_limits = true)
+    @test ITensors.leftlim(M) == 0
+    @test ITensors.rightlim(M) == N+1
+
+    # Test prime! without limits getting set
+    M = orthogonalize(M0, 1)
+    prime!(M)
+    @test ITensors.leftlim(M) == 0
+    @test ITensors.rightlim(M) == 2
+  end
+
 end
 
 nothing


### PR DESCRIPTION
* Makes map and map! reset the orthogonality limits by default.

* Add keyword argument set_limits to map and map! to let users turn
on and off setting the orthogonality limits (so it can be turned
off for cases like priming).

* Add orthogonalize, an out-of-place version of orthogonalize!.

* Add SiteType"S=\1/2" as an alias for SiteType"S=1/2".