### PR TITLE
Add movesites function

### DIFF
--- a/docs/src/ITensorType.md
+++ b/docs/src/ITensorType.md
@@ -90,6 +90,16 @@ settags(::ITensor, ::Any...)
 swaptags(::ITensor, ::Any...)
 ```
 
+## IndexSet set operations
+
+```@docs
+commoninds
+hascommoninds
+uniqueinds
+noncommoninds
+unioninds
+```
+
 ## Index Manipulations
 
 ```@docs

--- a/docs/src/MPSandMPO.md
+++ b/docs/src/MPSandMPO.md
@@ -37,6 +37,20 @@ maxlinkdim(::ITensors.AbstractMPS)
 linkind(::ITensors.AbstractMPS,::Int)
 ```
 
+## Grabbing and finding indices
+
+```@docs
+firstsiteind
+firstsiteinds
+siteind(::MPS, ::Int)
+siteinds(::MPS)
+siteind(::MPO, ::Int)
+siteinds(::MPO)
+siteinds(::ITensors.AbstractMPS, ::Int)
+findsite
+findsites
+```
+
 ## Priming and tagging
 
 ```@docs

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -178,9 +178,16 @@ export
   dag!,
   findfirstsiteind,
   findfirstsiteinds,
+  findsite,
+  findsites,
+  firstsiteind,
+  firstsiteinds,
   logdot,
   loginner,
   lognorm,
+  movesite,
+  movesites,
+  siteinds,
 
 # mps/mpo.jl
   # Types

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -129,6 +129,7 @@ export
   order,
   permute,
   prime!,
+  randn!,
   randomITensor,
   removetags!,
   replacetags!,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -695,10 +695,18 @@ hasinds(is::Index...) = hasinds(IndexSet(is...))
 """
     hascommoninds(A, B; kwargs...)
 
-Check if the ITensors or sets of indices have common indices.
+    hascommoninds(B; kwargs...) -> f::Function
+
+Check if the ITensors or sets of indices `A` and `B` have
+common indices.
+
+If only one ITensor or set of indices `B` is passed, return a
+function `f` such that `f(A) = hascommoninds(A, B; kwargs...)`
 """
 hascommoninds(A, B; kwargs...) =
   !isnothing(commonind(A, B; kwargs...))
+
+hascommoninds(B; kwargs...) = x -> hascommoninds(x, B; kwargs...)
 
 # issetequal
 hassameinds(A, B) =

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -670,6 +670,7 @@ end
 # TODO: name this `indexset` or `IndexSet`,
 # or maybe just `inds`?
 itensor2inds(A::ITensor) = inds(A)
+itensor2inds(i::Index) = IndexSet(i)
 itensor2inds(is::Vector{<:Index}) = IndexSet(is)
 itensor2inds(is::Tuple{Vararg{<:Index}}) = IndexSet(is)
 itensor2inds(A) = A
