### PR TITLE
Simplify implementation of Sweeps setting functions

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -330,8 +330,8 @@ let
   # for each sweep and maximum truncation cutoff
   # used when adapting internal dimensions:
   sweeps = Sweeps(5)
-  maxdim!(sweeps, 10,20,100,100,200)
-  cutoff!(sweeps, 1E-10)
+  setmaxdim!(sweeps, 10,20,100,100,200)
+  setcutoff!(sweeps, 1E-10)
   @show sweeps
 
   # Run the DMRG algorithm, returning energy 

--- a/examples/dmrg/1d_heisenberg.jl
+++ b/examples/dmrg/1d_heisenberg.jl
@@ -28,9 +28,9 @@ let
   # Plan to do 5 DMRG sweeps:
   sweeps = Sweeps(5)
   # Set maximum MPS bond dimensions for each sweep
-  maxdim!(sweeps, 10,20,100,100,200)
+  setmaxdim!(sweeps, 10,20,100,100,200)
   # Set maximum truncation error allowed when adapting bond dimensions
-  cutoff!(sweeps, 1E-11)
+  setcutoff!(sweeps, 1E-11)
   @show sweeps
 
   # Run the DMRG algorithm, returning energy and optimized MPS

--- a/examples/dmrg/1d_heisenberg_conserve_spin.jl
+++ b/examples/dmrg/1d_heisenberg_conserve_spin.jl
@@ -35,9 +35,9 @@ let
   # Plan to do 5 DMRG sweeps:
   sweeps = Sweeps(5)
   # Set maximum MPS bond dimensions for each sweep
-  maxdim!(sweeps, 10,20,100,100,200)
+  setmaxdim!(sweeps, 10,20,100,100,200)
   # Set maximum truncation error allowed when adapting bond dimensions
-  cutoff!(sweeps, 1E-10)
+  setcutoff!(sweeps, 1E-10)
   @show sweeps
 
   # Run the DMRG algorithm, returning energy and optimized MPS

--- a/examples/dmrg/1d_hubbard_extended.jl
+++ b/examples/dmrg/1d_hubbard_extended.jl
@@ -36,8 +36,8 @@ let
   H = MPO(ampo,sites)
 
   sweeps = Sweeps(6)
-  maxdim!(sweeps,50,100,200,400,800,800)
-  cutoff!(sweeps,1E-12)
+  setmaxdim!(sweeps,50,100,200,400,800,800)
+  setcutoff!(sweeps,1E-12)
   @show sweeps
 
   state = ["Emp" for n=1:N]

--- a/examples/dmrg/1d_ising_with_observer.jl
+++ b/examples/dmrg/1d_ising_with_observer.jl
@@ -29,8 +29,8 @@ let
 
   # define parameters for DMRG sweeps
   sweeps = Sweeps(15)
-  maxdim!(sweeps, 10,20,100,100,200)
-  cutoff!(sweeps, 1E-10)
+  setmaxdim!(sweeps, 10,20,100,100,200)
+  setcutoff!(sweeps, 1E-10)
 
   #=
   create observer which will measure Sᶻ at each

--- a/examples/dmrg/2d_heisenberg_conserve_spin.jl
+++ b/examples/dmrg/2d_heisenberg_conserve_spin.jl
@@ -26,8 +26,8 @@ let
   psi0 = randomMPS(sites,state,20)
 
   sweeps = Sweeps(10)
-  maxdim!(sweeps,20,60,100,100,200,400,800)
-  cutoff!(sweeps,1E-8)
+  setmaxdim!(sweeps,20,60,100,100,200,400,800)
+  setcutoff!(sweeps,1E-8)
   @show sweeps
 
   energy,psi = dmrg(H,psi0,sweeps)

