### PR TITLE
Add generic support for scalar ITensor contraction

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1268,9 +1268,6 @@ permute(T::ITensor,
                                             IndexSet(inds...); vargs...)
 
 function (T::ITensor{N} * x::Number)::ITensor{N} where {N}
-  if isone(x)
-    return T
-  end
   return itensor(x * tensor(T))
 end
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1267,7 +1267,12 @@ permute(T::ITensor,
         inds::Index...; vargs...) = permute(T,
                                             IndexSet(inds...); vargs...)
 
-(T::ITensor * x::Number) = itensor(x * tensor(T))
+function (T::ITensor{N} * x::Number)::ITensor{N} where {N}
+  if isone(x)
+    return T
+  end
+  return itensor(x * tensor(T))
+end
 
 (x::Number * T::ITensor) = T * x
 
@@ -1362,6 +1367,9 @@ function (A::ITensor * B::ITensor)
   C = using_combine_contract() ? combine_contract(A, B) : _contract(A, B)
   return C
 end
+
+(A::ITensor{0} * B::ITensor) = A[] * B
+(A::ITensor * B::ITensor{0}) = A * B[]
 
 # TODO: define for contraction order optimization
 #*(A1::ITensor,

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -1484,6 +1484,15 @@ end
     @test nnz(C2) == 0
     @test C1 ≈ C2
   end
+
+  @testset "Contraction with scalar ITensor" begin
+    i = Index([QN(0)=>2, QN(1)=>2])
+    A = randomITensor(i', dag(i))
+    A1 = A * ITensor(1)
+    A2 = ITensor(1) * A
+    @test A1 ≈ A
+    @test A2 ≈ A
+  end
 end
 
 end


### PR DESCRIPTION
This fixes #564.

@emstoudenmire, the main subtlety here is that in this implementation, it adds a special case when the ITensor has a scalar value of 1 and does nothing at all to it (just returns the non-scalar ITensor). The alternative would be that it performs a copy of the ITensor in that case, since it may be surprising for people that contractions sometimes return views of the input ITensors. Do you have an opinion on this?

There are other cases where we would not want to do a copy in ITensor contraction, for example with delta contractions that are just replacing indices (i.e. `randomITensor(i, j) * delta(j, j')`). In those cases, I would also want to return a view of the ITensor data, so perhaps contraction with `ITensor(1)` can be lumped in with that category. The main subtlety for contraction with `ITensor(1)` is that it is a pretty sneaky behavior change between contracting with `ITensor(1)` and any other scalar value, so maybe someone relies on the return not being a view and then one day they don't realize they are contracting by a value of exactly `1` and the view behavior changes... But maybe we can just make it clear in the docs that scalar-like ITensors have special behavior.