### PR TITLE
Define some missing methods for AbstractMPS broadcasting

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1733,9 +1733,9 @@ splitblocks(::typeof(linkinds), M::AbstractMPS; tol = 0) =
 #
 
 BroadcastStyle(MPST::Type{<:AbstractMPS}) = Style{MPST}()
-BroadcastStyle(::DefaultArrayStyle{1}, ::Style{MPST}) where {MPST<:AbstractMPS} = Style{MPST}()
-BroadcastStyle(::Style{MPST}, ::DefaultArrayStyle{1}) where {MPST<:AbstractMPS} = Style{MPST}()
+BroadcastStyle(::Style{MPST}, ::DefaultArrayStyle{N}) where {N, MPST<:AbstractMPS} = Style{MPST}()
 
+broadcastable(ψ::AbstractMPS) = ψ
 copyto!(ψ::AbstractMPS, b::Broadcasted) = copyto!(data(ψ), b)
 
 similar(::Broadcasted{Style{MPST}}, ::Type{ElType}, dims) where {N,ElType,MPST<:AbstractMPS} =

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -88,8 +88,7 @@ function orthocenter(m::T) where {T<:AbstractMPS}
   return leftlim(m)+1
 end
 
-getindex(M::AbstractMPS, n::Integer) =
-  getindex(data(M), n)
+getindex(M::AbstractMPS, n) = getindex(data(M), n)
 
 lastindex(M::AbstractMPS) =
   lastindex(data(M))
@@ -1734,9 +1733,13 @@ splitblocks(::typeof(linkinds), M::AbstractMPS; tol = 0) =
 #
 
 BroadcastStyle(MPST::Type{<:AbstractMPS}) = Style{MPST}()
+BroadcastStyle(::DefaultArrayStyle{1}, ::Style{MPST}) where {MPST<:AbstractMPS} = Style{MPST}()
+BroadcastStyle(::Style{MPST}, ::DefaultArrayStyle{1}) where {MPST<:AbstractMPS} = Style{MPST}()
 
 copyto!(ψ::AbstractMPS, b::Broadcasted) = copyto!(data(ψ), b)
 
+similar(::Broadcasted{Style{MPST}}, ::Type{ElType}, dims) where {N,ElType,MPST<:AbstractMPS} =
+    similar(Array{ElType}, dims)
 #
 # Printing functions
 #

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1738,8 +1738,10 @@ BroadcastStyle(::Style{MPST}, ::DefaultArrayStyle{N}) where {N, MPST<:AbstractMP
 broadcastable(ψ::AbstractMPS) = ψ
 copyto!(ψ::AbstractMPS, b::Broadcasted) = copyto!(data(ψ), b)
 
-similar(::Broadcasted{Style{MPST}}, ::Type{ElType}, dims) where {N,ElType,MPST<:AbstractMPS} =
+similar(::Broadcasted{Style{MPST}}, ::Type{ElType}, dims) where {ElType,MPST<:AbstractMPS} =
     similar(Array{ElType}, dims)
+similar(bc::Broadcasted{Style{MPST}}, ::Type{ElType}) where {ElType,MPST<:AbstractMPS} =
+    similar(Array{ElType}, axes(bc))
 #
 # Printing functions
 #


### PR DESCRIPTION
As discussed on Slack, added some definitions to help broadcasting work with ITensorsGPU. Also allows out of place bcasting on MPS like types now!