### PR TITLE
Add macros for warn ITensor order

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -19,10 +19,13 @@ export
   svd,
 
 # global_variables.jl
-  disable_warn_itensor_order!,
-  get_warn_itensor_order,
-  set_warn_itensor_order!,
-  reset_warn_itensor_order!,
+  disable_warn_order!,
+  get_warn_order,
+  set_warn_order!,
+  reset_warn_order!,
+  @disable_warn_order,
+  @reset_warn_order,
+  @set_warn_order,
 
 # index.jl
   # Types

--- a/src/global_variables.jl
+++ b/src/global_variables.jl
@@ -1,21 +1,21 @@
 
-const default_warn_itensor_order = 14
+const default_warn_order = 14
 
-const warn_itensor_order =
-  Ref{Union{Int, Nothing}}(default_warn_itensor_order)
+const warn_order =
+  Ref{Union{Int, Nothing}}(default_warn_order)
 
 """
-    get_warn_itensor_order()
+    get_warn_order()
 
 Return the threshold for the order of an ITensor above which 
 ITensors will emit a warning.
 
-You can set the threshold with the function `set_warn_itensor_order!(N::Int)`.
+You can set the threshold with the function `set_warn_order!(N::Int)`.
 """
-get_warn_itensor_order() = warn_itensor_order[]
+get_warn_order() = warn_order[]
 
 """
-    set_warn_itensor_order!(N::Int)
+    set_warn_order!(N::Int)
 
 After this is called, ITensor will warn about ITensor contractions
 that result in ITensors above the order `N`.
@@ -23,30 +23,30 @@ that result in ITensors above the order `N`.
 This function returns the initial warning threshold (what it was
 set to before this function was called).
 
-You can get the current threshold with the function `get_warn_itensor_order(N::Int)`. You can reset to the default value with
-`reset_warn_itensor_order!()`.
+You can get the current threshold with the function `get_warn_order(N::Int)`. You can reset to the default value with
+`reset_warn_order!()`.
 """
-function set_warn_itensor_order!(N::Union{Int, Nothing})
-  N_init = get_warn_itensor_order()
-  warn_itensor_order[] = N
+function set_warn_order!(N::Union{Int, Nothing})
+  N_init = get_warn_order()
+  warn_order[] = N
   return N_init
 end
 
 """
-    reset_warn_itensor_order!()
+    reset_warn_order!()
 
 After this is called, ITensor will warn about ITensor contractions
 that result in ITensors above the default order 
-$default_warn_itensor_order.
+$default_warn_order.
 
 This function returns the initial warning threshold (what it was
 set to before this function was called).
 """
-reset_warn_itensor_order!() =
-  set_warn_itensor_order!(default_warn_itensor_order)
+reset_warn_order!() =
+  set_warn_order!(default_warn_order)
 
 """
-    disable_warn_itensor_order!()
+    disable_warn_order!()
 
 After this is called, ITensor will not warn about ITensor
 contractions that result in large ITensor orders.
@@ -54,8 +54,73 @@ contractions that result in large ITensor orders.
 This function returns the initial warning threshold (what it was
 set to before this function was called).
 """
-disable_warn_itensor_order!() =
-  set_warn_itensor_order!(nothing)
+disable_warn_order!() =
+  set_warn_order!(nothing)
+
+"""
+    @disable_warn_order
+
+Disable warning about the ITensor order in a block of code.
+
+# Examples
+```julia
+@disable_warn_order begin
+  A * B
+end
+```
+"""
+macro disable_warn_order(block)
+  quote
+    old_order = disable_warn_order!()
+    r = $(esc(block))
+    set_warn_order!(old_order)
+    return r
+  end
+end
+
+"""
+    @set_warn_order
+
+Temporarily set the order threshold for warning about the ITensor
+order in a block of code.
+
+# Examples
+```julia
+@set_warn_order 12 begin
+  A * B
+end
+```
+"""
+macro set_warn_order(new_order, block)
+  quote
+    old_order = set_warn_order!($(esc(new_order)))
+    r = $(esc(block))
+    set_warn_order!(old_order)
+    return r
+  end
+end
+
+"""
+    @reset_warn_order
+
+Temporarily reset the order threshold for warning about the ITensor
+order in a block of code to the default value $default_warn_order.
+
+# Examples
+```julia
+@reset_warn_order begin
+  A * B
+end
+```
+"""
+macro reset_warn_order(block)
+  quote
+    old_order = reset_warn_order!()
+    r = $(esc(block))
+    set_warn_order!(old_order)
+    return r
+  end
+end
 
 const GLOBAL_TIMER = TimerOutput()
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1082,10 +1082,10 @@ function Base.:*(A::ITensor, B::ITensor)
   (labelsA,labelsB) = compute_contraction_labels(inds(A),inds(B))
   CT = contract(tensor(A),labelsA,tensor(B),labelsB)
   C = itensor(CT)
