### PR TITLE
Add tr(::MPO)

### DIFF
--- a/docs/src/MPSandMPO.md
+++ b/docs/src/MPSandMPO.md
@@ -93,6 +93,12 @@ swapbondsites(::ITensors.AbstractMPS, ::Int; kwargs...)
 truncate!
 ```
 
+## Gate evolution
+
+```@docs
+product(::Vector{ <: ITensor}, ::ITensors.AbstractMPS)
+```
+
 ## Algebra Operations
 
 ```@docs

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -714,6 +714,14 @@ hassameinds(A, B) =
   issetequal(itensor2inds(A), itensor2inds(B))
 
 # intersect
+"""
+    commoninds(A, B; kwargs...)
+    commoninds(::Order{N}, A, B; kwargs...)
+
+Return an IndexSet with indices that are common (in the interesection) between the indices of `A` and `B`.
+
+Optionally, specify the desired number of indices as `Order(N)`, which adds a check and can be a bit more efficient.
+"""
 commoninds(A...; kwargs...) =
   IndexSet(intersect(itensor2inds.(A)...; kwargs...))
 
@@ -725,6 +733,14 @@ commonind(A...; kwargs...) =
   firstintersect(itensor2inds.(A)...; kwargs...)
 
 # symdiff
+"""
+    noncommoninds(A, B; kwargs...)
+    noncommoninds(::Order{N}, A, B; kwargs...)
+
+Return an IndexSet with indices that are not common between the indices of `A` and `B` (the symmetric set difference).
+
+Optionally, specify the desired number of indices as `Order(N)`, which adds a check and can be a bit more efficient.
+"""
 noncommoninds(A...; kwargs...) =
   IndexSet(symdiff(itensor2inds.(A)...; kwargs...)...)
 
@@ -736,6 +752,14 @@ noncommonind(A...; kwargs...) =
   getfirst(symdiff(itensor2inds.(A)...; kwargs...))
 
 # setdiff
+"""
+    uniqueinds(A, B; kwargs...)
+    uniqueinds(::Order{N}, A, B; kwargs...)
+
+Return an IndexSet with indices that are unique to the set of indices of `A` and not in `B` (the set difference).
+
+Optionally, specify the desired number of indices as `Order(N)`, which adds a check and can be a bit more efficient.
+"""
 uniqueinds(A...; kwargs...) =
   IndexSet(setdiff(itensor2inds.(A)...; kwargs...)...)
 
@@ -747,6 +771,14 @@ uniqueind(A...; kwargs...) =
   firstsetdiff(itensor2inds.(A)...; kwargs...)
 
 # union
+"""
+    unioninds(A, B; kwargs...)
+    unioninds(::Order{N}, A, B; kwargs...)
+
+Return an IndexSet with indices that are the union of the indices of `A` and `B`.
+
+Optionally, specify the desired number of indices as `Order(N)`, which adds a check and can be a bit more efficient.
+"""
 unioninds(A...; kwargs...) =
   IndexSet(union(itensor2inds.(A)...; kwargs...)...)
 

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1218,6 +1218,7 @@ end
 
 """
     product(o::ITensor, ψ::Union{MPS, MPO}, [ns::Vector{Int}]; <keyword argument>)
+    apply([...])
 
 Get the product of the operator `o` with the MPS/MPO `ψ`,
 where the operator is applied to the sites `ns`. If `ns`
@@ -1267,9 +1268,87 @@ function product(o::ITensor,
 end
 
 """
-    product(As::Vector{<:ITensor}, M::Union{MPS, MPO})
+    product(As::Vector{<:ITensor}, M::Union{MPS, MPO}; <keyword arguments>)
+    apply([...])
 
