### PR TITLE
Add global flag for combining before contracting QN ITensors

### DIFF
--- a/examples/combine_contract/README.md
+++ b/examples/combine_contract/README.md
@@ -1,0 +1,114 @@
+For QN ITensors (ITensors with block sparse structure), ITensors.jl
+provides two "modes" for contracting them. The default mode is treating
+them as block sparse multi-dimensional arrays and contracting them
+"as is".
+
+In the second mode, the ITensors are reshaped into block
+sparse matrices before contracting. Making use of the QN information
+in the tensors, the second mode can lead to fewer blocks being contracted,
+which can lead to a speedup depending on the number of blocks, the sizes
+of the blocks, the order of the ITensors being contracted, etc.
+
+Run the example using parity symmetry as follows:
+```julia
+julia> include("main.jl")
+
+julia> main(Nmax = 8)
+#################################################
+# order = 2
+#################################################
+
+Contract:
+  2.410 μs (76 allocations: 5.70 KiB)
+
+Combine then contract:
+  48.111 μs (899 allocations: 92.98 KiB)
+
+C_contract ≈ C_combine_contract = true
+
+#################################################
+# order = 4
+#################################################
+
+Contract:
+  11.329 μs (311 allocations: 24.73 KiB)
+
+Combine then contract:
+  111.227 μs (1628 allocations: 182.69 KiB)
+
+C_contract ≈ C_combine_contract = true
+
+#################################################
+# order = 6
+#################################################
+
+Contract:
+  119.332 μs (2125 allocations: 200.11 KiB)
+
+Combine then contract:
+  284.701 μs (4019 allocations: 470.45 KiB)
+
+C_contract ≈ C_combine_contract = true
+
+#################################################
+# order = 8
+#################################################
+
+Contract:
+  1.291 ms (16988 allocations: 1.75 MiB)
+
+Combine then contract:
+  1.250 ms (18801 allocations: 1.75 MiB)
+
+C_contract ≈ C_combine_contract = true
+
+#################################################
+# order = 10
+#################################################
+
+Contract:
+  13.555 ms (138908 allocations: 16.22 MiB)
+
+Combine then contract:
+  6.233 ms (103211 allocations: 8.28 MiB)
+
+C_contract ≈ C_combine_contract = true
+
+#################################################
+# order = 12
+#################################################
+
+Contract:
+  165.222 ms (1261274 allocations: 141.49 MiB)
+
+Combine then contract:
+  37.353 ms (492436 allocations: 41.43 MiB)
+
+C_contract ≈ C_combine_contract = true
+
+#################################################
+# order = 14
+#################################################
+
+Contract:
+  2.256 s (10387274 allocations: 1.24 GiB)
+
+Combine then contract:
+  187.437 ms (2158837 allocations: 187.26 MiB)
+
+C_contract ≈ C_combine_contract = true
+
+#################################################
+# order = 16
+#################################################
+
+Contract:
+  28.637 s (104661017 allocations: 14.86 GiB)
+
+Combine then contract:
+  1.416 s (17813407 allocations: 1.32 GiB)
+
+C_contract ≈ C_combine_contract = true
+
+```
+

