### PR TITLE
Error messages for get and set index

### DIFF
--- a/Checklists.txt
+++ b/Checklists.txt
@@ -1,3 +1,10 @@
+Checklist for Formatting ITensor Code
+--------------------------------------
+- cd to the top level of the source code
+- open a Julia REPL session
+- run: using JuliaFormatter; format("."; verbose = true)
+- result will be true if code already formatted
+
 Checklist for Tagging a New Release
 --------------------------------------
 - Update the version = "x.y.z" line near the top of Project.toml

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -801,6 +801,9 @@ end
 
 @propagate_inbounds @inline function _getindex(T::Tensor, ivs::Vararg{<:Any,N}) where {N}
   # Tried ind.(ivs), val.(ivs) but it is slower
+  if N != ndims(T)
+    throw(DimensionMismatch("$N index values passed to ITensor getindex, expected $(ndims(T))"))
+  end
   p = NDTensors.getperm(inds(T), ntuple(n -> ind(@inbounds ivs[n]), Val(N)))
   return _getindex(T, NDTensors.permute(ntuple(n -> val(@inbounds ivs[n]), Val(N)), p)...)
 end
@@ -910,6 +913,9 @@ end
 ) where {N}
   # Would be nice to split off the functions for extracting the `ind` and `val` as Tuples,
   # but it was slower.
+  if N != ndims(T)
+    throw(DimensionMismatch("$N index values passed to ITensor setindex!, expected $(ndims(T))"))
+  end
   p = NDTensors.getperm(inds(T), ntuple(n -> ind(@inbounds ivs[n]), Val(N)))
   return _setindex!!(
     T, x, NDTensors.permute(ntuple(n -> val(@inbounds ivs[n]), Val(N)), p)...

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -802,7 +802,9 @@ end
 @propagate_inbounds @inline function _getindex(T::Tensor, ivs::Vararg{<:Any,N}) where {N}
   # Tried ind.(ivs), val.(ivs) but it is slower
   if N != ndims(T)
-    throw(DimensionMismatch("$N index values passed to ITensor getindex, expected $(ndims(T))"))
+    throw(
+      DimensionMismatch("$N index values passed to ITensor getindex, expected $(ndims(T))")
+    )
   end
   p = NDTensors.getperm(inds(T), ntuple(n -> ind(@inbounds ivs[n]), Val(N)))
   return _getindex(T, NDTensors.permute(ntuple(n -> val(@inbounds ivs[n]), Val(N)), p)...)
@@ -849,6 +851,11 @@ end
   ::SymmetryStyle, T::Tensor, x::Number, I::Vararg{Integer,N}
 ) where {N}
   # Generic version, doesn't check the flux
+  if N != ndims(T)
+    throw(
+      DimensionMismatch("$N index values passed to ITensor setindex!, expected $(ndims(T))")
+    )
+  end
   return setindex!!(T, x, I...)
 end
 
@@ -914,7 +921,9 @@ end
   # Would be nice to split off the functions for extracting the `ind` and `val` as Tuples,
   # but it was slower.
   if N != ndims(T)
-    throw(DimensionMismatch("$N index values passed to ITensor setindex!, expected $(ndims(T))"))
+    throw(
+      DimensionMismatch("$N index values passed to ITensor setindex!, expected $(ndims(T))")
+    )
   end
   p = NDTensors.getperm(inds(T), ntuple(n -> ind(@inbounds ivs[n]), Val(N)))
   return _setindex!!(

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -606,7 +606,7 @@ end
     T[i => 1, j => 1] = 3.3
     @test M[1, 1] == 3.3
     @test T[i => 1, j => 1] == 3.3
-    @test storage(T) isa Dense{Float64}
+    @test storage(T) isa NDTensors.Dense{Float64}
 
     M = [
       1 2
@@ -616,7 +616,7 @@ end
     T[i => 1, j => 1] = 3.3
     @test M[1, 1] == 1
     @test T[i => 1, j => 1] == 3.3
-    @test storage(T) isa Dense{Float64}
+    @test storage(T) isa NDTensors.Dense{Float64}
 
     M = [
       1 2
@@ -626,7 +626,7 @@ end
     T[i => 1, j => 1] = 6
     @test M[1, 1] == 6
     @test T[i => 1, j => 1] == 6
-    @test storage(T) isa Dense{Int}
+    @test storage(T) isa NDTensors.Dense{Int}
 
     # This version makes a copy
     M = [

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -80,6 +80,21 @@ end
       @test A[_i => 1, _j => dim(_j)] == 4.5
     end
 
+    @testset "Get and Set with Wrong Number of Values" begin
+      _i = Index(2, "i")
+      _j = Index(3, "j")
+
+      T = randomITensor(_i, _j)
+
+      @test_throws DimensionMismatch T[]
+      @test_throws DimensionMismatch T[_i => 1]
+      @test_throws DimensionMismatch T[_i => 1, j => 2, j' => 3]
+
+      @test_throws DimensionMismatch T[] = 1.0
+      @test_throws DimensionMismatch T[_i => 1] = 1.0
+      @test_throws DimensionMismatch T[_i => 1, j => 2, j' => 3] = 1.0
+    end
+
     @testset "Random" begin
       A = randomITensor(i, j)
 


### PR DESCRIPTION
This PR adds error checks for calls to ITensor getindex and setindex! with the wrong number of index values.
- Fix erroring tests
- Dimension checks for ITensor get and set index
- Extra check and formatting changes
- Add tests and checklist entry on formatting
