### PR TITLE
Add DMRG and contraction examples of using TBLIS

### DIFF
--- a/examples/TBLIS/1d_heisenberg.jl
+++ b/examples/TBLIS/1d_heisenberg.jl
@@ -1,0 +1,62 @@
+using ITensors
+using LinearAlgebra
+using Printf
+using Random
+using TBLIS
+
+Random.seed!(1234)
+
+let
+  nthreads = 4
+
+  N = 100
+  sites = siteinds("S=1",N)
+  ampo = AutoMPO()
+  for j=1:N-1
+    ampo += 0.5, "S+", j, "S-", j+1
+    ampo += 0.5, "S-", j, "S+", j+1
+    ampo +=      "Sz", j, "Sz", j+1
+  end
+  H = MPO(ampo,sites)
+  psi0 = randomMPS(sites,10)
+
+  sweeps_compile = Sweeps(2)
+  maxdim!(sweeps_compile, 10)
+  cutoff!(sweeps_compile, 1E-15)
+
+  sweeps = Sweeps(6)
+  maxdim!(sweeps, 10,20,100,100,200,300)
+  cutoff!(sweeps, 1E-15)
+  @show sweeps
+
+  #
+  # Using BLAS backend
+  #
+ 
+  disable_tblis!()
+  BLAS.set_num_threads(nthreads)
+
+  # Compile
+  dmrg(H, psi0, sweeps_compile; outputlevel = 0)
+
+  println("Using BLAS with $nthreads threads\n")
+  energy, psi = dmrg(H, psi0, sweeps)
+  @printf("Final energy = %.12f\n",energy)
+  println()
+
+  #
+  # Using TBLIS backend
+  #
+
+  enable_tblis!()
+  BLAS.set_num_threads(1)
+  TBLIS.set_num_threads(nthreads)
+
+  # Compile
+  dmrg(H, psi0, sweeps_compile; outputlevel = 0)
+
+  println("Using TBLIS with $(TBLIS.get_num_threads()) threads (and 1 BLAS thread)\n")
+  energy, psi = dmrg(H, psi0, sweeps)
+  @printf("Final energy = %.12f\n",energy)
+end
+

--- a/examples/TBLIS/1d_heisenberg.jl
+++ b/examples/TBLIS/1d_heisenberg.jl
@@ -25,8 +25,8 @@ let
   cutoff!(sweeps_compile, 1E-15)
 
   sweeps = Sweeps(6)
-  maxdim!(sweeps, 10,20,100,100,200,300)
-  cutoff!(sweeps, 1E-15)
+  maxdim!(sweeps, 20,100,200,300)
+  cutoff!(sweeps, 0.0)
   @show sweeps
 
   #

