### PR TITLE
Undef randomITensor

### DIFF
--- a/docs/settings.jl
+++ b/docs/settings.jl
@@ -21,6 +21,7 @@ settings = Dict(
                                  "SiteType and op" => "SiteType.md",
                                  "DMRG" => [
                                             "DMRG.md",
+                                            "Sweeps.md",
                                             "ProjMPO.md",
                                             "ProjMPOSum.md",
                                             "Observer.md",

--- a/docs/src/ITensorType.md
+++ b/docs/src/ITensorType.md
@@ -28,6 +28,7 @@ itensor(::Array{<:Number},::ITensors.Indices)
 ```@docs
 ITensor(::Type{<:Number}, ::QN, ::ITensors.Indices)
 ITensor(A::Array, inds::ITensors.QNIndexSet)
+ITensor(::Type{<:Number}, ::UndefInitializer, ::QN, ::ITensors.Indices)
 ```
 
 ## Empty Constructors

--- a/docs/src/Sweeps.md
+++ b/docs/src/Sweeps.md
@@ -1,0 +1,26 @@
+# Sweeps
+
+```@docs
+Sweeps
+Sweeps(nsw::Int, d::AbstractMatrix)
+```
+
+## Modifying Sweeps Objects
+
+```@docs
+maxdim!
+cutoff!
+noise!
+mindim!
+```
+
+## Getting Sweeps Object Data
+
+```@docs
+nsweep(sw::Sweeps)
+maxdim(sw::Sweeps,n::Int)
+cutoff(sw::Sweeps,n::Int)
+noise(sw::Sweeps,n::Int)
+mindim(sw::Sweeps,n::Int)
+```
+

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1206,7 +1206,7 @@ B = randomITensor(ComplexF64,undef,k,j)
 """
 function randomITensor(::Type{S},
                        inds::Indices) where {S <: Number}
-  T = ITensor(S, inds)
+  T = ITensor(S,undef,inds)
   randn!(T)
   return T
 end

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -6,6 +6,25 @@
 Construct an ITensor with BlockSparse storage filled with `zero(ElT)` where the nonzero blocks are determined by `flux`.
 
 If `ElT` is not specified it defaults to `Float64`.
+
+# Examples
+
+```julia
+i = Index([QN(0)=>1, QN(1)=>2], "i")
+
+# QN ITensors with flux of QN(0):
+
+A = ITensor(i',dag(i))
+B = ITensor(QN(0),i',dag(i))
+
+# QN ITensor with flux of QN(1):
+
+C = ITensor(QN(1),i',dag(i))
+
+# Complex QN ITensor with flux of QN(1):
+
+C = ITensor(ComplexF64,QN(1),i',dag(i))
+```
 """
 function ITensor(::Type{ElT}, flux::QN, inds::Indices) where {ElT <: Number}
   blocks = nzblocks(flux, IndexSet(inds))

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -143,7 +143,7 @@ Construct an ITensor with `NDTensors.BlockSparse` storage filled with random ele
 If `ElT` is not specified it defaults to `Float64`. If the flux is not specified it defaults to `QN()`.
 """
 function randomITensor(::Type{ElT}, flux::QN, inds::Indices) where {ElT <: Number}
-  T = ITensor(ElT, flux, inds)
+  T = ITensor(ElT, undef, flux, inds)
   randn!(T)
   return T
 end

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -32,6 +32,22 @@ ITensor(::Type{ElT}, inds::QNIndex...) where {ElT<:Number} =
 
 ITensor(inds::QNIndex...) = ITensor(Float64, QN(), IndexSet(inds...))
 
+"""
+    ITensor([::Type{ElT} = Float64, ]::UndefInitializer, inds)
+    ITensor([::Type{ElT} = Float64, ]::UndefInitializer, inds::Index...)
+
+Construct an ITensor with indices `inds` and BlockSparse storage with undefined elements of type `ElT`, where the nonzero (allocated) blocks are determined by the provided QN `flux`. One purpose for using this constructor is that initializing the elements in an undefined way is faster than initializing them to a set value such as zero.
+
+The storage will have `NDTensors.BlockSparse` type.
+"""
+function ITensor(::Type{ElT}, ::UndefInitializer, 
+                 flux::QN, inds::Indices) where {ElT <: Number}
+  blocks = nzblocks(flux, IndexSet(inds))
+  T = BlockSparseTensor(ElT,undef,blocks,inds)
+  return itensor(T)
+end
+
+
 function _ITensor(A::Array{ElT}, inds::QNIndexSet; tol = 0) where {ElT}
   length(A) ≠ dim(inds) && throw(DimensionMismatch("In ITensor(::Array, ::IndexSet), length of Array ($(length(A))) must match total dimension of IndexSet ($(dim(inds)))"))
   T = emptyITensor(ElT, inds)


### PR DESCRIPTION
- Change dense randomITensor to use undef constructor
- Add undef QN ITensor constructor
- Change QN randomITensor to use undef constructor
- Improve docs and document undef QN ITensor constructor
- Add docs for Sweeps objects

Fixes #399
