### PR TITLE
Allow conserving Sz up or down in Fermion type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ precompile/tmp
 .DS_Store
 benchmark/*.json
 .benchmarkci
+.vscode/

--- a/src/physics/site_types/fermion.jl
+++ b/src/physics/site_types/fermion.jl
@@ -5,12 +5,33 @@ function space(::SiteType"Fermion";
                conserve_nfparity=conserve_qns,
                qnname_nf = "Nf",
                qnname_nfparity = "NfParity",
+               qnname_sz = "Sz",
+               conserve_sz = false,
                # Deprecated
                conserve_parity=nothing)
   if !isnothing(conserve_parity)
     conserve_nfparity = conserve_parity
   end
-  if conserve_nf
+  if conserve_sz == true
+    conserve_sz = "Up"
+  end
+  if conserve_nf && conserve_sz == "Up"
+    zer = QN((qnname_nf,0,-1), (qnname_sz,0)) => 1
+    one = QN((qnname_nf,1,-1), (qnname_sz,1)) => 1
+    return [zer,one]
+  elseif conserve_nf && conserve_sz == "Dn"
+    zer = QN((qnname_nf,0,-1), (qnname_sz,0)) => 1
+    one = QN((qnname_nf,1,-1), (qnname_sz,-1)) => 1
+    return [zer,one]
+  elseif conserve_nfparity && conserve_sz == "Up"
+    zer = QN((qnname_nfparity,0,-2), (qnname_sz,0)) => 1
+    one = QN((qnname_nfparity,1,-2), (qnname_sz,1)) => 1
+    return [zer,one]
+  elseif conserve_nfparity && conserve_sz == "Dn"
+    zer = QN((qnname_nfparity,0,-2), (qnname_sz,0)) => 1
+    one = QN((qnname_nfparity,1,-2), (qnname_sz,-1)) => 1
+    return [zer,one]
+  elseif conserve_nf
     zer = QN(qnname_nf,0,-1) => 1
     one = QN(qnname_nf,1,-1) => 1
     return [zer,one]

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -303,11 +303,33 @@ function combineblocks(i::QNIndex)
   return iR,perm,comb
 end
 
-removeqns(i::QNIndex) = Index(id(i),
-                              dim(i),
-                              Neither,
-                              tags(i),
-                              plev(i))
+removeqns(i::QNIndex) =
+  Index(id(i), dim(i), Neither, tags(i), plev(i))
+
+function addqns(i::Index, qns::QNBlocks; dir::Arrow = Out)
+  @assert dim(i) == dim(qns)
+  return Index(id(i), qns, dir, tags(i), plev(i))
+end
+  
+function addqns(i::QNIndex, qns::QNBlocks)
+  @assert dim(i) == dim(qns)
+  @assert nblocks(qns) == nblocks(i)
+  iqns = space(i)
+  j = copy(i)
+  jqn = space(j)
+  for n in 1:nblocks(i)
+    @assert blockdim(iqns, n) == blockdim(qns, n)
+    iqn_n = qn(iqns, n)
+    qn_n = qn(qns, n)
+    newqn = iqn_n
+    for nqv in 1:nactive(qn_n)
+      qv = qn_n[nqv]
+      newqn = addqnval(newqn, qv)
+    end
+    jqn[n] = newqn => blockdim(iqns, n)
+  end
+  return j
+end
 
 mutable_storage(::Type{Order{N}},
                 ::Type{IndexT}) where {N, IndexT <: QNIndex} =

--- a/test/phys_site_types.jl
+++ b/test/phys_site_types.jl
@@ -124,6 +124,25 @@ using ITensors,
     @test qn(s,2) == QN("NfParity",1,-2)
     s = siteind("Fermion";conserve_qns=false)
     @test dim(s) == 2
+
+    s = siteind("Fermion";conserve_nf=true, conserve_sz=true)
+    @test qn(s,1) == QN(("Nf",0,-1),("Sz",0))
+    @test qn(s,2) == QN(("Nf",1,-1),("Sz",1))
+    s = siteind("Fermion";conserve_nfparity=true, conserve_sz=true)
+    @test qn(s,1) == QN(("NfParity",0,-2),("Sz",0))
+    @test qn(s,2) == QN(("NfParity",1,-2),("Sz",1))
+    s = siteind("Fermion";conserve_nf=true, conserve_sz="Up")
+    @test qn(s,1) == QN(("Nf",0,-1),("Sz",0))
+    @test qn(s,2) == QN(("Nf",1,-1),("Sz",1))
+    s = siteind("Fermion";conserve_nfparity=true, conserve_sz="Up")
+    @test qn(s,1) == QN(("NfParity",0,-2),("Sz",0))
+    @test qn(s,2) == QN(("NfParity",1,-2),("Sz",1))
+    s = siteind("Fermion";conserve_nf=true, conserve_sz="Dn")
+    @test qn(s,1) == QN(("Nf",0,-1),("Sz",0))
+    @test qn(s,2) == QN(("Nf",1,-1),("Sz",-1))
+    s = siteind("Fermion";conserve_nfparity=true, conserve_sz="Dn")
+    @test qn(s,1) == QN(("NfParity",0,-2),("Sz",0))
+    @test qn(s,2) == QN(("NfParity",1,-2),("Sz",-1))
   end
 
   @testset "Electron sites" begin


### PR DESCRIPTION
This allows a user to make the Fermion type have a specified spin of up or down. The application is so that someone can emulate an Electron-type lattice with alternating up and down spins, for example in https://github.com/mtfishman/GaussianMatrixProductStates.jl where it is more natural to work with the up and down fermions as separate sites.