### PR TITLE
Add setindex!(::MPS, _, ::Colon)

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -61,19 +61,15 @@ function Base.setindex!(M::AbstractMPS,
 end
 
 function Base.setindex!(M::MPST, v::MPST,
-                        ::Colon;
-                        set_limits::Bool = true) where {MPST <: AbstractMPS}
-  if set_limits
-    setleftlim!(M, -1)
-    setrightlim!(M, length(M)+1)
-  end
+                        ::Colon) where {MPST <: AbstractMPS}
+  setleftlim!(M, leftlim(v))
+  setrightlim!(M, rightlim(v))
   data(M)[:] = data(v)
   return M
 end
 
-Base.setindex!(M::AbstractMPS, v::Vector{<:ITensor},
-               ::Colon; kwargs...) =
-  setindex!(M, MPS(v), :; kwargs...)
+Base.setindex!(M::AbstractMPS, v::Vector{<:ITensor}, ::Colon) =
+  setindex!(M, MPS(v), :)
 
 Base.copy(m::AbstractMPS) = typeof(m)(copy(data(m)),
                                       leftlim(m),

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -9,6 +9,13 @@ The number of sites of an MPS/MPO.
 Base.length(m::AbstractMPS) = length(m.data)
 
 """
+    size::MPS/MPO)
+
+The number of sites of an MPS/MPO, in a tuple.
+"""
+Base.size(m::AbstractMPS) = size(m.data)
+
+"""
     ITensors.data(::MPS/MPO)
 
 The Vector storage of an MPS/MPO.
@@ -52,6 +59,21 @@ function Base.setindex!(M::AbstractMPS,
   data(M)[n] = T
   return M
 end
+
+function Base.setindex!(M::MPST, v::MPST,
+                        ::Colon;
+                        set_limits::Bool = true) where {MPST <: AbstractMPS}
+  if set_limits
+    setleftlim!(M, -1)
+    setrightlim!(M, length(M)+1)
+  end
+  data(M)[:] = data(v)
+  return M
+end
+
+Base.setindex!(M::AbstractMPS, v::Vector{<:ITensor},
+               ::Colon; kwargs...) =
+  setindex!(M, MPS(v), :; kwargs...)
 
 Base.copy(m::AbstractMPS) = typeof(m)(copy(data(m)),
                                       leftlim(m),

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -515,6 +515,19 @@ end
     @test ITensors.rightlim(M) == 2
   end
 
+  @testset "setindex!(::MPS, _, ::Colon)" begin
+    N = 4
+    s = siteinds("S=½", N)
+    ψ = randomMPS(s)
+    ϕ = productMPS(s, "↑")
+    ψ[:] = ϕ
+    @test inner(ψ, ϕ) ≈ 1
+
+    ψ = randomMPS(s)
+    ϕ = productMPS(s, "↑")
+    ψ[:] = ITensors.data(ϕ)
+    @test inner(ψ, ϕ) ≈ 1
+  end
 end
 
 nothing

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -520,12 +520,17 @@ end
     s = siteinds("S=½", N)
     ψ = randomMPS(s)
     ϕ = productMPS(s, "↑")
+    orthogonalize!(ϕ, 1)
     ψ[:] = ϕ
+    @test ITensors.orthocenter(ψ) == 1
     @test inner(ψ, ϕ) ≈ 1
 
     ψ = randomMPS(s)
     ϕ = productMPS(s, "↑")
+    orthogonalize!(ϕ, 1)
     ψ[:] = ITensors.data(ϕ)
+    @test ITensors.leftlim(ψ) == 0
+    @test ITensors.rightlim(ψ) == N+1
     @test inner(ψ, ϕ) ≈ 1
   end
 end


### PR DESCRIPTION
This adds functionality like the following:
```julia
N = 4
s = siteinds("S=½", N)
ψ = randomMPS(s)
ϕ = productMPS(s, "↑")
orthogonalize!(ϕ, 1) 
ψ[:] = ϕ
@test ITensors.orthocenter(ψ) == 1
```
so the MPS gets the orthogonality of the input MPS. One can also set an MPS from a Vector of ITensors (in which case the orthogonality can't be determined, and it is set to the boundaries).