### PR TITLE
Make OpName use Symbol instead of SmallString for longer operator names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+ITensors v0.1.34 Release Notes
+==============================
+* Allow operator names in the `op` system that are longer than 8 characters (PR #551).
+
 ITensors v0.1.33 Release Notes
 ==============================
 * Fix bug introduced in v0.1.32 involving inner(::MPS, ::MPS) if the MPS have more than one site Index per tensor (PR #549).

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>",
            "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.33"
+version = "0.1.34"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -150,12 +150,12 @@ macro notation: `OpName"MyTag"`.
 To make an OpName value or object, you can use
 the notation: `OpName("myop")`
 """
-OpName(s::AbstractString) = OpName{SmallString(s)}()
-OpName(s::SmallString) = OpName{s}()
+OpName(s::AbstractString) = OpName{Symbol(s)}()
+OpName(s::Symbol) = OpName{s}()
 name(::OpName{N}) where {N} = N
 
 macro OpName_str(s)
-  OpName{SmallString(s)}
+  OpName{Symbol(s)}
 end
 
 # Default implementations of op and op!

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -94,6 +94,26 @@ using ITensors,
     @test_throws ErrorException op("β", s2, s1)
   end
 
+  @testset "Custom OpName with long name" begin
+    function ITensors.op(::OpName"my_favorite_operator",
+                         ::SiteType"S=1/2",
+                         s::Index)
+      Op = emptyITensor(s', dag(s))
+      Op[s'=>1,s=>1] = 0.11 
+      Op[s'=>1,s=>2] = 0.12
+      Op[s'=>2,s=>1] = 0.21
+      Op[s'=>2,s=>2] = 0.22
+      return Op
+    end
+
+    s = Index(2, "S=1/2, Site")
+    Sz = op("my_favorite_operator", s)
+    @test Sz[s'=>1,s=>1] ≈ 0.11
+    @test Sz[s'=>1,s=>2] ≈ 0.12
+    @test Sz[s'=>2,s=>1] ≈ 0.21
+    @test Sz[s'=>2,s=>2] ≈ 0.22
+  end
+
   @testset "op with more than two indices" begin
     ITensors.space(::SiteType"qubit") = 2
 


### PR DESCRIPTION
Closes #550.