### PR TITLE
Introduce filterinds

### DIFF
--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -254,7 +254,7 @@ end
 
 function LinearAlgebra.eigen(A::ITensor;
                              kwargs...)
-  Ris = inds(A; plev = 0)
+  Ris = filterinds(A; plev = 0)
   Lis = Ris'
 
   return eigen(A, Lis, Ris; kwargs...)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -102,6 +102,7 @@ export
   diagITensor,
   dot,
   firstind,
+  filterinds,
   hascommoninds,
   hasind,
   hasinds,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -736,8 +736,13 @@ unionind(A...; kwargs...) = getfirst(union(itensor2inds.(A)...;
 firstind(A...; kwargs...) = getfirst(itensor2inds.(A)...;
                                      kwargs...)
 
-NDTensors.inds(A...; kwargs...) = filter(itensor2inds.(A)...;
-                                         kwargs...)
+filterinds(A...; kwargs...) = filter(itensor2inds.(A)...;
+                                     kwargs...)
+
+# Faster version when no filtering is requested
+filterinds(A::ITensor) = inds(A)
+
+#NDTensors.inds(A...; kwargs...) = filterinds(A...; kwargs...)
 
 # in-place versions of priming and tagging
 for fname in (:prime,
@@ -1197,7 +1202,7 @@ end
 
 function LinearAlgebra.exp(A::ITensor;
                            kwargs...)
-  Ris = inds(A; plev = 0)
+  Ris = filterinds(A; plev = 0)
   Lis = Ris'
   return exp(A, Lis, Ris; kwargs...)
 end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -742,7 +742,8 @@ filterinds(A...; kwargs...) = filter(itensor2inds.(A)...;
 # Faster version when no filtering is requested
 filterinds(A::ITensor) = inds(A)
 
-#NDTensors.inds(A...; kwargs...) = filterinds(A...; kwargs...)
+# For backwards compatibility
+NDTensors.inds(A...; kwargs...) = filterinds(A...; kwargs...)
 
 # in-place versions of priming and tagging
 for fname in (:prime,

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -411,8 +411,8 @@ function Base.:*(A::MPO, B::MPO; kwargs...)
   sites_A = Index[]
   sites_B = Index[]
   for (AA, BB) in zip(data(A_), data(B_))
-    sda = setdiff(inds(AA, "Site"), inds(BB, "Site"))
-    sdb = setdiff(inds(BB, "Site"), inds(AA, "Site"))
+    sda = setdiff(filterinds(AA; tags="Site"), filterinds(BB; tags="Site"))
+    sdb = setdiff(filterinds(BB; tags="Site"), filterinds(AA; tags="Site"))
     length(sda) != 1 && error("In contract(::MPO, ::MPO), MPOs must have exactly one shared site index")
     length(sdb) != 1 && error("In contract(::MPO, ::MPO), MPOs must have exactly one shared site index")
     push!(sites_A, sda[1])

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -181,7 +181,7 @@ function LinearAlgebra.dot(B::MPO, y::MPS,
   # Swap prime levels 1 -> 2 and 2 -> 1.
   for j in eachindex(Bdag)
     Axcommon = commonind(A[j], x[j])
-    ABcommon = uniqueind(inds(A[j], "Site"), IndexSet(Axcommon))
+    ABcommon = uniqueind(filterinds(A[j]; tags = "Site"), IndexSet(Axcommon))
     swapprime!(Bdag[j],2,3)
     swapprime!(Bdag[j],1,2)
     swapprime!(Bdag[j],3,1)
@@ -397,8 +397,8 @@ function Base.:*(A::MPO, B::MPO; kwargs...)
   B_ = copy(B)
   orthogonalize!(B_, 1)
 
-  links_A = inds.(A.data, "Link")
-  links_B = inds.(B.data, "Link")
+  links_A = filterinds.(A.data; tags = "Link")
+  links_B = filterinds.(B.data; tags = "Link")
 
   res = deepcopy(A_)
   for i in 1:N-1
@@ -445,7 +445,8 @@ function Base.:*(A::MPO, B::MPO; kwargs...)
   nfork = clust * A_[N] * B_[N]
 
   # in case we primed A
-  A_ind = uniqueind(inds(A_[N-1], "Site"), inds(B_[N-1], "Site"))
+  A_ind = uniqueind(filterinds(A_[N-1]; tags = "Site"),
+                    filterinds(B_[N-1]; tags = "Site"))
   Lis = IndexSet(A_ind, sites_B[N-1], commonind(res[N-2], res[N-1]))
   U, V = factorize(nfork, Lis; 
                    ortho="right",

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -1036,6 +1036,15 @@ end # End Dense storage test
   @test v4[1] ≈ orig_elt
 end
 
+@testset "filter ITensor indices" begin
+  i = Index(2, "i")
+  A = randomITensor(i, i')
+  @test hassameinds(filterinds(A; plev = 0), (i,))
+  @test hassameinds(inds(A; plev = 0), (i,))
+  is = inds(A)
+  @test hassameinds(filterinds(is; plev = 0), (i,))
+  @test hassameinds(inds(is; plev = 0), (i,))
+end
 
 end # End Dense ITensor basic functionality
 

--- a/test/iterativesolvers.jl
+++ b/test/iterativesolvers.jl
@@ -7,23 +7,23 @@ struct ITensorMap
   A::ITensor
 end
 Base.eltype(M::ITensorMap) = eltype(M.A)
-Base.size(M::ITensorMap) = dim(IndexSet(inds(M.A;plev=0)...))
-(M::ITensorMap)(v::ITensor) = noprime(M.A*v)
+Base.size(M::ITensorMap) = dim(IndexSet(filterinds(M.A; plev=0)...))
+(M::ITensorMap)(v::ITensor) = noprime(M.A * v)
 
 @testset "Complex davidson" begin
   d = 10
-  i = Index(d,"i")
-  A = randomITensor(ComplexF64,i,prime(i))
-  A = mapprime(A*mapprime(dag(A),0,2),2,1)
+  i = Index(d, "i")
+  A = randomITensor(ComplexF64, i, i')
+  A = mapprime(A * mapprime(dag(A), 0 => 2), 2 => 1)
   M = ITensorMap(A)
     
   v = randomITensor(i)
-  λ,v = davidson(M,v;maxiter=10)
-  @test M(v)≈λ*v
+  λ, v = davidson(M, v; maxiter = 10)
+  @test M(v) ≈ λ * v
     
   v = randomITensor(ComplexF64, i)
-  λ,v = davidson(M,v;maxiter=10)
-  @test M(v)≈λ*v
+  λ, v = davidson(M, v; maxiter = 10)
+  @test M(v) ≈ λ * v
     
 end
 


### PR DESCRIPTION
This introduces the function `filterinds`, which for now is an alias for `inds`. It is used for things like:
```julia
i = Index(2)
A = randomITensor(i, i')
hassameinds(filterinds(A; plev = 0), (i,))
```
Currently, the function `inds(A; plev = 0)` was used for this. The `inds` notation is still allowed, but `filterinds` will be preferred for this usage for clarity.