### PR TITLE
Add stacktrace output to warn tensor order

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -579,7 +579,7 @@ end
 
 function Base.getindex(T::ITensor) 
   if order(T) != 0
-    throw(DimensionMismatch("In scalar(T) or T[], ITensor T is not a scalar"))
+    throw(DimensionMismatch("In scalar(T) or T[], ITensor T is not a scalar (it has indices $(inds(T)))."))
   end
   return tensor(T)[]::Number
 end
@@ -1180,6 +1180,8 @@ function Base.:*(A::ITensor, B::ITensor)
   if !isnothing(warnTensorOrder) > 0 &&
      order(C) >= warnTensorOrder
      @warn "Contraction resulted in ITensor with $(order(C)) indices, which is greater than or equal to the ITensor order warning threshold $warnTensorOrder. You can modify the threshold with functions like `set_warn_order!(::Int)`, `reset_warn_order!()`, and `disable_warn_order!()`."
+     show(stdout, MIME"text/plain"(), stacktrace())
+     println()
   end
   return C
 end

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -44,8 +44,11 @@ function orthocenter(m::T) where {T<:AbstractMPS}
   return leftlim(m)+1
 end
 
-Base.getindex(M::AbstractMPS,
-              n::Integer) = getindex(data(M),n)
+Base.getindex(M::AbstractMPS, n::Integer) =
+  getindex(data(M), n)
+
+Base.lastindex(M::AbstractMPS) =
+  lastindex(data(M))
 
 function Base.setindex!(M::AbstractMPS,
                         T::ITensor,

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -179,7 +179,7 @@ function LinearAlgebra.dot(y::MPS, A::MPO, x::MPS;
                            make_inds_match::Bool = true)::Number
   N = length(A)
   if length(y) != N || length(x) != N
-      throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y))"))
+    throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y))"))
   end
   ydag = dag(y)
   sim_linkinds!(ydag)


### PR DESCRIPTION
Output the stacktrace with a tensor order warning, so the user can see where the contraction being warned about is happening. We could also output the indices of the contraction as well. Since the warning can be turned off easily now, I think it is ok to have a lot of output from the warning, since generally it is a mistake when it throws a warning.