### PR TITLE
Correlator function

### DIFF
--- a/docs/src/MPSandMPO.md
+++ b/docs/src/MPSandMPO.md
@@ -33,10 +33,11 @@ MPO(::MPS)
 ## Properties
 
 ```@docs
-length(::ITensors.AbstractMPS)
+eltype(::ITensors.AbstractMPS)
 flux(::ITensors.AbstractMPS)
-maxlinkdim(::ITensors.AbstractMPS)
 hasqns(::ITensors.AbstractMPS)
+length(::ITensors.AbstractMPS)
+maxlinkdim(::ITensors.AbstractMPS)
 ```
 
 ## Obtaining and finding indices

--- a/docs/src/MPSandMPO.md
+++ b/docs/src/MPSandMPO.md
@@ -105,6 +105,7 @@ settags(::typeof(siteinds), ::typeof(uniqueinds), ::ITensors.AbstractMPS, ::ITen
 ## Operations
 
 ```@docs
+correlator(::MPS,::AbstractString,::AbstractString)
 dag(::ITensors.AbstractMPS)
 dense(::ITensors.AbstractMPS)
 movesite(::ITensors.AbstractMPS, ::Pair{Int, Int};orthocenter::Int,kwargs...)

--- a/docs/src/MPSandMPO.md
+++ b/docs/src/MPSandMPO.md
@@ -105,6 +105,7 @@ settags(::typeof(siteinds), ::typeof(uniqueinds), ::ITensors.AbstractMPS, ::ITen
 ## Operations
 
 ```@docs
+expect(::MPS,::AbstractString...)
 correlator(::MPS,::AbstractString,::AbstractString)
 dag(::ITensors.AbstractMPS)
 dense(::ITensors.AbstractMPS)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -235,6 +235,7 @@ export
   MPS,
   # Methods
   ⋅,
+  correlator,
   inner,
   isortho,
   linkdim,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -236,6 +236,7 @@ export
   # Methods
   ⋅,
   correlation_matrix,
+  expect,
   inner,
   isortho,
   linkdim,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -235,7 +235,7 @@ export
   MPS,
   # Methods
   ⋅,
-  correlator,
+  correlation_matrix,
   inner,
   isortho,
   linkdim,

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -17,6 +17,24 @@ size(m::AbstractMPS) = size(data(m))
 ndims(m::AbstractMPS) = ndims(data(m))
 
 """
+    eltype(m::MPS)
+    eltype(m::MPO)
+
+Return the common element type of the
+tensors in the MPS or MPO. For example,
+if all tensors have type Float64 then
+return Float64. But if one or more tensors
+have type ComplexF64, return ComplexF64.
+"""
+function eltype(m::AbstractMPS)
+  T = eltype(m[1])
+  for n=2:length(m)
+    T = promote_type(T,eltype(m[n]))
+  end
+  return T
+end
+
+"""
     ITensors.data(::MPS/MPO)
 
 Returns a view of the Vector storage of an MPS/MPO.

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -552,6 +552,8 @@ function correlation_matrix(psi::MPS,
 
   psi = copy(psi)
   orthogonalize!(psi,start_site)
+  psi[start_site] ./= norm(psi[start_site])
+
   s = siteinds(psi)
   onsiteOp = "$Op1*$Op2"
   fermionic2 = has_fermion_string(Op2,s[1])
@@ -646,7 +648,11 @@ function expect(psi::MPS,
 
   site_range::UnitRange{Int} = get(kwargs,:site_range,1:N)
   Ns = length(site_range)
-  offset = first(site_range)-1
+  start_site = first(site_range)
+  offset = start_site-1
+
+  orthogonalize!(psi,start_site)
+  psi[start_site] ./= norm(psi[start_site])
 
   ex = ntuple(n->zeros(ElT,Ns),Nops)
   for j=site_range

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -508,10 +508,10 @@ function sample(m::MPS)
 end
 
 """
-    correlator(psi::MPS,
-               Op1::AbstractString,
-               Op2::AbstractString;
-               kwargs...)
+    correlation_matrix(psi::MPS,
+                       Op1::AbstractString,
+                       Op2::AbstractString;
+                       kwargs...)
 
 Given an MPS psi and two strings denoting
 operators (as recognized by the `op` function), 
@@ -520,8 +520,7 @@ C[i,j] = <psi| Op1i Op2j |psi>
 using efficient MPS techniques. Returns the matrix C.
 
 # Optional Keyword Arguments
-- `start_site::Int = 1`: measure the correlator starting from this site of the MPS
-- `end_site::Int = length(psi)`: measure the correlator up to and including this site of the MPS
+- `site_range = 1:length(psi)`: compute correlations only for sites in the given range
 
 For a correlation matrix of size NxN and an MPS of typical
 bond dimension m, the scaling of this algorithm is N^2*m^3.
@@ -537,19 +536,20 @@ Czz = correlator(psi,"Sz","Sz")
 
 s = siteinds("Electron",N; conserve_qns=true)
 psi = randomMPS(s,n->isodd(n) ? "Up" : "Dn",m)
-Cuu = correlator(psi,"Cdagup","Cup";start_site=2,end_site=8)
+Cuu = correlator(psi,"Cdagup","Cup";site_range=2:8)
 ```
 """
-function correlator(M::MPS,
-                    Op1::AbstractString,
-                    Op2::AbstractString;
-                    kwargs...)
-  N = length(M)
+function correlation_matrix(psi::MPS,
+                            Op1::AbstractString,
+                            Op2::AbstractString;
+                            kwargs...)
+  N = length(psi)
 
-  start_site::Int = get(kwargs, :start_site, 1)
-  end_site::Int = get(kwargs, :end_site, N)
+  site_range::UnitRange{Int} = get(kwargs,:site_range,1:N)
+  start_site = first(site_range)
+  end_site = last(site_range)
 
-  psi = copy(M)
+  psi = copy(psi)
   orthogonalize!(psi,start_site)
   s = siteinds(psi)
   onsiteOp = "$Op1*$Op2"

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -523,6 +523,35 @@ end
     @test flux(M) == QN("Sz",-4)
   end
 
+  @testset "Correlations" begin
+
+    N = 8
+    m = 4
+
+    # Non-fermionic case - spin system
+    s = siteinds("S=1/2",N;conserve_qns=true)
+    psi = randomMPS(s,n->isodd(n) ? "Up" : "Dn",m)
+    Cpm = correlator(psi,"S+","S-")
+    # Check using AutoMPO:
+    for i=1:N,j=i:N
+      a = AutoMPO()
+      a += "S+",i,"S-",j
+      @test inner(psi,MPO(a,s),psi) ≈ Cpm[i,j]
+    end
+
+    # Fermionic case
+    s = siteinds("Electron",N)
+    psi = randomMPS(s,m)
+    Cuu = correlator(psi,"Cdagup","Cup")
+    # Check using AutoMPO:
+    for i=1:N,j=i:N
+      a = AutoMPO()
+      a += "Cdagup",i,"Cup",j
+      @test inner(psi,MPO(a,s),psi) ≈ Cuu[i,j]
+    end
+
+  end
+
   @testset "swapbondsites" begin
     N = 5
     sites = siteinds("S=1/2", N)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -531,7 +531,7 @@ end
     # Non-fermionic case - spin system
     s = siteinds("S=1/2",N;conserve_qns=true)
     psi = randomMPS(s,n->isodd(n) ? "Up" : "Dn",m)
-    Cpm = correlator(psi,"S+","S-")
+    Cpm = correlation_matrix(psi,"S+","S-")
     # Check using AutoMPO:
     for i=1:N,j=i:N
       a = AutoMPO()
@@ -544,7 +544,8 @@ end
     psi = randomMPS(s,m)
     ss,es = 3,6
     Nb = es-ss+1
-    Cpm = correlator(psi,"S+","S-";start_site=ss,end_site=es)
+    Cpm = correlation_matrix(psi,"S+","S-";site_range=ss:es)
+    Czz = correlation_matrix(psi,"Sz","Sz";site_range=ss:es)
     @test size(Cpm) == (Nb,Nb)
     # Check using AutoMPO:
     for i=ss:es,j=i:es
@@ -556,7 +557,7 @@ end
     # Fermionic case
     s = siteinds("Electron",N)
     psi = randomMPS(s,m)
-    Cuu = correlator(psi,"Cdagup","Cup")
+    Cuu = correlation_matrix(psi,"Cdagup","Cup")
     # Check using AutoMPO:
     for i=1:N,j=i:N
       a = AutoMPO()

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -524,7 +524,7 @@ end
     @test flux(M) == QN("Sz",-4)
   end
 
-  @testset "Correlations" begin
+  @testset "Expected value and Correlations" begin
     N = 8
     m = 4
 
@@ -540,6 +540,9 @@ end
     end
     PM = expect(psi,"S+*S-")
     @test norm(PM-diag(Cpm)) < 1E-8
+
+    range = 3:7
+    @test norm(PM[range] - expect(psi,"S+*S-";site_range=range)) < 1E-8
 
     # With start_site, end_site arguments:
     s = siteinds("S=1/2",N)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -546,7 +546,7 @@ end
 
     # With start_site, end_site arguments:
     s = siteinds("S=1/2",N)
-    psi = randomMPS(s,m)
+    psi = randomMPS(ComplexF64,s,m)
     ss,es = 3,6
     Nb = es-ss+1
     Cpm = correlation_matrix(psi,"S+","S-";site_range=ss:es)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -539,6 +539,20 @@ end
       @test inner(psi,MPO(a,s),psi) ≈ Cpm[i,j]
     end
 
+    # With start_site, end_site arguments:
+    s = siteinds("S=1/2",N)
+    psi = randomMPS(s,m)
+    ss,es = 3,6
+    Nb = es-ss+1
+    Cpm = correlator(psi,"S+","S-";start_site=ss,end_site=es)
+    @test size(Cpm) == (Nb,Nb)
+    # Check using AutoMPO:
+    for i=ss:es,j=i:es
+      a = AutoMPO()
+      a += "S+",i,"S-",j
+      @test inner(psi,MPO(a,s),psi) ≈ Cpm[i-ss+1,j-ss+1]
+    end
+
     # Fermionic case
     s = siteinds("Electron",N)
     psi = randomMPS(s,m)
@@ -549,7 +563,6 @@ end
       a += "Cdagup",i,"Cup",j
       @test inner(psi,MPO(a,s),psi) ≈ Cuu[i,j]
     end
-
   end
 
   @testset "swapbondsites" begin

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -1,6 +1,7 @@
 using Combinatorics
 using ITensors
 using Random
+using LinearAlgebra: diag
 using Test
 
 Random.seed!(1234)
@@ -524,7 +525,6 @@ end
   end
 
   @testset "Correlations" begin
-
     N = 8
     m = 4
 
@@ -538,6 +538,8 @@ end
       a += "S+",i,"S-",j
       @test inner(psi,MPO(a,s),psi) ≈ Cpm[i,j]
     end
+    PM = expect(psi,"S+*S-")
+    @test norm(PM-diag(Cpm)) < 1E-8
 
     # With start_site, end_site arguments:
     s = siteinds("S=1/2",N)


### PR DESCRIPTION
Adds a function `correlator(psi::MPS,Op1,Op2;start_site=i,end_site=j)`
that returns a matrix C such that C[i,j]=<psi| Op1i Op2j |psi>.
Includes handling of fermionic operators, using `has_fermion_string` to
detect whether to put in Jordan-Wigner F string operators.

- Add correlator(MPS,A,B) measuring <A_i B_j>
- Unit tests for correlator function
- Add optional start_site, end_site args. Add docs.
