### PR TITLE
Add MPDO sampling

### DIFF
--- a/docs/src/MPSandMPO.md
+++ b/docs/src/MPSandMPO.md
@@ -27,6 +27,7 @@ productMPS(::Type{<:Number}, ::Vector{<:IndexVal})
 MPO(::Int)
 MPO(::Type{<:Number}, ::Vector{<:Index}, ::Vector{String})
 MPO(::Type{<:Number}, ::Vector{<:Index}, ::String)
+MPO(::MPS)
 ```
 
 ## Properties
@@ -80,6 +81,7 @@ truncate!
 replacebond!(::MPS, ::Int, ::ITensor)
 sample(::MPS)
 sample!(::MPS)
+sample(::MPO)
 ```
 
 ## Algebra Operations

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -810,17 +810,18 @@ function NDTensors.truncate!(M::AbstractMPS;
 
   # Left-orthogonalize all tensors to make
   # truncations controlled
-  orthogonalize!(M,N)
+  orthogonalize!(M, N)
 
   # Perform truncations in a right-to-left sweep
   for j in reverse(2:N)
-    rinds = uniqueinds(M[j],M[j-1])
-    U,S,V = svd(M[j],rinds;kwargs...)
+    rinds = uniqueinds(M[j], M[j-1])
+    ltags = tags(commonind(M[j], M[j-1]))
+    U, S, V = svd(M[j], rinds; lefttags = ltags, kwargs...)
     M[j] = U
-    M[j-1] *= (S*V)
-    setrightlim!(M,j)
+    M[j-1] *= (S * V)
+    setrightlim!(M, j)
   end
-
+  return M
 end
 
 NDTensors.contract(A::AbstractMPS,

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -463,9 +463,7 @@ function sample(m::MPS)
       (r < pdisc) && break
       n += 1
     end
-
     result[j] = n
-
     if j < N
       A = m[j+1]*An
       A *= (1.0/sqrt(pn))


### PR DESCRIPTION
This adds the function `sample(::MPO)` for sampling an MPO, treating it as a density matrix.