### PR TITLE
Add QN ITensor from Array constructor

### DIFF
--- a/docs/src/ITensorType.md
+++ b/docs/src/ITensorType.md
@@ -19,6 +19,7 @@ setelt(::IndexVal)
 
 ```@docs
 ITensor(::Type{<:Number}, ::QN, ::ITensors.Indices)
+ITensor(A::Array, inds::ITensors.QNIndexSet)
 ```
 
 ## Empty Constructors

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -106,6 +106,22 @@ ITensor(A::Array,
         tol = 0) =
   _ITensor(A, IndexSet(inds...); tol = tol)
 
+itensor(A::Array,
+        inds::QNIndexSet;
+        tol = 0) =
+  ITensor(A, inds; tol = tol)
+
+itensor(A::Array,
+        inds::QNIndex...;
+        tol = 0) =
+  ITensor(A, inds...; tol = tol)
+
+# Defined to fix ambiguity error
+itensor(A::Array{ <: Number},
+        inds::QNIndex...;
+        tol = 0) =
+  ITensor(A, inds...; tol = tol)
+
 """
     emptyITensor([::Type{ElT} = Float64, ]inds)
     emptyITensor([::Type{ElT} = Float64, ]inds::QNIndex...)

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -39,6 +39,44 @@ end
 
 ITensor(inds::QNIndex...) = ITensor(Float64, QN(), IndexSet(inds...))
 
+function _ITensor(A::Array{ElT},
+                  inds::QNIndexSet;
+                  tol = 0) where {ElT}
+  length(A) ≠ dim(inds) && throw(DimensionMismatch("In ITensor(::Array, ::IndexSet), length of Array ($(length(A))) must match total dimension of IndexSet ($(dim(inds)))"))
+  T = emptyITensor(ElT, inds)
+  A = reshape(A, dims(inds))
+  for vs in eachindex(T)
+    Avs = A[vs]
+    if abs(Avs) > tol
+      T[vs] = A[vs]
+    end
+  end
+  return T
+end
+
+"""
+    ITensor(::Array, ::QNIndexSet)
+
+Create a block sparse ITensor from the input Array, where zeros are
+dropped and nonzero blocks are determined from the zero values of
+the array.
+"""
+ITensor(A::Array,
+        inds::QNIndexSet;
+        tol = 0) =
+  _ITensor(A, inds; tol = tol)
+
+# Defined to fix ambiguity error
+ITensor(A::Array{ <: AbstractFloat},
+        inds::QNIndexSet;
+        tol = 0) =
+  _ITensor(A, inds; tol = tol)
+
+ITensor(A::Array,
+        inds::QNIndex...;
+        tol = 0) =
+  _ITensor(A, IndexSet(inds...); tol = tol)
+
 """
     emptyITensor([::Type{ElT} = Float64, ]inds)
     emptyITensor([::Type{ElT} = Float64, ]inds::QNIndex...)

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -55,11 +55,40 @@ function _ITensor(A::Array{ElT},
 end
 
 """
-    ITensor(::Array, ::QNIndexSet)
+    ITensor(::Array, ::IndexSet; tol = 0)
 
-Create a block sparse ITensor from the input Array, where zeros are
-dropped and nonzero blocks are determined from the zero values of
-the array.
+    ITensor(::Array, ::Index...; tol = 0)
+
+Create a block sparse ITensor from the input Array, and collection 
+of QN indices. Zeros are dropped and nonzero blocks are determined
+from the zero values of the array.
+
+Optionally, you can set a tolerance such that elements
+less than or equal to the tolerance are dropped.
+
+# Examples
+```julia
+julia> i = Index([QN(0)=>1, QN(1)=>2], "i");
+
+julia> A = [1e-9 0.0 0.0;
+            0.0 2.0 3.0;
+            0.0 1e-10 4.0];
+
+julia> @show ITensor(A, i', dag(i); tol = 1e-8);
+ITensor(A, i', dag(i); tol = 1.0e-8) = ITensor ord=2
+Dim 1: (dim=3|id=468|"i")' <Out>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+Dim 2: (dim=3|id=468|"i") <In>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+NDTensors.BlockSparse{Float64,Array{Float64,1},2}
+ 3×3
+Block: (2, 2)
+ [2:3, 2:3]
+ 2.0  3.0
+ 0.0  4.0
+```
 """
 ITensor(A::Array,
         inds::QNIndexSet;

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -33,6 +33,17 @@ Random.seed!(1234)
     @test T[3, 2] == 1e-10
     @test T[3, 3] == 4.0
 
+    T = itensor(A, i', dag(i))
+    @test flux(T) == QN(0)
+    @test nnzblocks(T) == 2
+    @test (1,1) in nzblocks(T)
+    @test (2,2) in nzblocks(T)
+    @test T[1, 1] == 1.0
+    @test T[2, 2] == 2.0
+    @test T[2, 3] == 3.0
+    @test T[3, 2] == 1e-10
+    @test T[3, 3] == 4.0
+
     T = ITensor(A, i', dag(i); tol = 1e-9)
     @test flux(T) == QN(0)
     @test nnzblocks(T) == 2

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -16,6 +16,68 @@ Random.seed!(1234)
     @test nnzblocks(A) == 2
   end
 
+  @testset "Construct from Array" begin
+    i = Index([QN(0)=>1, QN(1)=>2], "i")
+
+    A = [1.0 0.0 0.0;
+         0.0 2.0 3.0;
+         0.0 1e-10 4.0]
+    T = ITensor(A, i', dag(i))
+    @test flux(T) == QN(0)
+    @test nnzblocks(T) == 2
+    @test (1,1) in nzblocks(T)
+    @test (2,2) in nzblocks(T)
+    @test T[1, 1] == 1.0
+    @test T[2, 2] == 2.0
+    @test T[2, 3] == 3.0
+    @test T[3, 2] == 1e-10
+    @test T[3, 3] == 4.0
+
+    T = ITensor(A, i', dag(i); tol = 1e-9)
+    @test flux(T) == QN(0)
+    @test nnzblocks(T) == 2
+    @test (1,1) in nzblocks(T)
+    @test (2,2) in nzblocks(T)
+    @test T[1, 1] == 1.0
+    @test T[2, 2] == 2.0
+    @test T[2, 3] == 3.0
+    @test T[3, 2] == 0.0
+    @test T[3, 3] == 4.0
+
+    A = [1e-9 0.0 0.0;
+         0.0 2.0 3.0;
+         0.0 1e-10 4.0]
+    T = ITensor(A, i', dag(i); tol = 1e-8)
+    @test flux(T) == QN(0)
+    @test nnzblocks(T) == 1
+    @test (2,2) in nzblocks(T)
+    @test T[1, 1] == 0.0
+    @test T[2, 2] == 2.0
+    @test T[2, 3] == 3.0
+    @test T[3, 2] == 0.0
+    @test T[3, 3] == 4.0
+
+    A = [1e-9 2.0 3.0;
+         1e-9 1e-10 2e-10;
+         2e-9 1e-10 4e-10]
+    T = ITensor(A, i', dag(i); tol = 1e-8)
+    @test flux(T) == QN(-1)
+    @test nnzblocks(T) == 1
+    @test (1,2) in nzblocks(T)
+    @test T[1, 1] == 0.0
+    @test T[1, 2] == 2.0
+    @test T[1, 3] == 3.0
+    @test T[2, 2] == 0.0
+    @test T[2, 3] == 0.0
+    @test T[3, 2] == 0.0
+    @test T[3, 3] == 0.0
+
+    A = [1e-9 2.0 3.0;
+         1e-5 1e-10 2e-10;
+         2e-9 1e-10 4e-10]
+    @test_throws ErrorException ITensor(A, i', dag(i); tol = 1e-8)
+  end
+
   @testset "ITensor iteration" begin
     i = Index([QN(0)=>1,QN(1)=>2],"i")
     j = Index([QN(0)=>3,QN(1)=>4,QN(2)=>5],"j")


### PR DESCRIPTION
This adds a constructor for QN ITensors from an Array, where the block structure and flux is determined from the nonzero values of the Array. It also provides a keyword argument `tol` to choose a tolerance for when to drop values. For example:
```julia
julia> i = Index([QN(0)=>1, QN(1)=>2], "i");

julia> A = [1e-9 0.0 0.0;
            0.0 2.0 3.0;
            0.0 1e-10 4.0];

julia> @show ITensor(A, i', dag(i); tol = 1e-8);
ITensor(A, i', dag(i); tol = 1.0e-8) = ITensor ord=2
Dim 1: (dim=3|id=468|"i")' <Out>
 1: QN(0) => 1
 2: QN(1) => 2
Dim 2: (dim=3|id=468|"i") <In>
 1: QN(0) => 1
 2: QN(1) => 2
NDTensors.BlockSparse{Float64,Array{Float64,1},2}
 3×3
Block: (2, 2)
 [2:3, 2:3]
 2.0  3.0
 0.0  4.0
```