### PR TITLE
Fix broadcast bug and add new broadcast operations

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -65,6 +65,8 @@ export
   IndexSet,
   Order,
   # Methods
+  allhastags,
+  anyhastags,
   dims,
   firstintersect,
   firstsetdiff,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -92,6 +92,7 @@ export
   # Types
   ITensor,
   # Methods
+  ⊙,
   addblock!,
   addtags!,
   apply,
@@ -110,6 +111,7 @@ export
   dot,
   firstind,
   filterinds,
+  hadamard_product,
   hascommoninds,
   hasind,
   hasinds,

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -937,6 +937,25 @@ function _replacetags(i::Index,
   return i
 end
 
+"""
+    anyhastags(is::IndexSet, ts::Union{String, TagSet})
+    hastags(is::IndexSet, ts::Union{String, TagSet})
+
+Check if any of the indices in the IndexSet have the specified tags.
+"""
+anyhastags(is::IndexSet, ts) =
+  any(i -> hastags(i, ts), is)
+
+hastags(is::IndexSet, ts) = anyhastags(is, ts)
+
+"""
+    allhastags(is::IndexSet, ts::Union{String, TagSet})
+
+Check if all of the indices in the IndexSet have the specified tags.
+"""
+allhastags(is::IndexSet, ts::String) =
+  all(i -> hastags(i, ts), is)
+
 # Version taking a list of Pairs
 replacetags(f::Function,
             is::IndexSet,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -584,6 +584,11 @@ function Base.getindex(T::ITensor)
   return tensor(T)[]::Number
 end
 
+Base.lastindex(A::ITensor, n::Int64) = dim(A, n)
+
+# Implement when ITensors can be indexed by a single integer
+#Base.lastindex(A::ITensor) = dim(A)
+
 """
     setindex!(T::ITensor, x::Number, I::Int...)
 
@@ -997,6 +1002,23 @@ The indices must have the same space (i.e. the same dimension and QNs, if applic
 
 The storage of the ITensor is not modified or copied (the output ITensor is a view of the input ITensor).
 """ swapinds(::ITensor, ::Any...)
+
+"""
+    anyhastags(A::ITensor, ts::Union{String, TagSet})
+    hastags(A::ITensor, ts::Union{String, TagSet})
+
+Check if any of the indices in the ITensor have the specified tags.
+"""
+anyhastags(A::ITensor, ts) = anyhastags(inds(A), ts)
+
+hastags(A::ITensor, ts) = hastags(inds(A), ts)
+
+"""
+    allhastags(A::ITensor, ts::Union{String, TagSet})
+
+Check if all of the indices in the ITensor have the specified tags.
+"""
+allhastags(A::ITensor, ts) = allhastags(inds(A), ts)
 
 """
     adjoint(A::ITensor)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1286,6 +1286,38 @@ function LinearAlgebra.exp(A::ITensor;
 end
 
 """
+    hadamard_product!(C::ITensor{N}, A::ITensor{N}, B::ITensor{N})
+    hadamard_product(A::ITensor{N}, B::ITensor{N})
+    ⊙(A::ITensor{N}, B::ITensor{N})
+
+Elementwise product of 2 ITensors with the same indices.
+
+Alternative syntax `⊙` can be typed in the REPL with `\\odot <tab>`.
+"""
+function hadamard_product!(R::ITensor{N},
+                           T1::ITensor{N},
+                           T2::ITensor{N}) where {N}
+  if !hassameinds(T1, T2)
+    error("ITensors must have some indices to perform Hadamard product")
+  end
+  # Permute the indices to the same order
+  #if inds(A) ≠ inds(B)
+  #  B = permute(B, inds(A))
+  #end
+  #tensor(C) .= tensor(A) .* tensor(B)
+  map!((t1, t2) -> *(t1, t2), R, T1, T2)
+  return R
+end
+
+# TODO: instead of copy, use promote(A, B)
+function hadamard_product(A::ITensor, B::ITensor)
+  Ac = copy(A)
+  return hadamard_product!(Ac, Ac, B)
+end
+
+⊙(A::ITensor, B::ITensor) = hadamard_product(A, B)
+
+"""
     product(A::ITensor, B::ITensor)
 
 Get the product of ITensor `A` and ITensor `B`, which

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -61,7 +61,27 @@ using ITensors,
     @test Bc[2,1] == A[1,2] / α
     @test Bc[1,2] == A[2,1] / α
     @test Bc[2,2] == A[2,2] / α
-    @test_throws ErrorException Bc .= α ./ A
+
+    Bc = copy(B)
+    Bc .= α ./ A
+    @test Bc[1,1] == α / A[1,1]
+    @test Bc[2,1] == α / A[1,2]
+    @test Bc[1,2] == α / A[2,1]
+    @test Bc[2,2] == α / A[2,2]
+
+    Bc = copy(B)
+    Bc .= Bc ./ A
+    @test Bc[1,1] == B[1,1] / A[1,1]
+    @test Bc[2,1] == B[2,1] / A[1,2]
+    @test Bc[1,2] == B[1,2] / A[2,1]
+    @test Bc[2,2] == B[2,2] / A[2,2]
+
+    Bc = copy(B)
+    Bc .= A ./ Bc
+    @test Bc[1,1] == A[1,1] / B[1,1]
+    @test Bc[2,1] == A[1,2] / B[2,1]
+    @test Bc[1,2] == A[2,1] / B[1,2]
+    @test Bc[2,2] == A[2,2] / B[2,2]
   end
 
   @testset "Add and divide (in-place)" begin
@@ -236,6 +256,43 @@ using ITensors,
 
     @test Apow2[1] == A[1]^3
     @test Apow2[2] == A[2]^3
+
+    Ac = copy(A)
+    Ac .+= B .^ 2.0
+
+    @test Ac[1] == A[1] + B[1]^2
+    @test Ac[2] == A[2] + B[2]^2
+
+    Ac = copy(A)
+    Ac .-= B .^ 2.0
+
+    @test Ac[1] == A[1] - B[1]^2
+    @test Ac[2] == A[2] - B[2]^2
+
+    Ac = copy(A)
+    Ac .-= B .^ 3
+
+    @test Ac[1] == A[1] - B[1]^3
+    @test Ac[2] == A[2] - B[2]^3
+  end
+
+  @testset "Hadamard product" begin
+    i = Index(2,"i")
+    A = randomITensor(i, i')
+    B = randomITensor(i', i)
+
+    C = A ⊙ B
+    @test C[1,1] == A[1,1] * B[1,1]
+    @test C[1,2] == A[1,2] * B[2,1]
+    @test C[2,1] == A[2,1] * B[1,2]
+    @test C[2,2] == A[2,2] * B[2,2]
+
+    Ac = copy(A)
+    Ac .= Ac .⊙ B
+    @test C[1,1] == A[1,1] * B[1,1]
+    @test C[1,2] == A[1,2] * B[2,1]
+    @test C[2,1] == A[2,1] * B[1,2]
+    @test C[2,2] == A[2,2] * B[2,2]
   end
 
 end

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -235,6 +235,7 @@ using Compat
     @test swapprime(I,0,1,"i") == IndexSet(i',i,j)
     @test swapprime(I,0,1,"j") == IndexSet(i,i',j')
   end
+
   @testset "swaptags" begin
     i1 = Index(2,"Site,A")
     i2 = Index(2,"Site,B")
@@ -245,6 +246,17 @@ using Compat
       @test hastags(j,"Link")
     end
   end
+
+  @testset "hastags" begin
+    i = Index(2, "i, x")
+    j = Index(2, "j, x")
+    is = IndexSet(i, j)
+    @test hastags(is, "i")
+    @test anyhastags(is, "i")
+    @test !allhastags(is, "i")
+    @test allhastags(is, "x")
+  end
+
   @testset "broadcasting" begin
     I = IndexSet(i, j)
     J = prime.(I)

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -40,10 +40,10 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
   end
 
   @testset "Get element with end" begin
-    i = Index(2)
-    j = Index(3)
-    A = randomITensor(i, j)
-    @test A[end, end] == A[i => 2, j => 3]
+    a = Index(2)
+    b = Index(3)
+    A = randomITensor(a, b)
+    @test A[end, end] == A[a => 2, b => 3]
   end
 
   @testset "Random" begin

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -39,6 +39,13 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
     @test !hascommoninds(A, C)
   end
 
+  @testset "Get element with end" begin
+    i = Index(2)
+    j = Index(3)
+    A = randomITensor(i, j)
+    @test A[end, end] == A[i => 2, j => 3]
+  end
+
   @testset "Random" begin
     A = randomITensor(i, j)
 
@@ -1140,6 +1147,16 @@ end
   B = randomITensor(s1', s2', lB, rB)
   @test_throws ErrorException product(A, B)
 
+end
+
+@testset "hastags" begin
+  i = Index(2, "i, x")
+  j = Index(2, "j, x")
+  A = randomITensor(i, j)
+  @test hastags(A, "i")
+  @test anyhastags(A, "i")
+  @test !allhastags(A, "i")
+  @test allhastags(A, "x")
 end
 
 end # End Dense ITensor basic functionality

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -1028,7 +1028,6 @@ end
         end
         @set_warn_order 15 begin
           prodM = product(gates, prod(M0))
-          @show norm(prod(M) - prodM)
           @test prod(M) ≈ prodM rtol = 1e-6
         end
       end
@@ -1123,7 +1122,6 @@ end
       ψ = apply(gates, ψ0; cutoff = 1e-15, maxdim = 100)
       
       prodψ = apply(gates, prod(ψ0))
-      @show norm(prod(ψ) - prodψ)/norm(prodψ)
       @test prod(ψ) ≈ prodψ rtol = 1e-4
     end
 


### PR DESCRIPTION
This PR fixes and implements a few issues:
 - Adds an overload of `lastindex(A::ITensor, ::Int)` to implement the interface `A[end, end]` (#489)
 - Adds `hastags`, `anyhastags` and `allhastags` for IndexSets and ITensors (#491) 
 - Fixes a bug in the broadcasting call `A .+= B .^ 2` (#494)
 - Adds the broadcasting operations `1 ./ A` (the same as `A ^ -1`) and `A ./ B`, (Hadamard division) (#493)
 - Adds the Hadamard product `A ⊙ B`, as well as an in-place version `A .= A .⊙ B` (#493)

A reminder that standard Julia Array notation dictates that `C .= A .* B` is the Hadamard product, but we are using that for in-place tensor contractions.