--- a/examples/TBLIS/README.md
+++ b/examples/TBLIS/README.md
@@ -1,5 +1,11 @@
-TBLIS is a permutation-free tensor contraction library (https://github.com/devinamatthews/tblis). By default, ITensors.jl performs tensor contractions by first permuting the tensors 
-so the contraction can be mapped to a matrix multiplication, which is then performed by BLAS.
+TBLIS is a permutation-free tensor contraction library 
+(https://github.com/devinamatthews/tblis). By default, ITensors.jl performs 
+tensor contractions by first permuting the tensors 
+so the contraction can be mapped to a matrix multiplication, which is then 
+performed by BLAS. Instead, TBLIS avoids BLAS entirely, using a generalization of 
+BLAS-like general matrix multiplication (GEMM) algorithms directly to tensor
+contractions. See also other implementations of GEMM-like tensor contractions 
+like GETT (https://github.com/HPAC/tccg).
 
 To use TBLIS as a contraction backend in ITensors.jl, first install TBLIS.jl: https://github.com/mtfishman/TBLIS.jl
 

--- a/examples/TBLIS/README.md
+++ b/examples/TBLIS/README.md
@@ -1,0 +1,38 @@
+TBLIS is a permutation-free tensor contraction library (https://github.com/devinamatthews/tblis). By default, ITensors.jl performs tensor contractions by first permuting the tensors 
+so the contraction can be mapped to a matrix multiplication, which is then performed by BLAS.
+
+To use TBLIS as a contraction backend in ITensors.jl, first install TBLIS.jl: https://github.com/mtfishman/TBLIS.jl
+
+Then, set the number of TBLIS threads by setting the environment variable `TBLIS_NUM_THREADS`, for example by starting Julia with:
+```
+$ TBLIS_NUM_THREADS=4 julia 
+```
+Then, to tell ITensors.jl that you want to using TBLIS, type the command:
+```julia
+julia> using TBLIS
+```
+You can disable the use of TBLIS with the command:
+```julia
+julia> disable_tblis!()
+```
+and enable it again with the command:
+```julia
+julia> enable_tblis!()
+```
+and you can set the number of threads with:
+```julia
+julia> TBLIS.set_num_threads(4)
+```
+
+You can try out the example scripts like:
+```julia
+julia> include("contract.jl")
+
+julia> include("1d_heisenberg.jl")
+```
+
+Note that in general, we have not found that TBLIS accelerates DMRG calculations.
+We believe it is because many of the contractions involved in DMRG can be turned
+directly into matrix multiplications without the need for permuting the data first,
+so TBLIS doesn't gain an advantage since there is no permutation to avoid.
+

--- a/examples/TBLIS/contract.jl
+++ b/examples/TBLIS/contract.jl
@@ -1,0 +1,64 @@
+using ITensors
+using LinearAlgebra
+using TBLIS
+
+let
+  d = 25
+
+  nthreads = 4
+
+  i = Index(d, "i")
+  j = Index(d, "j")
+  k = Index(d, "k")
+  l = Index(d, "l")
+  a = Index(d, "a")
+  b = Index(d, "b")
+
+  A = randomITensor(i, a, j, b)
+  B = randomITensor(b, l, k, a)
+  C = randomITensor(i, j, k, l)
+
+  println("Contracting (d x d x d x d) tensors A * B -> C, d = ", d)
+  @show inds(A)
+  @show inds(B)
+  @show inds(C)
+
+  #
+  # Use BLAS
+  #
+
+  disable_tblis!()
+  BLAS.set_num_threads(nthreads)
+
+  println()
+  println("Using BLAS with $nthreads threads")
+
+  C_blas = copy(C)
+  time_blas = @belapsed $C_blas .= $A .* $B samples = 100
+
+  println()
+  println("Time (BLAS) = ", time_blas, " seconds")
+
+  #
+  # Use TBLIS
+  #
+
+  enable_tblis!()
+  TBLIS.set_num_threads(4)
+
+  println()
+  println("Using TBLIS with $(TBLIS.get_num_threads()) threads")
+
+  C_tblis = copy(C)
+  time_tblis = @belapsed $C_tblis .= $A .* $B samples = 100
+
+  println()
+  println("Time (TBLIS) = ", time_tblis, " seconds")
+
+  println()
+  @show C_blas ≈ C_tblis
+
+  println()
+  println("Time (TBLIS) / Time (BLAS) = ", time_tblis / time_blas)
+end
+

--- a/examples/TBLIS/contract_dmrg.jl
+++ b/examples/TBLIS/contract_dmrg.jl
@@ -1,0 +1,76 @@
+using ITensors
+using LinearAlgebra
+using TBLIS
+
+let
+  χ = 500
+  d = 3
+
+  nthreads = 4
+
+  l = Index(χ, "l")
+  r = Index(χ, "r")
+  s1 = Index(d, "s1")
+  s2 = Index(d, "s2")
+  h = Index(d, "h")
+
+  indsA = (l, h, l')
+  indsB = (s1, r, s2, l)
+  indsC = (h, l', s1, r, s2)
+
+  A = randomITensor(indsA)
+  B = randomITensor(indsB)
+  C = randomITensor(indsC)
+
+  println("Contracting tensors A * B -> C, χ = $χ, d = $d")
+  @show inds(A)
+  @show inds(B)
+  @show inds(C)
+
+  #
+  # Use BLAS
+  #
+
+  disable_tblis!()
+  BLAS.set_num_threads(nthreads)
+
+  println()
+  println("Using BLAS with $nthreads threads")
+
+  C_blas = copy(C)
+  time_blas = @belapsed $C_blas .= $A .* $B samples = 100
+
+  C_blas = copy(C)
+  allocated_blas = @ballocated $C_blas .= $A .* $B samples = 100
+
+  println()
+  println("Time (BLAS) = ", time_blas, " seconds")
+  println("Allocated (BLAS) = ", allocated_blas / 1024^2 , " MiB")
+
+  #
+  # Use TBLIS
+  #
+
+  enable_tblis!()
+  TBLIS.set_num_threads(4)
+
+  println()
+  println("Using TBLIS with $(TBLIS.get_num_threads()) threads")
+
+  C_tblis = copy(C)
+  time_tblis = @belapsed $C_tblis .= $A .* $B samples = 100
+
+  C_tblis = copy(C)
+  allocated_tblis = @ballocated $C_tblis .= $A .* $B samples = 100
+
+  println()
+  println("Time (TBLIS) = ", time_tblis, " seconds")
+  println("Allocated (TBLIS) = ", allocated_tblis * 1e-6, " MiB")
+
+  println()
+  @show norm(C_blas - C_tblis)
+
+  println()
+  println("Time (TBLIS) / Time (BLAS) = ", time_tblis / time_blas)
+end
+

--- a/examples/dmrg/1d_heisenberg.jl
+++ b/examples/dmrg/1d_heisenberg.jl
@@ -1,5 +1,8 @@
 using ITensors
 using Printf
+using Random
+
+Random.seed!(1234)
 
 let
   N = 100

--- a/examples/dmrg/1d_heisenberg_conserve_spin.jl
+++ b/examples/dmrg/1d_heisenberg_conserve_spin.jl
@@ -1,5 +1,8 @@
-using ITensors,
-      Printf
+using ITensors
+using Printf
+using Random
+
+Random.seed!(1234)
 
 let
   N = 100

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -10,7 +10,10 @@ export
 # NDTensors module
   # Types
   Spectrum,
+  # Methods
+  disable_tblis!,
   eigs,
+  enable_tblis!,
   entropy,
   truncerror,
 

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -1082,9 +1082,15 @@ function compute_contraction_labels(Cis::IndexSet{NC},
   for i = 1:NC
     locA = findfirst(==(Cis[i]), Ais)
     if !isnothing(locA)
+      if Alabels[locA] < 0
+        error("The noncommon indices of $Ais and $Bis must be the same as the indices $Cis.")
+      end
       Clabels[i] = Alabels[locA]
     else
       locB = findfirst(==(Cis[i]), Bis)
+      if isnothing(locB) || Blabels[locB] < 0
+        error("The noncommon indices of $Ais and $Bis must be the same as the indices $Cis.")
+      end
       Clabels[i] = Blabels[locB]
     end
   end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1253,9 +1253,9 @@ function mul!(C::ITensor, A::ITensor, B::ITensor,
                                                          inds(A),
                                                          inds(B))
   CT = NDTensors.contract!!(tensor(C), labelsC,
-                          tensor(A), labelsA,
-                          tensor(B), labelsB,
-                          α, β)
+                            tensor(A), labelsA,
+                            tensor(B), labelsB,
+                            α, β)
   C = itensor(CT)
   return C
 end
@@ -1267,8 +1267,8 @@ function mul!(C::ITensor, A::ITensor, B::ITensor)
                                                          inds(A),
                                                          inds(B))
   CT = NDTensors.contract!!(tensor(C), labelsC,
-                          tensor(A), labelsA,
-                          tensor(B), labelsB)
+                            tensor(A), labelsA,
+                            tensor(B), labelsB)
   C = itensor(CT)
   return C
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -147,7 +147,7 @@ using ITensors,
     C = randomITensor(i,i')
     @test_throws ErrorException C .= A .+ B
     @test_throws ErrorException C = A .+ B
-    @test_throws BoundsError C .= A .* B
+    @test_throws ErrorException C .= A .* B
   end
 
   @testset "Contraction" begin


### PR DESCRIPTION
This adds some examples of using TBLIS, based on the new TBLIS support in NDTensors: https://github.com/ITensor/NDTensors.jl/pull/48

It also adds some extra checks that the index sets involved in in-place contraction are correct (some ill-formed examples slipped through when using TBLIS as a backend).