### PR TITLE
Add check for Index arrows for map! (includes sum and difference etc)

### DIFF
--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -336,7 +336,9 @@ function factorize_eigen(A::ITensor, Linds...; kwargs...)
   if !isnothing(delta_A2)
     # This assumes delta_A2 has indices:
     # (Lis..., prime(Lis)...)
-    A2 += replaceinds(delta_A2, prime(Lis), simLis)
+    delta_A2 = replaceinds(delta_A2, Lis, dag(simLis))
+    noprime!(delta_A2)
+    A2 += delta_A2
   end
   F = eigen(A2, Lis, simLis; ishermitian=true,
                              kwargs...)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1719,7 +1719,7 @@ function map!(f::Function,
     # Check that Index arrows match
     for (n,p) in enumerate(perm)
       if dir(inds(R)[n]) != dir(inds(T2)[p])
-        println("Mismatched Index: \n$(inds(R)[n])")
+        #println("Mismatched Index: \n$(inds(R)[n])")
         error("Index arrows must be the same to add, subtract, map, or scale QN ITensors")
       end
     end

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1281,7 +1281,14 @@ permute(T::ITensor,
 
 -(A::ITensor) = itensor(-tensor(A))
 
+function check_add_arrows(A::ITensor{N},B::ITensor{N}) where {N}
+  if hasqns(A) && hasqns(B)
+
+  end
+end
+
 function (A::ITensor{N} + B::ITensor{N}) where {N}
+  check_add_arrows(A,B)
   C = copy(A)
   C .+= B
   return C
@@ -1707,11 +1714,27 @@ function map!(f::Function,
               T2::ITensor{N}) where {N}
   R !== T1 && error("`map!(f, R, T1, T2)` only supports `R === T1` right now")
   perm = NDTensors.getperm(inds(R),inds(T2))
+
+  if hasqns(T2) && hasqns(R)
+    # Check that Index arrows match
+    for (n,p) in enumerate(perm)
+      if dir(inds(R)[n]) != dir(inds(T2)[p])
+        println("Mismatched Index: \n$(inds(R)[n])")
+        error("Index arrows must be the same to add, subtract, map, or scale QN ITensors")
+      end
+    end
+  end
+
   TR,TT = tensor(R),tensor(T2)
 
   # TODO: Include type promotion from α
   TR = convert(promote_type(typeof(TR),typeof(TT)),TR)
   TR = permutedims!!(TR,TT,perm,f)
+  @show perm
+  @show typeof(TR)
+  @show inds(TR)
+  @show inds(TT)
+  @show inds(R)
 
   setstore!(R,store(TR))
   setinds!(R,inds(TR))

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1730,11 +1730,6 @@ function map!(f::Function,
   # TODO: Include type promotion from α
   TR = convert(promote_type(typeof(TR),typeof(TT)),TR)
   TR = permutedims!!(TR,TT,perm,f)
-  @show perm
-  @show typeof(TR)
-  @show inds(TR)
-  @show inds(TT)
-  @show inds(R)
 
   setstore!(R,store(TR))
   setinds!(R,inds(TR))

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -301,6 +301,14 @@ Random.seed!(1234)
     end
   end
 
+  @testset "Check arrows when summing" begin
+    s = siteinds("S=1/2",4;conserve_qns=true)
+    Tout = randomITensor(QN("Sz"=>2),s[2],s[1],s[3],s[4])
+    Tin = randomITensor(QN("Sz"=>2),dag(s[1]),dag(s[2]),dag(s[3]),dag(s[4]))
+    @test norm(Tout-Tout) < 1E-10 # this is ok
+    @test_throws Tout+Tin         # not ok
+  end
+
   @testset "Copy" begin
     s = Index([QN(0)=>1,QN(1)=>1],"s")
     T = randomITensor(QN(0),s,s')

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -306,7 +306,7 @@ Random.seed!(1234)
     Tout = randomITensor(QN("Sz"=>2),s[2],s[1],s[3],s[4])
     Tin = randomITensor(QN("Sz"=>2),dag(s[1]),dag(s[2]),dag(s[3]),dag(s[4]))
     @test norm(Tout-Tout) < 1E-10 # this is ok
-    @test_throws Tout+Tin         # not ok
+    @test_throws ErrorException (Tout+Tin)         # not ok
   end
 
   @testset "Copy" begin


### PR DESCRIPTION
I put a check into the `map!` function which is used to perform addition, subtraction, and scaling of ITensors among other things. The reason to put the check there is that the permutation between the indices is computed at that point anyway.

Adding this check already revealed a subtle bug in the `eigen_perturbation` feature of `factorize` which this PR fixes.