### PR TITLE
Fix bug in inner(::MPS, ::MPS) when MPS have multiple site  indices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+ITensors v0.1.33 Release Notes
+==============================
+* Fix bug introduced in v0.1.32 involving inner(::MPS, ::MPS) if the MPS have more than one site Index per tensor (PR #549).
+
 ITensors v0.1.32 Release Notes
 ==============================
 * Update to NDTensors v0.1.21, which includes a bug fix for scalar-like tensor contractions involving mixed element types (NDTensors PR #58).

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>",
            "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.32"
+version = "0.1.33"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -993,6 +993,9 @@ end
 replaceind(is::IndexSet, i1::Index, i2::Index) =
   replaceinds(is, (i1,), (i2,))
 
+replaceind(is::IndexSet, i1::Index, i2::IndexSet{1}) =
+  replaceinds(is, (i1,), i2)
+
 replaceind(is::IndexSet, rep_i::Pair{ <: Index, <: Index}) =
   replaceinds(is, rep_i)
 

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -132,26 +132,26 @@ function MPO(A::MPS; kwargs...)
   return M
 end
 
+# XXX: rename originalsiteind?
 """
     siteind(M::MPO, j::Int; plev = 0, kwargs...)
 
 Get the first site Index of the MPO found, by
 default with prime level 0. 
 """
-siteind(M::MPO, j::Int; kwargs...) =
-  firstsiteind(M, j; plev = 0, kwargs...)
+siteind(M::MPO, j::Int; kwargs...) = siteind(first, M, j; plev = 0, kwargs...)
 
 # TODO: make this return the site indices that would have
-# been used to create the MPO, i.e.:
+# been used to create the MPO? I.e.:
 # [dag(siteinds(M, j; plev = 0, kwargs...)) for j in 1:length(M)]
 """
     siteinds(M::MPO; kwargs...)
 
-Get a Vector of IndexSets the all of the site indices of M.
+Get a Vector of IndexSets of all the site indices of M.
 """
-siteinds(M::MPO; kwargs...) =
-  [siteinds(M, j; kwargs...) for j in 1:length(M)]
+siteinds(M::MPO; kwargs...) = siteinds(all, M; kwargs...)
 
+# XXX: rename originalsiteinds?
 """
     firstsiteinds(M::MPO; kwargs...)
 
@@ -159,8 +159,7 @@ Get a Vector of the first site Index found on each site of M.
 
 By default, it finds the first site Index with prime level 0.
 """
-firstsiteinds(M::MPO; kwargs...) =
-  [siteind(M, j; kwargs...) for j in 1:length(M)]
+firstsiteinds(M::MPO; kwargs...) = siteinds(first, M; plev = 0, kwargs...)
 
 """
     dot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool = true)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -343,15 +343,24 @@ function siteind(::typeof(only), M::MPS, j::Int; kwargs...)
   if isempty(is)
     return nothing
   end
-  return only(siteinds(M, j; kwargs...))
+  return only(is)
 end
 
 """
     siteinds(M::MPS)
+    siteinds(::typeof(first), M::MPS)
 
-Get a vector of the site indices of the MPS.
+Get a vector of the first site Index found on each tensor of the MPS.
+
+    siteinds(::typeof(only), M::MPS)
+
+Get a vector of the only site Index found on each tensor of the MPS. Errors if more than one is found.
+
+    siteinds(::typeof(all), M::MPS)
+
+Get a vector of the all site Indices found on each tensor of the MPS. Returns a Vector of IndexSets.
 """
-siteinds(M::MPS) = [siteind(M, j) for j in 1:length(M)]
+siteinds(M::MPS; kwargs...) = siteinds(first, M; kwargs...)
 
 function replace_siteinds!(M::MPS, sites)
   for j in eachindex(M)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -1370,6 +1370,20 @@ end
     @test sz1 ≈ qsz1
   end
 
+  @testset "inner of MPS with more than one site Index" begin
+    s = siteinds("S=½", 4)
+    sout = addtags.(s, "out")
+    sin = addtags.(s, "in")
+    sinds = IndexSet.(sout, sin)
+    Cs = combiner.(sinds)
+    cinds = combinedind.(Cs)
+    ψ = randomMPS(cinds)
+    @test norm(ψ) ≈ 1
+    @test inner(ψ, ψ) ≈ 1
+    ψ .*= dag.(Cs)
+    @test norm(ψ) ≈ 1
+    @test inner(ψ, ψ) ≈ 1
+  end
 end
 
 nothing


### PR DESCRIPTION
This fixes a bug introduced in v0.1.32 for `inner(::MPS, ::MPS)` and related functions when the MPS have multiple site indices per tensor. For MPS, by default it tries to match the site indices with each other, so `inner(prime(psi), psi)` "just works", however performing that matching logic is not well defined if the MPS have multiple site indices. Here, it now checks for that case and doesn't perform that logic.