### PR TITLE
Add flux of IndexVal functionality

### DIFF
--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -96,7 +96,7 @@ function svd(A::ITensor, Linds...; kwargs...)
     for b in nzblocks(UC)
       i1 = inds(UC)[1]
       i2 = inds(UC)[2]
-      newqn = -dir(i2)*qn(i1,b[1])
+      newqn = -dir(i2)*flux(i1 => Block(b[1]))
       setblockqn!(i2,newqn,b[2])
       setblockqn!(u,newqn,b[2])
     end
@@ -104,7 +104,7 @@ function svd(A::ITensor, Linds...; kwargs...)
     for b in nzblocks(VC)
       i1 = inds(VC)[1]
       i2 = inds(VC)[2]
-      newqn = -dir(i2)*qn(i1,b[1])
+      newqn = -dir(i2)*flux(i1 => Block(b[1]))
       setblockqn!(i2,newqn,b[2])
       setblockqn!(v,newqn,b[2])
     end
@@ -217,7 +217,7 @@ function eigen(A::ITensor{N}, Linds, Rinds; kwargs...) where {N}
     i1, i2 = inds(VC)
     for b in nzblocks(VC)
       if flux(VC, b) != QN()
-        new_flux = dir(i1)*qn(i1, b[1])
+        new_flux = dir(i1) * flux(i1 => Block(b[1]))
         setblockqn!(i2, new_flux, b[2])
         setblockqn!(d, new_flux, b[2])
       end

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -303,22 +303,6 @@ Get the dimension of the Index n of the IndexSet.
 NDTensors.dim(is::IndexSet, pos::Int) = dim(is[pos])
 
 """
-    NDTensors.strides(is::IndexSet)
-
-Get the strides of the n-dimensional tensor if it had
-this IndexSet.
-"""
-NDTensors.strides(is::IndexSet) = Base.size_to_strides(1, dims(is)...)
-
-"""
-    NDTensors.stride(is::IndexSet. i::Int)
-
-Get the stride of the n-dimensional tensor if it had
-this IndexSet in the dimension `i`.
-"""
-NDTensors.stride(is::IndexSet, k::Int) = NDTensors.strides(is)[k]
-
-"""
     dag(is::IndexSet)
 
 Return a new IndexSet with the indices daggered (flip
@@ -982,7 +966,7 @@ replaceinds(is::IndexSet, rep_inds::Pair{ <: Index, <: Index}...) =
   replaceinds(is, zip(rep_inds...)...)
 
 # Check that the QNs are all the same
-hassameqns(i1::Index, i2::Index) = (dim(i1) == dim(i2))
+hassameflux(i1::Index, i2::Index) = (dim(i1) == dim(i2))
 
 function replaceinds(is::IndexSet, inds1, inds2)
   is1 = IndexSet(inds1)
@@ -1273,7 +1257,7 @@ function flux(inds::IndexSet, block)
   qntot = QN()
   for n in 1:length(inds)
     ind = inds[n]
-    qntot += qn(ind, block[n])
+    qntot += flux(ind, Block(block[n]))
   end
   return qntot
 end

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -783,9 +783,11 @@ function qn_svdMPO(ampo::AutoMPO,
     rl = llinks[n+1]
 
     function defaultMat(ll,rl,lqn,rqn) 
-      ldim = qnblockdim(ll,lqn)
-      rdim = qnblockdim(rl,rqn)
-      return zeros(ValType,ldim,rdim)
+      #ldim = qnblockdim(ll,lqn)
+      #rdim = qnblockdim(rl,rqn)
+      ldim = blockdim(ll, lqn)
+      rdim = blockdim(rl, rqn)
+      return zeros(ValType, ldim, rdim)
     end
 
     idTerm = [SiteOp("Id",n)]
@@ -844,13 +846,16 @@ function qn_svdMPO(ampo::AutoMPO,
       sq = flux(Op)
       cq = rq-sq
 
-      rn = qnblocknum(ll,rq)
-      cn = qnblocknum(rl,cq)
+      #rn = qnblocknum(ll,rq)
+      #cn = qnblocknum(rl,cq)
+      rn = block(first, ll, rq)
+      cn = block(first, rl, cq)
 
       #TODO: wrap following 3 lines into a function
-      block = (rn,cn)
-      T = BlockSparseTensor(ValType,[block],IndexSet(dag(ll),rl))
-      blockview(T, block) .= M
+      _block = Block(rn, cn)
+      T = BlockSparseTensor(ValType,[_block],IndexSet(dag(ll),rl))
+      #blockview(T, _block) .= M
+      T[_block] .= M
 
       IT = itensor(T)
       H[n] += IT * Op

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -185,9 +185,9 @@ using Compat
   end
   @testset "strides" begin
     I = IndexSet(i, j)
-    @test NDTensors.strides(I) == (1, idim)
-    @test NDTensors.stride(I, 1) == 1
-    @test NDTensors.stride(I, 2) == idim
+    @test NDTensors.dim_to_strides(I) == (1, idim)
+    @test NDTensors.dim_to_stride(I, 1) == 1
+    @test NDTensors.dim_to_stride(I, 2) == idim
   end
   @testset "setprime" begin
     I = IndexSet(i, j)


### PR DESCRIPTION
This adds the function `flux` that returns the QN flux for an Index, and makes it consistent the `qn` just returns the "bare" QN:
```julia
julia> i = dag(Index([QN(0)=>2, QN(1)=>2], "i"))
(dim=4|id=262|"i") <In>
 1: QN(0) => 2
 2: QN(1) => 2

julia> flux(i => 3)
QN(-1)

julia> qn(i => 3)
QN(1)

julia> flux(i => Block(2))
QN(-1)

julia> qn(i => Block(2))
QN(1)
```
This PR also moves towards using the NDTensors `Block` type more consistently to specify blocks of an ITensor or Index.