### PR TITLE
Make ITensors compatible with Julia v1.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.3'
           - '1.4'
+          - 'nightly'
         os:
           - ubuntu-latest
           - windows-latest

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
-NDTensors = "0.1.13"
+NDTensors = "0.1.14"
 PackageCompiler = "1.0.0"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["mfishman <mfishman@caltech.edu>"]
 version = "0.1.19"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -17,11 +18,11 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
-NDTensors = "0.1.12"
+NDTensors = "0.1.13"
 PackageCompiler = "1.0.0"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"
-julia = "1.4"
+julia = "1.3"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
+Compat = "2.1, 3"
 HDF5 = "0.13.1"
 KrylovKit = "0.4.2"
 NDTensors = "0.1.14"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -40,7 +40,7 @@ Or, equivalently, via the `Pkg` API:
 ```julia
 julia> import Pkg; Pkg.add("ITensors")
 ```
-Please note that right now, ITensors.jl requires that you use Julia v1.4 or later (since we are using a feature that was introduced in Julia v1.4). We will work on supporting older minor versions.
+Please note that right now, ITensors.jl requires that you use Julia v1.3 or later (since ITensors.jl relies on a feature that was introduced in Julia v1.3).
 
 We recommend using ITensors.jl with Intel MKL in order to get the best possible performance. If you have not done so already, you can replace your current BLAS and LAPACK implementation with MKL by using the MKL.jl package. Please follow the instructions [here](https://github.com/JuliaComputing/MKL.jl).
 

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -10,6 +10,7 @@ module ITensors
 #####################################
 # External packages
 #
+using Compat
 using HDF5
 using KrylovKit
 using LinearAlgebra

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -411,10 +411,9 @@ end
 
 Swap the sites `b` and `b+1`.
 """
-function swapbondsites(ψ::MPS, b::Int; kwargs...)
-  kwargs = setindex(values(kwargs), true, :swapsites)
-  return replacebond(ψ, b, ψ[b] * ψ[b+1]; kwargs...)
-end
+swapbondsites(ψ::MPS, b::Int; kwargs...) =
+  replacebond(ψ, b, ψ[b] * ψ[b+1];
+              kwargs..., swapsites = true)
 
 """
     sample!(m::MPS)

--- a/test/decomp.jl
+++ b/test/decomp.jl
@@ -52,13 +52,13 @@ using ITensors,
     A = randomITensor(l,s,r)
     Q,R, = factorize(A,l,s; which_decomp="qr")
     q = commonind(Q,R)
-    @test A ≈ Q*R atol=1e-14
-    @test Q*dag(prime(Q,q)) ≈ δ(Float64,q,q') atol=1e-14
+    @test A ≈ Q*R atol=1e-13
+    @test Q*dag(prime(Q,q)) ≈ δ(Float64,q,q') atol=1e-13
 
     R,Q, = factorize(A,l,s; which_decomp="qr", ortho="right")
     q = commonind(Q,R)
     @test A ≈ Q*R atol=1e-13
-    @test Q*dag(prime(Q,q)) ≈ δ(Float64,q,q') atol=1e-14
+    @test Q*dag(prime(Q,q)) ≈ δ(Float64,q,q') atol=1e-13
   end
 
   @testset "eigen" begin

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -1,5 +1,6 @@
-using ITensors,
-      Test
+using ITensors
+using Test
+using Compat
 
 @testset "IndexSet" begin
   idim = 2

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -861,28 +861,28 @@ end
       U,S,V,spec,u,v = svd(A,(j,l))
       @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A≈U*S*V
-      @test U*dag(prime(U,u))≈δ(SType,u,u') atol=1e-14
-      @test V*dag(prime(V,v))≈δ(SType,v,v') atol=1e-14
+      @test U*dag(prime(U,u))≈δ(SType,u,u') atol=1e-13
+      @test V*dag(prime(V,v))≈δ(SType,v,v') atol=1e-13
     end
 
     @testset "Test SVD of an ITensor with different algorithms" begin
       U, S, V, spec, u, v = svd(A, j, l; alg = "recursive")
       @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A ≈ U * S * V
-      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-14
-      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-14
+      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-13
+      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-13
 
       U, S, V, spec, u, v = svd(A, j,l; alg = "divide_and_conquer")
       @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A ≈ U * S * V
-      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-14
-      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-14
+      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-13
+      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-13
 
       U, S, V, spec, u, v = svd(A, j,l; alg = "qr_iteration")
       @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A ≈ U * S * V
-      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-14
-      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-14
+      @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-13
+      @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-13
 
       @test_throws ErrorException svd(A, j,l; alg = "bad_alg")
     end
@@ -899,8 +899,8 @@ end
       v = commonind(V, S)
       @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A≈U*S*V
-      @test U*dag(prime(U,u))≈δ(SType,u,u') atol=1e-14
-      @test V*dag(prime(V,v))≈δ(SType,v,v') atol=1e-14
+      @test U*dag(prime(U,u))≈δ(SType,u,u') atol=1e-13
+      @test V*dag(prime(V,v))≈δ(SType,v,v') atol=1e-13
     end
     @testset "Test SVD truncation" begin
         ii = Index(4)
@@ -914,8 +914,8 @@ end
     @testset "Test QR decomposition of an ITensor" begin
       Q,R,q = qr(A,(i,l))
       q = commonind(Q,R)
-      @test A ≈ Q*R atol=1e-14
-      @test Q*dag(prime(Q,q)) ≈ δ(SType,q,q') atol=1e-14
+      @test A ≈ Q*R atol=1e-13
+      @test Q*dag(prime(Q,q)) ≈ δ(SType,q,q') atol=1e-13
     end
 
     @testset "Test polar decomposition of an ITensor" begin
@@ -933,9 +933,9 @@ end
           jjp ∈ 1:dim(u[2])
         val = UUᵀ[u[1](ii),u[2](jj),u[1]'(iip),u[2]'(jjp)]
         if ii==iip && jj==jjp
-          @test val ≈ one(SType) atol=1e-14
+          @test val ≈ one(SType) atol=1e-13
         else
-          @test val ≈ zero(SType) atol=1e-14
+          @test val ≈ zero(SType) atol=1e-13
         end
       end
     end

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -742,10 +742,10 @@ Random.seed!(1234)
       @test hassameinds(U, (i,j,u))
       @test hassameinds(D, (u,up))
 
-      @test norm(A - dag(U) * D * U') ≈ 0.0 atol=1e-11
-      @test norm(A - dag(U) * D * Ut) ≈ 0.0 atol=1e-11
-      @test norm(A * U - U' * D) ≈ 0.0 atol=1e-11
-      @test norm(A * U - Ut * D) ≈ 0.0 atol=1e-11
+      @test A ≈ dag(U) * D * U' atol=1e-11
+      @test A ≈ dag(U) * D * Ut atol=1e-11
+      @test A * U ≈ U' * D atol=1e-11
+      @test A * U ≈ Ut * D atol=1e-11
     end
 
     @testset "eigen hermitian (truncate)" begin
@@ -803,7 +803,7 @@ Random.seed!(1234)
       @test spec.truncerr ≤ cutoff
       err = sqrt(1-(Ap*dag(Ap))[]/(A*dag(A))[])
       @test err ≤ cutoff
-      @test err ≈ spec.truncerr rtol=1e-1
+      @test err ≈ spec.truncerr rtol=3e-1
 		end
 
     @testset "eigen non-hermitian" begin
@@ -828,10 +828,10 @@ Random.seed!(1234)
       @test hastags(up,"x")
       @test plev(up) == 1
 
-      @test norm(A - U' * D * dag(U)) ≉ 0.0 atol=1e-12
-      @test norm(A - Ut * D * dag(U)) ≉ 0.0 atol=1e-12
-      @test norm(A * U - U' * D) ≈ 0.0 atol=1e-12
-      @test norm(A * U - Ut * D) ≈ 0.0 atol=1e-12
+      @test A ≉ U' * D * dag(U) atol=1e-12
+      @test A ≉ Ut * D * dag(U) atol=1e-12
+      @test A * U ≈ U' * D atol=1e-12
+      @test A * U ≈ Ut * D atol=1e-12
     end
 
     @testset "eigen non-hermitian (general inds)" begin
@@ -865,8 +865,8 @@ Random.seed!(1234)
       @test hassameinds(U, (ĩ, j̃, r))
       @test hassameinds(Ut, (i, j, l))
 
-      @test norm(A * U - Ut * D) ≈ 0.0 atol=1e-12
-      @test norm(A - Ut * D * dag(U)) ≉ 0.0 atol=1e-12
+      @test A * U ≈ Ut * D atol=1e-12
+      @test A ≉ Ut * D * dag(U) atol=1e-12
     end
 
     @testset "eigen mixed arrows" begin
@@ -876,7 +876,7 @@ Random.seed!(1234)
       F = eigen(A, (i1, i1'), (i2', i2))
       D, U = F
       Ut = F.Vt
-      @test norm(A * U - Ut * D) ≈ 0.0 atol=1e-12
+      @test A * U ≈ Ut * D atol=1e-12
     end
 
   end
@@ -905,7 +905,7 @@ Random.seed!(1234)
       for b in nzblocks(V)
         @test flux(V,b)==QN(0)
       end
-      @test isapprox(norm(U*S*V-A),0.0; atol=1e-14)
+      @test U * S * V ≈ A atol=1e-14
     end
 
     @testset "svd example 2" begin
@@ -930,7 +930,7 @@ Random.seed!(1234)
       for b in nzblocks(V)
         @test flux(V,b)==QN(0)
       end
-      @test isapprox(norm(U*S*V-A),0.0; atol=1e-14)
+      @test U * S * V ≈ A atol=1e-14
     end
 
     @testset "svd example 3" begin
@@ -955,7 +955,7 @@ Random.seed!(1234)
       for b in nzblocks(V)
         @test flux(V,b)==QN(0)
       end
-      @test isapprox(norm(U*S*V-A),0.0; atol=1e-14)
+      @test U * S * V ≈ A atol=1e-14
     end
 
     @testset "svd example 4" begin
@@ -983,7 +983,7 @@ Random.seed!(1234)
       for b in nzblocks(V)
         @test flux(V,b)==QN(0,2)
       end
-      @test isapprox(norm(U*S*V-A),0.0; atol=1e-14)
+      @test U * S * V ≈ A atol=1e-14
     end
 
     @testset "svd example 5" begin
@@ -1011,7 +1011,7 @@ Random.seed!(1234)
       for b in nzblocks(V)
         @test flux(V,b)==QN(0,2)
       end
-      @test isapprox(norm(U*S*V-A),0.0; atol=1e-14)
+      @test U * S * V ≈ A atol=1e-14
     end
 
     @testset "svd example 6" begin
@@ -1039,7 +1039,7 @@ Random.seed!(1234)
       for b in nzblocks(V)
         @test flux(V,b)==QN(0,2)
       end
-      @test isapprox(norm(U*S*V-A),0.0; atol=1e-14)
+      @test U * S * V ≈ A atol=1e-14
     end
 
     @testset "svd truncation example 1" begin
@@ -1298,7 +1298,7 @@ Random.seed!(1234)
       for b in nzblocks(V)
         @test flux(V,b)==QN()
       end
-      @test norm(U*S*V-A) ≈ 0 atol=1e-15
+      @test U * S * V ≈ A atol=1e-15
     end
 
     @testset "SVD no truncate bug" begin


### PR DESCRIPTION
This uses [Compat.jl](https://github.com/JuliaLang/Compat.jl) to make ITensors backwards compatible with Julia v1.3. There are a few small features we are using that were introduced in Julia v1.4, and Compat automatically defines them if someone is using Julia v1.3 and ITensors.

Unfortunately we can't easily become compatible with older versions, mostly because the keyword argument `alg` in LinearAlgebra's `svd` function (for choosing the LAPACK svd algorithm) was introduced in Julia v1.3.