@@ -985,9 +986,7 @@ function Base.isapprox(A::ITensor,
     return isapprox(array(A), array(B); kwargs...)
 end
 
-function Random.randn!(T::ITensor)
-  return randn!(tensor(T))
-end
+Random.randn!(T::ITensor) = randn!(tensor(T))
 
 """
     randomITensor([::Type{ElT <: Number} = Float64, ]inds)

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1,4 +1,3 @@
-
 abstract type AbstractMPS end
 
 """
@@ -134,6 +133,67 @@ end
 
 Base.keys(ψ::AbstractMPS) = keys(data(ψ))
 
+#
+# Find sites of an MPS or MPO
+#
+
+# TODO: accept a keyword argument sitedict that
+# is a dictionary from the site indices to the site.
+"""
+    findsite(M::Union{MPS, MPO}, is)
+
+Return the first site of the MPS or MPO that has at least one
+Index in common with the Index or collection of indices `is`.
+
+To find all sites with common indices with `is`, use the 
+`findsites` function.
+
+# Examples
+```julia
+s = siteinds("S=1/2", 5)
+ψ = randomMPS(s)
+findsite(ψ, s[3]) == 3
+findsite(ψ, (s[3], s[4])) == 3
+
+M = MPO(s)
+findsite(M, s[4]) == 4
+findsite(M, s[4]') == 4
+findsite(M, (s[4]', s[4])) == 4
+findsite(M, (s[4]', s[3])) == 3
+```
+"""
+findsite(ψ::AbstractMPS, is) = findfirst(hascommoninds(is), ψ)
+
+findsite(ψ::AbstractMPS, s::Index) = findsite(ψ, IndexSet(s))
+
+"""
+    findsites(M::Union{MPS, MPO}, is)
+
+Return the sites of the MPS or MPO that have
+indices in common with the collection of site indices
+`is`.
+
+# Examples
+```julia
+s = siteinds("S=1/2", 5)
+ψ = randomMPS(s)
+findsites(ψ, s[3]) == [3]
+findsites(ψ, (s[4], s[1])) == [1, 4]
+
+M = MPO(s)
+findsites(M, s[4]) == [4]
+findsites(M, s[4]') == [4]
+findsites(M, (s[4]', s[4])) == [4]
+findsites(M, (s[4]', s[3])) == [3, 4]
+```
+"""
+findsites(ψ::ITensors.AbstractMPS, is) =
+  findall(hascommoninds(is), ψ)
+
+findsites(ψ::ITensors.AbstractMPS, s::Index) =
+ findsites(ψ, IndexSet(s))
+
+# TODO: depracate in favor of findsite.
 """
     findfirstsiteind(M::MPS, i::Index)
 
@@ -147,6 +207,7 @@ function findfirstsiteind(ψ::AbstractMPS,
   return findfirst(hasind(s), ψ)
 end
 
+# TODO: depracate in favor of findsite.
 """
     findfirstsiteind(M::MPS, is)
 
@@ -160,6 +221,52 @@ function findfirstsiteinds(ψ::AbstractMPS,
   return findfirst(hasinds(s), ψ)
 end
 
+"""
+    firstsiteind(M::Union{MPS,MPO}, j::Int; kwargs...)
+
+Return the first site Index found on the MPS or MPO
+(the first Index unique to the `j`th MPS/MPO tensor).
+
+You can choose different filters, like prime level
+and tags, with the `kwargs`.
+"""
+function firstsiteind(M::AbstractMPS, j::Int;
+                      kwargs...)
+  N = length(M)
+  (N==1) && return firstind(M[1]; kwargs...)
+  if j == 1
+    si = uniqueind(M[j], M[j+1]; kwargs...)
+  elseif j == N
+    si = uniqueind(M[j], M[j-1]; kwargs...)
+  else
+    si = uniqueind(M[j], M[j-1], M[j+1]; kwargs...)
+  end
+  return si
+end
+
+"""
+    siteinds(M::Union{MPS, MPO}}, j::Int; kwargs...)
+
+Return the site Indices found of the MPO or MPO
+at the site `j` as an IndexSet.
+
+Optionally filter prime tags and prime levels with
+keyword arguments like `plev` and `tags`.
+"""
+function siteinds(M::AbstractMPS, j::Int; kwargs...)
+  N = length(M)
+  (N==1) && return inds(M[1]; kwargs...)
+  if j == 1
+    si = uniqueinds(M[j], M[j+1]; kwargs...)
+  elseif j == N
+    si = uniqueinds(M[j], M[j-1]; kwargs...)
+  else
+    si = uniqueinds(M[j], M[j-1], M[j+1]; kwargs...)
+  end
+  return si
+end
+
+# TODO: change kwarg from `set_limits` to `preserve_ortho`
 function Base.map!(f::Function, M::AbstractMPS;
                    set_limits::Bool = true)
   for i in eachindex(M)
@@ -168,6 +275,7 @@ function Base.map!(f::Function, M::AbstractMPS;
   return M
 end
 
+# TODO: change kwarg from `set_limits` to `preserve_ortho`
 Base.map(f::Function, M::AbstractMPS; set_limits::Bool = true) =
   map!(f, copy(M); set_limits = set_limits)
 
@@ -740,6 +848,286 @@ function Base.:*(x::Number, M::AbstractMPS)
 end
 
 Base.:-(M::AbstractMPS) = Base.:*(-1,M)
+
+"""
+    setindex!(::Union{MPS, MPO}, ::Union{MPS, MPO},
+              r::UnitRange{Int64})
+
+Sets a contiguous range of MPS/MPO tensors
+"""
+function Base.setindex!(ψ::MPST, ϕ::MPST,
+                        r::UnitRange{Int64}) where {MPST <: AbstractMPS}
+  @assert length(r) == length(ϕ)
+  # TODO: accept r::Union{AbstractRange{Int}, Vector{Int}}
+  # if r isa AbstractRange
+  #   @assert step(r) = 1
+  # else
+  #   all(==(1), diff(r))
+  # end
+  llim = leftlim(ψ)
+  rlim = rightlim(ψ)
+  for (j, n) in enumerate(r)
+    ψ[n] = ϕ[j]
+  end
+  if llim + 1 ≥ r[1]
+    setleftlim!(ψ, leftlim(ϕ) + r[1] - 1)
+  end
+  if rlim - 1 ≤ r[end]
+    setrightlim!(ψ, rightlim(ϕ) + r[1] - 1)
+  end
+  return ψ
+end
+
+# TODO: add a version that determines the sites
+# from common site indices of ψ and A
+"""
+    setindex!(ψ::Union{MPS, MPO},
+              A::ITensor,
+              r::UnitRange{Int};
+              orthocenter::Int = last(r),
+              perm = nothing,
+              kwargs...)
+
+    replacesites!([...])
+
+    replacesites([...])
+
+Replace the sites in the range `r` with tensors made
+from decomposing `A` into an MPS or MPO.
+
+The MPS or MPO must be orthogonalized such that
+```
+firstsite ≤ ITensors.orthocenter(ψ) ≤ lastsite
+```
+
+Choose the new orthogonality center with `orthocenter`, which
+should be within `r`.
+
+Optionally, permute the order of the sites with `perm`.
+"""
+function Base.setindex!(ψ::MPST,
+                        A::ITensor,
+                        r::UnitRange{Int};
+                        orthocenter::Int = last(r),
+                        perm = nothing,
+                        kwargs...) where {MPST <: AbstractMPS}
+  # Replace the sites of ITensor ψ
+  # with the tensor A, splitting up A
+  # into MPS tensors
+  firstsite = first(r)
+  lastsite = last(r)
+  @assert firstsite ≤ ITensors.orthocenter(ψ) ≤ lastsite
+  @assert firstsite ≤ leftlim(ψ) + 1
+  @assert rightlim(ψ) - 1 ≤ lastsite
+
+  # TODO: allow orthocenter outside of this
+  # range, and orthogonalize/truncate as needed
+  @assert firstsite ≤ orthocenter ≤ lastsite
+
+  # Check that A has the proper common
+  # indices with ψ
+  l = linkind(ψ, firstsite-1)
+  r = linkind(ψ, lastsite)
+
+  sites = [siteinds(ψ, j) for j in firstsite:lastsite]
+
+  #s = collect(Iterators.flatten(sites))
+  indsA = filter(x -> !isnothing(x),
+                 [l, Iterators.flatten(sites)..., r])
+
+  @assert hassameinds(A, indsA)
+
+  # For MPO case, restrict to 0 prime level
+  #sites = filter(hasplev(0), sites)
+
+    if !isnothing(perm)
+    sites = sites[[perm...]]
+  end
+
+  ψA = MPST(A, sites;
+            firstlinkind = l,
+            lastlinkind = r,
+            kwargs...)
+  #@assert prod(ψA) ≈ A
+
+  ψ[firstsite:lastsite] = ψA
+
+  return ψ
+end
+
+Base.setindex!(ψ::MPST,
+               A::ITensor,
+               r::UnitRange{Int},
+               args::Pair{Symbol}...;
+               kwargs...) where {MPST <: AbstractMPS} =
+  setindex!(ψ, A, r; args..., kwargs...)
+
+replacesites!(ψ::AbstractMPS, args...; kwargs...) =
+  setindex!(ψ, args...; kwargs...)
+
+replacesites(ψ::AbstractMPS, args...; kwargs...) =
+  setindex!(copy(ψ), args...; kwargs...)
+
+_number_inds(s::Index) = 1
+_number_inds(s::IndexSet) = length(s)
+_number_inds(sites) = sum(_number_inds(s) for s in sites)
+
+"""
+    MPS(::ITensor, sites)
+
+    MPO(::ITensor, sites)
+
+Construct an MPS/MPO from an ITensor by decomposing it site
+by site.
+"""
+function (::Type{MPST})(A::ITensor, sites;
+                        firstlinkind::Union{Nothing, Index} = nothing,
+                        lastlinkind::Union{Nothing, Index} = nothing,
+                        orthocenter::Int = length(sites),
+                        kwargs...) where {MPST <: AbstractMPS}
+  N = length(sites)
+  @assert order(A) == _number_inds(sites) +
+                      !isnothing(firstlinkind) +
+                      !isnothing(lastlinkind)
+  for s in sites
+    @assert hasinds(A, s)
+  end
+  @assert isnothing(firstlinkind) || hasind(A, firstlinkind)
+  @assert isnothing(lastlinkind) || hasind(A, lastlinkind)
+
+  @assert 1 ≤ orthocenter ≤ N
+
+  ψ = Vector{ITensor}(undef, N)
+  Ã = A
+  l = firstlinkind
+  # TODO: To minimize work, loop from
+  # 1:orthocenter and reverse(orthocenter:N)
+  # so the orthogonality center is set correctly.
+  for n in 1:N-1
+    Lis = sites[n]
+    if !isnothing(l)
+      Lis = push(Lis, l)
+    end
+    L, R = factorize(Ã, Lis; kwargs..., ortho = "left")
+    l = commonind(L, R)
+    ψ[n] = L
+    Ã = R
+  end
+  ψ[N] = Ã
+  M = MPST(ψ)
+  setleftlim!(M, N-1)
+  setrightlim!(M, N+1)
+  orthogonalize!(M, orthocenter)
+  return M
+end
+
+"""
+    swapbondsites(ψ::AbstractMPS, b::Int; kwargs...)
+
+Swap the sites `b` and `b+1`.
+"""
+function swapbondsites(ψ::AbstractMPS, b::Int; kwargs...)
+  ortho = get(kwargs, :ortho, "right")
+  ψ = copy(ψ)
+  if ortho == "left"
+    orthocenter = b + 1
+  elseif ortho == "right"
+    orthocenter = b
+  end
+  if leftlim(ψ) < b - 1
+    orthogonalize!(ψ, b)
+  elseif rightlim(ψ) > b + 2
+    orthogonalize!(ψ, b + 1)
+  end
+  ψ[b:b + 1,
+    orthocenter = orthocenter,
+    perm = [2, 1], kwargs...] = ψ[b] * ψ[b + 1]
+  return ψ
+end
+
+"""
+    movesite(::Union{MPS, MPO}, n1n2::Pair{Int, Int})
+
+Create a new MPS/MPO where the site at `n1` is moved to `n2`,
+for a pair `n1n2 = n1 => n2`.
+
+This is done with a series a pairwise swaps, and can introduce
+a lot of entanglement into your state, so use with caution.
+"""
+function movesite(ψ::AbstractMPS, n1n2::Pair{Int, Int};
+                  orthocenter::Int = last(n1n2),
+                  kwargs...)
+  n1, n2 = n1n2
+  n1 == n2 && return copy(ψ)
+  ψ = orthogonalize(ψ, n2)
+  r = n1:n2-1
+  ortho = "left"
+  if n1 > n2
+    r = reverse(n2:n1-1)
+    ortho = "right"
+  end
+  for n in r
+    ψ = swapbondsites(ψ, n; ortho = ortho, kwargs...)
+  end
+  ψ = orthogonalize(ψ, orthocenter)
+  return ψ
+end
+
+# Helper function for permuting a vector for the 
+# movesites function.
+function _movesite(ns::Vector{Int},
+                   n1n2::Pair{Int, Int})
+  n1, n2 = n1n2
+  n1 == n2 && return copy(ns)
+  r = n1:n2-1
+  if n1 > n2
+    r = reverse(n2:n1-1)
+  end
+  for n in r
+    ns = replace(ns, n => n+1, n+1 => n)
+  end
+  return ns
+end
+
+# TODO: make a permutesites(::MPS/MPO, perm)
+# function that takes a permutation of the sites
+# p(1:N) for N sites
+function movesites(ψ::AbstractMPS,
+                   nsns′::Vector{Pair{Int, Int}}; kwargs...)
+  ns = first.(nsns′)
+  ns′ = last.(nsns′)
+  ψ = copy(ψ)
+  N = length(ns)
+  @assert N == length(ns′)
+  p = sortperm(ns′)
+  ns = ns[p]
+  ns′ = ns′[p]
+  ns = collect(ns)
+  for i in 1:N
+    ψ = movesite(ψ, ns[i] => ns′[i]; kwargs...)
+    ns = _movesite(ns, ns[i] => ns′[i])
+  end
+  return ψ
+end
+
+# TODO: make a permutesites(::MPS/MPO, perm)
+# function that that a permutation of the sites
+# p(1:N) for N sites
+function movesites(ψ::AbstractMPS,
+                   ns, ns′; kwargs...)
+  ψ = copy(ψ)
+  N = length(ns)
+  @assert N == length(ns′)
+  p = sortperm(ns′)
+  ns = ns[p]
+  ns′ = ns′[p]
+  ns = collect(ns)
+  for i in 1:N
+    ψ = movesite(ψ, ns[i] => ns′[i]; kwargs...)
+    ns = _movesite(ns, ns[i] => ns′[i])
+  end
+  return ψ
+end
 
 """
     hasqns(M::MPS)

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1022,7 +1022,7 @@ function (::Type{MPST})(A::ITensor, sites;
 end
 
 """
-    swapbondsites(ψ::AbstractMPS, b::Int; kwargs...)
+    swapbondsites(ψ::Union{MPS, MPO}, b::Int; kwargs...)
 
 Swap the sites `b` and `b+1`.
 """

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -491,30 +491,6 @@ function Base.:*(A::MPO, B::MPO; kwargs...)
   return res
 end
 
-"""
-    swapbondsites(ψ::MPO, b::Int; kwargs...)
-
-Swap the sites `b` and `b+1`.
-"""
-function ITensors.swapbondsites(ψ::MPO, b::Int; kwargs...)
-  ortho = get(kwargs, :ortho, "right")
-  ψ = copy(ψ)
-  if ortho == "left"
-    orthocenter = b + 1
-  elseif ortho == "right"
-    orthocenter = b
-  end
-  if leftlim(ψ) < b - 1
-    orthogonalize!(ψ, b)
-  elseif rightlim(ψ) > b + 2
-    orthogonalize!(ψ, b + 1)
-  end
-  ψ[b:b + 1,
-    orthocenter = orthocenter,
-    perm = [2, 1], kwargs...] = ψ[b] * ψ[b + 1]
-  return ψ
-end
-
 function HDF5.write(parent::Union{HDF5File,HDF5Group},
                     name::AbstractString,
                     M::MPO)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -117,6 +117,9 @@ function randomMPO(sites::Vector{<:Index}, m::Int=1)
   return M
 end
 
+MPO(A::ITensor, sites::Vector{ <: Index}; kwargs...) =
+  MPO(A, IndexSet.(prime.(sites), dag.(sites)); kwargs...)
+
 """
     siteind(M::MPO, j::Int; plev = 0, kwargs...)
 

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -318,23 +318,19 @@ productMPS(sites::Vector{ <: Index},
            states) =
   productMPS(Float64, sites, states)
 
-function siteind(M::MPS, j::Int)
-  N = length(M)
-  (N==1) && return inds(M[1])[1]
+"""
+    siteind(M::MPS, j::Int; kwargs...)
 
-  if j == 1
-    si = uniqueind(M[j], M[j+1])
-  elseif j == N
-    si = uniqueind(M[j], M[j-1])
-  else
-    si = uniqueind(M[j], M[j-1], M[j+1])
-  end
-  return si
-end
+Get the site Index of the MPS.
+"""
+siteind(M::MPS, j::Int; kwargs...) = firstsiteind(M, j; kwargs...)
 
-function siteinds(M::MPS)
-  return [siteind(M, j) for j in 1:length(M)]
-end
+"""
+    siteinds(M::MPS)
+
+Get a vector of the site indices of the MPS.
+"""
+siteinds(M::MPS) = [siteind(M, j) for j in 1:length(M)]
 
 function replace_siteinds!(M::MPS, sites)
   for j in eachindex(M)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -403,15 +403,6 @@ function replacebond(M0::MPS, b::Int, phi::ITensor;
 end
 
 """
-    swapbondsites(ψ::MPS, b::Int; kwargs...)
-
-Swap the sites `b` and `b+1`.
-"""
-swapbondsites(ψ::MPS, b::Int; kwargs...) =
-  replacebond(ψ, b, ψ[b] * ψ[b+1];
-              kwargs..., swapsites = true)
-
-"""
     sample!(m::MPS)
 
 Given a normalized MPS m, returns a `Vector{Int}`

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -462,6 +462,34 @@ end
     @test ITensors.orthocenter(ψ) == 3
   end
 
+  @testset "swapbondsites MPO" begin
+    N = 5
+    sites = siteinds("S=1/2", N)
+    ψ0 = randomMPO(sites)
+
+    # TODO: implement this?
+    #ψ = replacebond(ψ0, 3, ψ0[3] * ψ0[4];
+    #                swapsites = true,
+    #                cutoff = 1e-15)
+    #@test siteind(ψ, 1) == siteind(ψ0, 1)
+    #@test siteind(ψ, 2) == siteind(ψ0, 2)
+    #@test siteind(ψ, 4) == siteind(ψ0, 3)
+    #@test siteind(ψ, 3) == siteind(ψ0, 4)
+    #@test siteind(ψ, 5) == siteind(ψ0, 5)
+    #@test prod(ψ) ≈ prod(ψ0)
+    #@test maxlinkdim(ψ) == 1
+
+    ψ = swapbondsites(ψ0, 4;
+                      cutoff = 1e-15)
+    @test siteind(ψ, 1) == siteind(ψ0, 1)
+    @test siteind(ψ, 2) == siteind(ψ0, 2)
+    @test siteind(ψ, 3) == siteind(ψ0, 3)
+    @test siteind(ψ, 5) == siteind(ψ0, 4)
+    @test siteind(ψ, 4) == siteind(ψ0, 5)
+    @test prod(ψ) ≈ prod(ψ0)
+    @test maxlinkdim(ψ) == 1
+  end
+
 end
 
 nothing

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -456,7 +456,7 @@ end
     @test flux(M) == QN("Sz",-4)
   end
 
-  @testset "swapsites" begin
+  @testset "swapbondsites" begin
     N = 5
     sites = siteinds("S=1/2", N)
     ψ0 = randomMPS(sites)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -687,6 +687,16 @@ end
     @test ITensors.orthocenter(ψ) == 3
   end
 
+  @testset "movesites reverse sites" begin
+    N = 6
+    s = siteinds("S=1/2", N)
+    ψ0 = randomMPS(s)
+    ψ = movesites(ψ0, 1:N .=> reverse(1:N))
+    for n in 1:N
+      @test siteind(ψ, n) == s[N-n+1]
+    end
+  end
+
 end
 
 nothing

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,5 +1,5 @@
-using ITensors,
-      Random
+using ITensors
+using Random
 
 function makeRandomMPS(sites;
                        chi::Int=4)::MPS


### PR DESCRIPTION
* Adds `findsite[s](::MPS/MPO, is)` for finding which sites of an MPS or MPO contain specified indices.

* Add `siteinds(::MPO)` for getting the site indices of an MPO as a vector of IndexSets.

* Add `firstsiteinds(::MPO)` for getting a vector of Index of the first site indices of the MPO that are found.

* `movesite(::MPS/MPO, n1 => m1)` to move the site `n1` to `m1` by swapping pairwise sites.

* `movesites(::MPS/MPO, [n1 => m1, n2 => m2, ...])` to move the sites `[n1, n2, ...]` to `[m1, m2, ...]` by swapping pairwise sites.

* `MPS(A::ITensor, s::Vector{Index}; kwargs...)` for decomposing an ITensor A into an MPS, such that the site indices are `[s[1], s[2], ...]`. Truncation and dangling left and right link indices can be specified with keyword arguments.

* `MPO(A::ITensor, s::Vector{IndexSet}; kwargs...)` for decomposing an ITensor `A` into an MPO, such that the site indices are `[s[1], s[2], ...]`. Truncation and dangling left and right link indices can be specified with keyword arguments.

* `setindex!(psi::MPS/MPO, phi::MPS/MPO, n1:n2)` for setting the MPS/MPO tensors of psi between sites `n1` and `n2` to the tensors of the MPS/MPO phi.

* `setindex!(psi::MPS/MPO, A::ITensor, n1:n2; kwargs...)` for decomposing the ITensor `A` into an MPS/MPO and inserting it into the sites `n1:n2` of MPS/MPO `psi`. With aliases `replacesites!` and `replacesites`.

* Add `swapbondsites[!]` for MPO.