### PR TITLE
Add checks for common site indices in DMRG, dot, and inner

### DIFF
--- a/benchmark/bench_autompo.jl
+++ b/benchmark/bench_autompo.jl
@@ -1,0 +1,36 @@
+module BenchAutoMPO
+
+using BenchmarkTools
+using ITensors
+
+suite = BenchmarkGroup()
+
+let N = 30
+  s = siteinds("S=1/2", N; conserve_qns = false)
+  a = AutoMPO()
+  for k in 1:N, l in 1:N, m in 1:N, n in 1:N
+    a .+= "projDn", k, "projDn", l, "projDn", m, "projDn", n
+  end
+
+  # Precompile
+  MPO(a, s)
+
+  suite["Quartic Hamiltonian"] = @benchmarkable MPO($a, $s)
+end
+
+let N = 30
+  s = siteinds("S=1/2", N; conserve_qns = true)
+  a = AutoMPO()
+  for k in 1:N, l in 1:N, m in 1:N, n in 1:N
+    a .+= "projDn", k, "projDn", l, "projDn", m, "projDn", n
+  end
+
+  # Precompile
+  MPO(a, s)
+
+  suite["Quartic QN Hamiltonian"] = @benchmarkable MPO($a, $s)
+end
+
+end
+
+BenchAutoMPO.suite

--- a/benchmark/bench_op.jl
+++ b/benchmark/bench_op.jl
@@ -1,0 +1,20 @@
+module BenchOp
+
+using BenchmarkTools
+using ITensors
+
+suite = BenchmarkGroup()
+
+let N = 4
+  s = siteinds("S=1/2", N; conserve_qns = false)
+  suite["op"] = @benchmarkable op("Sz", $s, 1)
+end
+
+let N = 4
+  s = siteinds("S=1/2", N; conserve_qns = true)
+  suite["op QN"] = @benchmarkable op("Sz", $s, 1)
+end
+
+end
+
+BenchOp.suite

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -474,6 +474,26 @@ for fname in (:dag, :prime, :setprime, :noprime, :addtags, :removetags,
   end
 end
 
+adjoint(M::AbstractMPS) = prime(M)
+
+function hascommoninds(::typeof(siteinds), A::AbstractMPS, B::AbstractMPS)
+  N = length(A)
+  for n in 1:N
+    !hascommoninds(siteinds(A, n), siteinds(B, n)) && return false
+  end
+  return true
+end
+
+function check_hascommoninds(::typeof(siteinds), A::AbstractMPS, B::AbstractMPS)
+  N = length(A)
+  if length(B) ≠ N
+    throw(DimensionMismatch("$(typeof(A)) and $(typeof(B)) have mismatched lengths $N and $(length(B))."))
+  end
+  for n in 1:N
+    !hascommoninds(siteinds(A, n), siteinds(B, n)) && error("$(typeof(A)) A and $(typeof(B)) B must share site indices. On site $n, A has site indices $(siteinds(A, n)) while B has site indices $(siteinds(B, n)).")
+  end
+end
+
 function map_linkinds!(f::Function, M::AbstractMPS)
   for i in eachindex(M)[1:end-1]
     l = linkind(M, i)

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -30,6 +30,8 @@ Returns:
 * `psi::MPS` - optimized MPS
 """
 function dmrg(H::MPO, psi0::MPS, sweeps::Sweeps; kwargs...)
+  check_hascommoninds(siteinds, H, psi0)
+  check_hascommoninds(siteinds, H, psi0')
   # Permute the indices to have a better memory layout
   # and minimize permutations
   H = permute(H, (linkind, siteinds, linkind))
@@ -59,6 +61,10 @@ Returns:
 * `psi::MPS` - optimized MPS
 """
 function dmrg(Hs::Vector{MPO}, psi0::MPS, sweeps::Sweeps; kwargs...)
+  for H in Hs
+    check_hascommoninds(siteinds, H, psi0)
+    check_hascommoninds(siteinds, H, psi0')
+  end
   Hs .= permute.(Hs, Ref((linkind, siteinds, linkind)))
   PHS = ProjMPOSum(Hs)
   return dmrg(PHS,psi0,sweeps;kwargs...)
@@ -85,6 +91,11 @@ Returns:
 * `psi::MPS` - optimized MPS
 """
 function dmrg(H::MPO, Ms::Vector{MPS}, psi0::MPS, sweeps::Sweeps; kwargs...)
+  check_hascommoninds(siteinds, H, psi0)
+  check_hascommoninds(siteinds, H, psi0')
+  for M in Ms
+    check_hascommoninds(siteinds, M, psi0)
+  end
   H = permute(H, (linkind, siteinds, linkind))
   Ms .= permute.(Ms, Ref((linkind, siteinds, linkind)))
   weight = get(kwargs,:weight,1.0)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -178,14 +178,14 @@ dimensions or QN blocks).
 function dot(y::MPS, A::MPO, x::MPS;
              make_inds_match::Bool = true)::Number
   N = length(A)
-  if length(y) != N || length(x) != N
-    throw(DimensionMismatch("inner: mismatched lengths $N and $(length(x)) or $(length(y))"))
-  end
+  check_hascommoninds(siteinds, A, x)
   ydag = dag(y)
   sim_linkinds!(ydag)
   if make_inds_match
     sAx = unique_siteinds(A, x)
     replace_siteinds!(ydag, sAx)
+  else
+    check_hascommoninds(siteinds, A, y)
   end
   O = ydag[1] * A[1] * x[1]
   for j in 2:N
@@ -194,7 +194,7 @@ function dot(y::MPS, A::MPO, x::MPS;
   return O[]
 end
 
-inner(y::MPS, A::MPO, x::MPS) = dot(y, A, x)
+inner(y::MPS, A::MPO, x::MPS; kwargs...) = dot(y, A, x; kwargs...)
 
 """
     dot(B::MPO, y::MPS, A::MPO, x::MPS; make_inds_match::Bool = true)

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -545,6 +545,25 @@ end
     @test tr(H2) ≈ d^N
   end
 
+  @testset "check_hascommonsiteinds checks in DMRG, inner, dot" begin
+    N = 4
+    s1 = siteinds("S=1/2", N)
+    s2 = siteinds("S=1/2", N)
+    psi1 = randomMPS(s1)
+    psi2 = randomMPS(s2)
+    H1 = MPO(AutoMPO() + ("Id", 1), s1)
+    H2 = MPO(AutoMPO() + ("Id", 1), s2)
+
+    @test_throws ErrorException inner(psi1, H2, psi1)
+    @test_throws ErrorException inner(psi1, H2, psi2; make_inds_match = false)
+
+    sweeps = Sweeps(1)
+    maxdim!(sweeps, 10)
+
+    @test_throws ErrorException dmrg(H2, psi1, sweeps)
+    @test_throws ErrorException dmrg(H1, [psi2], psi1, sweeps)
+    @test_throws ErrorException dmrg([H1, H2], psi1, sweeps)
+  end
 end
 
 nothing


### PR DESCRIPTION
This adds checks for common site indices in `dmrg`, `dot`, and `inner`, which should help people catch issues like: http://itensor.org/support/2780/julia-initial-state-for-dmrg.

Also adds benchmarks for `op` and `MPO(::AutoMPO, sites)`.