### PR TITLE
Add tests for threaded contraction with no output blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+ITensors v0.1.37 Release Notes
+==============================
+- Bump to NDTensors v0.1.23 which fixes a bug in block sparse multithreading when a block sparse tensor contraction results in a tensor with no blocks (PR #565) (@mtfishman).
+
 ITensors v0.1.36 Release Notes
 ==============================
 - Bump to v0.1.22 of NDTensors which introduces block sparse multithreading. Add documentation and examples for using block sparse multithreading (PR #561) (@mtfishman).

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>",
            "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.36"
+version = "0.1.37"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -21,7 +21,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 Compat = "2.1, 3"
 HDF5 = "0.14,0.15"
 KrylovKit = "0.4.2, 0.5"
-NDTensors = "= 0.1.22"
+NDTensors = "= 0.1.23"
 PackageCompiler = "1.0.0"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -315,6 +315,45 @@ using ITensors, Test, Random
     energy,psi = dmrg(H, psi0, sweeps; outputlevel=0)
   end
 
+  @testset "Bug fixed in threaded block sparse" begin
+    maxdim = 10
+    nsweeps = 2
+    outputlevel = 1
+    cutoff = 0.0
+    Nx = 4
+    Ny = 2
+    U = 4.0
+    t = 1.0
+    N = Nx * Ny
+    sweeps = Sweeps(nsweeps)
+    maxdims = min.(maxdim, [100, 200, 400, 800, 2000, 3000, maxdim])
+    maxdim!(sweeps, maxdims...)
+    cutoff!(sweeps, cutoff)
+    noise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
+    sites = siteinds("Electron", N; conserve_qns = true)
+    lattice = square_lattice(Nx, Ny; yperiodic = true)
+    ampo = AutoMPO()
+    for b in lattice
+      ampo .+= -t, "Cdagup", b.s1, "Cup", b.s2
+      ampo .+= -t, "Cdagup", b.s2, "Cup", b.s1
+      ampo .+= -t, "Cdagdn", b.s1, "Cdn", b.s2
+      ampo .+= -t, "Cdagdn", b.s2, "Cdn", b.s1
+    end
+    for n in 1:N
+      ampo .+= U, "Nupdn", n
+    end
+    H = MPO(ampo,sites)
+    Hsplit = splitblocks(linkinds, H)
+    state = [isodd(n) ? "↑" : "↓" for n in 1:N]
+    ψ0 = productMPS(sites, state)
+    using_threaded_blocksparse = ITensors.enable_threaded_blocksparse()
+    energy, _ = dmrg(H, ψ0, sweeps; outputlevel = outputlevel)
+    energy_split, _ = dmrg(Hsplit, ψ0, sweeps; outputlevel = outputlevel)
+    @test energy_split ≈ energy
+    if !using_threaded_blocksparse
+      ITensors.disable_threaded_blocksparse()
+    end
+  end
 end
 
 nothing


### PR DESCRIPTION
See ITensor/NDTensors.jl/pull/63.