-  warnTensorOrder = get_warn_itensor_order()
+  warnTensorOrder = get_warn_order()
   if !isnothing(warnTensorOrder) > 0 &&
      order(C) >= warnTensorOrder
-     @warn "Contraction resulted in ITensor with $(order(C)) indices, which is greater than or equal to the ITensor order warning threshold $warnTensorOrder. You can modify the threshold with functions like `set_warn_itensor_order!(::Int)`, `reset_warn_itensor_order!()`, and `disable_warn_itensor_order!()`."
+     @warn "Contraction resulted in ITensor with $(order(C)) indices, which is greater than or equal to the ITensor order warning threshold $warnTensorOrder. You can modify the threshold with functions like `set_warn_order!(::Int)`, `reset_warn_order!()`, and `disable_warn_order!()`."
   end
   return C
 end

--- a/test/global_variables.jl
+++ b/test/global_variables.jl
@@ -3,18 +3,51 @@ using Test
 
 @testset "Warn ITensor order" begin
   # Check it starts at default value
-  @test get_warn_itensor_order() == ITensors.default_warn_itensor_order
+  @test get_warn_order() == ITensors.default_warn_order
 
   # Set to 4 and reset
-  @test set_warn_itensor_order!(4) == ITensors.default_warn_itensor_order
-  @test get_warn_itensor_order() == 4
-  @test reset_warn_itensor_order!() == 4
-  @test get_warn_itensor_order() == ITensors.default_warn_itensor_order
+  @test set_warn_order!(4) == ITensors.default_warn_order
+  @test get_warn_order() == 4
+  @test reset_warn_order!() == 4
+  @test get_warn_order() == ITensors.default_warn_order
 
   # Disable it (set to nothing) and reset
-  @test disable_warn_itensor_order!() == ITensors.default_warn_itensor_order
-  @test isnothing(get_warn_itensor_order())
-  @test isnothing(reset_warn_itensor_order!())
-  @test get_warn_itensor_order() == ITensors.default_warn_itensor_order
+  @test disable_warn_order!() == ITensors.default_warn_order
+  @test isnothing(get_warn_order())
+  @test isnothing(reset_warn_order!())
+  @test get_warn_order() == ITensors.default_warn_order
+
+  # Disable macro
+  @test get_warn_order() == ITensors.default_warn_order
+  set_warn_order!(6)
+  @test get_warn_order() == 6
+  @disable_warn_order begin
+    @test isnothing(get_warn_order())
+  end
+  @test get_warn_order() == 6
+  reset_warn_order!()
+  @test get_warn_order() == ITensors.default_warn_order
+
+  # Set macro
+  @test get_warn_order() == ITensors.default_warn_order
+  set_warn_order!(6)
+  @test get_warn_order() == 6
+  @set_warn_order 10 begin
+    @test get_warn_order() == 10
+  end
+  @test get_warn_order() == 6
+  reset_warn_order!()
+  @test get_warn_order() == ITensors.default_warn_order
+
+  # Reset macro
+  @test get_warn_order() == ITensors.default_warn_order
+  set_warn_order!(6)
+  @test get_warn_order() == 6
+  @reset_warn_order begin
+    @test get_warn_order() == ITensors.default_warn_order
+  end
+  @test get_warn_order() == 6
+  reset_warn_order!()
+  @test get_warn_order() == ITensors.default_warn_order
 end
 


### PR DESCRIPTION
This adds the macros `@set_warn_order`, `@reset_warn_order`, and `@disable_warn_order` macros to temporarily change the ITensor order warning threshold in a block of code. It is reset to the threshold it was set to before the macro was called.

This also changes the function names `*_warn_itensor_order(...)` to `*_warn_order(...)`, which is shorter and I think still clear (and we may warn about other orders, such as IndexSet, for example we could warn about the ITensor order before the contraction happens).