### PR TITLE
Fix and Improve DMRGObserver Constructor

### DIFF
--- a/docs/src/DMRGObserver.md
+++ b/docs/src/DMRGObserver.md
@@ -34,7 +34,7 @@ end
 ## Constructors
 
 ```@docs
-DMRGObserver(energy_tol::Float64,minsweeps::Int)
+DMRGObserver(;energy_tol::Float64,minsweeps::Int)
 DMRGObserver(ops::Vector{String},sites::Vector{<:Index};energy_tol::Float64,minsweeps::Int)
 ```
 

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -47,18 +47,16 @@ end
 Construct a DMRGObserver by providing the energy
 tolerance used for early stopping, and minimum number
 of sweeps that must be done.
-    - energy_tol: if the energy from one sweep to the
-      next no longer changes by more than this amount,
-      stop after the current sweep
-    - minsweeps: do at least this many sweeps
+
+  - energy_tol: if the energy from one sweep to the
+    next no longer changes by more than this amount,
+    stop after the current sweep
+  - minsweeps: do at least this many sweeps
 """
 function DMRGObserver(;energy_tol=0.0, 
                       minsweeps=2) 
   DMRGObserver([],Index[],Dict{String,DMRGMeasurement}(),[],[],energy_tol,minsweeps)
 end
-
-# Without named arguments for backwards compatibility:
-DMRGObserver(energy_tol=0.0, minsweeps=2) = DMRGObserver(;energy_tol,minsweeps)
 
 
 """
@@ -80,10 +78,11 @@ the DMRG calculation.
 Optionally, one can provide an energy
 tolerance used for early stopping, and minimum number
 of sweeps that must be done.
-    - energy_tol: if the energy from one sweep to the
-      next no longer changes by more than this amount,
-      stop after the current sweep
-    - minsweeps: do at least this many sweeps
+
+  - energy_tol: if the energy from one sweep to the
+    next no longer changes by more than this amount,
+    stop after the current sweep
+  - minsweeps: do at least this many sweeps
 """
 function DMRGObserver(ops::Vector{String}, 
                       sites::Vector{<:Index};

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -41,8 +41,8 @@ struct DMRGObserver <: AbstractObserver
 end
 
 """
-    DMRGObserver(energy_tol=0.0,
-                 minsweeps=2)
+    DMRGObserver(;energy_tol=0.0,
+                  minsweeps=2)
 
 Construct a DMRGObserver by providing the energy
 tolerance used for early stopping, and minimum number
@@ -52,10 +52,14 @@ of sweeps that must be done.
       stop after the current sweep
     - minsweeps: do at least this many sweeps
 """
-function DMRGObserver(energy_tol=0.0, 
+function DMRGObserver(;energy_tol=0.0, 
                       minsweeps=2) 
-  DMRGObserver([],[],Dict{String,DMRGMeasurement}(),[],[],energy_tol,minsweeps)
+  DMRGObserver([],Index[],Dict{String,DMRGMeasurement}(),[],[],energy_tol,minsweeps)
 end
+
+# Without named arguments for backwards compatibility:
+DMRGObserver(energy_tol=0.0, minsweeps=2) = DMRGObserver(;energy_tol,minsweeps)
+
 
 """
     DMRGObserver(ops::Vector{String}, 

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -108,6 +108,12 @@ using ITensors, Test, Random
   end
 
   @testset "DMRGObserver" begin
+
+    # Test basic constructors
+    observer = DMRGObserver()
+    observer = DMRGObserver(1E-4,2)
+
+    # Test in a DMRG calculation
     N = 10
     sites = siteinds("S=1/2",N)
     Random.seed!(42)

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -111,7 +111,6 @@ using ITensors, Test, Random
 
     # Test that basic constructors work
     observer = DMRGObserver()
-    observer = DMRGObserver(1E-4,2)
     observer = DMRGObserver(;minsweeps=2,energy_tol=1E-4)
 
     # Test in a DMRG calculation

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -109,9 +109,10 @@ using ITensors, Test, Random
 
   @testset "DMRGObserver" begin
 
-    # Test basic constructors
+    # Test that basic constructors work
     observer = DMRGObserver()
     observer = DMRGObserver(1E-4,2)
+    observer = DMRGObserver(;minsweeps=2,energy_tol=1E-4)
 
     # Test in a DMRG calculation
     N = 10


### PR DESCRIPTION

The simpler DMRGObserver constructor was erroring, and
also did not take keyword arguments. This PR fixes
both issues. Technically it is a breaking change but
no one could have been using the previous constructor
since it would result in an error anyway.

- Add basic DMRGObserver constructors to test
- Add DMRGObserver constructor taking named args
- Remove conflicting definition and fix Markdown
- Update docs