--- a/examples/dmrg/2d_hubbard_conserve_momentum.jl
+++ b/examples/dmrg/2d_hubbard_conserve_momentum.jl
@@ -16,9 +16,9 @@ function main(; Nx::Int = 6, Ny::Int = 3, U::Float64 = 4.0,
 
   sweeps = Sweeps(10)
   maxdims = min.([100, 200, 400, 800, 2000, 3000, maxdim], maxdim)
-  maxdim!(sweeps, maxdims...)
-  cutoff!(sweeps, 1e-6)
-  noise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
+  setmaxdim!(sweeps, maxdims...)
+  setcutoff!(sweeps, 1e-6)
+  setnoise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
   @show sweeps
 
   sites = siteinds("ElecK", N; conserve_qns = true,

--- a/examples/dmrg/2d_hubbard_conserve_particles.jl
+++ b/examples/dmrg/2d_hubbard_conserve_particles.jl
@@ -7,9 +7,9 @@ function main(; Nx = 6,
   N = Nx * Ny
 
   sweeps = Sweeps(10)
-  maxdim!(sweeps, 100, 200, 400, 800, 1600)
-  cutoff!(sweeps, 1e-6)
-  noise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
+  setmaxdim!(sweeps, 100, 200, 400, 800, 1600)
+  setcutoff!(sweeps, 1e-6)
+  setnoise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
   @show sweeps
 
   sites = siteinds("Electron", N;

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -298,6 +298,10 @@ export
   noise,
   noise!,
   nsweep,
+  setmaxdim!,
+  setmindim!,
+  setcutoff!,
+  setnoise!,
   sweepnext,
 
 # physics/autompo.jl

--- a/src/mps/sweeps.jl
+++ b/src/mps/sweeps.jl
@@ -138,13 +138,9 @@ If fewer values are provided, the last value
 is repeated for the remaining sweeps.
 """
 function maxdim!(sw::Sweeps,maxdims::Int...)::Nothing
-  Nm = length(maxdims)
-  N = min(nsweep(sw),Nm)
-  for i=1:N
-    sw.maxdim[i] = maxdims[i]
-  end
-  for i=Nm+1:nsweep(sw)
-    sw.maxdim[i] = maxdims[Nm]
+  mdims = collect(maxdims)
+  for i=1:nsweep(sw)
+    sw.maxdim[i] = get(mdims,i,maxdims[end])
   end
 end
 
@@ -157,13 +153,9 @@ If fewer values are provided, the last value
 is repeated for the remaining sweeps.
 """
 function mindim!(sw::Sweeps,mindims::Int...)::Nothing
-  Nm = length(mindims)
-  N = min(nsweep(sw),Nm)
-  for i=1:N
-    sw.mindim[i] = mindims[i]
-  end
-  for i=Nm+1:nsweep(sw)
-    sw.mindim[i] = mindims[Nm]
+  mdims = collect(mindims)
+  for i=1:nsweep(sw)
+    sw.mindim[i] = get(mdims,i,mindims[end])
   end
 end
 
@@ -176,13 +168,9 @@ If fewer values are provided, the last value
 is repeated for the remaining sweeps.
 """
 function cutoff!(sw::Sweeps,cutoffs::Float64...)::Nothing
-  Nm = length(cutoffs)
-  N = min(nsweep(sw),Nm)
-  for i=1:N
-    sw.cutoff[i] = cutoffs[i]
-  end
-  for i=Nm+1:nsweep(sw)
-    sw.cutoff[i] = cutoffs[Nm]
+  cuts = collect(cutoffs)
+  for i=1:nsweep(sw)
+    sw.cutoff[i] = get(cuts,i,cutoffs[end])
   end
 end
 
@@ -195,13 +183,9 @@ If fewer values are provided, the last value
 is repeated for the remaining sweeps.
 """
 function noise!(sw::Sweeps,noises::Float64...)::Nothing
-  Nm = length(noises)
-  N = min(nsweep(sw),Nm)
-  for i=1:N
-    sw.noise[i] = noises[i]
-  end
-  for i=Nm+1:nsweep(sw)
-    sw.noise[i] = noises[Nm]
+  nvals = collect(noises)
+  for i=1:nsweep(sw)
+    sw.noise[i] = get(nvals,i,noises[end])
   end
 end
 

--- a/src/mps/sweeps.jl
+++ b/src/mps/sweeps.jl
@@ -137,12 +137,13 @@ sweep by providing up to `nsweep(sw)` values.
 If fewer values are provided, the last value
 is repeated for the remaining sweeps.
 """
-function maxdim!(sw::Sweeps,maxdims::Int...)::Nothing
+function setmaxdim!(sw::Sweeps,maxdims::Int...)::Nothing
   mdims = collect(maxdims)
   for i=1:nsweep(sw)
     sw.maxdim[i] = get(mdims,i,maxdims[end])
   end
 end
+maxdim!(sw::Sweeps,maxdims::Int...) = setmaxdim!(sw,maxdims...)
 
 """
     mindim!(sw::Sweeps,maxdims::Int...)
@@ -152,12 +153,13 @@ sweep by providing up to `nsweep(sw)` values.
 If fewer values are provided, the last value
 is repeated for the remaining sweeps.
 """
-function mindim!(sw::Sweeps,mindims::Int...)::Nothing
+function setmindim!(sw::Sweeps,mindims::Int...)::Nothing
   mdims = collect(mindims)
   for i=1:nsweep(sw)
     sw.mindim[i] = get(mdims,i,mindims[end])
   end
 end
+mindim!(sw::Sweeps,mindims::Int...) = setmindim!(sw,mindims...)
 
 """
     cutoff!(sw::Sweeps,maxdims::Int...)
@@ -167,12 +169,13 @@ sweep by providing up to `nsweep(sw)` values.
 If fewer values are provided, the last value
 is repeated for the remaining sweeps.
 """
-function cutoff!(sw::Sweeps,cutoffs::Float64...)::Nothing
+function setcutoff!(sw::Sweeps,cutoffs::Real...)::Nothing
   cuts = collect(cutoffs)
   for i=1:nsweep(sw)
     sw.cutoff[i] = get(cuts,i,cutoffs[end])
   end
 end
+cutoff!(sw::Sweeps,cutoffs::Real...) = setcutoff!(sw,cutoffs...)
 
 """
     noise!(sw::Sweeps,maxdims::Int...)
@@ -182,12 +185,13 @@ sweep by providing up to `nsweep(sw)` values.
 If fewer values are provided, the last value
 is repeated for the remaining sweeps.
 """
-function noise!(sw::Sweeps,noises::Float64...)::Nothing
+function setnoise!(sw::Sweeps,noises::Real...)::Nothing
   nvals = collect(noises)
   for i=1:nsweep(sw)
     sw.noise[i] = get(nvals,i,noises[end])
   end
 end
+noise!(sw::Sweeps,noises::Real...) = setnoise!(sw,noises...)
 
 function Base.show(io::IO,
                    sw::Sweeps)

--- a/test/sweeps.jl
+++ b/test/sweeps.jl
@@ -114,6 +114,19 @@ using Test
     @test noise(sw, 4) == 0
     @test noise(sw, 5) == 1e-11
   end
+
+  @testset "Variable types of input" begin
+    sw = Sweeps(5)
+    setnoise!(sw,1E-8,0)
+    @test noise(sw,1) ≈ 1E-8
+    @test noise(sw,2) ≈ 0.0
+    @test noise(sw,3) ≈ 0.0
+    setcutoff!(sw,0,1E-8,0,1E-12)
+    @test cutoff(sw,1) ≈ 0.0
+    @test cutoff(sw,2) ≈ 1E-8
+    @test cutoff(sw,3) ≈ 0.0
+    @test cutoff(sw,4) ≈ 1E-12
+  end
 end
 
 nothing


### PR DESCRIPTION
Use `get` and `end` to shorten code for setting parameters of Sweeps objects. Could be even simpler if `get` was defined for tuples - best I could do was to use `collect` to convert the argument tuple into an array.

Fixes #474
