### PR TITLE
Generalize `tr(::MPO)`

### DIFF
--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -278,8 +278,8 @@ end
 
 # TODO: allow custom tags in internal indices?
 function NDTensors.polar(A::ITensor,
-                       Linds...;
-                       kwargs...)
+                         Linds...;
+                         kwargs...)
   Lis = commoninds(A, IndexSet(Linds...))
   Ris = uniqueinds(A, Lis)
   Lpos, Rpos = NDTensors.getperms(inds(A), Lis, Ris)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,5 +1,8 @@
-
 export
+# From external modules
+  # LinearAlgebra
+  tr,
+
 # Modules
   LinearAlgebra,
   NDTensors,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1246,6 +1246,9 @@ function LinearAlgebra.tr(T::ITensor;
   for indpair in trpairs
     T *= δ(dag.(Tuple(indpair)))
   end
+  if order(T) == 0
+    return T[]
+  end
   return T
 end
 

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -264,11 +264,23 @@ function logdot(M1::MPO, M2::MPO;
                          make_inds_match = make_inds_match)
 end
 
-function LinearAlgebra.tr(M::MPO)
+function LinearAlgebra.tr(M::MPO;
+                          plev::Pair{Int, Int} = 0 => 1,
+                          tags::Pair = ts"" => ts"")
   N = length(M)
-  L = M[1] * delta(dag(siteinds(M, 1)))
+  #
+  # TODO: choose whether to contract or trace
+  # first depending on the bond dimension. The scaling is:
+  #
+  # 1. Trace last:  O(χ²d²) + O(χd²)
+  # 2. Trace first: O(χ²d²) + O(χ²)
+  #
+  # So tracing first is better if d > √χ.
+  #
+  L = tr(M[1])
   for j in 2:N
-    L = L * M[j] * delta(dag(siteinds(M, j)))
+    L *= M[j]
+    L = tr(L; plev = plev, tags = tags)
   end
   return L[]
 end

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -277,12 +277,12 @@ function LinearAlgebra.tr(M::MPO;
   #
   # So tracing first is better if d > √χ.
   #
-  L = tr(M[1])
+  L = tr(M[1]; plev = plev, tags = tags)
   for j in 2:N
     L *= M[j]
     L = tr(L; plev = plev, tags = tags)
   end
-  return L[]
+  return L
 end
 
 """

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -503,6 +503,16 @@ end
     @test tr(H) ≈ d^N
   end
 
+  @testset "tr(::MPO) multiple site indices" begin
+    N = 6
+    s = siteinds("S=1/2", N)
+    H = MPO(s, "Id")
+    H2 = MPO([H[j] * H[j+1] for j in 1:2:N-1])
+    d = dim(s[1])
+    @test tr(H) ≈ d^N
+    @test tr(H2) ≈ d^N
+  end
+
 end
 
 nothing


### PR DESCRIPTION
This generalizes `tr(::MPO)` to work with MPOs with more than one pair of site indices per tensor. This index structure is common for things like PEPS transfer matrices and Choi matrices.

It also adds `tr(::ITensor)`, where by default pairs of primed and unprimed indices are traced over. Pairs of tags and prime levels can be specified to determine which indices to pair together. In addition, indices that aren't in pairs are left alone, corresponding to a "batched" trace.