### PR TITLE
Improve contractions involving scalar-like ITensors or blocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["mfishman <mfishman@caltech.edu>"]
-version = "0.1.30"
+version = "0.1.31"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -19,7 +19,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 Compat = "2.1, 3"
 HDF5 = "0.13.1, 0.14"
 KrylovKit = "0.4.2, 0.5"
-NDTensors = "= 0.1.19"
+NDTensors = "= 0.1.20"
 PackageCompiler = "1.0.0"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"

--- a/examples/dmrg/2d_hubbard_conserve_momentum.jl
+++ b/examples/dmrg/2d_hubbard_conserve_momentum.jl
@@ -12,7 +12,7 @@ function main(; Nx::Int = 6,
                 t::Float64 = 1.0,
                 maxdim::Int = 3000,
                 conserve_ky = true,
-                use_splitblocks = false)
+                use_splitblocks = true)
   N = Nx * Ny
 
   sweeps = Sweeps(10)
@@ -64,7 +64,7 @@ function main(; Nx::Int = 6,
 
   psi0 = randomMPS(sites, state, 10)
 
-  energy, psi = dmrg(H, psi0, sweeps; svd_alg = "divide_and_conquer")
+  energy, psi = @time dmrg(H, psi0, sweeps; svd_alg = "divide_and_conquer")
   @show Nx, Ny
   @show t, U
   @show flux(psi)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -163,7 +163,6 @@ export
   scale!,
   scalar,
   setelt,
-  setwarnorder!,
   store,
   setprime!,
   swapprime!,

--- a/src/global_variables.jl
+++ b/src/global_variables.jl
@@ -129,7 +129,7 @@ end
 # A global timer used with TimerOutputs.jl
 #
 
-const GLOBAL_TIMER = TimerOutput()
+using NDTensors: timer
 
 #
 # Turn enable or disable combining QN ITensors before contracting

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1372,13 +1372,15 @@ end
 #  A2::ITensor,
 #  A3::ITensor, As::ITensor...)
 
+# XXX: rename contract!
 function mul!(C::ITensor, A::ITensor, B::ITensor,
               α::Number, β::Number=0)
   labelsCAB = compute_contraction_labels(inds(C), inds(A), inds(B))
   labelsC, labelsA, labelsB = labelsCAB
   CT = NDTensors.contract!!(tensor(C), labelsC, tensor(A), labelsA,
                             tensor(B), labelsB, α, β)
-  C = itensor(CT)
+  setstore!(C, store(CT))
+  setinds!(C, inds(C))
   return C
 end
 
@@ -1389,7 +1391,8 @@ function mul!(C::ITensor, A::ITensor, B::ITensor)
   labelsC, labelsA, labelsB = labelsCAB
   CT = NDTensors.contract!!(tensor(C), labelsC, tensor(A), labelsA,
                             tensor(B), labelsB)
-  C = itensor(CT)
+  setstore!(C, store(CT))
+  setinds!(C, inds(C))
   return C
 end
 
@@ -1958,10 +1961,6 @@ function readcpp(io::IO,
   else
     throw(ArgumentError("read ITensor: format=$format not supported"))
   end
-end
-
-function setwarnorder!(ord::Int)
-  ITensors.GLOBAL_PARAMS["WarnTensorOrder"] = ord
 end
 
 function HDF5.write(parent::Union{HDF5File,HDF5Group},

--- a/src/iterativesolvers.jl
+++ b/src/iterativesolvers.jl
@@ -82,9 +82,7 @@ function davidson(A,
     error("linear size of A and dimension of phi should match in davidson")
   end
 
-@timeit_debug GLOBAL_TIMER "A(q)" begin
   Aphi = A(phi)
-end
 
   V = ITensorT[copy(phi)]
   AV = ITensorT[Aphi]
@@ -110,26 +108,18 @@ end
 
     last_lambda = lambda
 
-@timeit_debug GLOBAL_TIMER "orthogonalize!" begin
     for pass = 1:Northo_pass
       orthogonalize!(q,V,ni)
     end
-end
 
-@timeit_debug GLOBAL_TIMER "A(q)" begin
     Aq = A(q)
-end
 
     push!(V,copy(q))
     push!(AV,Aq)
 
-@timeit_debug GLOBAL_TIMER "expand_krylov_space" begin
     M = expand_krylov_space(M,V,AV,ni)
-end
 
-@timeit_debug GLOBAL_TIMER "get_vecs!" begin
     lambda = get_vecs!((phi,q),M,V,AV,ni+1)
-end
 
   end #for ni=1:actual_maxiter+1
 

--- a/test/contract.jl
+++ b/test/contract.jl
@@ -124,7 +124,7 @@ digits(::Type{T},i,j,k) where {T} = T(i*10^2+j*10+k)
     @testset "Test contract ITensors (3-Tensor*Scalar -> 3-Tensor)" begin
       Aijk = permute(Aijk,i,j,k)
       C = Aijk*A
-      @test array(permute(C,i,j,k))==scalar(A)*array(Aijk)
+      @test array(permute(C,i,j,k)) ≈ scalar(A)*array(Aijk)
     end
     @testset "Test contract ITensors (3-Tensor*Vector -> Matrix)" begin
       Aijk = permute(Aijk,i,j,k)

--- a/test/itensor_scalar_contract.jl
+++ b/test/itensor_scalar_contract.jl
@@ -16,7 +16,7 @@ Random.seed!(1234)
   B = ITensor(2, α, α', α'')
 
   C = A * B
-  @assert C ≈ B[1, 1, 1] * A * ITensor(1, inds(B))
+  @test C ≈ B[1, 1, 1] * A * ITensor(1, inds(B))
 
   C = emptyITensor(is..., α', α'')
   C .= A .* B

--- a/test/itensor_scalar_contract.jl
+++ b/test/itensor_scalar_contract.jl
@@ -1,0 +1,29 @@
+using Test
+using ITensors
+using Random
+
+Random.seed!(1234)
+
+@testset "Test contractions with scalar-like ITensors" begin
+  i = Index(2, "i")
+  j = Index(2, "j")
+  k = Index(2, "k")
+  α = Index(1, "α")
+
+  is = (i, j, k)
+
+  A = randomITensor(is..., dag(α))
+  B = ITensor(2, α, α', α'')
+
+  C = A * B
+  @assert C ≈ B[1, 1, 1] * A * ITensor(1, inds(B))
+
+  C = emptyITensor(is..., α', α'')
+  C .= A .* B
+  @test C ≈ B[1, 1, 1] * A * ITensor(1, inds(B))
+
+  C = emptyITensor(shuffle([(is..., α', α'')...])...)
+  C .= A .* B
+  @test C ≈ B[1, 1, 1] * A * ITensor(1, inds(B))
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
     "not.jl",
     "itensor.jl",
     "itensor_slice.jl",
+    "itensor_scalar_contract.jl",
     "itensor_combine_contract.jl",
     "broadcast.jl",
     "diagitensor.jl",


### PR DESCRIPTION
This bumps NDTensors to v0.1.20, which has optimizations for contractions involving scalar-like tensors (https://github.com/ITensor/NDTensors.jl/pull/57). This particularly improves the efficiency of block sparse contractions that involve many blocks of size 1 (which is common for MPO tensors of local Hamiltonians).