### PR TITLE
ITensor constructors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ ITensor v0.2.0 Release Notes
 - Contraction sequence optimization (PR #589) (@mtfishman).
 - Make TagSet code cleaner and more generic, and improve constructor from String performance (PR #610) (@saolof).
 - Define some missing methods for AbstractMPS broadcasting (#609) (@kshyatt).
-- ITensor constructors from Array now only convert to floating point for `Array{Int}` and `Array{Complex{Int}}` (IS #612).
+- ITensor constructors from Array now only convert to floating point for `Array{Int}` and `Array{Complex{Int}}`. That same conversion is added for QN ITensor constructors to be consistent with non-QN versions (IS #612).
 - New ITensor constructors like `itensor(Int, [0 1; 1 0], i, j)` to specify the exact element type desired (IS #612).
 - Speed up randomITensor with undef constructor (PR #616) (@emstoudenmire).
 - Fix definition of Adagdn for Electron (PR #615) (@emstoudenmire).

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,8 @@ ITensor v0.2.0 Release Notes
 - Contraction sequence optimization (PR #589) (@mtfishman).
 - Make TagSet code cleaner and more generic, and improve constructor from String performance (PR #610) (@saolof).
 - Define some missing methods for AbstractMPS broadcasting (#609) (@kshyatt).
-- ITensor constructors from Array now only convert to floating point for `Array{Int}` and `Array{Complex{Int}}`. That same conversion is added for QN ITensor constructors to be consistent with non-QN versions (IS #612).
-- New ITensor constructors like `itensor(Int, [0 1; 1 0], i, j)` to specify the exact element type desired (IS #612).
+- ITensor constructors from Array now only convert to floating point for `Array{Int}` and `Array{Complex{Int}}`. That same conversion is added for QN ITensor constructors to be consistent with non-QN versions (PR #620) (@mtfishman).
+- New ITensor constructors like `itensor(Int, [0 1; 1 0], i, j)` to specify the exact element type desired (PR #620) (@mtfishman).
 - Speed up randomITensor with undef constructor (PR #616) (@emstoudenmire).
 - Fix definition of Adagdn for Electron (PR #615) (@emstoudenmire).
 - Make ops less strict about input (PR #602) (@emstoudenmire).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+ITensor v0.2.0 Release Notes
+==============================
+- Remove size type parameter from ITensor and IndexSet (PR #591) (@kshyatt).
+- Add support for using end in setindex! for ITensors (PR #596) (@mtfishman).
+- Contraction sequence optimization (PR #589) (@mtfishman).
+- Make TagSet code cleaner and more generic, and improve constructor from String performance (PR #610) (@saolof).
+- Define some missing methods for AbstractMPS broadcasting (#609) (@kshyatt).
+- ITensor constructors from Array now only convert to floating point for `Array{Int}` and `Array{Complex{Int}}` (IS #612).
+- New ITensor constructors like `itensor(Int, [0 1; 1 0], i, j)` to specify the exact element type desired (IS #612).
+- Speed up randomITensor with undef constructor (PR #616) (@emstoudenmire).
+- Fix definition of Adagdn for Electron (PR #615) (@emstoudenmire).
+- Make ops less strict about input (PR #602) (@emstoudenmire).
+- Add onehot as new name for setelt (PR #580) (@emstoudenmire).
+- Support randomMPS(ComplexF64,s,chi) (PR #377) (@emstoudenmire).
+
+Deprecations:
+- `store` is deprecated in favor of `storage` for getting the storage of an ITensor. Similarly `ITensors.setstore[!]` -> `ITensors.setstorage[!]`.
+
+ITensors v0.1.41 Release Notes
+==============================
+- Add "Qubit" site type (alias for "S=1/2"), along with many quantum gate definitions (PR #592) (@emstoudenmire).
+
 ITensors v0.1.40 Release Notes
 ==============================
 - Remove eigen QN fix code (simplify ITensors eigen code by handling QNs better in NDTensors eigen) (PR #587) (@emstoudenmire).

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -23,6 +23,12 @@ using StaticArrays
 using TimerOutputs
 
 #####################################
+# NDTensors (definitions that will be moved to NDTensors
+# module)
+#
+include("NDTensors/NDTensors.jl")
+
+#####################################
 # ContractionSequenceOptimization
 #
 include("ContractionSequenceOptimization/ContractionSequenceOptimization.jl")

--- a/src/NDTensors/NDTensors.jl
+++ b/src/NDTensors/NDTensors.jl
@@ -1,0 +1,7 @@
+
+#
+# Definitions to move to NDTensors
+#
+
+storage(T::Tensor) = store(T)
+

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -16,12 +16,16 @@
 
 # itensor.jl
 @deprecate commonindex(args...; kwargs...) commonind(args...; kwargs...)
+@deprecate emptyITensor(::Type{Any}) emptyITensor()
 @deprecate findindex(args...; kwargs...) firstind(args...; kwargs...)
 @deprecate findinds(args...; kwargs...) inds(args...; kwargs...)
 @deprecate linkindex(args...; kwargs...) linkind(args...; kwargs...)
 @deprecate matmul(A::ITensor, B::ITensor) product(A, B)
 @deprecate replaceindex!(args...; kwargs...) replaceind!(args...; kwargs...)
 @deprecate siteindex(args...; kwargs...) siteind(args...; kwargs...)
+@deprecate store(A::ITensor) storage(A)
+@deprecate setstore!(T::ITensor, st) setstorage!(T, st) false
+@deprecate setstore(T::ITensor, st) setstorage(T, st) false
 @deprecate uniqueindex(args...; kwargs...) uniqueind(args...; kwargs...)
 
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -160,7 +160,7 @@ export
   scale!,
   scalar,
   setelt,
-  store,
+  storage,
   setprime!,
   swapprime!,
   settags!,

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -237,6 +237,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
         @printf("  Truncated using cutoff=%.1E maxdim=%d mindim=%d\n",
                 cutoff(sweeps, sw),maxdim(sweeps, sw),mindim(sweeps, sw))
         @printf("  Trunc. err=%.2E, bond dimension %d\n",spec.truncerr,dim(linkind(psi,b)))
+        flush(stdout)
       end
 
       sweep_is_done = (b==1 && ha==2)
@@ -253,6 +254,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
     if outputlevel >= 1
       @printf("After sweep %d energy=%.12f maxlinkdim=%d maxerr=%.2E time=%.3f\n",
               sw, energy, maxlinkdim(psi), maxtruncerr, sw_time)
+      flush(stdout)
     end
     isdone = checkdone!(obs;energy=energy,
                             psi=psi,

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -142,10 +142,18 @@ ITensor(A::Array, inds::QNIndexSet; tol = 0) =
   _ITensor(A, inds; tol = tol)
 
 # Defined to fix ambiguity error
-ITensor(A::Array{ <: AbstractFloat}, inds::QNIndexSet; tol = 0) =
+ITensor(A::Array{<: AbstractFloat}, inds::QNIndexSet; tol = 0) =
+  _ITensor(A, inds; tol = tol)
+
+# Defined to fix ambiguity error
+ITensor(A::Array{<: RealOrComplex{Int}}, inds::QNIndexSet; tol = 0) =
   _ITensor(A, inds; tol = tol)
 
 ITensor(A::Array, inds::QNIndex...; tol = 0) =
+  _ITensor(A, IndexSet(inds...); tol = tol)
+
+# Defined to fix ambiguity error
+ITensor(A::Array{<: RealOrComplex{Int}}, inds::QNIndex...; tol = 0) =
   _ITensor(A, IndexSet(inds...); tol = tol)
 
 itensor(A::Array, inds::QNIndexSet; tol = 0) =

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -155,7 +155,11 @@ itensor(A::Array, inds::QNIndex...; tol = 0) =
   ITensor(A, inds...; tol = tol)
 
 # Defined to fix ambiguity error
-itensor(A::Array{ <: Number}, inds::QNIndex...; tol = 0) =
+itensor(A::Array{<: Number}, inds::QNIndex...; tol = 0) =
+  ITensor(A, inds...; tol = tol)
+
+# Defined to fix ambiguity error
+itensor(A::Array{<: RealOrComplex{Int}}, inds::QNIndex...; tol = 0) =
   ITensor(A, inds...; tol = tol)
 
 """

--- a/test/combiner.jl
+++ b/test/combiner.jl
@@ -12,7 +12,7 @@ A = randomITensor(i, j, k, l)
 
 @testset "Basic combiner properties" begin
   C = combiner(i, j, k)
-  @test eltype(store(C)) === Number
+  @test eltype(storage(C)) === Number
   @test_throws ErrorException ITensors.data(C)
   @test NDTensors.uncombinedinds(NDTensors.tensor(C)) == (i, j, k)
 end

--- a/test/diagitensor.jl
+++ b/test/diagitensor.jl
@@ -132,7 +132,7 @@ using ITensors,
       D = diagITensor(v,i,j,k)
       T = dense(D)
       
-      @test store(T) isa NDTensors.Dense{Float64}
+      @test storage(T) isa NDTensors.Dense{Float64}
       for ii = 1:d, jj = 1:d, kk = 1:d
         if ii == jj == kk
           @test T[ii,ii,ii] == ii
@@ -343,7 +343,7 @@ using ITensors,
       D = δ(i,j,k)
       T = dense(D)
 
-      @test store(T) isa NDTensors.Dense{Float64}
+      @test storage(T) isa NDTensors.Dense{Float64}
       for ii = 1:d, jj = 1:d, kk = 1:d
         if ii == jj == kk
           @test T[ii,ii,ii] == 1.0

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -611,6 +611,53 @@ end
   @test T[i => 1, j => 1] == 3.3
 end
 
+@testset "ITensor Array constructor view behavior" begin
+  d = 2
+  i = Index(d)
+
+  # view
+  A = randn(Float64, d, d)
+  T = itensor(A, i', dag(i))
+  @test storage(T) isa NDTensors.Dense{Float64}
+  A[1, 1] = 2.0
+  T[1, 1] == 2.0
+
+  # view
+  A = rand(Int, d, d)
+  T = itensor(Int, A, i', dag(i))
+  @test storage(T) isa NDTensors.Dense{Int}
+  A[1, 1] = 2
+  T[1, 1] == 2
+
+  # no view
+  A = rand(Int, d, d)
+  T = itensor(A, i', dag(i))
+  @test storage(T) isa NDTensors.Dense{Float64}
+  A[1, 1] = 2
+  T[1, 1] ≠ 2
+
+  # no view
+  A = randn(Float64, d, d)
+  T = ITensor(A, i', dag(i))
+  @test storage(T) isa NDTensors.Dense{Float64}
+  A[1, 1] = 2
+  T[1, 1] ≠ 2
+
+  # no view
+  A = rand(Int, d, d)
+  T = ITensor(Int, A, i', dag(i))
+  @test storage(T) isa NDTensors.Dense{Int}
+  A[1, 1] = 2
+  T[1, 1] ≠ 2
+
+  # no view
+  A = rand(Int, d, d)
+  T = ITensor(A, i', dag(i))
+  @test storage(T) isa NDTensors.Dense{Float64}
+  A[1, 1] = 2
+  T[1, 1] ≠ 2
+end
+
 @testset "Convert to Array" begin
   i = Index(2,"i")
   j = Index(3,"j")

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -20,17 +20,17 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
 
   @testset "Default" begin
     A = ITensor()
-    @test store(A) isa NDTensors.Dense{Float64}
+    @test storage(A) isa NDTensors.Dense{Float64}
   end
 
   @testset "Undef with index" begin
     A = ITensor(undef, i)
-    @test store(A) isa NDTensors.Dense{Float64}
+    @test storage(A) isa NDTensors.Dense{Float64}
   end
 
   @testset "Default with indices" begin
     A = ITensor(i,j)
-    @test store(A) isa NDTensors.Dense{Float64}
+    @test storage(A) isa NDTensors.Dense{Float64}
   end
 
   @testset "Index set operations" begin
@@ -100,7 +100,7 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
     @test hasinds((i, j))(A)
     @test hasinds(IndexSet(i, j))(A)
 
-    @test store(A) isa NDTensors.Dense{Float64}
+    @test storage(A) isa NDTensors.Dense{Float64}
 
     @test ndims(A) == order(A) == 2 == length(inds(A))
     @test size(A) == dims(A) == (2,2)
@@ -113,7 +113,7 @@ digits(::Type{T},x...) where {T} = T(sum([x[length(x)-k+1]*10^(k-1) for k=1:leng
     @test dim(At, 2) == 3
 
     B = randomITensor(IndexSet(i,j))
-    @test store(B) isa NDTensors.Dense{Float64}
+    @test storage(B) isa NDTensors.Dense{Float64}
     @test ndims(B) == order(B) == 2 == length(inds(B))
     @test size(B) == dims(B) == (2,2)
 
@@ -142,7 +142,7 @@ end
   @testset "From matrix" begin
     M = [1 2; 3 4]
     A = itensor(M,i,j)
-    @test store(A) isa NDTensors.Dense{Float64}
+    @test storage(A) isa NDTensors.Dense{Float64}
 
     @test M ≈ Matrix(A,i,j)
     @test M' ≈ Matrix(A,j,i)
@@ -152,12 +152,13 @@ end
     @test_throws BoundsError size(A,3)
     @test_throws BoundsError size(A,0)
     @test_throws ErrorException size(M,0)
-    # setstore changes the internal data but not indices
+    # setstorage changes the internal data but not indices
     N = [5 6; 7 8]
     A = itensor(M, i, j)
-    B = ITensors.setstore(A, N)
+    B = ITensors.setstorage(A, NDTensors.Dense(vec(N)))
     @test N == Matrix(B, i, j)
-    @test store(B) isa NDTensors.Dense{Float64}
+    @test storage(A) isa NDTensors.Dense{Float64}
+    @test storage(B) isa NDTensors.Dense{Int}
 
     M = [1 2 3; 4 5 6]
     @test_throws DimensionMismatch itensor(M,i,j)
@@ -206,18 +207,18 @@ end
 
   @testset "Complex" begin
     A = ITensor(Complex,i,j)
-    @test store(A) isa NDTensors.Dense{Complex}
+    @test storage(A) isa NDTensors.Dense{Complex}
   end
 
   @testset "Random complex" begin
     A = randomITensor(ComplexF64,i,j)
-    @test store(A) isa NDTensors.Dense{ComplexF64}
+    @test storage(A) isa NDTensors.Dense{ComplexF64}
   end
 
   @testset "From complex matrix" begin
     M = [1+2im 2; 3 4]
     A = itensor(M,i,j)
-    @test store(A) isa NDTensors.Dense{ComplexF64}
+    @test storage(A) isa NDTensors.Dense{ComplexF64}
   end
 
 end
@@ -239,7 +240,7 @@ end
   B = similar(A)
   @test inds(B) == inds(A)
   Ac = similar(A, ComplexF32)
-  @test store(Ac) isa NDTensors.Dense{ComplexF32}
+  @test storage(Ac) isa NDTensors.Dense{ComplexF32}
 end
 
 @testset "fill!" begin
@@ -574,6 +575,42 @@ end
   @test ITensors.data(mul!(B, A, 2.0)) == 2.0*vec(transpose(M))
 end
 
+@testset "Construct from Array" begin
+  i = Index(2,"index_i")
+  j = Index(2,"index_j")
+
+  M = [1. 2;
+       3 4]
+  T = itensor(M, i, j)
+  T[i => 1, j => 1] = 3.3
+  @test M[1, 1] == 3.3
+  @test T[i => 1, j => 1] == 3.3
+  @test storage(T) isa Dense{Float64}
+
+  M = [1 2;
+       3 4]
+  T = itensor(M, i, j)
+  T[i => 1, j => 1] = 3.3
+  @test M[1, 1] == 1
+  @test T[i => 1, j => 1] == 3.3
+  @test storage(T) isa Dense{Float64}
+
+  M = [1 2;
+       3 4]
+  T = itensor(Int, M, i, j)
+  T[i => 1, j => 1] = 6
+  @test M[1, 1] == 6
+  @test T[i => 1, j => 1] == 6
+  @test storage(T) isa Dense{Int}
+
+  M = [1. 2;
+       3 4]
+  T = ITensor(M, i, j)
+  T[i => 1, j => 1] = 3.3
+  @test M[1, 1] == 1
+  @test T[i => 1, j => 1] == 3.3
+end
+
 @testset "Convert to Array" begin
   i = Index(2,"i")
   j = Index(3,"j")
@@ -841,8 +878,8 @@ end #End "ITensor other index operations"
 
     S1 = TC+TR
     S2 = TR+TC
-    @test typeof(S1.store) == NDTensors.Dense{ComplexF64,Vector{ComplexF64}}
-    @test typeof(S2.store) == NDTensors.Dense{ComplexF64,Vector{ComplexF64}}
+    @test typeof(S1.storage) == NDTensors.Dense{ComplexF64,Vector{ComplexF64}}
+    @test typeof(S2.storage) == NDTensors.Dense{ComplexF64,Vector{ComplexF64}}
     for ii=1:dim(i),jj=1:dim(j)
       @test S1[i=>ii,j=>jj] ≈ TC[i=>ii,j=>jj]+TR[i=>ii,j=>jj]
       @test S2[i=>ii,j=>jj] ≈ TC[i=>ii,j=>jj]+TR[i=>ii,j=>jj]
@@ -936,7 +973,7 @@ end
 
     @testset "Test SVD of an ITensor" begin
       U,S,V,spec,u,v = svd(A,(j,l))
-      @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
+      @test storage(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A≈U*S*V
       @test U*dag(prime(U,u))≈δ(SType,u,u') atol=1e-13
       @test V*dag(prime(V,v))≈δ(SType,v,v') atol=1e-13
@@ -944,19 +981,19 @@ end
 
     @testset "Test SVD of an ITensor with different algorithms" begin
       U, S, V, spec, u, v = svd(A, j, l; alg = "recursive")
-      @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
+      @test storage(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A ≈ U * S * V
       @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-13
       @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-13
 
       U, S, V, spec, u, v = svd(A, j,l; alg = "divide_and_conquer")
-      @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
+      @test storage(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A ≈ U * S * V
       @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-13
       @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-13
 
       U, S, V, spec, u, v = svd(A, j,l; alg = "qr_iteration")
-      @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
+      @test storage(S) isa NDTensors.Diag{Float64,Vector{Float64}}
       @test A ≈ U * S * V
       @test U * dag(prime(U, u)) ≈ δ(SType, u, u') atol = 1e-13
       @test V * dag(prime(V, v)) ≈ δ(SType, v, v') atol = 1e-13
@@ -976,7 +1013,7 @@ end
     #  V = itensor(Vt)
     #  u = commonind(U, S)
     #  v = commonind(V, S)
-    #  @test store(S) isa NDTensors.Diag{Float64,Vector{Float64}}
+    #  @test storage(S) isa NDTensors.Diag{Float64,Vector{Float64}}
     #  @test A≈U*S*V
     #  @test U*dag(prime(U,u))≈δ(SType,u,u') atol=1e-13
     #  @test V*dag(prime(V,v))≈δ(SType,v,v') atol=1e-13

--- a/test/qndiagitensor.jl
+++ b/test/qndiagitensor.jl
@@ -46,7 +46,7 @@ using ITensors,
 
     δiĩ = δ(dag(i), ĩ)
 
-    @test store(δiĩ) isa NDTensors.DiagBlockSparse{ElT,
+    @test storage(δiĩ) isa NDTensors.DiagBlockSparse{ElT,
                                                    ElT} where {ElT<:Number}
 
     B = A * δiĩ

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -743,8 +743,8 @@ Random.seed!(1234)
       Ut = F.Vt
 
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(D) isa NDTensors.DiagBlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(D) isa NDTensors.DiagBlockSparse
 
       u = commonind(D,U)
       up = uniqueind(D,U)
@@ -784,8 +784,8 @@ Random.seed!(1234)
       D, U, spec = F
       Ut = F.Vt
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(D) isa NDTensors.DiagBlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(D) isa NDTensors.DiagBlockSparse
 
       u = commonind(D, U)
       up = uniqueind(D, U)
@@ -832,8 +832,8 @@ Random.seed!(1234)
       D, U = F
       Ut = F.Vt
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(D) isa NDTensors.DiagBlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(D) isa NDTensors.DiagBlockSparse
 
       u = commonind(D,U)
       up = uniqueind(D,U)
@@ -863,8 +863,8 @@ Random.seed!(1234)
       D, U = F
       Ut = F.Vt
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(D) isa NDTensors.DiagBlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(D) isa NDTensors.DiagBlockSparse
 
       l = uniqueind(D, U)
       r = commonind(D, U)
@@ -907,9 +907,9 @@ Random.seed!(1234)
       end
       U,S,V = svd(A,i)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       for b in nzblocks(U)
         @test flux(U,b)==QN(0)
@@ -932,9 +932,9 @@ Random.seed!(1234)
       end
       U,S,V = svd(A,i)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       for b in nzblocks(U)
         @test flux(U,b)==QN(0)
@@ -957,9 +957,9 @@ Random.seed!(1234)
       end
       U,S,V = svd(A,i)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       for b in nzblocks(U)
         @test flux(U,b)==QN(0)
@@ -981,9 +981,9 @@ Random.seed!(1234)
 
 			U,S,V = svd(A,i,j)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       for b in nzblocks(A)
         @test flux(A,b)==QN(0,2)
@@ -1009,9 +1009,9 @@ Random.seed!(1234)
 
 			U,S,V = svd(A,i,j)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       for b in nzblocks(A)
         @test flux(A,b)==QN(1,2)
@@ -1037,9 +1037,9 @@ Random.seed!(1234)
 
 			U,S,V = svd(A,i,i')
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       for b in nzblocks(A)
         @test flux(A,b)==QN(1,2)
@@ -1069,9 +1069,9 @@ Random.seed!(1234)
       cutoff = 1e-5
       U,S,V,spec = svd(A,i,j; utags="x", vtags="y", cutoff=cutoff)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       u = commonind(S,U)
       v = commonind(S,V)
@@ -1115,9 +1115,9 @@ Random.seed!(1234)
       maxdim = 4
       U,S,V,spec = svd(A,i,j; utags="x", vtags="y", maxdim=maxdim)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       u = commonind(S,U)
       v = commonind(S,V)
@@ -1158,9 +1158,9 @@ Random.seed!(1234)
       maxdim = 4
       U,S,V,spec = svd(A,i,j; utags="x", vtags="y", maxdim=maxdim)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       u = commonind(S,U)
       v = commonind(S,V)
@@ -1201,9 +1201,9 @@ Random.seed!(1234)
       maxdim = 4
       U,S,V,spec = svd(A,i,j; utags="x", vtags="y", maxdim=maxdim)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       u = commonind(S,U)
       v = commonind(S,V)
@@ -1244,9 +1244,9 @@ Random.seed!(1234)
       maxdim = 4
       U,S,V,spec = svd(A,i,j'; utags="x", vtags="y", maxdim=maxdim)
 
-      @test store(U) isa NDTensors.BlockSparse
-      @test store(S) isa NDTensors.DiagBlockSparse
-      @test store(V) isa NDTensors.BlockSparse
+      @test storage(U) isa NDTensors.BlockSparse
+      @test storage(S) isa NDTensors.DiagBlockSparse
+      @test storage(V) isa NDTensors.BlockSparse
 
       u = commonind(S,U)
       v = commonind(S,V)

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -89,6 +89,53 @@ Random.seed!(1234)
     @test_throws ErrorException ITensor(A, i', dag(i); tol = 1e-8)
   end
 
+  @testset "QN ITensor Array constructor view behavior" begin
+    d = 2
+    i = Index([QN(0) => d ÷ 2, QN(1) => d ÷ 2])
+
+    # no view
+    A = diagm(randn(Float64, d))
+    T = itensor(A, i', dag(i); tol = 1e-12)
+    @test storage(T) isa NDTensors.BlockSparse{Float64}
+    A[1, 1] = 2.0
+    T[1, 1] ≠ 2.0
+
+    # no view
+    A = diagm(rand(Int, d))
+    T = itensor(Int, A, i', dag(i); tol = 1e-12)
+    @test storage(T) isa NDTensors.BlockSparse{Int}
+    A[1, 1] = 2
+    T[1, 1] ≠ 2
+
+    # no view
+    A = diagm(rand(Int, d))
+    T = itensor(A, i', dag(i); tol = 1e-12)
+    @test storage(T) isa NDTensors.BlockSparse{Float64}
+    A[1, 1] = 2
+    T[1, 1] ≠ 2
+
+    # no view
+    A = diagm(randn(Float64, d))
+    T = ITensor(A, i', dag(i); tol = 1e-12)
+    @test storage(T) isa NDTensors.BlockSparse{Float64}
+    A[1, 1] = 2
+    T[1, 1] ≠ 2
+
+    # no view
+    A = diagm(rand(Int, d))
+    T = ITensor(Int, A, i', dag(i); tol = 1e-12)
+    @test storage(T) isa NDTensors.BlockSparse{Int}
+    A[1, 1] = 2
+    T[1, 1] ≠ 2
+
+    # no view
+    A = diagm(rand(Int, d))
+    T = ITensor(A, i', dag(i); tol = 1e-12)
+    @test storage(T) isa NDTensors.BlockSparse{Float64}
+    A[1, 1] = 2
+    T[1, 1] ≠ 2
+  end
+
   @testset "Constructor Leads to No Blocks" begin
     i=Index(QN(0)=>2,QN(1)=>3;tags="i")
     j=Index(QN(1)=>2,QN(2)=>1;tags="j")

--- a/test/qnmpo.jl
+++ b/test/qnmpo.jl
@@ -240,9 +240,9 @@ end
         fluxψ = flux(ψ)
         d = commonind(D, V)
         b = ITensors.findfirstblock(indblock -> ITensors.qn(indblock) == fluxψ, d)
-        @test e ≈ minimum(store(D[Block(b, b)]))
+        @test e ≈ minimum(storage(D[Block(b, b)]))
       else
-        @test e ≈ minimum(store(D))
+        @test e ≈ minimum(storage(D))
       end
     end
   end

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -72,7 +72,7 @@ include("util.jl")
     fi = h5open("data.h5","r")
     rT = read(fi,"defaultT",ITensor)
     close(fi)
-    @test typeof(store(T)) == typeof(store(ITensor()))
+    @test typeof(storage(T)) == typeof(storage(ITensor()))
 
     # real case
     T = randomITensor(i,j,k)


### PR DESCRIPTION
This fixes #612. It doesn't remove the floating point conversion entirely, but only does it for `Int` and `Complex{Int}`, i.e. `itensor([0 1; 1 0], i, j)` and `itensor([0 1+2im; 1 0], i, j)` still convert to floating point. In addition, it adds an API where the element type can be specified explicitly with `itensor(Int, [0 1; 1 0], i, j)` in the rare cases when integer types are desired.

I'm open to removing the automatic conversion entirely, since at some point (through packages like https://github.com/JuliaLinearAlgebra/Octavian.jl) we should be able to have fast tensor contractions/matrix multiplications over generic element types. In addition, my guess is that a vast majority of the time people are making relatively small ITensors from array data (for example the common case is `op`) in which case it's not a big deal to convert to float before the BLAS call. In addition, I think in cases like `op` it is best practice to define it as a floating point directly with something like `itensor([0. 1.; 1. 0.], i, j)` or `itensor(Float64[0 1; 1 0], i, j)`, which makes the construction faster. In fact we should be doing this internally in our Qubit `op` definitions, for example:
```julia
julia> f() = [0 1; 1 0]
f (generic function with 1 method)

julia> g() = Float64[0 1; 1 0]
g (generic function with 1 method)

julia> h() = float([0 1; 1 0])
h (generic function with 1 method)

julia> @btime f()
  83.924 ns (2 allocations: 160 bytes)
2×2 Matrix{Int64}:
 0  1
 1  0

julia> @btime g()
  26.859 ns (1 allocation: 112 bytes)
2×2 Matrix{Float64}:
 0.0  1.0
 1.0  0.0

julia> @btime h()
  118.722 ns (3 allocations: 272 bytes)
2×2 Matrix{Float64}:
 0.0  1.0
 1.0  0.0
```
The version with the element type specified is also nice because it allows specifying a different element type as well.

I've added warnings in ITensor constructors saying that the conversion behavior may change in the future and shouldn't be relied on.