### PR TITLE
Add RegisterAction

### DIFF
--- a/.github/workflows/register.yml
+++ b/.github/workflows/register.yml
@@ -1,0 +1,14 @@
+name: Register Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to register or component to bump
+        required: true
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/RegisterAction@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add RegisterAction Github Action to make it easier to register a new version through Github.