### PR TITLE
Fix bug in BlockSparse-DiagBlockSparse contraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>",
            "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.37"
+version = "0.1.38"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -21,7 +21,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 Compat = "2.1, 3"
 HDF5 = "0.14,0.15"
 KrylovKit = "0.4.2, 0.5"
-NDTensors = "= 0.1.23"
+NDTensors = "= 0.1.24"
 PackageCompiler = "1.0.0"
 StaticArrays = "0.12.3"
 TimerOutputs = "0.5.5"

--- a/test/itensor_combine_contract.jl
+++ b/test/itensor_combine_contract.jl
@@ -11,16 +11,16 @@ seed!(12345)
   A = randomITensor(is'..., dag(is)...)
   B = randomITensor(is'..., dag(is)...)
 
-  @test !ITensors.use_combine_contract()
+  @test !ITensors.using_combine_contract()
 
   C_contract = A' * B
 
-  enable_combine_contract!()
-  @test ITensors.use_combine_contract()
+  ITensors.enable_combine_contract()
+  @test ITensors.using_combine_contract()
 
   C_combine_contract = A' * B
 
-  disable_combine_contract!()
+  ITensors.disable_combine_contract()
   @test !ITensors.use_combine_contract()
 
   @test C_contract ≈ C_combine_contract

--- a/test/qndiagitensor.jl
+++ b/test/qndiagitensor.jl
@@ -69,6 +69,28 @@ using ITensors,
     end
   end
 
+  @testset "Regression test for QN delta contraction bug" begin
+    # http://itensor.org/support/2814/block-sparse-itensor-wrong-results-multiplying-delta-tensor
+    s = Index([QN(("N",i,1))=>1 for i = 1:2])
+    l = dag(addtags(s,"left"))
+    r = addtags(s,"right")
+    u = addtags(s,"up")
+    d = dag(addtags(s,"down"))
+    A = emptyITensor(l,r,u,d)
+    A[1,1,1,1] = 1.0
+    A[1,1,2,2] = 1.0
+    A[2,2,1,1] = 1.0
+    A[2,2,2,2] = 1.0
+    δlr = δ(dag(l), dag(r))
+    δud = δ(dag(u), dag(d))
+    A1 = A * δlr
+    denseA1 = dense(A) * dense(δlr)
+    A2 = A1 * δud
+    denseA2 = denseA1 * dense(δud)
+    @test dense(A1) ≈ denseA1
+    @test dense(A2) ≈ denseA2
+    @test A2[] ≈ 4
+  end
 end
 
 nothing


### PR DESCRIPTION
Bump to NDTensors v0.1.24 and ITensors v0.1.38, which fixes a bug in BlockSparse-DiagBlockSparse contraction.