-Product the ITensors `As` with the MPS or MPO `M`.
+Apply the ITensors `As` to the MPS or MPO `M`, treating them as gates or matrices from pairs of prime or unprimed indices.
+
+# Examples
+
+Apply one-site gates to an MPS:
+```julia
+N = 3
+
+ITensors.op(::OpName"σx", ::SiteType"S=1/2", s::Index) =
+  2*op("Sx", s)
+
+ITensors.op(::OpName"σz", ::SiteType"S=1/2", s::Index) =
+  2*op("Sz", s)
+
+# Make the operator list.
+os = [("σx", n) for n in 1:N]
+append!(os, [("σz", n) for n in 1:N])
+
+@show os
+
+s = siteinds("S=1/2", N)
+gates = ops(os, s)
+
+# Starting state |↑↑↑⟩
+ψ0 = productMPS(s, "↑")
+
+# Apply the gates.
+ψ = apply(gates, ψ0; cutoff = 1e-15)
+
+# Test against exact (full) wavefunction
+prodψ = apply(gates, prod(ψ0))
+@show prod(ψ) ≈ prodψ
+
+# The result is:
+# σz₃ σz₂ σz₁ σx₃ σx₂ σx₁ |↑↑↑⟩ = -|↓↓↓⟩
+@show inner(ψ, productMPS(s, "↓")) == -1
+```
+Apply nonlocal two-site gates and one-site gates to an MPS:
+```julia
+# 2-site gate
+function ITensors.op(::OpName"CX", ::SiteType"S=1/2", s1::Index, s2::Index)
+  mat = [1 0 0 0
+         0 1 0 0
+         0 0 0 1
+         0 0 1 0]
+  return itensor(mat, s2', s1', s2, s1)
+end
+
+os = [("CX", 1, 3), ("σz", 3)]
+
+@show os
+
+# Start with the state |↓↑↑⟩
+ψ0 = productMPS(s, n -> n == 1 ? "↓" : "↑")
+
+# The result is:
+# σz₃ CX₁₃ |↓↑↑⟩ = -|↓↑↓⟩
+ψ = apply(ops(os, s), ψ0; cutoff = 1e-15)
+@show inner(ψ, productMPS(s, n -> n == 1 || n == 3 ? "↓" : "↑")) == -1
+```
+Perform TEBD-like time evolution:
+```julia
+# Define the nearest neighbor term `S⋅S` for the Heisenberg model
+function ITensors.op(::OpName"expS⋅S", ::SiteType"S=1/2",
+                     s1::Index, s2::Index; τ::Number)
+  O = 0.5 * op("S+", s1) * op("S-", s2) +
+      0.5 * op("S-", s1) * op("S+", s2) +
+            op("Sz", s1) * op("Sz", s2)
+  return exp(τ * O)
+end
+
+τ = -0.1im
+os = [("expS⋅S", (1, 2), (τ = τ,)),
+      ("expS⋅S", (2, 3), (τ = τ,))]
+ψ0 = productMPS(s, n -> n == 1 ? "↓" : "↑")
+expτH = ops(os, s)
+ψτ = apply(expτH, ψ0)
+```
 """
 function product(As::Vector{ <: ITensor}, ψ::AbstractMPS;
                  move_sites_back::Bool = true, kwargs...)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -264,6 +264,15 @@ function logdot(M1::MPO, M2::MPO;
                          make_inds_match = make_inds_match)
 end
 
+function LinearAlgebra.tr(M::MPO)
+  N = length(M)
+  L = M[1] * delta(dag(siteinds(M, 1)))
+  for j in 2:N
+    L = L * M[j] * delta(dag(siteinds(M, j)))
+  end
+  return L[]
+end
+
 """
     error_contract(y::MPS, A::MPO, x::MPS;
                    make_inds_match::Bool = true)

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -495,6 +495,14 @@ end
     @test prod(ρ) ≈ M
   end
 
+  @test "tr(::MPO)" begin
+    N = 5
+    s = siteinds("S=1/2", N)
+    H = MPO(s, "Id")
+    d = dim(s[1])
+    @test tr(H) ≈ d^N
+  end
+
 end
 
 nothing

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -495,7 +495,7 @@ end
     @test prod(ρ) ≈ M
   end
 
-  @test "tr(::MPO)" begin
+  @testset "tr(::MPO)" begin
     N = 5
     s = siteinds("S=1/2", N)
     H = MPO(s, "Id")


### PR DESCRIPTION
Add `tr(::MPO)`.

Also adds:
* Docstrings with examples and docs for `apply(::Vector{ITensor}, ::MPS)`
* Add docstrings for IndexSet set functions like `commoninds`, `uniqueinds`, etc.