--- a/examples/combine_contract/main.jl
+++ b/examples/combine_contract/main.jl
@@ -1,0 +1,36 @@
+using BenchmarkTools
+using ITensors
+
+function main(; Nmax = 8)
+  # Don't warn about large tensor orders
+  disable_warn_order!()
+
+  for N in 1:Nmax
+    println("#################################################")
+    println("# order = ", 2 * N)
+    println("#################################################")
+    println()
+
+    d = 1
+    i = Index(QN(0) => d, QN(1) => d)
+    is = IndexSet(ntuple(n -> settags(i, "i$n"), Val(N)))
+    A = randomITensor(is'..., dag(is)...)
+    B = randomITensor(is'..., dag(is)...)
+
+    # Use standard algorithm, without combining first
+    println("Contract:")
+    C_contract = @btime $A' * $B samples = 5
+    println()
+
+    # Reshape the ITensors into matrices before contracting
+    println("Combine then contract:")
+    enable_combine_contract!()
+    C_combine_contract = @btime $A' * $B samples = 5
+    disable_combine_contract!()
+    println()
+
+    @show C_contract ≈ C_combine_contract
+    println()
+  end
+end
+

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -22,24 +22,6 @@ using StaticArrays
 using TimerOutputs
 
 #####################################
-# Global flags
-#
-const _use_combine_contract = Ref(false)
-
-use_combine_contract() = _use_combine_contract[]
-
-function enable_combine_contract!()
-  _use_combine_contract[] = true
-  return nothing
-end
-
-function disable_combine_contract!()
-  _use_combine_contract[] = false
-  return nothing
-end
-
-
-#####################################
 # Directory helper functions (useful for
 # running examples)
 #

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -22,6 +22,24 @@ using StaticArrays
 using TimerOutputs
 
 #####################################
+# Global flags
+#
+const _use_combine_contract = Ref(false)
+
+use_combine_contract() = _use_combine_contract[]
+
+function enable_combine_contract!()
+  _use_combine_contract[] = true
+  return nothing
+end
+
+function disable_combine_contract!()
+  _use_combine_contract[] = false
+  return nothing
+end
+
+
+#####################################
 # Directory helper functions (useful for
 # running examples)
 #

--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -309,7 +309,7 @@ function factorize_svd(A::ITensor, Linds...; kwargs...)
   if ortho == "left"
     L, R = U, S * V
   elseif ortho == "right"
-    L,R = U*S,V
+    L,R = U * S, V
   elseif ortho == "none"
     sqrtS = S
     sqrtS .= sqrt.(S)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -28,10 +28,14 @@ export
   svd,
 
 # global_variables.jl
+  # Methods
+  disable_combine_contract!,
   disable_warn_order!,
+  enable_combine_contract!,
   get_warn_order,
   set_warn_order!,
   reset_warn_order!,
+  # Macros
   @disable_warn_order,
   @reset_warn_order,
   @set_warn_order,

--- a/src/global_variables.jl
+++ b/src/global_variables.jl
@@ -1,4 +1,8 @@
 
+#
+# Warn about the order of the ITensor after contractions
+#
+
 const default_warn_order = 14
 
 const warn_order =
@@ -121,5 +125,27 @@ macro reset_warn_order(block)
   end
 end
 
+#
+# A global timer used with TimerOutputs.jl
+#
+
 const GLOBAL_TIMER = TimerOutput()
+
+#
+# Turn enable or disable combining QN ITensors before contracting
+#
+
+const _use_combine_contract = Ref(false)
+
+use_combine_contract() = _use_combine_contract[]
+
+function enable_combine_contract!()
+  _use_combine_contract[] = true
+  return nothing
+end
+
+function disable_combine_contract!()
+  _use_combine_contract[] = false
+  return nothing
+end
 

--- a/test/itensor_combine_contract.jl
+++ b/test/itensor_combine_contract.jl
@@ -1,0 +1,30 @@
+using ITensors
+using Test
+import Random: seed!
+
+seed!(12345)
+
+@testset "ITensor combine contract" begin
+  for N in 1:5
+    d = 1
+    i = Index(QN(0) => d, QN(1) => d)
+    is = IndexSet(ntuple(n -> settags(i, "i$n"), Val(N)))
+    A = randomITensor(is'..., dag(is)...)
+    B = randomITensor(is'..., dag(is)...)
+
+    @test !ITensors.use_combine_contract()
+
+    C_contract = A' * B
+
+    enable_combine_contract!()
+    @test ITensors.use_combine_contract()
+
+    C_combine_contract = A' * B
+
+    disable_combine_contract!()
+    @test !ITensors.use_combine_contract()
+
+    @test C_contract ≈ C_combine_contract
+  end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
     "not.jl",
     "itensor.jl",
     "itensor_slice.jl",
+    "itensor_combine_contract.jl",
     "broadcast.jl",
     "diagitensor.jl",
     "contract.jl",


### PR DESCRIPTION
This adds a global flag for reshaping QN ITensors into matrices before contracting, which can improve the efficiency for contracting high order block sparse tensors. It is basically the technique described in this comment: https://github.com/ITensor/ITensors.jl/issues/266#issuecomment-629369474

Here is a benchmark using the technique, which you can turn on and off with the functions `enable_combine_contract!()` and `disable_combine_contract!()`:
```julia
using BenchmarkTools
using ITensors

function main(; Nmax = 8)
  # Don't warn about large tensor orders
  disable_warn_order!()

  for N in 1:Nmax
    println("#################################################")
    println("# order = ", 2 * N)
    println("#################################################")
    println()

    d = 1
    i = Index(QN(0,2) => d, QN(1,2) => d)
    is = IndexSet(ntuple(n -> settags(i, "i$n"), Val(N)))
    A = randomITensor(is'..., dag(is)...)
    B = randomITensor(is'..., dag(is)...)

    # Use standard algorithm, without combining first
    println("Contract:")
    C_contract = @btime $A' * $B samples = 5
    println()

    # Reshape the ITensors into matrices before contracting
    println("Combine then contract:")
    enable_combine_contract!()
    C_combine_contract = @btime $A' * $B samples = 5
    disable_combine_contract!()
    println()

    @show C_contract ≈ C_combine_contract
    println()
  end
end
```
which gives the results (using NDTensors#master which has some block sparse optimizations):
```julia
julia> main(Nmax = 8)
#################################################
# order = 2
#################################################

Contract:
  2.410 μs (76 allocations: 5.70 KiB)

Combine then contract:
  48.111 μs (899 allocations: 92.98 KiB)

C_contract ≈ C_combine_contract = true

#################################################
# order = 4
#################################################

Contract:
  11.329 μs (311 allocations: 24.73 KiB)

Combine then contract:
  111.227 μs (1628 allocations: 182.69 KiB)

C_contract ≈ C_combine_contract = true

#################################################
# order = 6
#################################################

Contract:
  119.332 μs (2125 allocations: 200.11 KiB)

Combine then contract:
  284.701 μs (4019 allocations: 470.45 KiB)

C_contract ≈ C_combine_contract = true

#################################################
# order = 8
#################################################

Contract:
  1.291 ms (16988 allocations: 1.75 MiB)

Combine then contract:
  1.250 ms (18801 allocations: 1.75 MiB)

C_contract ≈ C_combine_contract = true

#################################################
# order = 10
#################################################

Contract:
  13.555 ms (138908 allocations: 16.22 MiB)

Combine then contract:
  6.233 ms (103211 allocations: 8.28 MiB)

C_contract ≈ C_combine_contract = true

#################################################
# order = 12
#################################################

Contract:
  165.222 ms (1261274 allocations: 141.49 MiB)

Combine then contract:
  37.353 ms (492436 allocations: 41.43 MiB)

C_contract ≈ C_combine_contract = true

#################################################
# order = 14
#################################################

Contract:
  2.256 s (10387274 allocations: 1.24 GiB)

Combine then contract:
  187.437 ms (2158837 allocations: 187.26 MiB)

C_contract ≈ C_combine_contract = true

#################################################
# order = 16
#################################################

Contract:
  28.637 s (104661017 allocations: 14.86 GiB)

Combine then contract:
  1.416 s (17813407 allocations: 1.32 GiB)

C_contract ≈ C_combine_contract = true

```
You can see the crossover is now around order 6-8 ITensors, which is a bit better than the last time I checked.

An immediate way to make this work better, besides low-level optimizations of the combiner code, would be to fuse the two combiners/uncombiners into one operation. Currently, the QN ITensors are turned into matrix-like (order 2) ITensors by contracting two combiners sequentially. We could fuse that operation into a single operation and minimize the amount of work the combiner step has to take (minimize the number of permutations needed, for example). My guess is that, at least for this example, that could make this combining technique match the speed of the standard contraction method for all of the ITensor orders. Note that this example of parity symmetry is particularly suited for this technique, since the order 2 ITensors end up with only 2 dense blocks to contract, so for other symmetries like U(1) this may not help as much (for example I see a crossover at order 8-10 for this same example when I switch to U(1) symmetry).