### PR TITLE
Move `NDTensors` module into `ITensors` module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,27 +1,28 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
-authors = ["Matthew Fishman <mfishman@flatironinstitute.org>",
-           "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
+authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
 version = "0.2.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-NDTensors = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
 Compat = "2.1, 3"
 HDF5 = "0.14,0.15"
 KrylovKit = "0.4.2, 0.5"
-NDTensors = "= 0.1.32"
 PackageCompiler = "1.0.0"
 StaticArrays = "0.12, 1.0"
 TimerOutputs = "0.5.5"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,7 +1,3 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
-NDTensors = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
-
-[compat]
-NDTensors = "= 0.1.32"

--- a/src/ContractionSequenceOptimization/ContractionSequenceOptimization.jl
+++ b/src/ContractionSequenceOptimization/ContractionSequenceOptimization.jl
@@ -1,10 +1,6 @@
 
 module ContractionSequenceOptimization
 
-using NDTensors
-
-import NDTensors: dim
-
 export optimal_contraction_sequence, contraction_cost
 
 include("utils.jl")

--- a/src/ContractionSequenceOptimization/utils.jl
+++ b/src/ContractionSequenceOptimization/utils.jl
@@ -21,6 +21,10 @@
 # 64 elements in the set.
 # (See https://discourse.julialang.org/t/parse-an-array-of-bits-bitarray-to-an-integer/42361/11).
 
+# Previously we used the definition in NDTensors:
+#import NDTensors: dim
+import ITensors: dim
+
 # `is` could be Vector{Int} for BitSet
 function dim(is::IndexSetT, ind_dims::Vector) where {IndexSetT<:Union{Vector{Int},BitSet}}
   isempty(is) && return one(eltype(inds_dims))

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -14,7 +14,6 @@ using Compat
 using HDF5
 using KrylovKit
 using LinearAlgebra
-using NDTensors
 using PackageCompiler
 using Pkg
 using Printf
@@ -23,10 +22,10 @@ using StaticArrays
 using TimerOutputs
 
 #####################################
-# NDTensors (definitions that will be moved to NDTensors
-# module)
+# NDTensors
 #
 include("NDTensors/NDTensors.jl")
+using .NDTensors
 
 #####################################
 # ContractionSequenceOptimization

--- a/src/NDTensors/NDTensors.jl
+++ b/src/NDTensors/NDTensors.jl
@@ -1,10 +1,186 @@
+module NDTensors
 
+using Base.Threads
+using Compat
+using Dictionaries
+using Random
+using LinearAlgebra
+using StaticArrays
+using HDF5
+using Requires
+using Strided
+using TimerOutputs
+using TupleTools
+
+using Base: @propagate_inbounds, ReshapedArray
+
+using Base.Cartesian: @nexprs
+
+using Base.Threads: @spawn
+
+#####################################
+# Imports and exports
 #
-# Definitions to move to NDTensors
+include("exports.jl")
+include("imports.jl")
+
+#####################################
+# DenseTensor and DiagTensor
+#
+include("aliasstyle.jl")
+include("similar.jl")
+include("tupletools.jl")
+include("dims.jl")
+include("tensorstorage.jl")
+include("tensor.jl")
+include("contraction_logic.jl")
+include("dense.jl")
+include("symmetric.jl")
+include("linearalgebra.jl")
+include("diag.jl")
+include("combiner.jl")
+include("truncate.jl")
+include("svd.jl")
+
+#####################################
+# BlockSparseTensor
+#
+include("blocksparse/blockdims.jl")
+include("blocksparse/block.jl")
+include("blocksparse/blockoffsets.jl")
+include("blocksparse/blocksparse.jl")
+include("blocksparse/blocksparsetensor.jl")
+include("blocksparse/diagblocksparse.jl")
+include("blocksparse/combiner.jl")
+include("blocksparse/linearalgebra.jl")
+
+#####################################
+# Empty
+#
+include("empty.jl")
+
+#####################################
+# Deprecations
+#
+include("deprecated.jl")
+
+#####################################
+# A global timer used with TimerOutputs.jl
 #
 
-storage(T::Tensor) = store(T)
+const timer = TimerOutput()
 
-#function NDTensors.blockdims(inds::IndexSet, block::Tuple)
-#  return ntuple(i -> blockdim(inds,block,i), ValLength(block))
-#end
+#####################################
+# Optional block sparse multithreading
+#
+
+include("blas_get_num_threads.jl")
+
+const _using_threaded_blocksparse = Ref(false)
+
+function enable_threaded_blocksparse_docstring(module_name)
+  return """
+             $(module_name).enable_threaded_blocksparse()
+             $(module_name).disable_threaded_blocksparse()
+
+         Enable or disable block sparse multithreading.
+
+         Returns the current state of `$(module_name).using_threaded_blocksparse()`, i.e. `true` if threaded block sparse was previously enabled, and `false` if threaded block sparse was previously disabled. This is helpful for turning block sparse threading on or off temporarily. For example:
+         ```julia
+         using_threaded_blocksparse = $(module_name).enable_threaded_blocksparse()
+         # Run code that you want to be threaded
+         if !using_threaded_blocksparse
+           $(module_name).disable_threaded_blocksparse()
+         end
+         ```
+
+         Note that you need to start Julia with multiple threads. For example, to start Julia with 4 threads, you can use any of the following:
+         ```
+         \$ julia --threads=4
+
+         \$ julia -t 4
+
+         \$ JULIA_NUM_THREADS=4 julia
+         ```
+
+         In addition, we have found that it is best to disable `BLAS` and `Strided` multithreading when using block sparse multithreading. You can do that with the commands `using LinearAlgebra; BLAS.set_num_threads(1)` and `$(module_name).Strided.disable_threads()`.
+
+         See also: `$(module_name).enable_threaded_blocksparse`, `$(module_name).disable_threaded_blocksparse`, `$(module_name).using_threaded_blocksparse`.
+         """
+end
+
+function _enable_threaded_blocksparse()
+  current_using_threaded_blocksparse = using_threaded_blocksparse()
+  if !current_using_threaded_blocksparse
+    if Threads.nthreads() == 1
+      println(
+        "WARNING: You are trying to enable block sparse multithreading, but you have started Julia with only a single thread. You can start Julia with `N` threads with `julia -t N`, and check the number of threads Julia can use with `Threads.nthreads()`. Your system has $(Sys.CPU_THREADS) threads available to use, which you can determine by running `Sys.CPU_THREADS`.\n",
+      )
+    end
+    if blas_get_num_threads() > 1 && Threads.nthreads() > 1
+      println(
+        "WARNING: You are enabling block sparse multithreading, but BLAS $(BLAS.vendor()) is currently set to use $(blas_get_num_threads()) threads. When using block sparse multithreading, we recommend setting BLAS to use only a single thread, otherwise you may see suboptimal performance. You can set it with `using LinearAlgebra; BLAS.set_num_threads(1)`.\n",
+      )
+    end
+    if Strided.get_num_threads() > 1
+      println(
+        "WARNING: You are enabling block sparse multithreading, but Strided.jl is currently set to use $(Strided.get_num_threads()) threads for performing dense tensor permutations. When using block sparse multithreading, we recommend setting Strided.jl to use only a single thread, otherwise you may see suboptimal performance. You can set it with `NDTensors.Strided.disable_threads()` and see the current number of threads it is using with `NDTensors.Strided.get_num_threads()`.\n",
+      )
+    end
+    _using_threaded_blocksparse[] = true
+  end
+  return current_using_threaded_blocksparse
+end
+
+function _disable_threaded_blocksparse()
+  current_using_threaded_blocksparse = using_threaded_blocksparse()
+  if current_using_threaded_blocksparse
+    _using_threaded_blocksparse[] = false
+  end
+  return current_using_threaded_blocksparse
+end
+
+"""
+$(enable_threaded_blocksparse_docstring(@__MODULE__))
+"""
+using_threaded_blocksparse() = _using_threaded_blocksparse[]
+
+"""
+$(enable_threaded_blocksparse_docstring(@__MODULE__))
+"""
+enable_threaded_blocksparse() = _enable_threaded_blocksparse()
+
+"""
+$(enable_threaded_blocksparse_docstring(@__MODULE__))
+"""
+disable_threaded_blocksparse() = _disable_threaded_blocksparse()
+
+#####################################
+# Optional TBLIS contraction backend
+#
+
+const _using_tblis = Ref(false)
+
+using_tblis() = _using_tblis[]
+
+function enable_tblis()
+  _using_tblis[] = true
+  return nothing
+end
+
+function disable_tblis()
+  _using_tblis[] = false
+  return nothing
+end
+
+function __init__()
+  @require TBLIS = "48530278-0828-4a49-9772-0f3830dfa1e9" begin
+    enable_tblis()
+    include("tblis.jl")
+  end
+  @require Octavian = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4" begin
+    include("octavian.jl")
+  end
+end
+
+end # module NDTensors

--- a/src/NDTensors/aliasstyle.jl
+++ b/src/NDTensors/aliasstyle.jl
@@ -1,0 +1,34 @@
+"""
+    AliasStyle
+
+A trait that determines the aliasing behavior of a constructor or function,
+for example whether or not a function or constructor might return an alias
+of one of the inputs (i.e. the output shares memory with one of the inputs,
+such that modifying the output also modifies the input or vice versa).
+
+See also [`AllowAlias`](@ref) and [`NeverAlias`](@ref).
+"""
+abstract type AliasStyle end
+
+"""
+    AllowAlias
+
+Singleton type used in a constructor or function indicating
+that the constructor or function may return an alias of the input data when
+possible, i.e. the output may share data with the input. For a constructor
+`T(AllowAlias(), args...)`, this would act like `Base.convert(T, args...)`.
+
+See also [`AliasStyle`](@ref) and [`NeverAlias`](@ref).
+"""
+struct AllowAlias <: AliasStyle end
+
+"""
+    NeverAlias
+
+Singleton type used in a constructor or function indicating
+that the constructor or function will never return an alias of the input data,
+i.e. the output will never share data with one of the inputs.
+
+See also [`AliasStyle`](@ref) and [`AllowAlias`](@ref).
+"""
+struct NeverAlias <: AliasStyle end

--- a/src/NDTensors/blas_get_num_threads.jl
+++ b/src/NDTensors/blas_get_num_threads.jl
@@ -1,0 +1,40 @@
+
+#
+# blas_get_num_threads()
+# Get the number of BLAS threads
+# This can be replaced by BLAS.get_num_threads() in Julia v1.6
+#
+
+function guess_vendor()
+  # like determine_vendor, but guesses blas in some cases
+  # where determine_vendor returns :unknown
+  ret = BLAS.vendor()
+  if Sys.isapple() && (ret == :unknown)
+    ret = :osxblas
+  end
+  return ret
+end
+
+_tryparse_env_int(key) = tryparse(Int, get(ENV, key, ""))
+
+blas_get_num_threads()::Union{Int,Nothing} = _get_num_threads()
+
+function _get_num_threads(; _blas=guess_vendor())::Union{Int,Nothing}
+  if _blas === :openblas || _blas === :openblas64
+    return Int(ccall((BLAS.@blasfunc(openblas_get_num_threads), BLAS.libblas), Cint, ()))
+  elseif _blas === :mkl
+    return Int(ccall((:mkl_get_max_threads, BLAS.libblas), Cint, ()))
+  elseif _blas === :osxblas
+    key = "VECLIB_MAXIMUM_THREADS"
+    nt = _tryparse_env_int(key)
+    if nt === nothing
+      @warn "Failed to read environment variable $key" maxlog = 1
+    else
+      return nt
+    end
+  else
+    @assert _blas === :unknown
+  end
+  @warn "Could not get number of BLAS threads. Returning `nothing` instead." maxlog = 1
+  return nothing
+end

--- a/src/NDTensors/blocksparse/block.jl
+++ b/src/NDTensors/blocksparse/block.jl
@@ -1,0 +1,180 @@
+
+#
+# Block
+#
+
+struct Block{N}
+  data::NTuple{N,UInt}
+  hash::UInt
+  function Block{N}(data::NTuple{N,UInt}) where {N}
+    h = _hash(data)
+    return new{N}(data, h)
+  end
+  function Block{0}(::Tuple{})
+    h = _hash(())
+    return new{0}((), h)
+  end
+end
+
+#
+# Constructors
+#
+
+Block{N}(t::Tuple{Vararg{<:Any,N}}) where {N} = Block{N}(UInt.(t))
+
+Block{N}(I::CartesianIndex{N}) where {N} = Block{N}(I.I)
+
+Block{N}(v::MVector{N}) where {N} = Block{N}(Tuple(v))
+
+Block{N}(v::SVector{N}) where {N} = Block{N}(Tuple(v))
+
+Block(b::Block) = b
+
+Block(I::CartesianIndex{N}) where {N} = Block{N}(I)
+
+Block(v::MVector{N}) where {N} = Block{N}(v)
+
+Block(v::SVector{N}) where {N} = Block{N}(v)
+
+Block(t::NTuple{N,UInt}) where {N} = Block{N}(t)
+
+Block(t::Tuple{Vararg{<:Any,N}}) where {N} = Block{N}(t)
+
+Block(::Tuple{}) where {N} = Block{0}(())
+
+Block(I::Union{Integer,Block{1}}...) = Block(I)
+
+#
+# Conversions
+#
+
+CartesianIndex(b::Block) = CartesianIndex(Tuple(b))
+
+Tuple(b::Block{N}) where {N} = NTuple{N,UInt}(b.data)
+
+convert(::Type{Block}, I::CartesianIndex{N}) where {N} = Block{N}(I.I)
+
+convert(::Type{Block{N}}, I::CartesianIndex{N}) where {N} = Block{N}(I.I)
+
+convert(::Type{Block}, t::Tuple) where {N} = Block(t)
+
+convert(::Type{Block{N}}, t::Tuple) where {N} = Block{N}(t)
+
+(::Type{IntT})(b::Block{1}) where {IntT<:Integer} = IntT(only(b))
+
+#
+# Getting and setting fields
+#
+
+gethash(b::Block) = b.hash[]
+
+sethash!(b::Block, h::UInt) = (b.hash[] = h; return b)
+
+#
+# Basic functions
+#
+
+length(::Block{N}) where {N} = N
+
+isless(b1::Block, b2::Block) = isless(Tuple(b1), Tuple(b2))
+
+iterate(b::Block, args...) = iterate(b.data, args...)
+
+@propagate_inbounds function getindex(b::Block, i::Integer)
+  return b.data[i]
+end
+
+@propagate_inbounds function setindex(b::Block{N}, val, i::Integer) where {N}
+  return Block{N}(setindex(b.data, UInt(val), i))
+end
+
+ValLength(::Type{<:Block{N}}) where {N} = Val{N}
+
+deleteat(b::Block, pos) = Block(deleteat(Tuple(b), pos))
+
+insertafter(b::Block, val, pos) = Block(insertafter(Tuple(b), UInt.(val), pos))
+
+getindices(b::Block, I) = getindices(Tuple(b), I)
+
+#
+# checkbounds
+#
+
+# XXX: define this properly
+checkbounds(::Tensor, ::Block) = nothing
+
+#
+# Hashing
+#
+
+# Borrowed from:
+# https://github.com/JuliaLang/julia/issues/37073
+# This is the same as Julia's Base tuple hash, but is
+# a bit faster.
+_hash(t::Tuple) = _hash(t, zero(UInt))
+_hash(::Tuple{}, h::UInt) = h + Base.tuplehash_seed
+@generated function _hash(b::NTuple{N}, h::UInt) where {N}
+  quote
+    out = h + Base.tuplehash_seed
+    @nexprs $N i -> out = hash(b[$N - i + 1], out)
+  end
+end
+
+if VERSION < v"1.7.0-DEV.933"
+  # Stop inlining after some number of arguments to avoid code blowup
+  function _hash(t::Base.Any16, h::UInt)
+    out = h + Base.tuplehash_seed
+    for i in length(t):-1:1
+      out = hash(t[i], out)
+    end
+    return out
+  end
+else
+  # Stop inlining after some number of arguments to avoid code blowup
+  function _hash(t::Base.Any32, h::UInt)
+    out = h + Base.tuplehash_seed
+    for i in length(t):-1:1
+      out = hash(t[i], out)
+    end
+    return out
+  end
+end
+
+hash(b::Block) = UInt(b.hash)
+hash(b::Block, h::UInt) = h + hash(b)
+
+#
+# Custom NTuple{N, Int} hashes
+# These are faster, but have a lot of collisions
+#
+
+# Borrowed from:
+# https://stackoverflow.com/questions/20511347/a-good-hash-function-for-a-vector
+# This seems to have a lot of clashes
+#function hash(b::Block, seed::UInt)
+#  h = UInt(0x9e3779b9)
+#  for n in b
+#    seed ⊻= n + h + (seed << 6) + (seed >> 2)
+#  end
+#  return seed
+#end
+
+# Borrowed from:
+# http://www.docjar.com/html/api/java/util/Arrays.java.html
+# Could also consider uring the CPython tuple hash:
+# https://github.com/python/cpython/blob/0430dfac629b4eb0e899a09b899a494aa92145f6/Objects/tupleobject.c#L406
+#function hash(b::Block, h::UInt)
+#  h += Base.tuplehash_seed
+#  for n in b
+#    h = 31 * h + n ⊻ (n >> 32)
+#  end
+#  return h
+#end
+
+#
+# Printing for Block type
+#
+
+show(io::IO, mime::MIME"text/plain", b::Block) = print(io, "Block$(Int.(Tuple(b)))")
+
+show(io::IO, b::Block) = show(io, MIME("text/plain"), b)

--- a/src/NDTensors/blocksparse/blockdims.jl
+++ b/src/NDTensors/blocksparse/blockdims.jl
@@ -1,0 +1,183 @@
+"""
+BlockDim
+
+An index for a BlockSparseTensor.
+"""
+const BlockDim = Vector{Int}
+
+# Makes for generic code
+dim(d::BlockDim) = sum(d)
+
+"""
+BlockDims{N}
+
+Dimensions used for BlockSparse NDTensors.
+Each entry lists the block sizes in each dimension.
+"""
+const BlockDims{N} = NTuple{N,BlockDim}
+
+Base.ndims(ds::Type{<:BlockDims{N}}) where {N} = N
+
+similartype(::Type{<:BlockDims}, ::Type{Val{N}}) where {N} = BlockDims{N}
+
+Base.copy(ds::BlockDims) = ds
+
+"""
+dim(::BlockDims,::Integer)
+
+Return the total extent of the specified dimensions.
+"""
+function dim(ds::BlockDims{N}, i::Integer) where {N}
+  return sum(ds[i])
+end
+
+"""
+dims(::BlockDims)
+
+Return the total extents of the dense space
+the block dimensions live in.
+"""
+function dims(ds::BlockDims{N}) where {N}
+  return ntuple(i -> dim(ds, i), Val(N))
+end
+
+"""
+dim(::BlockDims)
+
+Return the total extent of the dense space
+the block dimensions live in.
+"""
+function dim(ds::BlockDims{N}) where {N}
+  return prod(dims(ds))
+end
+
+"""
+nblocks(::BlockDim)
+
+The number of blocks of the BlockDim.
+"""
+function nblocks(ind::BlockDim)
+  return length(ind)
+end
+
+"""
+nblocks(::BlockDims,i::Integer)
+
+The number of blocks in the specified dimension.
+"""
+function nblocks(inds::Tuple, i::Integer)
+  return nblocks(inds[i])
+end
+
+"""
+nblocks(::BlockDims,is)
+
+The number of blocks in the specified dimensions.
+"""
+function nblocks(inds::Tuple, is::NTuple{N,Int}) where {N}
+  return ntuple(i -> nblocks(inds, is[i]), Val(N))
+end
+
+"""
+nblocks(::BlockDims)
+
+A tuple of the number of blocks in each
+dimension.
+"""
+function nblocks(inds::NTuple{N,<:Any}) where {N}
+  return ntuple(i -> nblocks(inds, i), Val(N))
+end
+
+"""
+blockdim(::BlockDim,::Integer)
+
+The size of the specified block in the specified
+dimension.
+"""
+function blockdim(ind::BlockDim, i::Integer)
+  return ind[i]
+end
+
+"""
+    blockdim(::BlockDims,block,::Integer)
+
+The size of the specified block in the specified
+dimension.
+"""
+function blockdim(inds, block, i::Integer)
+  return blockdim(inds[i], block[i])
+end
+
+"""
+    blockdims(::BlockDims,block)
+
+The size of the specified block.
+"""
+function blockdims(inds, block)
+  return ntuple(i -> blockdim(inds, block, i), ValLength(inds))
+end
+
+"""
+    blockdim(::BlockDims,block)
+
+The total size of the specified block.
+"""
+function blockdim(inds, block)
+  return prod(blockdims(inds, block))
+end
+
+"""
+blockdiaglength(inds::BlockDims,block)
+
+The length of the diagonal of the specified block.
+"""
+function blockdiaglength(inds, block)
+  return minimum(blockdims(inds, block))
+end
+
+function outer(dim1, dim2, dim3, dims...; kwargs...)
+  return outer(outer(dim1, dim2), dim3, dims...; kwargs...)
+end
+
+function outer(dim1::BlockDim, dim2::BlockDim)
+  dimR = BlockDim(undef, nblocks(dim1) * nblocks(dim2))
+  for (i, t) in enumerate(Iterators.product(dim1, dim2))
+    dimR[i] = prod(t)
+  end
+  return dimR
+end
+
+function permuteblocks(dim::BlockDim, perm)
+  return dim[perm]
+end
+
+# Given a CartesianIndex in the range dims(T), get the block it is in
+# and the index within that block
+function blockindex(T, i::Vararg{Int,N}) where {ElT,N}
+  # Start in the (1,1,...,1) block
+  current_block_loc = @MVector ones(Int, N)
+  current_block_dims = blockdims(T, Tuple(current_block_loc))
+  block_index = MVector(i)
+  for dim in 1:N
+    while block_index[dim] > current_block_dims[dim]
+      block_index[dim] -= current_block_dims[dim]
+      current_block_loc[dim] += 1
+      current_block_dims = blockdims(T, Tuple(current_block_loc))
+    end
+  end
+  return Tuple(block_index), Block{N}(current_block_loc)
+end
+
+blockindex(T) = (), Block{0}()
+
+#
+# This is to help with ITensor compatibility
+#
+
+setblockdim!(dim1::BlockDim, newdim::Int, n::Int) = setindex!(dim1, newdim, n)
+
+sim(dim::BlockDim) = copy(dim)
+
+dir(::BlockDim) = 0
+
+dag(dim::BlockDim) = copy(dim)

--- a/src/NDTensors/blocksparse/blockoffsets.jl
+++ b/src/NDTensors/blocksparse/blockoffsets.jl
@@ -1,0 +1,165 @@
+#
+# BlockOffsets
+#
+
+const Blocks{N} = Vector{Block{N}}
+const BlockOffset{N} = Pair{Block{N},Int}
+# Use Dictionary from Dictionaries.jl (faster
+# iteration than Base.Dict)
+const BlockOffsets{N} = Dictionary{Block{N},Int}
+
+BlockOffset(block::Block{N}, offset::Int) where {N} = BlockOffset{N}(block, offset)
+
+nzblock(bof::BlockOffset) = first(bof)
+
+offset(bof::BlockOffset) = last(bof)
+
+nzblock(block::Block) = block
+
+# Get the offset if the nth block in the block-offsets
+# list
+offset(bofs::BlockOffsets, n) = offset(bofs[n])
+
+nnzblocks(bofs::BlockOffsets) = length(bofs)
+nnzblocks(bs::Blocks) = length(bs)
+
+eachnzblock(bofs::BlockOffsets) = keys(bofs)
+
+nzblocks(bofs::BlockOffsets) = collect(eachnzblock(bofs))
+
+# define block ordering with reverse lexographical order
+function isblockless(b1::Block{N}, b2::Block{N}) where {N}
+  return CartesianIndex(b1) < CartesianIndex(b2)
+end
+
+function isblockless(bof1::BlockOffset{N}, bof2::BlockOffset{N}) where {N}
+  return isblockless(nzblock(bof1), nzblock(bof2))
+end
+
+function isblockless(bof1::BlockOffset{N}, b2::Block{N}) where {N}
+  return isblockless(nzblock(bof1), b2)
+end
+
+function isblockless(b1::Block{N}, bof2::BlockOffset{N}) where {N}
+  return isblockless(b1, nzblock(bof2))
+end
+
+function offset(bofs::BlockOffsets{N}, block::Block{N}) where {N}
+  if !isassigned(bofs, block)
+    return nothing
+  end
+  return bofs[block]
+end
+
+function nnz(bofs::BlockOffsets, inds)
+  _nnz = 0
+  nnzblocks(bofs) == 0 && return _nnz
+  for block in eachnzblock(bofs)
+    _nnz += blockdim(inds, block)
+  end
+  return _nnz
+end
+
+blockoffsets(blocks::Vector{<:NTuple}, inds) = blockoffsets(Block.(blocks), inds)
+
+# TODO: should this be a constructor?
+function blockoffsets(blocks::Vector{<:Block{N}}, inds) where {N}
+  blockoffsets = BlockOffsets{N}()
+  nnz = 0
+  for block in blocks
+    insert!(blockoffsets, block, nnz)
+    current_block_dim = blockdim(inds, block)
+    nnz += current_block_dim
+  end
+  return blockoffsets, nnz
+end
+
+"""
+    diagblockoffsets(blocks::Blocks,inds)
+
+Get the blockoffsets only along the diagonal.
+The offsets are along the diagonal.
+
+Assumes the blocks are allong the diagonal.
+"""
+function diagblockoffsets(
+  blocks::Vector{BlockT}, inds
+) where {BlockT<:Union{Block{N},Tuple{Vararg{<:Any,N}}}} where {N}
+  blockoffsets = BlockOffsets{N}()
+  nnzdiag = 0
+  for (i, block) in enumerate(blocks)
+    insert!(blockoffsets, Block(block), nnzdiag)
+    current_block_diaglength = blockdiaglength(inds, block)
+    nnzdiag += current_block_diaglength
+  end
+  return blockoffsets, nnzdiag
+end
+
+# Permute the blockoffsets and indices
+function permutedims(boffs::BlockOffsets{N}, inds, perm::NTuple{N,Int}) where {N}
+  blocksR = Blocks{N}(undef, nnzblocks(boffs))
+  for (i, block) in enumerate(keys(boffs))
+    blocksR[i] = permute(block, perm)
+  end
+  indsR = permute(inds, perm)
+  blockoffsetsR, _ = blockoffsets(blocksR, indsR)
+  return blockoffsetsR, indsR
+end
+
+function permutedims(blocks::Vector{Block{N}}, perm::NTuple{N,Int}) where {N}
+  blocks_perm = Vector{Block{N}}(undef, length(blocks))
+  for (i, block) in enumerate(blocks)
+    blocks_perm[i] = permute(block, perm)
+  end
+  return blocks_perm
+end
+
+"""
+blockdim(T::BlockOffsets,nnz::Int,pos::Int)
+
+Get the block dimension of the block at position pos.
+"""
+function blockdim(boffs::BlockOffsets, nnz::Int, pos::Int)
+  if nnzblocks(boffs) == 0
+    return 0
+  elseif pos == nnzblocks(boffs)
+    return nnz - offset(boffs, pos)
+  end
+  return offset(boffs, pos + 1) - offset(boffs, pos)
+end
+
+function Base.union(
+  boffs1::BlockOffsets{N}, nnz1::Int, boffs2::BlockOffsets{N}, nnz2::Int
+) where {N}
+  n1, n2 = 1, 1
+  boffsR = BlockOffset{N}[]
+  current_offset = 0
+  while n1 <= length(boffs1) && n2 <= length(boffs2)
+    if isblockless(boffs1[n1], boffs2[n2])
+      push!(boffsR, BlockOffset(nzblock(boffs1[n1]), current_offset))
+      current_offset += blockdim(boffs1, nnz1, n1)
+      n1 += 1
+    elseif isblockless(boffs2[n2], boffs1[n1])
+      push!(boffsR, BlockOffset(nzblock(boffs2[n2]), current_offset))
+      current_offset += blockdim(boffs2, nnz2, n2)
+      n2 += 1
+    else
+      push!(boffsR, BlockOffset(nzblock(boffs1[n1]), current_offset))
+      current_offset += blockdim(boffs1, nnz1, n1)
+      n1 += 1
+      n2 += 1
+    end
+  end
+  if n1 <= length(boffs1)
+    for n in n1:length(boffs1)
+      push!(boffsR, BlockOffset(nzblock(boffs1[n]), current_offset))
+      current_offset += blockdim(boffs1, nnz1, n)
+    end
+  elseif n2 <= length(boffs2)
+    for n in n2:length(bofss2)
+      push!(boffsR, BlockOffset(nzblock(boffs2[n]), current_offset))
+      current_offset += blockdim(boffs2, nnz2, n)
+    end
+  end
+  return boffsR, current_offset
+end

--- a/src/NDTensors/blocksparse/blocksparse.jl
+++ b/src/NDTensors/blocksparse/blocksparse.jl
@@ -1,0 +1,218 @@
+#
+# BlockSparse storage
+#
+
+struct BlockSparse{ElT,VecT,N} <: TensorStorage{ElT}
+  data::VecT
+  blockoffsets::BlockOffsets{N}  # Block number-offset pairs
+  function BlockSparse(
+    data::VecT, blockoffsets::BlockOffsets{N}
+  ) where {VecT<:AbstractVector{ElT},N} where {ElT}
+    return new{ElT,VecT,N}(data, blockoffsets)
+  end
+end
+
+function BlockSparse(
+  ::Type{ElT}, blockoffsets::BlockOffsets, dim::Integer; vargs...
+) where {ElT<:Number}
+  return BlockSparse(zeros(ElT, dim), blockoffsets; vargs...)
+end
+
+function BlockSparse(
+  ::Type{ElT}, ::UndefInitializer, blockoffsets::BlockOffsets, dim::Integer; vargs...
+) where {ElT<:Number}
+  return BlockSparse(Vector{ElT}(undef, dim), blockoffsets; vargs...)
+end
+
+function BlockSparse(blockoffsets::BlockOffsets, dim::Integer; vargs...)
+  return BlockSparse(Float64, blockoffsets, dim; vargs...)
+end
+
+function BlockSparse(::UndefInitializer, blockoffsets::BlockOffsets, dim::Integer; vargs...)
+  return BlockSparse(Float64, undef, blockoffsets, dim; vargs...)
+end
+
+copy(D::BlockSparse) = BlockSparse(copy(data(D)), copy(blockoffsets(D)))
+
+setdata(B::BlockSparse, ndata) = BlockSparse(ndata, blockoffsets(B))
+
+#
+# Random
+#
+
+function randn(
+  ::Type{<:BlockSparse{ElT}}, blockoffsets::BlockOffsets, dim::Integer
+) where {ElT<:Number}
+  return BlockSparse(randn(ElT, dim), blockoffsets)
+end
+
+#function BlockSparse{ElR}(data::VecT,offsets) where {ElR,VecT<:AbstractVector{ElT}} where {ElT}
+#  ElT == ElR ? BlockSparse(data,offsets) : BlockSparse(ElR.(data),offsets)
+#end
+#BlockSparse{ElT}() where {ElT} = BlockSparse(ElT[],BlockOffsets())
+
+datatype(::Type{<:BlockSparse{<:Any,DataT}}) where {DataT} = DataT
+
+similar(D::BlockSparse) = setdata(D, similar(data(D)))
+
+# TODO: test this function
+similar(D::BlockSparse, ::Type{ElT}) where {ElT} = setdata(D, similar(data(D), ElT))
+
+function similartype(::Type{StoreT}, ::Type{ElT}) where {StoreT<:BlockSparse,ElT}
+  return BlockSparse{ElT,similartype(datatype(StoreT), ElT),ndims(StoreT)}
+end
+
+# TODO: check the offsets are the same?
+function copyto!(D1::BlockSparse, D2::BlockSparse)
+  blockoffsets(D1) ≠ blockoffsets(D1) &&
+    error("Cannot copy between BlockSparse storages with different offsets")
+  copyto!(data(D1), data(D2))
+  return D1
+end
+
+Base.real(::Type{BlockSparse{T}}) where {T} = BlockSparse{real(T)}
+
+complex(::Type{BlockSparse{T}}) where {T} = BlockSparse{complex(T)}
+
+ndims(::BlockSparse{T,V,N}) where {T,V,N} = N
+
+eltype(::BlockSparse{T}) where {T} = eltype(T)
+# This is necessary since for some reason inference doesn't work
+# with the more general definition (eltype(Nothing) === Any)
+eltype(::BlockSparse{Nothing}) = Nothing
+eltype(::Type{BlockSparse{T}}) where {T} = eltype(T)
+
+dense(::Type{<:BlockSparse{ElT,VecT}}) where {ElT,VecT} = Dense{ElT,VecT}
+
+function promote_rule(
+  ::Type{<:BlockSparse{ElT1,VecT1,N}}, ::Type{<:BlockSparse{ElT2,VecT2,N}}
+) where {ElT1,ElT2,VecT1,VecT2,N}
+  return BlockSparse{promote_type(ElT1, ElT2),promote_type(VecT1, VecT2),N}
+end
+
+function promote_rule(
+  ::Type{<:BlockSparse{ElT1,VecT1,N1}}, ::Type{<:BlockSparse{ElT2,VecT2,N2}}
+) where {ElT1,ElT2,VecT1,VecT2,N1,N2}
+  return BlockSparse{promote_type(ElT1, ElT2),promote_type(VecT1, VecT2),NR} where {NR}
+end
+
+function promote_rule(
+  ::Type{<:BlockSparse{ElT1,Vector{ElT1},N1}}, ::Type{ElT2}
+) where {ElT1,ElT2<:Number,N1}
+  ElR = promote_type(ElT1, ElT2)
+  VecR = Vector{ElR}
+  return BlockSparse{ElR,VecR,N1}
+end
+
+function convert(
+  ::Type{<:BlockSparse{ElR,VecR,N}}, D::BlockSparse{ElD,VecD,N}
+) where {ElR,VecR,N,ElD,VecD}
+  return setdata(D, convert(VecR, data(D)))
+end
+
+"""
+isblocknz(T::BlockSparse,
+          block::Block)
+
+Check if the specified block is non-zero.
+"""
+function isblocknz(T::BlockSparse{ElT,VecT,N}, block::Block{N}) where {ElT,VecT,N}
+  return isassigned(blockoffsets(T), block)
+end
+
+# If block is input as Tuple
+isblocknz(T::BlockSparse, block) = isblocknz(T, Block(block))
+
+# Given a specified block, return a Dense storage that is a view to the data
+# in that block. Return nothing if the block is structurally zero
+function blockview(T::BlockSparse, block)
+  #error("Block must be structurally non-zero to get a view")
+  !isblocknz(T, block) && return nothing
+  blockoffsetT = offset(T, block)
+  blockdimT = blockdim(T, block)
+  dataTslice = @view data(T)[(blockoffsetT + 1):(blockoffsetT + blockdimT)]
+  return Dense(dataTslice)
+end
+
+# XXX this is not well defined with new Dictionary design
+#function (D1::BlockSparse + D2::BlockSparse)
+#  # This could be of order nnzblocks, avoid?
+#  if blockoffsets(D1) == blockoffsets(D2)
+#    return BlockSparse(data(D1)+data(D2),blockoffsets(D1))
+#  end
+#  blockoffsetsR,nnzR = union(blockoffsets(D1),nnz(D1),
+#                             blockoffsets(D2),nnz(D2))
+#  R = BlockSparse(undef,blockoffsetsR,nnzR)
+#  for (blockR,offsetR) in blockoffsets(R)
+#    blockview1 = blockview(D1,blockR)
+#    blockview2 = blockview(D2,blockR)
+#    blockviewR = blockview(R,blockR)
+#    if isnothing(blockview1)
+#      copyto!(blockviewR,blockview2)
+#    elseif isnothing(blockview2)
+#      copyto!(blockviewR,blockview1)
+#    else
+#      # TODO: is this fast?
+#      blockviewR .= blockview1 .+ blockview2
+#    end
+#  end
+#  return R
+#end
+
+# Helper function for HDF5 write/read of BlockSparse
+function offsets_to_array(boff::BlockOffsets{N}) where {N}
+  nblocks = length(boff)
+  asize = (N + 1) * nblocks
+  n = 1
+  a = Vector{Int}(undef, asize)
+  for bo in pairs(boff)
+    for j in 1:N
+      a[n] = bo[1][j]
+      n += 1
+    end
+    a[n] = bo[2]
+    n += 1
+  end
+  return a
+end
+
+# Helper function for HDF5 write/read of BlockSparse
+function array_to_offsets(a, N::Int)
+  asize = length(a)
+  nblocks = div(asize, N + 1)
+  boff = BlockOffsets{N}()
+  j = 0
+  for b in 1:nblocks
+    insert!(boff, Block(ntuple(i -> (a[j + i]), N)), a[j + N + 1])
+    j += (N + 1)
+  end
+  return boff
+end
+
+function HDF5.write(parent::Union{HDF5.File,HDF5.Group}, name::String, B::BlockSparse)
+  g = create_group(parent, name)
+  attributes(g)["type"] = "BlockSparse{$(eltype(B))}"
+  attributes(g)["version"] = 1
+  if eltype(B) != Nothing
+    write(g, "ndims", ndims(B))
+    write(g, "data", data(B))
+    off_array = offsets_to_array(blockoffsets(B))
+    write(g, "offsets", off_array)
+  end
+end
+
+function HDF5.read(
+  parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, ::Type{Store}
+) where {Store<:BlockSparse}
+  g = open_group(parent, name)
+  ElT = eltype(Store)
+  typestr = "BlockSparse{$ElT}"
+  if read(attributes(g)["type"]) != typestr
+    error("HDF5 group or file does not contain $typestr data")
+  end
+  N = read(g, "ndims")
+  data = read(g, "data")
+  off_array = read(g, "offsets")
+  boff = array_to_offsets(off_array, N)
+  return BlockSparse(data, boff)
+end

--- a/src/NDTensors/blocksparse/blocksparsetensor.jl
+++ b/src/NDTensors/blocksparse/blocksparsetensor.jl
@@ -1,0 +1,1229 @@
+#
+# BlockSparseTensor (Tensor using BlockSparse storage)
+#
+
+const BlockSparseTensor{ElT,N,StoreT,IndsT} =
+  Tensor{ElT,N,StoreT,IndsT} where {StoreT<:BlockSparse}
+
+nonzeros(T::Tensor) = data(T)
+
+# Special version for BlockSparseTensor
+# Generic version doesn't work since BlockSparse us parametrized by
+# the Tensor order
+function similartype(
+  ::Type{<:Tensor{ElT,NT,<:BlockSparse{ElT,VecT},<:Any}}, ::Type{IndsR}
+) where {NT,ElT,VecT,IndsR}
+  NR = length(IndsR)
+  return Tensor{ElT,NR,BlockSparse{ElT,VecT,NR},IndsR}
+end
+
+function similartype(
+  ::Type{<:Tensor{ElT,NT,<:BlockSparse{ElT,VecT},<:Any}}, ::Type{IndsR}
+) where {NT,ElT,VecT,IndsR<:NTuple{NR}} where {NR}
+  return Tensor{ElT,NR,BlockSparse{ElT,VecT,NR},IndsR}
+end
+
+function BlockSparseTensor(
+  ::Type{ElT}, ::UndefInitializer, boffs::BlockOffsets, inds
+) where {ElT<:Number}
+  nnz_tot = nnz(boffs, inds)
+  storage = BlockSparse(ElT, undef, boffs, nnz_tot)
+  return tensor(storage, inds)
+end
+
+function BlockSparseTensor(
+  ::Type{ElT}, ::UndefInitializer, blocks::Vector{BlockT}, inds
+) where {ElT<:Number,BlockT<:Union{Block,NTuple}}
+  boffs, nnz = blockoffsets(blocks, inds)
+  storage = BlockSparse(ElT, undef, boffs, nnz)
+  return tensor(storage, inds)
+end
+
+"""
+    BlockSparseTensor(::UndefInitializer, blocks, inds)
+
+Construct a block sparse tensor with uninitialized memory
+from indices and locations of non-zero blocks.
+"""
+function BlockSparseTensor(::UndefInitializer, blockoffsets, inds)
+  return BlockSparseTensor(Float64, undef, blockoffsets, inds)
+end
+
+function BlockSparseTensor(
+  ::Type{ElT}, blockoffsets::BlockOffsets{N}, inds
+) where {ElT<:Number,N}
+  nnz_tot = nnz(blockoffsets, inds)
+  storage = BlockSparse(ElT, blockoffsets, nnz_tot)
+  return tensor(storage, inds)
+end
+
+function BlockSparseTensor(blockoffsets::BlockOffsets, inds)
+  return BlockSparseTensor(Float64, blockoffsets, inds)
+end
+
+"""
+    BlockSparseTensor(inds)
+
+Construct a block sparse tensor with no blocks.
+"""
+BlockSparseTensor(inds) = BlockSparseTensor(BlockOffsets{length(inds)}(), inds)
+
+function BlockSparseTensor(::Type{ElT}, inds) where {ElT<:Number,N}
+  return BlockSparseTensor(ElT, BlockOffsets{length(inds)}(), inds)
+end
+
+"""
+    BlockSparseTensor(inds)
+
+Construct a block sparse tensor with no blocks.
+"""
+function BlockSparseTensor(inds::Vararg{DimT,N}) where {DimT,N}
+  return BlockSparseTensor(BlockOffsets{N}(), inds)
+end
+
+"""
+    BlockSparseTensor(blocks::Vector{Block{N}}, inds)
+
+Construct a block sparse tensor with the specified blocks.
+Defaults to setting structurally non-zero blocks to zero.
+"""
+function BlockSparseTensor(blocks::Vector{BlockT}, inds) where {BlockT<:Union{Block,NTuple}}
+  return BlockSparseTensor(Float64, blocks, inds)
+end
+
+function BlockSparseTensor(
+  ::Type{ElT}, blocks::Vector{BlockT}, inds
+) where {ElT<:Number,BlockT<:Union{Block,NTuple}}
+  boffs, nnz = blockoffsets(blocks, inds)
+  storage = BlockSparse(ElT, boffs, nnz)
+  return tensor(storage, inds)
+end
+
+#complex(::Type{BlockSparseTensor{ElT,N,StoreT,IndsT}}) where {ElT<:Number,N,StoreT<:BlockSparse
+#  = Tensor{ElT,N,StoreT,IndsT} where {StoreT<:BlockSparse}
+
+function randn(
+  ::Type{<:BlockSparseTensor{ElT,N}}, blocks::Vector{<:BlockT}, inds
+) where {ElT,BlockT<:Union{Block{N},NTuple{N,<:Integer}}} where {N}
+  boffs, nnz = blockoffsets(blocks, inds)
+  storage = randn(BlockSparse{ElT}, boffs, nnz)
+  return tensor(storage, inds)
+end
+
+# XXX: use the syntax:
+# BlockSparseTensor(randn, ElT, blocks, inds)
+function randomBlockSparseTensor(
+  ::Type{ElT}, blocks::Vector{<:BlockT}, inds
+) where {ElT,BlockT<:Union{Block{N},NTuple{N,<:Integer}}} where {N}
+  return randn(BlockSparseTensor{ElT,N}, blocks, inds)
+end
+
+function randomBlockSparseTensor(blocks::Vector, inds)
+  return randomBlockSparseTensor(Float64, blocks, inds)
+end
+
+"""
+BlockSparseTensor(blocks::Vector{Block{N}},
+                  inds::BlockDims...)
+
+Construct a block sparse tensor with the specified blocks.
+Defaults to setting structurally non-zero blocks to zero.
+"""
+function BlockSparseTensor(
+  blocks::Vector{BlockT}, inds::Vararg{BlockDim,N}
+) where {BlockT<:Union{Block{N},NTuple{N,<:Integer}}} where {N}
+  return BlockSparseTensor(blocks, inds)
+end
+
+function similar(
+  ::BlockSparseTensor{ElT,N}, blockoffsets::BlockOffsets{N}, inds
+) where {ElT,N}
+  return BlockSparseTensor(ElT, undef, blockoffsets, inds)
+end
+
+function similar(
+  ::Type{<:BlockSparseTensor{ElT,N}}, blockoffsets::BlockOffsets{N}, inds
+) where {ElT,N}
+  return BlockSparseTensor(ElT, undef, blockoffsets, inds)
+end
+
+# This version of similar creates a tensor with no blocks
+function similar(::Type{TensorT}, inds::Tuple) where {TensorT<:BlockSparseTensor}
+  return similar(TensorT, BlockOffsets{ndims(TensorT)}(), inds)
+end
+
+function zeros(
+  ::BlockSparseTensor{ElT,N}, blockoffsets::BlockOffsets{N}, inds
+) where {ElT,N}
+  return BlockSparseTensor(ElT, blockoffsets, inds)
+end
+
+function zeros(
+  ::Type{<:BlockSparseTensor{ElT,N}}, blockoffsets::BlockOffsets{N}, inds
+) where {ElT,N}
+  return BlockSparseTensor(ElT, blockoffsets, inds)
+end
+
+function zeros(::BlockSparseTensor{ElT,N}, inds) where {ElT,N}
+  return BlockSparseTensor(ElT, inds)
+end
+
+function zeros(::Type{<:BlockSparseTensor{ElT,N}}, inds) where {ElT,N}
+  return BlockSparseTensor(ElT, inds)
+end
+
+# Basic functionality for AbstractArray interface
+IndexStyle(::Type{<:BlockSparseTensor}) = IndexCartesian()
+
+# Get the CartesianIndices for the range of indices
+# of the specified
+function blockindices(T::BlockSparseTensor{ElT,N}, block) where {ElT,N}
+  return CartesianIndex(blockstart(T, block)):CartesianIndex(blockend(T, block))
+end
+
+"""
+indexoffset(T::BlockSparseTensor,i::Int...) -> offset,block,blockoffset
+
+Get the offset in the data of the specified
+CartesianIndex. If it falls in a block that doesn't
+exist, return nothing for the offset.
+Also returns the block the index is found in and the offset
+within the block.
+"""
+function indexoffset(T::BlockSparseTensor{ElT,N}, i::Vararg{Int,N}) where {ElT,N}
+  index_within_block, block = blockindex(T, i...)
+  block_dims = blockdims(T, block)
+  offset_within_block = LinearIndices(block_dims)[CartesianIndex(index_within_block)]
+  offset_of_block = offset(T, block)
+  offset_of_i = isnothing(offset_of_block) ? nothing : offset_of_block + offset_within_block
+  return offset_of_i, block, offset_within_block
+end
+
+# TODO: Add a checkbounds
+# TODO: write this nicer in terms of blockview?
+#       Could write: 
+#       block,index_within_block = blockindex(T,i...)
+#       return blockview(T,block)[index_within_block]
+@propagate_inbounds function getindex(
+  T::BlockSparseTensor{ElT,N}, i::Vararg{Int,N}
+) where {ElT,N}
+  offset, _ = indexoffset(T, i...)
+  isnothing(offset) && return zero(ElT)
+  return storage(T)[offset]
+end
+
+@propagate_inbounds function getindex(T::BlockSparseTensor{ElT,0}) where {ElT}
+  nnzblocks(T) == 0 && return zero(ElT)
+  return storage(T)[]
+end
+
+# These may not be valid if the Tensor has no blocks
+#@propagate_inbounds getindex(T::BlockSparseTensor{<:Number,1},ind::Int) = storage(T)[ind]
+
+#@propagate_inbounds getindex(T::BlockSparseTensor{<:Number,0}) = storage(T)[1]
+
+# Add the specified block to the BlockSparseTensor
+# Insert it such that the blocks remain ordered.
+# Defaults to adding zeros.
+# Returns the offset of the new block added.
+# XXX rename to insertblock!, no need to return offset
+function insertblock_offset!(T::BlockSparseTensor{ElT,N}, newblock::Block{N}) where {ElT,N}
+  newdim = blockdim(T, newblock)
+  newoffset = nnz(T)
+  insert!(blockoffsets(T), newblock, newoffset)
+  # Insert new block into data
+  splice!(data(storage(T)), (newoffset + 1):newoffset, zeros(ElT, newdim))
+  return newoffset
+end
+
+function insertblock!(T::BlockSparseTensor{<:Number,N}, block::Block{N}) where {N}
+  insertblock_offset!(T, block)
+  return T
+end
+
+insertblock!(T::BlockSparseTensor, block) = insertblock!(T, Block(block))
+
+# TODO: Add a checkbounds
+@propagate_inbounds function setindex!(
+  T::BlockSparseTensor{ElT,N}, val, i::Vararg{Int,N}
+) where {ElT,N}
+  offset, block, offset_within_block = indexoffset(T, i...)
+  if isnothing(offset)
+    offset_of_block = insertblock_offset!(T, block)
+    offset = offset_of_block + offset_within_block
+  end
+  storage(T)[offset] = val
+  return T
+end
+
+hasblock(T::Tensor, block::Block) = isassigned(blockoffsets(T), block)
+
+@propagate_inbounds function setindex!(
+  T::BlockSparseTensor{ElT,N}, val, b::Block{N}
+) where {ElT,N}
+  if !hasblock(T, b)
+    insertblock!(T, b)
+  end
+  Tb = T[b]
+  Tb .= val
+  return T
+end
+
+getindex(T::BlockSparseTensor, block::Block) = blockview(T, block)
+
+to_indices(T::Tensor{<:Any,N}, b::Tuple{Block{N}}) where {N} = blockindices(T, b...)
+
+function blockview(T::BlockSparseTensor, block::Block)
+  return blockview(T, BlockOffset(block, offset(T, block)))
+end
+
+blockview(T::BlockSparseTensor, block) = blockview(T, Block(block))
+
+function blockview(T::BlockSparseTensor, bof::BlockOffset)
+  blockT, offsetT = bof
+  blockdimsT = blockdims(T, blockT)
+  blockdimT = prod(blockdimsT)
+  dataTslice = @view data(storage(T))[(offsetT + 1):(offsetT + blockdimT)]
+  return tensor(Dense(dataTslice), blockdimsT)
+end
+
+view(T::BlockSparseTensor, b::Block) = blockview(T, b)
+
+# convert to Dense
+function dense(T::TensorT) where {TensorT<:BlockSparseTensor}
+  R = zeros(dense(TensorT), inds(T))
+  for block in keys(blockoffsets(T))
+    # TODO: make sure this assignment is efficient
+    R[blockindices(T, block)] = blockview(T, block)
+  end
+  return R
+end
+
+#
+# Operations
+#
+
+# TODO: extend to case with different block structures
+function +(T1::BlockSparseTensor{<:Number,N}, T2::BlockSparseTensor{<:Number,N}) where {N}
+  inds(T1) ≠ inds(T2) &&
+    error("Cannot add block sparse tensors with different block structure")
+  R = copy(T1)
+  return permutedims!!(R, T2, ntuple(identity, Val(N)), +)
+end
+
+function permutedims(T::BlockSparseTensor{<:Number,N}, perm::NTuple{N,Int}) where {N}
+  blockoffsetsR, indsR = permutedims(blockoffsets(T), inds(T), perm)
+  R = similar(T, blockoffsetsR, indsR)
+  permutedims!(R, T, perm)
+  return R
+end
+
+function _permute_combdims(combdims::NTuple{NC,Int}, perm::NTuple{NP,Int}) where {NC,NP}
+  res = MVector{NC,Int}(undef)
+  iperm = invperm(perm)
+  for i in 1:NC
+    res[i] = iperm[combdims[i]]
+  end
+  return Tuple(res)
+end
+
+#
+# These are functions to help with combining and uncombining
+#
+
+# Note that combdims is expected to be contiguous and ordered
+# smallest to largest
+function combine_dims(blocks::Vector{Block{N}}, inds, combdims::NTuple{NC,Int}) where {N,NC}
+  nblcks = nblocks(inds, combdims)
+  blocks_comb = Vector{Block{N - NC + 1}}(undef, length(blocks))
+  for (i, block) in enumerate(blocks)
+    blocks_comb[i] = combine_dims(block, inds, combdims)
+  end
+  return blocks_comb
+end
+
+function combine_dims(block::Block, inds, combdims::NTuple{NC,Int}) where {NC}
+  nblcks = nblocks(inds, combdims)
+  slice = getindices(block, combdims)
+  slice_comb = LinearIndices(nblcks)[slice...]
+  block_comb = deleteat(block, combdims)
+  block_comb = insertafter(block_comb, tuple(slice_comb), minimum(combdims) - 1)
+  return block_comb
+end
+
+# In the dimension dim, permute the blocks
+function perm_blocks(blocks::Blocks{N}, dim::Int, perm) where {N}
+  blocks_perm = Blocks{N}(undef, nnzblocks(blocks))
+  iperm = invperm(perm)
+  for (i, block) in enumerate(blocks)
+    blocks_perm[i] = setindex(block, iperm[block[dim]], dim)
+  end
+  return blocks_perm
+end
+
+# In the dimension dim, permute the block
+function perm_block(block::Block, dim::Int, perm) where {N}
+  iperm = invperm(perm)
+  return setindex(block, iperm[block[dim]], dim)
+end
+
+# In the dimension dim, combine the specified blocks
+function combine_blocks(blocks::Blocks, dim::Int, blockcomb::Vector{Int})
+  blocks_comb = copy(blocks)
+  nnz_comb = nnzblocks(blocks)
+  for (i, block) in enumerate(blocks)
+    dimval = block[dim]
+    blocks_comb[i] = setindex(block, blockcomb[dimval], dim)
+  end
+  unique!(blocks_comb)
+  return blocks_comb
+end
+
+function permutedims_combine_output(
+  T::BlockSparseTensor{ElT,N},
+  is,
+  perm::NTuple{N,Int},
+  combdims::NTuple{NC,Int},
+  blockperm::Vector{Int},
+  blockcomb::Vector{Int},
+) where {ElT,N,NC}
+  # Permute the indices
+  indsT = inds(T)
+  inds_perm = permute(indsT, perm)
+
+  # Now that the indices are permuted, compute
+  # which indices are now combined
+  combdims_perm = sort(_permute_combdims(combdims, perm))
+
+  # Permute the nonzero blocks (dimension-wise)
+  blocks = nzblocks(T)
+  blocks_perm = permutedims(blocks, perm)
+
+  # Combine the nonzero blocks (dimension-wise)
+  blocks_perm_comb = combine_dims(blocks_perm, inds_perm, combdims_perm)
+
+  # Permute the blocks (within the newly combined dimension)
+  comb_ind_loc = minimum(combdims_perm)
+  blocks_perm_comb = perm_blocks(blocks_perm_comb, comb_ind_loc, blockperm)
+  blocks_perm_comb = sort(blocks_perm_comb; lt=isblockless)
+
+  # Combine the blocks (within the newly combined and permuted dimension)
+  blocks_perm_comb = combine_blocks(blocks_perm_comb, comb_ind_loc, blockcomb)
+
+  return BlockSparseTensor(ElT, blocks_perm_comb, is)
+end
+
+function permutedims_combine(
+  T::BlockSparseTensor{ElT,N},
+  is,
+  perm::NTuple{N,Int},
+  combdims::NTuple{NC,Int},
+  blockperm::Vector{Int},
+  blockcomb::Vector{Int},
+) where {ElT,N,NC}
+  R = permutedims_combine_output(T, is, perm, combdims, blockperm, blockcomb)
+
+  # Permute the indices
+  inds_perm = permute(inds(T), perm)
+
+  # Now that the indices are permuted, compute
+  # which indices are now combined
+  combdims_perm = sort(_permute_combdims(combdims, perm))
+  comb_ind_loc = minimum(combdims_perm)
+
+  # Determine the new index before combining
+  inds_to_combine = getindices(inds_perm, combdims_perm)
+  ind_comb = ⊗(inds_to_combine...)
+  ind_comb = permuteblocks(ind_comb, blockperm)
+
+  for bof in pairs(blockoffsets(T))
+    Tb = blockview(T, bof)
+    b = nzblock(bof)
+    b_perm = permute(b, perm)
+    b_perm_comb = combine_dims(b_perm, inds_perm, combdims_perm)
+    b_perm_comb = perm_block(b_perm_comb, comb_ind_loc, blockperm)
+    b_in_combined_dim = b_perm_comb[comb_ind_loc]
+    new_b_in_combined_dim = blockcomb[b_in_combined_dim]
+    offset = 0
+    pos_in_new_combined_block = 1
+    while b_in_combined_dim - pos_in_new_combined_block > 0 &&
+      blockcomb[b_in_combined_dim - pos_in_new_combined_block] == new_b_in_combined_dim
+      offset += blockdim(ind_comb, b_in_combined_dim - pos_in_new_combined_block)
+      pos_in_new_combined_block += 1
+    end
+    b_new = setindex(b_perm_comb, new_b_in_combined_dim, comb_ind_loc)
+
+    Rb_total = blockview(R, b_new)
+    dimsRb_tot = dims(Rb_total)
+    subind = ntuple(
+      i -> if i == comb_ind_loc
+        range(1 + offset; stop=offset + blockdim(ind_comb, b_in_combined_dim))
+      else
+        range(1; stop=dimsRb_tot[i])
+      end,
+      N - NC + 1,
+    )
+    Rb = @view array(Rb_total)[subind...]
+
+    # XXX Are these equivalent?
+    #Tb_perm = permutedims(Tb,perm)
+    #copyto!(Rb,Tb_perm)
+
+    # XXX Not sure what this was for
+    Rb = reshape(Rb, permute(dims(Tb), perm))
+    Tbₐ = convert(Array, Tb)
+    @strided Rb .= permutedims(Tbₐ, perm)
+  end
+
+  return R
+end
+
+# TODO: optimize by avoiding findfirst
+function _number_uncombined(blockval::Integer, blockcomb::Vector)
+  if blockval == blockcomb[end]
+    return length(blockcomb) - findfirst(==(blockval), blockcomb) + 1
+  end
+  return findfirst(==(blockval + 1), blockcomb) - findfirst(==(blockval), blockcomb)
+end
+
+# TODO: optimize by avoiding findfirst
+function _number_uncombined_shift(blockval::Integer, blockcomb::Vector)
+  if blockval == 1
+    return 0
+  end
+  ncomb_shift = 0
+  for i in 1:(blockval - 1)
+    ncomb_shift += findfirst(==(i + 1), blockcomb) - findfirst(==(i), blockcomb) - 1
+  end
+  return ncomb_shift
+end
+
+# Uncombine the blocks along the dimension dim
+# according to the pattern in blockcomb (for example, blockcomb
+# is [1,2,2,3] and dim = 2, so the blocks (1,2),(2,3) get
+# split into (1,2),(1,3),(2,4))
+function uncombine_blocks(blocks::Blocks{N}, dim::Int, blockcomb::Vector{Int}) where {N}
+  blocks_uncomb = Blocks{N}()
+  ncomb_tot = 0
+  for i in 1:length(blocks)
+    block = blocks[i]
+    blockval = block[dim]
+    ncomb = _number_uncombined(blockval, blockcomb)
+    ncomb_shift = _number_uncombined_shift(blockval, blockcomb)
+    push!(blocks_uncomb, setindex(block, blockval + ncomb_shift, dim))
+    for j in 1:(ncomb - 1)
+      push!(blocks_uncomb, setindex(block, blockval + ncomb_shift + j, dim))
+    end
+  end
+  return blocks_uncomb
+end
+
+function uncombine_block(block::Block{N}, dim::Int, blockcomb::Vector{Int}) where {N}
+  blocks_uncomb = Blocks{N}()
+  ncomb_tot = 0
+  blockval = block[dim]
+  ncomb = _number_uncombined(blockval, blockcomb)
+  ncomb_shift = _number_uncombined_shift(blockval, blockcomb)
+  push!(blocks_uncomb, setindex(block, blockval + ncomb_shift, dim))
+  for j in 1:(ncomb - 1)
+    push!(blocks_uncomb, setindex(block, blockval + ncomb_shift + j, dim))
+  end
+  return blocks_uncomb
+end
+
+function uncombine_output(
+  T::BlockSparseTensor{ElT,N},
+  is,
+  combdim::Int,
+  blockperm::Vector{Int},
+  blockcomb::Vector{Int},
+) where {ElT<:Number,N}
+  ind_uncomb_perm = ⊗(setdiff(is, inds(T))...)
+  inds_uncomb_perm = insertat(inds(T), ind_uncomb_perm, combdim)
+  # Uncombine the blocks of T
+  blocks_uncomb = uncombine_blocks(nzblocks(T), combdim, blockcomb)
+  blocks_uncomb_perm = perm_blocks(blocks_uncomb, combdim, invperm(blockperm))
+  boffs_uncomb_perm, nnz_uncomb_perm = blockoffsets(blocks_uncomb_perm, inds_uncomb_perm)
+  T_uncomb_perm = tensor(
+    BlockSparse(ElT, boffs_uncomb_perm, nnz_uncomb_perm), inds_uncomb_perm
+  )
+  R = reshape(T_uncomb_perm, is)
+  return R
+end
+
+function reshape(blockT::Block{NT}, indsT, indsR) where {NT}
+  nblocksT = nblocks(indsT)
+  nblocksR = nblocks(indsR)
+  blockR = Tuple(
+    CartesianIndices(nblocksR)[LinearIndices(nblocksT)[CartesianIndex(blockT)]]
+  )
+  return blockR
+end
+
+function uncombine(
+  T::BlockSparseTensor{<:Number,NT},
+  is,
+  combdim::Int,
+  blockperm::Vector{Int},
+  blockcomb::Vector{Int},
+) where {NT}
+  NR = length(is)
+  R = uncombine_output(T, is, combdim, blockperm, blockcomb)
+  invblockperm = invperm(blockperm)
+
+  # This is needed for reshaping the block
+  # It is already calculated in uncombine_output, use it from there
+  ind_uncomb_perm = ⊗(setdiff(is, inds(T))...)
+  ind_uncomb = permuteblocks(ind_uncomb_perm, blockperm)
+  # Same as inds(T) but with the blocks uncombined
+  inds_uncomb = insertat(inds(T), ind_uncomb, combdim)
+  inds_uncomb_perm = insertat(inds(T), ind_uncomb_perm, combdim)
+  for bof in pairs(blockoffsets(T))
+    b = nzblock(bof)
+    Tb_tot = blockview(T, bof)
+    dimsTb_tot = dims(Tb_tot)
+    bs_uncomb = uncombine_block(b, combdim, blockcomb)
+    offset = 0
+    for i in 1:length(bs_uncomb)
+      b_uncomb = bs_uncomb[i]
+      b_uncomb_perm = perm_block(b_uncomb, combdim, invblockperm)
+      b_uncomb_perm_reshape = reshape(b_uncomb_perm, inds_uncomb_perm, is)
+      Rb = blockview(R, b_uncomb_perm_reshape)
+      b_uncomb_in_combined_dim = b_uncomb_perm[combdim]
+      start = offset + 1
+      stop = offset + blockdim(ind_uncomb_perm, b_uncomb_in_combined_dim)
+      subind = ntuple(
+        i -> i == combdim ? range(start; stop=stop) : range(1; stop=dimsTb_tot[i]), NT
+      )
+      offset = stop
+      Tb = @view array(Tb_tot)[subind...]
+
+      # Alternative (but maybe slower):
+      #copyto!(Rb,Tb)
+
+      if length(Tb) == 1
+        Rb[1] = Tb[1]
+      else
+        # XXX: this used to be:
+        # Rbₐᵣ = ReshapedArray(parent(Rbₐ), size(Tb), ())
+        # however that doesn't work with subarrays
+        Rbₐ = convert(Array, Rb)
+        Rbₐᵣ = ReshapedArray(Rbₐ, size(Tb), ())
+        @strided Rbₐᵣ .= Tb
+      end
+    end
+  end
+  return R
+end
+
+function copyto!(R::BlockSparseTensor, T::BlockSparseTensor)
+  for bof in pairs(blockoffsets(T))
+    copyto!(blockview(R, nzblock(bof)), blockview(T, bof))
+  end
+  return R
+end
+
+# TODO: handle case where:
+# f(zero(ElR),zero(ElT)) != promote_type(ElR,ElT)
+function permutedims!!(
+  R::BlockSparseTensor{ElR,N},
+  T::BlockSparseTensor{ElT,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {ElR,ElT,N}
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  #@timeit_debug timer "block sparse permutedims!!" begin
+  bofsRR = blockoffsets(RR)
+  bofsT = blockoffsets(T)
+
+  # Determine if bofsRR has been copied
+  copy_bofsRR = false
+
+  new_nnz = nnz(RR)
+  for (blockT, offsetT) in pairs(bofsT)
+    blockTperm = permute(blockT, perm)
+    if !isassigned(bofsRR, blockTperm)
+      if !copy_bofsRR
+        bofsRR = deepcopy(bofsRR)
+        copy_bofsRR = true
+      end
+      insert!(bofsRR, blockTperm, new_nnz)
+      new_nnz += blockdim(T, blockT)
+    end
+  end
+
+  ## RR = BlockSparseTensor(promote_type(ElR,ElT), undef,
+  ##                        bofsRR, inds(R))
+  ## # Directly copy the data since it is the same blocks
+  ## # and offsets
+  ## copyto!(data(RR), data(R))
+
+  if new_nnz > nnz(RR)
+    dataRR = append!(data(RR), zeros(new_nnz - nnz(RR)))
+    RR = Tensor(BlockSparse(dataRR, bofsRR), inds(RR))
+  end
+
+  permutedims!(RR, T, perm, f)
+  return RR
+  #end
+end
+
+# <fermions>
+scale_blocks!(T, compute_fac::Function=(b) -> 1) = T
+
+# <fermions>
+function scale_blocks!(
+  T::BlockSparseTensor{<:Number,N}, compute_fac::Function=(b) -> 1
+) where {N}
+  for blockT in keys(blockoffsets(T))
+    fac = compute_fac(blockT)
+    if fac != 1
+      Tblock = blockview(T, blockT)
+      scale!(Tblock, fac)
+    end
+  end
+  return T
+end
+
+# <fermions>
+permfactor(perm, block, inds) = 1.0
+
+# Version where it is known that R has the same blocks
+# as T
+function permutedims!(
+  R::BlockSparseTensor{<:Number,N},
+  T::BlockSparseTensor{<:Number,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {N}
+  for blockT in keys(blockoffsets(T))
+    # Loop over non-zero blocks of T/R
+    Tblock = blockview(T, blockT)
+    Rblock = blockview(R, permute(blockT, perm))
+
+    # <fermions>
+    pfac = permfactor(perm, blockT, inds(T))
+    fac_f = (r, t) -> f(r, pfac * t)
+
+    permutedims!(Rblock, Tblock, perm, fac_f)
+  end
+  return R
+end
+
+#
+# Contraction
+#
+
+# TODO: complete this function: determine the output blocks from the input blocks
+# Also, save the contraction list (which block-offsets contract with which),
+# may not be generic with other contraction functions!
+function contraction_output(
+  T1::TensorT1, T2::TensorT2, indsR::IndsR
+) where {TensorT1<:BlockSparseTensor,TensorT2<:BlockSparseTensor,IndsR}
+  TensorR = contraction_output_type(TensorT1, TensorT2, IndsR)
+  return similar(TensorR, blockoffsetsR, indsR)
+end
+
+"""
+find_matching_positions(t1,t2) -> t1_to_t2
+
+In a tuple of length(t1), store the positions in t2
+where the element of t1 is found. Otherwise, store 0
+to indicate that the element of t1 is not in t2.
+
+For example, for all t1[pos1] == t2[pos2], t1_to_t2[pos1] == pos2,
+otherwise t1_to_t2[pos1] == 0.
+"""
+function find_matching_positions(t1, t2)
+  t1_to_t2 = @MVector zeros(Int, length(t1))
+  for pos1 in 1:length(t1)
+    for pos2 in 1:length(t2)
+      if t1[pos1] == t2[pos2]
+        t1_to_t2[pos1] = pos2
+      end
+    end
+  end
+  return Tuple(t1_to_t2)
+end
+
+function contract_labels(labels1, labels2, labelsR)
+  labels1_to_labels2 = find_matching_positions(labels1, labels2)
+  labels1_to_labelsR = find_matching_positions(labels1, labelsR)
+  labels2_to_labelsR = find_matching_positions(labels2, labelsR)
+  return labels1_to_labels2, labels1_to_labelsR, labels2_to_labelsR
+end
+
+function are_blocks_contracted(
+  block1::Block{N1}, block2::Block{N2}, labels1_to_labels2::NTuple{N1,Int}
+) where {N1,N2}
+  t1 = Tuple(block1)
+  t2 = Tuple(block2)
+  for i1 in 1:N1
+    i2 = @inbounds labels1_to_labels2[i1]
+    if i2 > 0
+      # This dimension is contracted
+      if @inbounds t1[i1] != @inbounds t2[i2]
+        return false
+      end
+    end
+  end
+  return true
+end
+
+function contract_blocks(
+  block1::Block{N1}, labels1_to_labelsR, block2::Block{N2}, labels2_to_labelsR, ::Val{NR}
+) where {N1,N2,NR}
+  blockR = ntuple(_ -> UInt(0), Val(NR))
+  t1 = Tuple(block1)
+  t2 = Tuple(block2)
+  for i1 in 1:N1
+    iR = @inbounds labels1_to_labelsR[i1]
+    if iR > 0
+      blockR = @inbounds setindex(blockR, t1[i1], iR)
+    end
+  end
+  for i2 in 1:N2
+    iR = @inbounds labels2_to_labelsR[i2]
+    if iR > 0
+      blockR = @inbounds setindex(blockR, t2[i2], iR)
+    end
+  end
+  return Block{NR}(blockR)
+end
+
+function _contract_blockoffsets(
+  boffs1::BlockOffsets{N1},
+  inds1,
+  labels1,
+  boffs2::BlockOffsets{N2},
+  inds2,
+  labels2,
+  indsR,
+  labelsR,
+) where {N1,N2}
+  NR = length(labelsR)
+  ValNR = ValLength(labelsR)
+  labels1_to_labels2, labels1_to_labelsR, labels2_to_labelsR = contract_labels(
+    labels1, labels2, labelsR
+  )
+  blockoffsetsR = BlockOffsets{NR}()
+  nnzR = 0
+  contraction_plan = Tuple{Block{N1},Block{N2},Block{NR}}[]
+  # Reserve some capacity
+  # In theory the maximum is length(boffs1) * length(boffs2)
+  # but in practice that is too much
+  sizehint!(contraction_plan, max(length(boffs1), length(boffs2)))
+  for block1 in keys(boffs1)
+    for block2 in keys(boffs2)
+      if are_blocks_contracted(block1, block2, labels1_to_labels2)
+        blockR = contract_blocks(
+          block1, labels1_to_labelsR, block2, labels2_to_labelsR, ValNR
+        )
+        push!(contraction_plan, (block1, block2, blockR))
+        if !isassigned(blockoffsetsR, blockR)
+          insert!(blockoffsetsR, blockR, nnzR)
+          nnzR += blockdim(indsR, blockR)
+        end
+      end
+    end
+  end
+  return blockoffsetsR, contraction_plan
+end
+
+function _threaded_contract_blockoffsets(
+  boffs1::BlockOffsets{N1},
+  inds1,
+  labels1,
+  boffs2::BlockOffsets{N2},
+  inds2,
+  labels2,
+  indsR,
+  labelsR,
+) where {N1,N2}
+  NR = length(labelsR)
+  ValNR = ValLength(labelsR)
+  labels1_to_labels2, labels1_to_labelsR, labels2_to_labelsR = contract_labels(
+    labels1, labels2, labelsR
+  )
+  contraction_plans = [Tuple{Block{N1},Block{N2},Block{NR}}[] for _ in 1:nthreads()]
+
+  #
+  # Reserve some capacity
+  # In theory the maximum is length(boffs1) * length(boffs2)
+  # but in practice that is too much
+  #for contraction_plan in contraction_plans
+  #  sizehint!(contraction_plan, max(length(boffs1), length(boffs2)))
+  #end
+  #
+
+  blocks1 = keys(boffs1)
+  blocks2 = keys(boffs2)
+  if length(blocks1) > length(blocks2)
+    @sync for blocks1_partition in
+              Iterators.partition(blocks1, max(1, length(blocks1) ÷ nthreads()))
+      @spawn for block1 in blocks1_partition
+        for block2 in blocks2
+          if are_blocks_contracted(block1, block2, labels1_to_labels2)
+            blockR = contract_blocks(
+              block1, labels1_to_labelsR, block2, labels2_to_labelsR, ValNR
+            )
+            push!(contraction_plans[threadid()], (block1, block2, blockR))
+          end
+        end
+      end
+    end
+  else
+    @sync for blocks2_partition in
+              Iterators.partition(blocks2, max(1, length(blocks2) ÷ nthreads()))
+      @spawn for block2 in blocks2_partition
+        for block1 in blocks1
+          if are_blocks_contracted(block1, block2, labels1_to_labels2)
+            blockR = contract_blocks(
+              block1, labels1_to_labelsR, block2, labels2_to_labelsR, ValNR
+            )
+            push!(contraction_plans[threadid()], (block1, block2, blockR))
+          end
+        end
+      end
+    end
+  end
+
+  contraction_plan = vcat(contraction_plans...)
+  blockoffsetsR = BlockOffsets{NR}()
+  nnzR = 0
+  for (_, _, blockR) in contraction_plan
+    if !isassigned(blockoffsetsR, blockR)
+      insert!(blockoffsetsR, blockR, nnzR)
+      nnzR += blockdim(indsR, blockR)
+    end
+  end
+
+  return blockoffsetsR, contraction_plan
+end
+
+function contract_blockoffsets(args...)
+  if using_threaded_blocksparse() && nthreads() > 1
+    return _threaded_contract_blockoffsets(args...)
+  end
+  return _contract_blockoffsets(args...)
+end
+
+function contraction_output(
+  T1::TensorT1, labelsT1, T2::TensorT2, labelsT2, labelsR
+) where {TensorT1<:BlockSparseTensor,TensorT2<:BlockSparseTensor}
+  indsR = contract_inds(inds(T1), labelsT1, inds(T2), labelsT2, labelsR)
+  TensorR = contraction_output_type(TensorT1, TensorT2, typeof(indsR))
+  blockoffsetsR, contraction_plan = contract_blockoffsets(
+    blockoffsets(T1),
+    inds(T1),
+    labelsT1,
+    blockoffsets(T2),
+    inds(T2),
+    labelsT2,
+    indsR,
+    labelsR,
+  )
+  R = similar(TensorR, blockoffsetsR, indsR)
+  return R, contraction_plan
+end
+
+function contract(
+  T1::BlockSparseTensor{<:Any,N1},
+  labelsT1,
+  T2::BlockSparseTensor{<:Any,N2},
+  labelsT2,
+  labelsR=contract_labels(labelsT1, labelsT2),
+) where {N1,N2}
+  #@timeit_debug timer "Block sparse contract" begin
+  R, contraction_plan = contraction_output(T1, labelsT1, T2, labelsT2, labelsR)
+  R = contract!(R, labelsR, T1, labelsT1, T2, labelsT2, contraction_plan)
+  return R
+  #end
+end
+
+# <fermions>
+function compute_alpha(
+  ElR, labelsR, blockR, indsR, labelsT1, blockT1, indsT1, labelsT2, blockT2, indsT2
+)
+  return one(ElR)
+end
+
+# XXX: this is not thread safe, divide into groups of
+# contractions that contract into the same block
+function _threaded_contract!(
+  R::BlockSparseTensor{ElR,NR},
+  labelsR,
+  T1::BlockSparseTensor{ElT1,N1},
+  labelsT1,
+  T2::BlockSparseTensor{ElT2,N2},
+  labelsT2,
+  contraction_plan,
+) where {ElR,ElT1,ElT2,N1,N2,NR}
+  # Sort the contraction plan by the output blocks
+  # This is to help determine which output blocks are the result
+  # of multiple contractions
+  sort!(contraction_plan; by=last)
+
+  # Ranges of contractions to the same block
+  repeats = Vector{UnitRange{Int}}(undef, nnzblocks(R))
+  ncontracted = 1
+  posR = last(contraction_plan[1])
+  posR_unique = posR
+  for n in 1:(nnzblocks(R) - 1)
+    start = ncontracted
+    while posR == posR_unique
+      ncontracted += 1
+      posR = last(contraction_plan[ncontracted])
+    end
+    posR_unique = posR
+    repeats[n] = start:(ncontracted - 1)
+  end
+  repeats[end] = ncontracted:length(contraction_plan)
+
+  contraction_plan_blocks = Vector{Tuple{Tensor,Tensor,Tensor}}(
+    undef, length(contraction_plan)
+  )
+  for ncontracted in 1:length(contraction_plan)
+    block1, block2, blockR = contraction_plan[ncontracted]
+    T1block = T1[block1]
+    T2block = T2[block2]
+    Rblock = R[blockR]
+    contraction_plan_blocks[ncontracted] = (T1block, T2block, Rblock)
+  end
+
+  α = one(ElR)
+  @sync for repeats_partition in
+            Iterators.partition(repeats, max(1, length(repeats) ÷ nthreads()))
+    @spawn for ncontracted_range in repeats_partition
+      # Overwrite the block since it hasn't been written to
+      # R .= α .* (T1 * T2)
+      β = zero(ElR)
+      for ncontracted in ncontracted_range
+        blockT1, blockT2, blockR = contraction_plan_blocks[ncontracted]
+        # R .= α .* (T1 * T2) .+ β .* R
+
+        # <fermions>:
+        α = compute_alpha(
+          ElR,
+          labelsR,
+          blockR,
+          inds(R),
+          labelsT1,
+          block1,
+          inds(T1),
+          labelsT2,
+          block2,
+          inds(T2),
+        )
+
+        contract!(blockR, labelsR, blockT1, labelsT1, blockT2, labelsT2, α, β)
+        # Now keep adding to the block, since it has
+        # been written to
+        # R .= α .* (T1 * T2) .+ R
+        β = one(ElR)
+      end
+    end
+  end
+  return R
+end
+
+function contract!(
+  R::BlockSparseTensor{ElR,NR},
+  labelsR,
+  T1::BlockSparseTensor{ElT1,N1},
+  labelsT1,
+  T2::BlockSparseTensor{ElT2,N2},
+  labelsT2,
+  contraction_plan,
+) where {ElR,ElT1,ElT2,N1,N2,NR}
+  if isempty(contraction_plan)
+    return R
+  end
+  if using_threaded_blocksparse() && nthreads() > 1
+    _threaded_contract!(R, labelsR, T1, labelsT1, T2, labelsT2, contraction_plan)
+    return R
+  end
+  already_written_to = Dict{Block{NR},Bool}()
+  # In R .= α .* (T1 * T2) .+ β .* R
+  for (block1, block2, blockR) in contraction_plan
+
+    #<fermions>
+    α = compute_alpha(
+      ElR, labelsR, blockR, inds(R), labelsT1, block1, inds(T1), labelsT2, block2, inds(T2)
+    )
+
+    T1block = T1[block1]
+    T2block = T2[block2]
+    Rblock = R[blockR]
+    β = one(ElR)
+    if !haskey(already_written_to, blockR)
+      already_written_to[blockR] = true
+      # Overwrite the block of R
+      β = zero(ElR)
+    end
+    contract!(Rblock, labelsR, T1block, labelsT1, T2block, labelsT2, α, β)
+  end
+  return R
+end
+
+const IntTuple = NTuple{N,Int} where {N}
+const IntOrIntTuple = Union{Int,IntTuple}
+
+function permute_combine(inds::IndsT, pos::Vararg{IntOrIntTuple,N}) where {IndsT,N}
+  IndT = eltype(IndsT)
+  # Using SizedVector since setindex! doesn't
+  # work for MVector when eltype not isbitstype
+  newinds = SizedVector{N,IndT}(undef)
+  for i in 1:N
+    pos_i = pos[i]
+    newind_i = inds[pos_i[1]]
+    for p in 2:length(pos_i)
+      newind_i = newind_i ⊗ inds[pos_i[p]]
+    end
+    newinds[i] = newind_i
+  end
+  IndsR = similartype(IndsT, Val{N})
+  indsR = IndsR(Tuple(newinds))
+  return indsR
+end
+
+"""
+Indices are combined according to the grouping of the input,
+for example (1,2),3 will combine the first two indices.
+"""
+function combine(inds::IndsT, com::Vararg{IntOrIntTuple,N}) where {IndsT,N}
+  IndT = eltype(IndsT)
+  # Using SizedVector since setindex! doesn't
+  # work for MVector when eltype not isbitstype
+  newinds = SizedVector{N,IndT}(undef)
+  i_orig = 1
+  for i in 1:N
+    newind_i = inds[i_orig]
+    i_orig += 1
+    for p in 2:length(com[i])
+      newind_i = newind_i ⊗ inds[i_orig]
+      i_orig += 1
+    end
+    newinds[i] = newind_i
+  end
+  IndsR = similartype(IndsT, Val{N})
+  indsR = IndsR(Tuple(newinds))
+  return indsR
+end
+
+function permute_combine(
+  boffs::BlockOffsets, inds::IndsT, pos::Vararg{IntOrIntTuple,N}
+) where {IndsT,N}
+  perm = flatten(pos...)
+  boffsp, indsp = permutedims(boffs, inds, perm)
+  indsR = combine(indsp, pos...)
+  boffsR = reshape(boffsp, indsp, indsR)
+  return boffsR, indsR
+end
+
+function reshape(boffsT::BlockOffsets{NT}, indsT, indsR) where {NT}
+  NR = length(indsR)
+  boffsR = BlockOffsets{NR}()
+  nblocksT = nblocks(indsT)
+  nblocksR = nblocks(indsR)
+  for (blockT, offsetT) in pairs(boffsT)
+    blockR = Block(
+      CartesianIndices(nblocksR)[LinearIndices(nblocksT)[CartesianIndex(blockT)]]
+    )
+    insert!(boffsR, blockR, offsetT)
+  end
+  return boffsR
+end
+
+function reshape(boffsT::BlockOffsets{NT}, blocksR::Vector{Block{NR}}) where {NR,NT}
+  boffsR = BlockOffsets{NR}()
+  # TODO: check blocksR is ordered and are properly reshaped
+  # versions of the blocks of boffsT
+  for (i, (blockT, offsetT)) in enumerate(boffsT)
+    blockR = blocksR[i]
+    boffsR[blockR] = offsetT
+  end
+  return boffsR
+end
+
+reshape(T::BlockSparse, boffsR::BlockOffsets) = BlockSparse(data(T), boffsR)
+
+function reshape(T::BlockSparseTensor, boffsR::BlockOffsets, indsR)
+  storeR = reshape(storage(T), boffsR)
+  return tensor(storeR, indsR)
+end
+
+function reshape(T::BlockSparseTensor, indsR)
+  # TODO: add some checks that the block dimensions
+  # are consistent (e.g. nnzblocks(T) == nnzblocks(R), etc.)
+  boffsR = reshape(blockoffsets(T), inds(T), indsR)
+  R = reshape(T, boffsR, indsR)
+  return R
+end
+
+function permute_combine(
+  T::BlockSparseTensor{ElT,NT,IndsT}, pos::Vararg{IntOrIntTuple,NR}
+) where {ElT,NT,IndsT,NR}
+  boffsR, indsR = permute_combine(blockoffsets(T), inds(T), pos...)
+
+  perm = flatten(pos...)
+
+  length(perm) ≠ NT && error("Index positions must add up to order of Tensor ($NT)")
+  isperm(perm) || error("Index positions must be a permutation")
+
+  if !is_trivial_permutation(perm)
+    Tp = permutedims(T, perm)
+  else
+    Tp = copy(T)
+  end
+  NR == NT && return Tp
+  R = reshape(Tp, boffsR, indsR)
+  return R
+end
+
+#
+# Print block sparse tensors
+#
+
+#function summary(io::IO,
+#                 T::BlockSparseTensor{ElT,N}) where {ElT,N}
+#  println(io,Base.dims2string(dims(T))," ",typeof(T))
+#  for (dim,ind) in enumerate(inds(T))
+#    println(io,"Dim $dim: ",ind)
+#  end
+#  println(io,"Number of nonzero blocks: ",nnzblocks(T))
+#end
+
+#function summary(io::IO,
+#                 T::BlockSparseTensor{ElT,N}) where {ElT,N}
+#  println(io,typeof(T))
+#  println(io,Base.dims2string(dims(T))," ",typeof(T))
+#  for (dim,ind) in enumerate(inds(T))
+#    println(io,"Dim $dim: ",ind)
+#  end
+#  println("Number of nonzero blocks: ",nnzblocks(T))
+#end
+
+function _range2string(rangestart::NTuple{N,Int}, rangeend::NTuple{N,Int}) where {N}
+  s = ""
+  for n in 1:N
+    s = string(s, rangestart[n], ":", rangeend[n])
+    if n < N
+      s = string(s, ", ")
+    end
+  end
+  return s
+end
+
+function show(io::IO, mime::MIME"text/plain", T::BlockSparseTensor)
+  summary(io, T)
+  for (n, block) in enumerate(keys(blockoffsets(T)))
+    blockdimsT = blockdims(T, block)
+    println(io, block)
+    println(io, " [", _range2string(blockstart(T, block), blockend(T, block)), "]")
+    print_tensor(io, blockview(T, block))
+    n < nnzblocks(T) && print(io, "\n\n")
+  end
+end
+
+show(io::IO, T::BlockSparseTensor) = show(io, MIME("text/plain"), T)

--- a/src/NDTensors/blocksparse/combiner.jl
+++ b/src/NDTensors/blocksparse/combiner.jl
@@ -1,0 +1,65 @@
+#<fermions>:
+before_combiner_signs(T, labelsT, indsT, C, labelsC, indsC, labelsR, indsR) = T
+after_combiner_signs(R, labelsR, indsR, C, labelsC, indsC) = R
+
+function contract(T::BlockSparseTensor, labelsT, C::CombinerTensor, labelsC)
+  #@timeit_debug timer "Block sparse (un)combiner" begin
+  # Get the label marking the combined index
+  # By convention the combined index is the first one
+  # TODO: consider storing the location of the combined
+  # index in preperation for multiplce combined indices
+  cpos_in_labelsC = 1
+  clabel = labelsC[cpos_in_labelsC]
+  c = combinedindex(C)
+  labels_uc = deleteat(labelsC, cpos_in_labelsC)
+  if labelsC[1] ∉ labelsT
+    # Combine
+    labelsRc = contract_labels(labelsC, labelsT)
+    cpos_in_labelsRc = findfirst(==(clabel), labelsRc)
+    labelsRuc = insertat(labelsRc, labels_uc, cpos_in_labelsRc)
+    indsRc = contract_inds(inds(C), labelsC, inds(T), labelsT, labelsRc)
+
+    #<fermions>:
+    T = before_combiner_signs(T, labelsT, inds(T), C, labelsC, inds(C), labelsRc, indsRc)
+
+    perm = getperm(labelsRuc, labelsT)
+    ucpos_in_labelsT = Tuple(findall(x -> x in labels_uc, labelsT))
+    Rc = permutedims_combine(T, indsRc, perm, ucpos_in_labelsT, blockperm(C), blockcomb(C))
+    return Rc
+  else
+    # Uncombine
+    labelsRc = labelsT
+    cpos_in_labelsRc = findfirst(==(clabel), labelsRc)
+    # Move combined index to first position
+    if cpos_in_labelsRc != 1
+      labelsRc_orig = labelsRc
+      labelsRc = deleteat(labelsRc, cpos_in_labelsRc)
+      labelsRc = insertafter(labelsRc, clabel, 0)
+      cpos_in_labelsRc = 1
+      perm = getperm(labelsRc, labelsRc_orig)
+      T = permutedims(T, perm)
+      labelsT = permute(labelsT, perm)
+    end
+    labelsRuc = insertat(labelsRc, labels_uc, cpos_in_labelsRc)
+    indsRuc = contract_inds(inds(C), labelsC, inds(T), labelsT, labelsRuc)
+
+    # <fermions>:
+    T = before_combiner_signs(T, labelsT, inds(T), C, labelsC, inds(C), labelsRuc, indsRuc)
+
+    Ruc = uncombine(T, indsRuc, cpos_in_labelsRc, blockperm(C), blockcomb(C))
+
+    # <fermions>:
+    Ruc = after_combiner_signs(Ruc, labelsRuc, indsRuc, C, labelsC, inds(C))
+
+    return Ruc
+  end
+  #end # @timeit
+end
+
+function contract(C::CombinerTensor, labelsC, T::BlockSparseTensor, labelsT)
+  return contract(T, labelsT, C, labelsC)
+end
+
+# Special case when no indices are combined
+# XXX: no copy
+contract(T::BlockSparseTensor, labelsT, C::CombinerTensor{<:Any,0}, labelsC) = copy(T)

--- a/src/NDTensors/blocksparse/diagblocksparse.jl
+++ b/src/NDTensors/blocksparse/diagblocksparse.jl
@@ -1,0 +1,618 @@
+export DiagBlockSparse, DiagBlockSparseTensor
+
+# DiagBlockSparse can have either Vector storage, in which case
+# it is a general DiagBlockSparse tensor, or scalar storage,
+# in which case the diagonal has a uniform value
+struct DiagBlockSparse{ElT,VecT,N} <: TensorStorage{ElT}
+  data::VecT
+  diagblockoffsets::BlockOffsets{N}  # Block number-offset pairs
+
+  # Nonuniform case
+  function DiagBlockSparse(
+    data::VecT, blockoffsets::BlockOffsets{N}
+  ) where {VecT<:AbstractVector{ElT},N} where {ElT}
+    return new{ElT,VecT,N}(data, blockoffsets)
+  end
+
+  # Uniform case
+  function DiagBlockSparse(data::VecT, blockoffsets::BlockOffsets{N}) where {VecT<:Number,N}
+    return new{VecT,VecT,N}(data, blockoffsets)
+  end
+end
+
+function DiagBlockSparse(
+  ::Type{ElT}, boffs::BlockOffsets, diaglength::Integer
+) where {ElT<:Number}
+  return DiagBlockSparse(zeros(ElT, diaglength), boffs)
+end
+
+function DiagBlockSparse(boffs::BlockOffsets, diaglength::Integer)
+  return DiagBlockSparse(Float64, boffs, diaglength)
+end
+
+function DiagBlockSparse(
+  ::Type{ElT}, ::UndefInitializer, boffs::BlockOffsets, diaglength::Integer
+) where {ElT<:Number}
+  return DiagBlockSparse(Vector{ElT}(undef, diaglength), boffs)
+end
+
+function DiagBlockSparse(::UndefInitializer, boffs::BlockOffsets, diaglength::Integer)
+  return DiagBlockSparse(Float64, undef, boffs, diaglength)
+end
+
+diagblockoffsets(D::DiagBlockSparse) = D.diagblockoffsets
+
+blockoffsets(D::DiagBlockSparse) = D.diagblockoffsets
+
+function findblock(
+  D::DiagBlockSparse{<:Number,<:Union{Number,AbstractVector},N}, block::Block{N}; vargs...
+) where {N}
+  return findblock(diagblockoffsets(D), block; vargs...)
+end
+
+const NonuniformDiagBlockSparse{ElT,VecT} =
+  DiagBlockSparse{ElT,VecT} where {VecT<:AbstractVector}
+const UniformDiagBlockSparse{ElT,VecT} = DiagBlockSparse{ElT,VecT} where {VecT<:Number}
+
+@propagate_inbounds function getindex(D::NonuniformDiagBlockSparse, i::Int)
+  return data(D)[i]
+end
+
+getindex(D::UniformDiagBlockSparse, i::Int) = data(D)
+
+@propagate_inbounds function setindex!(D::DiagBlockSparse, val, i::Int)
+  data(D)[i] = val
+  return D
+end
+
+function setindex!(D::UniformDiagBlockSparse, val, i::Int)
+  return error("Cannot set elements of a uniform DiagBlockSparse storage")
+end
+
+#fill!(D::DiagBlockSparse,v) = fill!(data(D),v)
+
+copy(D::DiagBlockSparse) = DiagBlockSparse(copy(data(D)), copy(diagblockoffsets(D)))
+
+setdata(D::DiagBlockSparse, ndata) = DiagBlockSparse(ndata, diagblockoffsets(D))
+
+## convert to complex
+## TODO: this could be a generic TensorStorage function
+#complex(D::DiagBlockSparse) = DiagBlockSparse(complex(data(D)), diagblockoffsets(D))
+
+#conj(D::DiagBlockSparse{<:Real}) = D
+#conj(D::DiagBlockSparse{<:Complex}) = DiagBlockSparse(conj(data(D)), diagblockoffsets(D))
+
+# TODO: make this generic for all storage types
+eltype(::DiagBlockSparse{ElT}) where {ElT} = ElT
+eltype(::Type{<:DiagBlockSparse{ElT}}) where {ElT} = ElT
+
+# Deal with uniform DiagBlockSparse conversion
+#convert(::Type{<:DiagBlockSparse{ElT,VecT}},D::DiagBlockSparse) where {ElT,VecT} = DiagBlockSparse(convert(VecT,data(D)))
+
+size(D::DiagBlockSparse) = size(data(D))
+
+# TODO: write in terms of ::Int, not inds
+similar(D::NonuniformDiagBlockSparse) = setdata(D, similar(data(D)))
+
+similar(D::NonuniformDiagBlockSparse, ::Type{S}) where {S} = setdata(D, similar(data(D), S))
+#similar(D::NonuniformDiagBlockSparse,inds) = DiagBlockSparse(similar(data(D),minimum(dims(inds))), diagblockoffsets(D))
+#function similar(D::Type{<:NonuniformDiagBlockSparse{ElT,VecT}},inds) where {ElT,VecT}
+#  return DiagBlockSparse(similar(VecT,diaglength(inds)), diagblockoffsets(D))
+#end
+
+similar(D::UniformDiagBlockSparse) = setdata(D, zero(eltype(D)))
+similar(D::UniformDiagBlockSparse, inds) = similar(D)
+function similar(::Type{<:UniformDiagBlockSparse{ElT}}, inds) where {ElT}
+  return DiagBlockSparse(zero(ElT), diagblockoffsets(D))
+end
+
+similar(D::DiagBlockSparse, n::Int) = setdata(D, similar(data(D), n))
+
+function similar(D::DiagBlockSparse, ::Type{ElR}, n::Int) where {ElR}
+  return setdata(D, similar(data(D), ElR, n))
+end
+
+# TODO: make this work for other storage besides Vector
+function zeros(::Type{<:NonuniformDiagBlockSparse{ElT}}, dim::Int64) where {ElT}
+  return DiagBlockSparse(zeros(ElT, dim))
+end
+function zeros(::Type{<:UniformDiagBlockSparse{ElT}}, dim::Int64) where {ElT}
+  return DiagBlockSparse(zero(ElT))
+end
+
+#
+# Type promotions involving DiagBlockSparse
+# Useful for knowing how conversions should work when adding and contracting
+#
+
+function promote_rule(
+  ::Type{<:UniformDiagBlockSparse{ElT1}}, ::Type{<:UniformDiagBlockSparse{ElT2}}
+) where {ElT1,ElT2}
+  ElR = promote_type(ElT1, ElT2)
+  return DiagBlockSparse{ElR,ElR}
+end
+
+function promote_rule(
+  ::Type{<:NonuniformDiagBlockSparse{ElT1,VecT1}},
+  ::Type{<:NonuniformDiagBlockSparse{ElT2,VecT2}},
+) where {ElT1,VecT1<:AbstractVector,ElT2,VecT2<:AbstractVector}
+  ElR = promote_type(ElT1, ElT2)
+  VecR = promote_type(VecT1, VecT2)
+  return DiagBlockSparse{ElR,VecR}
+end
+
+# This is an internal definition, is there a more general way?
+#promote_type(::Type{Vector{ElT1}},
+#                  ::Type{ElT2}) where {ElT1<:Number,
+#                                       ElT2<:Number} = Vector{promote_type(ElT1,ElT2)}
+#
+#promote_type(::Type{ElT1},
+#                  ::Type{Vector{ElT2}}) where {ElT1<:Number,
+#                                               ElT2<:Number} = promote_type(Vector{ElT2},ElT1)
+
+# TODO: how do we make this work more generally for T2<:AbstractVector{S2}?
+# Make a similartype(AbstractVector{S2},T1) -> AbstractVector{T1} function?
+function promote_rule(
+  ::Type{<:UniformDiagBlockSparse{ElT1,VecT1}},
+  ::Type{<:NonuniformDiagBlockSparse{ElT2,Vector{ElT2}}},
+) where {ElT1,VecT1<:Number,ElT2}
+  ElR = promote_type(ElT1, ElT2)
+  VecR = Vector{ElR}
+  return DiagBlockSparse{ElR,VecR}
+end
+
+function promote_rule(
+  ::Type{BlockSparseT1}, ::Type{<:NonuniformDiagBlockSparse{ElT2,VecT2,N2}}
+) where {BlockSparseT1<:BlockSparse,ElT2<:Number,VecT2<:AbstractVector,N2}
+  return promote_type(BlockSparseT1, BlockSparse{ElT2,VecT2,N2})
+end
+
+function promote_rule(
+  ::Type{BlockSparseT1}, ::Type{<:UniformDiagBlockSparse{ElT2,ElT2}}
+) where {BlockSparseT1<:BlockSparse,ElT2<:Number}
+  return promote_type(BlockSparseT1, ElT2)
+end
+
+# Convert a DiagBlockSparse storage type to the closest Dense storage type
+dense(::Type{<:NonuniformDiagBlockSparse{ElT,VecT}}) where {ElT,VecT} = Dense{ElT,VecT}
+dense(::Type{<:UniformDiagBlockSparse{ElT}}) where {ElT} = Dense{ElT,Vector{ElT}}
+
+const DiagBlockSparseTensor{ElT,N,StoreT,IndsT} =
+  Tensor{ElT,N,StoreT,IndsT} where {StoreT<:DiagBlockSparse}
+const NonuniformDiagBlockSparseTensor{ElT,N,StoreT,IndsT} =
+  Tensor{ElT,N,StoreT,IndsT} where {StoreT<:NonuniformDiagBlockSparse}
+const UniformDiagBlockSparseTensor{ElT,N,StoreT,IndsT} =
+  Tensor{ElT,N,StoreT,IndsT} where {StoreT<:UniformDiagBlockSparse}
+
+function DiagBlockSparseTensor(
+  ::Type{ElT}, ::UndefInitializer, blocks::Vector, inds
+) where {ElT}
+  blockoffsets, nnz = diagblockoffsets(blocks, inds)
+  storage = DiagBlockSparse(ElT, undef, blockoffsets, nnz)
+  return tensor(storage, inds)
+end
+
+function DiagBlockSparseTensor(::UndefInitializer, blocks::Vector, inds)
+  return DiagBlockSparseTensor(Float64, undef, blocks, inds)
+end
+
+function DiagBlockSparseTensor(::Type{ElT}, blocks::Vector, inds) where {ElT}
+  blockoffsets, nnz = diagblockoffsets(blocks, inds)
+  storage = DiagBlockSparse(ElT, blockoffsets, nnz)
+  return tensor(storage, inds)
+end
+
+DiagBlockSparseTensor(blocks::Vector, inds) = DiagBlockSparseTensor(Float64, blocks, inds)
+
+# Uniform case
+function DiagBlockSparseTensor(x::Number, blocks::Vector, inds)
+  blockoffsets, nnz = diagblockoffsets(blocks, inds)
+  storage = DiagBlockSparse(x, blockoffsets)
+  return tensor(storage, inds)
+end
+
+diagblockoffsets(T::DiagBlockSparseTensor) = diagblockoffsets(storage(T))
+
+"""
+blockview(T::DiagBlockSparseTensor, block::Block)
+
+Given a block in the block-offset list, return a Diag Tensor
+that is a view to the data in that block (to avoid block lookup if the position
+is known already).
+"""
+function blockview(T::DiagBlockSparseTensor, blockT::Block)
+  return blockview(T, BlockOffset(blockT, offset(T, blockT)))
+end
+
+getindex(T::DiagBlockSparseTensor, block::Block) = blockview(T, block)
+
+function blockview(T::DiagBlockSparseTensor, bof::BlockOffset)
+  blockT, offsetT = bof
+  blockdimsT = blockdims(T, blockT)
+  blockdiaglengthT = minimum(blockdimsT)
+  dataTslice = @view data(storage(T))[(offsetT + 1):(offsetT + blockdiaglengthT)]
+  return tensor(Diag(dataTslice), blockdimsT)
+end
+
+function blockview(T::UniformDiagBlockSparseTensor, bof::BlockOffset)
+  blockT, offsetT = bof
+  blockdimsT = blockdims(T, blockT)
+  return tensor(Diag(getdiagindex(T, 1)), blockdimsT)
+end
+
+IndexStyle(::Type{<:DiagBlockSparseTensor}) = IndexCartesian()
+
+# TODO: this needs to be better (promote element type, check order compatibility,
+# etc.
+function convert(
+  ::Type{<:DenseTensor{ElT,N}}, T::DiagBlockSparseTensor{ElT,N}
+) where {ElT<:Number,N}
+  return dense(T)
+end
+
+# These are rules for determining the output of a pairwise contraction of NDTensors
+# (given the indices of the output tensors)
+function contraction_output_type(
+  TensorT1::Type{<:DiagBlockSparseTensor}, TensorT2::Type{<:BlockSparseTensor}, IndsR::Type
+)
+  return similartype(promote_type(TensorT1, TensorT2), IndsR)
+end
+
+function contraction_output_type(
+  TensorT1::Type{<:BlockSparseTensor}, TensorT2::Type{<:DiagBlockSparseTensor}, IndsR::Type
+)
+  return contraction_output_type(TensorT2, TensorT1, IndsR)
+end
+
+# This performs the logic that DiagBlockSparseTensor*DiagBlockSparseTensor -> DiagBlockSparseTensor if it is not an outer
+# product but -> DenseTensor if it is
+# TODO: if the tensors are both order 2 (or less), or if there is an Index replacement,
+# then they remain diagonal. Should we limit DiagBlockSparseTensor*DiagBlockSparseTensor to cases that
+# result in a DiagBlockSparseTensor, for efficiency and type stability? What about a general
+# SparseTensor result?
+function contraction_output_type(
+  TensorT1::Type{<:DiagBlockSparseTensor{<:Number,N1}},
+  TensorT2::Type{<:DiagBlockSparseTensor{<:Number,N2}},
+  IndsR::Type,
+) where {N1,N2}
+  if ValLength(IndsR) === Val{N1 + N2}
+    # Turn into is_outer(inds1,inds2,indsR) function?
+    # How does type inference work with arithmatic of compile time values?
+    return similartype(dense(promote_type(TensorT1, TensorT2)), IndsR)
+  end
+  return similartype(promote_type(TensorT1, TensorT2), IndsR)
+end
+
+# The output must be initialized as zero since it is sparse, cannot be undefined
+function contraction_output(T1::DiagBlockSparseTensor, T2::Tensor, indsR)
+  return zero_contraction_output(T1, T2, indsR)
+end
+function contraction_output(T1::Tensor, T2::DiagBlockSparseTensor, indsR)
+  return contraction_output(T2, T1, indsR)
+end
+
+function contraction_output(T1::DiagBlockSparseTensor, T2::DiagBlockSparseTensor, indsR)
+  return zero_contraction_output(T1, T2, indsR)
+end
+
+function array(T::DiagBlockSparseTensor{ElT,N}) where {ElT,N}
+  return array(dense(T))
+end
+matrix(T::DiagBlockSparseTensor{<:Number,2}) = array(T)
+vector(T::DiagBlockSparseTensor{<:Number,1}) = array(T)
+
+function Array{ElT,N}(T::DiagBlockSparseTensor{ElT,N}) where {ElT,N}
+  return array(T)
+end
+
+function Array(T::DiagBlockSparseTensor{ElT,N}) where {ElT,N}
+  return Array{ElT,N}(T)
+end
+
+# Needed to get slice of DiagBlockSparseTensor like T[1:3,1:3]
+function similar(
+  T::DiagBlockSparseTensor{<:Number,N}, ::Type{ElR}, inds::Dims{N}
+) where {ElR<:Number,N}
+  return tensor(similar(storage(T), ElR, minimum(inds)), inds)
+end
+
+getdiagindex(T::DiagBlockSparseTensor{<:Number}, ind::Int) = storage(T)[ind]
+
+# XXX: handle case of missing diagonal blocks
+function setdiagindex!(T::DiagBlockSparseTensor{<:Number}, val, ind::Int)
+  storage(T)[ind] = val
+  return T
+end
+
+function setdiag(T::DiagBlockSparseTensor, val, ind::Int)
+  return tensor(DiagBlockSparse(val), inds(T))
+end
+
+@propagate_inbounds function getindex(
+  T::DiagBlockSparseTensor{ElT,N}, inds::Vararg{Int,N}
+) where {ElT,N}
+  if all(==(inds[1]), inds)
+    return storage(T)[inds[1]]
+  else
+    return zero(eltype(ElT))
+  end
+end
+
+@propagate_inbounds function getindex(T::DiagBlockSparseTensor{<:Number,1}, ind::Int)
+  return storage(T)[ind]
+end
+
+@propagate_inbounds function getindex(T::DiagBlockSparseTensor{<:Number,0})
+  return storage(T)[1]
+end
+
+# Set diagonal elements
+# Throw error for off-diagonal
+@propagate_inbounds function setindex!(
+  T::DiagBlockSparseTensor{<:Number,N}, val, inds::Vararg{Int,N}
+) where {N}
+  all(==(inds[1]), inds) ||
+    error("Cannot set off-diagonal element of DiagBlockSparse storage")
+  storage(T)[inds[1]] = val
+  return T
+end
+
+@propagate_inbounds function setindex!(T::DiagBlockSparseTensor{<:Number,1}, val, ind::Int)
+  storage(T)[ind] = val
+  return T
+end
+
+@propagate_inbounds function setindex!(T::DiagBlockSparseTensor{<:Number,0}, val)
+  storage(T)[1] = val
+  return T
+end
+
+function setindex!(
+  T::UniformDiagBlockSparseTensor{<:Number,N}, val, inds::Vararg{Int,N}
+) where {N}
+  return error("Cannot set elements of a uniform DiagBlockSparse storage")
+end
+
+# TODO: make a fill!! that works for uniform and non-uniform
+#fill!(T::DiagBlockSparseTensor,v) = fill!(storage(T),v)
+
+function dense(
+  ::Type{<:Tensor{ElT,N,StoreT,IndsT}}
+) where {ElT,N,StoreT<:DiagBlockSparse,IndsT}
+  return Tensor{ElT,N,dense(StoreT),IndsT}
+end
+
+# convert to Dense
+function dense(T::TensorT) where {TensorT<:DiagBlockSparseTensor}
+  R = zeros(dense(TensorT), inds(T))
+  for i in 1:diaglength(T)
+    setdiagindex!(R, getdiagindex(T, i), i)
+  end
+  return R
+end
+
+function outer!(
+  R::DenseTensor{<:Number,NR},
+  T1::DiagBlockSparseTensor{<:Number,N1},
+  T2::DiagBlockSparseTensor{<:Number,N2},
+) where {NR,N1,N2}
+  for i1 in 1:diaglength(T1), i2 in 1:diaglength(T2)
+    indsR = CartesianIndex{NR}(ntuple(r -> r ≤ N1 ? i1 : i2, Val(NR)))
+    R[indsR] = getdiagindex(T1, i1) * getdiagindex(T2, i2)
+  end
+  return R
+end
+
+# TODO: write an optimized version of this?
+function outer!(R::DenseTensor{ElR}, T1::DenseTensor, T2::DiagBlockSparseTensor) where {ElR}
+  R .= zero(ElR)
+  outer!(R, T1, dense(T2))
+  return R
+end
+
+function outer!(R::DenseTensor{ElR}, T1::DiagBlockSparseTensor, T2::DenseTensor) where {ElR}
+  R .= zero(ElR)
+  outer!(R, dense(T1), T2)
+  return R
+end
+
+# Right an in-place version
+function outer(
+  T1::DiagBlockSparseTensor{ElT1,N1}, T2::DiagBlockSparseTensor{ElT2,N2}
+) where {ElT1,ElT2,N1,N2}
+  indsR = unioninds(inds(T1), inds(T2))
+  R = tensor(Dense(zeros(promote_type(ElT1, ElT2), dim(indsR))), indsR)
+  outer!(R, T1, T2)
+  return R
+end
+
+function permutedims!(
+  R::DiagBlockSparseTensor{<:Number,N},
+  T::DiagBlockSparseTensor{<:Number,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {N}
+  # TODO: check that inds(R)==permute(inds(T),perm)?
+  for i in 1:diaglength(R)
+    @inbounds setdiagindex!(R, f(getdiagindex(R, i), getdiagindex(T, i)), i)
+  end
+  return R
+end
+
+function permutedims(
+  T::DiagBlockSparseTensor{<:Number,N}, perm::NTuple{N,Int}, f::Function=identity
+) where {N}
+  R = similar(T, permute(inds(T), perm))
+  permutedims!(R, T, perm, f)
+  return R
+end
+
+function permutedims(
+  T::UniformDiagBlockSparseTensor{ElT,N}, perm::NTuple{N,Int}, f::Function=identity
+) where {ElR,ElT,N}
+  R = tensor(DiagBlockSparse(f(getdiagindex(T, 1))), permute(inds(T), perm))
+  return R
+end
+
+# Version that may overwrite in-place or may return the result
+function permutedims!!(
+  R::NonuniformDiagBlockSparseTensor{<:Number,N},
+  T::NonuniformDiagBlockSparseTensor{<:Number,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {N}
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  permutedims!(RR, T, perm, f)
+  return RR
+end
+
+function permutedims!!(
+  R::UniformDiagBlockSparseTensor{ElR,N},
+  T::UniformDiagBlockSparseTensor{ElT,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {ElR,ElT,N}
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  RR = tensor(DiagBlockSparse(f(getdiagindex(RR, 1), getdiagindex(T, 1))), inds(RR))
+  return RR
+end
+
+function permutedims!(
+  R::DenseTensor{ElR,N},
+  T::DiagBlockSparseTensor{ElT,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {ElR,ElT,N}
+  for i in 1:diaglength(T)
+    @inbounds setdiagindex!(R, f(getdiagindex(R, i), getdiagindex(T, i)), i)
+  end
+  return R
+end
+
+function permutedims!!(
+  R::DenseTensor{ElR,N},
+  T::DiagBlockSparseTensor{ElT,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {ElR,ElT,N}
+  permutedims!(R, T, perm, f)
+  return R
+end
+
+function _contract!!(
+  R::UniformDiagBlockSparseTensor{ElR,NR},
+  labelsR,
+  T1::UniformDiagBlockSparseTensor{<:Number,N1},
+  labelsT1,
+  T2::UniformDiagBlockSparseTensor{<:Number,N2},
+  labelsT2,
+) where {ElR,NR,N1,N2}
+  if NR == 0  # If all indices of A and B are contracted
+    # all indices are summed over, just add the product of the diagonal
+    # elements of A and B
+    R = setdiag(R, diaglength(T1) * getdiagindex(T1, 1) * getdiagindex(T2, 1), 1)
+  else
+    # not all indices are summed over, set the diagonals of the result
+    # to the product of the diagonals of A and B
+    R = setdiag(R, getdiagindex(T1, 1) * getdiagindex(T2, 1), 1)
+  end
+  return R
+end
+
+function contraction_output(
+  T1::TensorT1, labelsT1, T2::TensorT2, labelsT2, labelsR
+) where {TensorT1<:BlockSparseTensor,TensorT2<:DiagBlockSparseTensor}
+  indsR = contract_inds(inds(T1), labelsT1, inds(T2), labelsT2, labelsR)
+  TensorR = contraction_output_type(TensorT1, TensorT2, typeof(indsR))
+  blockoffsetsR, contraction_plan = contract_blockoffsets(
+    blockoffsets(T1),
+    inds(T1),
+    labelsT1,
+    blockoffsets(T2),
+    inds(T2),
+    labelsT2,
+    indsR,
+    labelsR,
+  )
+  R = zeros(TensorR, blockoffsetsR, indsR)
+  return R, contraction_plan
+end
+
+function contract(
+  T1::BlockSparseTensor,
+  labelsT1,
+  T2::DiagBlockSparseTensor,
+  labelsT2,
+  labelsR=contract_labels(labelsT1, labelsT2),
+)
+  R, contraction_plan = contraction_output(T1, labelsT1, T2, labelsT2, labelsR)
+  R = contract!(R, labelsR, T1, labelsT1, T2, labelsT2, contraction_plan)
+  return R
+end
+
+function contract(
+  T1::DiagBlockSparseTensor,
+  labelsT1,
+  T2::BlockSparseTensor,
+  labelsT2,
+  labelsR=contract_labels(labelsT2, labelsT1),
+)
+  return contract(T2, labelsT2, T1, labelsT1, labelsR)
+end
+
+function contract!(
+  R::BlockSparseTensor{ElR,NR},
+  labelsR,
+  T1::BlockSparseTensor,
+  labelsT1,
+  T2::DiagBlockSparseTensor,
+  labelsT2,
+  contraction_plan,
+) where {ElR<:Number,NR}
+  already_written_to = Dict{Block{NR},Bool}()
+  # In R .= α .* (T1 * T2) .+ β .* R
+  α = one(ElR)
+  for (block1, block2, blockR) in contraction_plan
+    T1block = T1[block1]
+    T2block = T2[block2]
+    Rblock = R[blockR]
+
+    # <fermions>
+    α = compute_alpha(
+      ElR, labelsR, blockR, inds(R), labelsT1, block1, inds(T1), labelsT2, block2, inds(T2)
+    )
+
+    β = one(ElR)
+    if !haskey(already_written_to, blockR)
+      already_written_to[blockR] = true
+      # Overwrite the block of R
+      β = zero(ElR)
+    end
+    contract!(Rblock, labelsR, T1block, labelsT1, T2block, labelsT2, α, β)
+  end
+  return R
+end
+
+function contract!(
+  C::BlockSparseTensor,
+  Clabels,
+  A::BlockSparseTensor,
+  Alabels,
+  B::DiagBlockSparseTensor,
+  Blabels,
+)
+  return contract!(C, Clabels, B, Blabels, A, Alabels)
+end
+
+function show(io::IO, mime::MIME"text/plain", T::DiagBlockSparseTensor)
+  summary(io, T)
+  for (n, block) in enumerate(keys(diagblockoffsets(T)))
+    blockdimsT = blockdims(T, block)
+    println(io, block)
+    println(io, " [", _range2string(blockstart(T, block), blockend(T, block)), "]")
+    print_tensor(io, blockview(T, block))
+    n < nnzblocks(T) && print(io, "\n\n")
+  end
+end
+
+show(io::IO, T::DiagBlockSparseTensor) = show(io, MIME("text/plain"), T)

--- a/src/NDTensors/blocksparse/linearalgebra.jl
+++ b/src/NDTensors/blocksparse/linearalgebra.jl
@@ -1,0 +1,315 @@
+
+const BlockSparseMatrix{ElT,StoreT,IndsT} = BlockSparseTensor{ElT,2,StoreT,IndsT}
+const DiagBlockSparseMatrix{ElT,StoreT,IndsT} = DiagBlockSparseTensor{ElT,2,StoreT,IndsT}
+const DiagMatrix{ElT,StoreT,IndsT} = DiagTensor{ElT,2,StoreT,IndsT}
+
+function _truncated_blockdim(
+  S::DiagMatrix, docut::Float64; singular_values=false, truncate=true
+)
+  !truncate && return diaglength(S)
+  newdim = 0
+  val = singular_values ? getdiagindex(S, newdim + 1)^2 : getdiagindex(S, newdim + 1)
+  while newdim + 1 ≤ diaglength(S) && val > docut
+    newdim += 1
+    if newdim + 1 ≤ diaglength(S)
+      val = singular_values ? getdiagindex(S, newdim + 1)^2 : getdiagindex(S, newdim + 1)
+    end
+  end
+  return newdim
+end
+
+"""
+    svd(T::BlockSparseTensor{<:Number,2}; kwargs...)
+
+svd of an order-2 BlockSparseTensor.
+
+This function assumes that there is one block
+per row/column, otherwise it fails.
+This assumption makes it so the result can be
+computed from the dense svds of seperate blocks.
+"""
+function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
+  alg::String = get(kwargs, :alg, "divide_and_conquer")
+
+  truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
+
+  #@timeit_debug timer "block sparse svd" begin
+  Us = Vector{DenseTensor{ElT,2}}(undef, nnzblocks(T))
+  Ss = Vector{DiagTensor{real(ElT),2}}(undef, nnzblocks(T))
+  Vs = Vector{DenseTensor{ElT,2}}(undef, nnzblocks(T))
+
+  # Sorted eigenvalues
+  d = Vector{real(ElT)}()
+
+  for (n, b) in enumerate(eachnzblock(T))
+    blockT = blockview(T, b)
+    USVb = svd(blockT; alg=alg)
+    if isnothing(USVb)
+      return nothing
+    end
+    Ub, Sb, Vb = USVb
+    Us[n] = Ub
+    Ss[n] = Sb
+    Vs[n] = Vb
+    # Previously this was:
+    # vector(diag(Sb))
+    # But it broke, did `diag(::Tensor)` change types?
+    # TODO: call this a function `diagonal`, i.e.:
+    # https://github.com/JuliaLang/julia/issues/30250
+    # or make `diag(::Tensor)` return a view by default.
+    append!(d, data(Sb))
+  end
+
+  # Square the singular values to get
+  # the eigenvalues
+  d .= d .^ 2
+  sort!(d; rev=true)
+
+  # Get the list of blocks of T
+  # that are not dropped
+  nzblocksT = nzblocks(T)
+
+  dropblocks = Int[]
+  if truncate
+    truncerr, docut = truncate!(d; kwargs...)
+    for n in 1:nnzblocks(T)
+      blockdim = _truncated_blockdim(Ss[n], docut; singular_values=true, truncate=truncate)
+      if blockdim == 0
+        push!(dropblocks, n)
+      else
+        Strunc = tensor(Diag(storage(Ss[n])[1:blockdim]), (blockdim, blockdim))
+        Us[n] = Us[n][1:dim(Us[n], 1), 1:blockdim]
+        Ss[n] = Strunc
+        Vs[n] = Vs[n][1:dim(Vs[n], 1), 1:blockdim]
+      end
+    end
+    deleteat!(Us, dropblocks)
+    deleteat!(Ss, dropblocks)
+    deleteat!(Vs, dropblocks)
+    deleteat!(nzblocksT, dropblocks)
+  else
+    truncerr, docut = 0.0, 0.0
+  end
+
+  # The number of blocks of T remaining
+  nnzblocksT = nnzblocks(T) - length(dropblocks)
+
+  #
+  # Put the blocks into U,S,V
+  # 
+
+  nb1_lt_nb2 = (
+    nblocks(T)[1] < nblocks(T)[2] ||
+    (nblocks(T)[1] == nblocks(T)[2] && dim(T, 1) < dim(T, 2))
+  )
+
+  if nb1_lt_nb2
+    uind = sim(ind(T, 1))
+  else
+    uind = sim(ind(T, 2))
+  end
+
+  deleteat!(uind, dropblocks)
+
+  # uind may have too many blocks
+  if nblocks(uind) > nnzblocksT
+    resize!(uind, nnzblocksT)
+  end
+
+  for n in 1:nnzblocksT
+    setblockdim!(uind, minimum(dims(Ss[n])), n)
+  end
+
+  if dir(uind) != dir(inds(T)[1])
+    uind = dag(uind)
+  end
+  indsU = setindex(inds(T), dag(uind), 2)
+
+  vind = sim(uind)
+  if dir(vind) != dir(inds(T)[2])
+    vind = dag(vind)
+  end
+  indsV = setindex(inds(T), dag(vind), 1)
+  indsV = permute(indsV, (2, 1))
+
+  indsS = setindex(inds(T), uind, 1)
+  indsS = setindex(indsS, vind, 2)
+
+  nzblocksU = Vector{Block{2}}(undef, nnzblocksT)
+  nzblocksS = Vector{Block{2}}(undef, nnzblocksT)
+  nzblocksV = Vector{Block{2}}(undef, nnzblocksT)
+
+  for n in 1:nnzblocksT
+    blockT = nzblocksT[n]
+
+    blockU = (blockT[1], UInt(n))
+    nzblocksU[n] = blockU
+
+    blockS = (n, n)
+    nzblocksS[n] = blockS
+
+    blockV = (blockT[2], UInt(n))
+    nzblocksV[n] = blockV
+  end
+
+  U = BlockSparseTensor(ElT, undef, nzblocksU, indsU)
+  S = DiagBlockSparseTensor(real(ElT), undef, nzblocksS, indsS)
+  V = BlockSparseTensor(ElT, undef, nzblocksV, indsV)
+
+  for n in 1:nnzblocksT
+    Ub, Sb, Vb = Us[n], Ss[n], Vs[n]
+
+    blockU = nzblocksU[n]
+    blockS = nzblocksS[n]
+    blockV = nzblocksV[n]
+
+    if VERSION < v"1.5"
+      # In v1.3 and v1.4 of Julia, Ub has
+      # a very complicated view wrapper that
+      # can't be handled efficiently
+      Ub = copy(Ub)
+      Vb = copy(Vb)
+    end
+
+    blockview(U, blockU) .= Ub
+    blockviewS = blockview(S, blockS)
+    for i in 1:diaglength(Sb)
+      setdiagindex!(blockviewS, getdiagindex(Sb, i), i)
+    end
+
+    blockview(V, blockV) .= Vb
+  end
+
+  return U, S, V, Spectrum(d, truncerr)
+  #end # @timeit_debug
+end
+
+_eigen_eltypes(T::Hermitian{ElT,<:BlockSparseMatrix{ElT}}) where {ElT} = real(ElT), ElT
+
+_eigen_eltypes(T::BlockSparseMatrix{ElT}) where {ElT} = complex(ElT), complex(ElT)
+
+function LinearAlgebra.eigen(
+  T::Union{Hermitian{ElT,<:BlockSparseMatrix{ElT}},BlockSparseMatrix{ElT}}; kwargs...
+) where {ElT<:Union{Real,Complex}}
+  truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
+
+  ElD, ElV = _eigen_eltypes(T)
+
+  # Sorted eigenvalues
+  d = Vector{real(ElT)}()
+
+  for b in eachnzblock(T)
+    all(==(b[1]), b) || error("Eigen currently only supports block diagonal matrices.")
+  end
+
+  b = first(eachnzblock(T))
+  blockT = blockview(T, b)
+  Db, Vb = eigen(blockT)
+  Ds = [Db]
+  Vs = [Vb]
+  append!(d, abs.(data(Db)))
+  for (n, b) in enumerate(eachnzblock(T))
+    n == 1 && continue
+    blockT = blockview(T, b)
+    Db, Vb = eigen(blockT)
+    push!(Ds, Db)
+    push!(Vs, Vb)
+    append!(d, abs.(data(Db)))
+  end
+
+  dropblocks = Int[]
+  sort!(d; rev=true, by=abs)
+
+  if truncate
+    truncerr, docut = truncate!(d; kwargs...)
+    for n in 1:nnzblocks(T)
+      blockdim = _truncated_blockdim(Ds[n], docut)
+      if blockdim == 0
+        push!(dropblocks, n)
+      else
+        Dtrunc = tensor(Diag(storage(Ds[n])[1:blockdim]), (blockdim, blockdim))
+        Ds[n] = Dtrunc
+        Vs[n] = copy(Vs[n][1:dim(Vs[n], 1), 1:blockdim])
+      end
+    end
+    deleteat!(Ds, dropblocks)
+    deleteat!(Vs, dropblocks)
+  else
+    truncerr = 0.0
+  end
+
+  # Get the list of blocks of T
+  # that are not dropped
+  nzblocksT = nzblocks(T)
+  deleteat!(nzblocksT, dropblocks)
+
+  # The number of blocks of T remaining
+  nnzblocksT = nnzblocks(T) - length(dropblocks)
+
+  #
+  # Put the blocks into D, V
+  #
+
+  i1, i2 = inds(T)
+  l = sim(i1)
+
+  lkeepblocks = Int[bT[1] for bT in nzblocksT]
+  ldropblocks = setdiff(1:nblocks(l), lkeepblocks)
+  deleteat!(l, ldropblocks)
+
+  # l may have too many blocks
+  (nblocks(l) > nnzblocksT) && error("New index l in eigen has too many blocks")
+
+  # Truncation may have changed
+  # some block sizes
+  for n in 1:nnzblocksT
+    setblockdim!(l, minimum(dims(Ds[n])), n)
+  end
+
+  r = dag(sim(l))
+
+  indsD = (l, r)
+  indsV = (dag(i2), r)
+
+  nzblocksD = Vector{Block{2}}(undef, nnzblocksT)
+  nzblocksV = Vector{Block{2}}(undef, nnzblocksT)
+  for n in 1:nnzblocksT
+    blockT = nzblocksT[n]
+
+    blockD = (n, n)
+    nzblocksD[n] = blockD
+
+    blockV = (blockT[1], n)
+    nzblocksV[n] = blockV
+  end
+
+  D = DiagBlockSparseTensor(ElD, undef, nzblocksD, indsD)
+  V = BlockSparseTensor(ElV, undef, nzblocksV, indsV)
+
+  for n in 1:nnzblocksT
+    Db, Vb = Ds[n], Vs[n]
+
+    blockD = nzblocksD[n]
+    blockviewD = blockview(D, blockD)
+    for i in 1:diaglength(Db)
+      setdiagindex!(blockviewD, getdiagindex(Db, i), i)
+    end
+
+    blockV = nzblocksV[n]
+    blockview(V, blockV) .= Vb
+  end
+
+  return D, V, Spectrum(d, truncerr)
+end
+
+function LinearAlgebra.exp(
+  T::Union{BlockSparseMatrix{ElT},Hermitian{ElT,<:BlockSparseMatrix{ElT}}}
+) where {ElT<:Union{Real,Complex}}
+  expT = BlockSparseTensor(ElT, undef, nzblocks(T), inds(T))
+  for b in eachnzblock(T)
+    all(==(b[1]), b) || error("exp currently supports only block-diagonal matrices")
+    blockT = blockview(T, b)
+    blockview(expT, b) .= exp(blockT)
+  end
+  return expT
+end

--- a/src/NDTensors/combiner.jl
+++ b/src/NDTensors/combiner.jl
@@ -1,0 +1,135 @@
+export Combiner
+
+# TODO: Have combiner store the locations
+# of the uncombined and combined indices
+# This can generalize to a Combiner that combines
+# multiple set of indices, e.g. (i,j),(k,l) -> (a,b)
+struct Combiner <: TensorStorage{Number}
+  perm::Vector{Int}
+  comb::Vector{Int}
+  cind::Vector{Int}
+  isconj::Bool
+  function Combiner(perm::Vector{Int}, comb::Vector{Int}, cind::Vector{Int}, isconj::Bool)
+    return new(perm, comb, cind, isconj)
+  end
+end
+
+Combiner() = Combiner(Int[], Int[], Int[1], false)
+
+Combiner(perm::Vector{Int}, comb::Vector{Int}) = Combiner(perm, comb, Int[1], false)
+
+data(::Combiner) = error("Combiner storage has no data")
+
+blockperm(C::Combiner) = C.perm
+blockcomb(C::Combiner) = C.comb
+cinds(C::Combiner) = C.cind
+isconj(C::Combiner) = C.isconj
+setisconj(C::Combiner, isconj) = Combiner(blockperm(C), blockcomb(C), cinds(C), isconj)
+
+function copy(C::Combiner)
+  return Combiner(copy(blockperm(C)), copy(blockcomb(C)), copy(cinds(C)), isconj(C))
+end
+
+eltype(::Type{<:Combiner}) = Number
+
+eltype(::Combiner) = eltype(Combiner)
+
+promote_rule(::Type{<:Combiner}, StorageT::Type{<:Dense}) = StorageT
+
+conj(::AllowAlias, C::Combiner) = setisconj(C, !isconj(C))
+conj(::NeverAlias, C::Combiner) = conj(AllowAlias(), copy(C))
+
+#
+# CombinerTensor (Tensor using Combiner storage)
+#
+
+const CombinerTensor{ElT,N,StoreT,IndsT} =
+  Tensor{ElT,N,StoreT,IndsT} where {StoreT<:Combiner}
+
+combinedindex(T::CombinerTensor) = inds(T)[1]
+uncombinedinds(T::CombinerTensor) = popfirst(inds(T))
+
+blockperm(C::CombinerTensor) = blockperm(storage(C))
+blockcomb(C::CombinerTensor) = blockcomb(storage(C))
+
+function contraction_output(
+  ::TensorT1, ::TensorT2, indsR::IndsR
+) where {TensorT1<:CombinerTensor,TensorT2<:DenseTensor,IndsR}
+  TensorR = contraction_output_type(TensorT1, TensorT2, IndsR)
+  return similar(TensorR, indsR)
+end
+
+function contraction_output(
+  T1::TensorT1, T2::TensorT2, indsR
+) where {TensorT1<:DenseTensor,TensorT2<:CombinerTensor}
+  return contraction_output(T2, T1, indsR)
+end
+
+function contract!!(R::Tensor, labelsR, T1::CombinerTensor, labelsT1, T2::Tensor, labelsT2)
+  NR = ndims(R)
+  N1 = ndims(T1)
+  N2 = ndims(T2)
+  if N1 ≤ 1
+    # Empty combiner, acts as multiplying by 1
+    R = permutedims!!(R, T2, getperm(labelsR, labelsT2))
+    return R
+  elseif N1 + N2 == NR
+    error("Cannot perform outer product involving a combiner")
+  elseif count_common(labelsT1, labelsT2) == 1 && N1 == 2
+    # This is the case of index replacement
+    ui = setdiff(labelsT1, labelsT2)[]
+    newind = inds(T1)[findfirst(==(ui), labelsT1)]
+    cpos1, cpos2 = intersect_positions(labelsT1, labelsT2)
+    storeR = copy(storage(T2))
+    indsR = setindex(inds(T2), newind, cpos2)
+    return tensor(storeR, indsR)
+  elseif count_common(labelsT1, labelsT2) == 1 && length(inds(T1)) != 2
+    # This is the case of uncombining
+    cpos1, cpos2 = intersect_positions(labelsT1, labelsT2)
+    storeR = copy(storage(T2))
+    indsC = deleteat(inds(T1), cpos1)
+    indsR = insertat(inds(T2), indsC, cpos2)
+    return tensor(storeR, indsR)
+  elseif is_combiner(labelsT1, labelsT2)
+    # This is the case of combining
+    Alabels, Blabels = labelsT2, labelsT1
+    final_labels = contract_labels(Blabels, Alabels)
+    final_labels_n = contract_labels(labelsT1, labelsT2)
+    indsR = inds(R)
+    if final_labels != final_labels_n
+      perm = getperm(final_labels_n, final_labels)
+      indsR = permute(inds(R), perm)
+      labelsR = permute(labelsR, perm)
+    end
+    cpos1, cposR = intersect_positions(labelsT1, labelsR)
+    labels_comb = deleteat(labelsT1, cpos1)
+    vlR = [labelsR...]
+    for (ii, li) in enumerate(labels_comb)
+      insert!(vlR, cposR + ii, li)
+    end
+    deleteat!(vlR, cposR)
+    labels_perm = tuple(vlR...)
+    perm = getperm(labels_perm, labelsT2)
+    T2p = reshape(R, permute(inds(T2), perm))
+    permutedims!(T2p, T2, perm)
+    R = reshape(T2p, indsR)
+  end
+  return R
+end
+
+function contract!!(
+  R::Tensor, labelsR, T1::Tensor, labelsT1, T2::CombinerTensor, labelsT2
+) where {NR,N1,N2}
+  return contract!!(R, labelsR, T2, labelsT2, T1, labelsT1)
+end
+
+function show(io::IO, mime::MIME"text/plain", S::Combiner)
+  println(io, "Permutation of blocks: ", S.perm)
+  return println(io, "Combination of blocks: ", S.comb)
+end
+
+function show(io::IO, mime::MIME"text/plain", T::CombinerTensor)
+  summary(io, T)
+  println(io)
+  return show(io, mime, storage(T))
+end

--- a/src/NDTensors/contraction_logic.jl
+++ b/src/NDTensors/contraction_logic.jl
@@ -1,0 +1,638 @@
+
+const Labels{N} = NTuple{N,Int}
+
+# Automatically determine the output labels given
+# input labels of a contraction
+function contract_labels(T1labels::Labels{N1}, T2labels::Labels{N2}) where {N1,N2}
+  ncont = 0
+  for i in T1labels
+    i < 0 && (ncont += 1)
+  end
+  NR = N1 + N2 - 2 * ncont
+  ValNR = Val{NR}
+  return contract_labels(ValNR, T1labels, T2labels)
+end
+
+function contract_labels(
+  ::Type{Val{NR}}, T1labels::Labels{N1}, T2labels::Labels{N2}
+) where {NR,N1,N2}
+  Rlabels = MVector{NR,Int}(undef)
+  u = 1
+  # TODO: use Rlabels, don't assume ncon convention
+  for i in 1:N1
+    if T1labels[i] > 0
+      @inbounds Rlabels[u] = T1labels[i]
+      u += 1
+    end
+  end
+  for i in 1:N2
+    if T2labels[i] > 0
+      @inbounds Rlabels[u] = T2labels[i]
+      u += 1
+    end
+  end
+  return Labels{NR}(Rlabels)
+end
+
+function _contract_inds!(
+  Ris, T1is, T1labels::Labels{N1}, T2is, T2labels::Labels{N2}, Rlabels::Labels{NR}
+) where {N1,N2,NR}
+  for n in 1:NR
+    Rlabel = @inbounds Rlabels[n]
+    found = false
+    for n1 in 1:N1
+      if Rlabel == @inbounds T1labels[n1]
+        @inbounds Ris[n] = @inbounds T1is[n1]
+        found = true
+        break
+      end
+    end
+    if !found
+      for n2 in 1:N2
+        if Rlabel == @inbounds T2labels[n2]
+          @inbounds Ris[n] = @inbounds T2is[n2]
+          break
+        end
+      end
+    end
+  end
+  return nothing
+end
+
+# Old version that doesn't take into account Rlabels
+#function _contract_inds!(Ris,
+#                         T1is,
+#                         T1labels::Labels{N1},
+#                         T2is,
+#                         T2labels::Labels{N2},
+#                         Rlabels::Labels{NR}) where {N1,N2,NR}
+#  ncont = 0
+#  for i in T1labels
+#    i < 0 && (ncont += 1)
+#  end
+#  IndT = promote_type(eltype(T1is), eltype(T2is))
+#  u = 1
+#  # TODO: use Rlabels, don't assume ncon convention
+#  for i1 ∈ 1:N1
+#    if T1labels[i1] > 0
+#      Ris[u] = T1is[i1]
+#      u += 1 
+#    else
+#      # This is to check that T1is and T2is
+#      # can contract
+#      i2 = findfirst(==(T1labels[i1]),T2labels)
+#      dir(T1is[i1]) == -dir(T2is[i2]) || error("Attempting to contract index:\n\n$(T1is[i1])\nwith index:\n\n$(T2is[i2])\nIndices must have opposite directions to contract.")
+#    end
+#  end
+#  for i2 ∈ 1:N2
+#    if T2labels[i2] > 0
+#      Ris[u] = T2is[i2]
+#      u += 1 
+#    end
+#  end
+#  return nothing
+#end
+
+function contract_inds(
+  T1is, T1labels::Labels{N1}, T2is, T2labels::Labels{N2}, Rlabels::Labels{NR}
+) where {N1,N2,NR}
+  if length(T1is) == 0 && length(T2is) == 0
+    return ()
+  end
+  IndT = promote_type(eltype(T1is), eltype(T2is))
+  if (length(T1is) > 0 && isbits(T1is[1])) || isbits(T2is[1])
+    Ris = MVector{NR,IndT}(undef)
+  else
+    Ris = SizedVector{NR,IndT}(undef)
+  end
+  _contract_inds!(Ris, T1is, T1labels, T2is, T2labels, Rlabels)
+  return Tuple(Ris)
+end
+
+mutable struct ContractionProperties{NA,NB,NC}
+  ai::NTuple{NA,Int}
+  bi::NTuple{NB,Int}
+  ci::NTuple{NC,Int}
+  nactiveA::Int
+  nactiveB::Int
+  nactiveC::Int
+  AtoB::NTuple{NA,Int}
+  AtoC::NTuple{NA,Int}
+  BtoC::NTuple{NB,Int}
+  permuteA::Bool
+  permuteB::Bool
+  permuteC::Bool
+  dleft::Int
+  dmid::Int
+  dright::Int
+  ncont::Int
+  Acstart::Int
+  Bcstart::Int
+  Austart::Int
+  Bustart::Int
+  PA::NTuple{NA,Int}
+  PB::NTuple{NB,Int}
+  PC::NTuple{NC,Int}
+  ctrans::Bool
+  newArange::NTuple{NA,Int}
+  newBrange::NTuple{NB,Int}
+  newCrange::NTuple{NC,Int}
+  function ContractionProperties(
+    ai::NTuple{NA,Int}, bi::NTuple{NB,Int}, ci::NTuple{NC,Int}
+  ) where {NA,NB,NC}
+    return new{NA,NB,NC}(
+      ai,
+      bi,
+      ci,
+      0,
+      0,
+      0,
+      ntuple(_ -> 0, Val(NA)),
+      ntuple(_ -> 0, Val(NA)),
+      ntuple(_ -> 0, Val(NB)),
+      false,
+      false,
+      false,
+      1,
+      1,
+      1,
+      0,
+      NA,
+      NB,
+      NA,
+      NB,
+      ntuple(i -> i, Val(NA)),
+      ntuple(i -> i, Val(NB)),
+      ntuple(i -> i, Val(NC)),
+      false,
+      ntuple(_ -> 0, Val(NA)),
+      ntuple(_ -> 0, Val(NB)),
+      ntuple(_ -> 0, Val(NC)),
+    )
+  end
+end
+
+function compute_perms!(props::ContractionProperties{NA,NB,NC}) where {NA,NB,NC}
+  #leng.th(props.AtoB)!=0 && return
+
+  # Access the fields before the loop
+  # since getting fields from the mutable struct
+  # takes nontrivial time
+  ai = props.ai
+  bi = props.bi
+  ci = props.ci
+
+  ncont = props.ncont
+  AtoB = props.AtoB
+  Acstart = props.Acstart
+  Bcstart = props.Bcstart
+  for i in 1:NA
+    for j in 1:NB
+      if @inbounds ai[i] == @inbounds bi[j]
+        ncont += 1
+        #TODO: check this if this should be i,j or i-1,j-1 (0-index or 1-index)
+        i <= Acstart && (Acstart = i)
+        j <= Bcstart && (Bcstart = j)
+        #AtoB[i] = j
+        AtoB = setindex(AtoB, j, i)
+        break
+      end
+    end
+  end
+  props.ncont = ncont
+  props.AtoB = AtoB
+  props.Acstart = Acstart
+  props.Bcstart = Bcstart
+
+  Austart = props.Austart
+  AtoC = props.AtoC
+  for i in 1:NA
+    for k in 1:NC
+      if @inbounds ai[i] == @inbounds ci[k]
+        #TODO: check this if this should be i,j or i-1,j-1 (0-index or 1-index)
+        i <= Austart && (Austart = i)
+        #AtoC[i] = k
+        AtoC = setindex(AtoC, k, i)
+        break
+      end
+    end
+  end
+  props.Austart = Austart
+  props.AtoC = AtoC
+
+  Bustart = props.Bustart
+  BtoC = props.BtoC
+  for j in 1:NB
+    for k in 1:NC
+      if bi[j] == ci[k]
+        #TODO: check this if this should be i,j or i-1,j-1 (0-index or 1-index)
+        j <= Bustart && (Bustart = j)
+        #BtoC[j] = k
+        BtoC = setindex(BtoC, k, j)
+        break
+      end
+    end
+  end
+  props.Bustart = Bustart
+  props.BtoC = BtoC
+
+  return nothing
+end
+
+function checkACsameord(props::ContractionProperties)::Bool
+  AtoC = props.AtoC
+
+  props.Austart >= length(props.ai) && return true
+  aCind = props.AtoC[props.Austart]
+  for i in 1:length(props.ai)
+    if !contractedA(props, i)
+      AtoC[i] != aCind && return false
+      aCind += 1
+    end
+  end
+  return true
+end
+
+function checkBCsameord(props::ContractionProperties)::Bool
+  props.Bustart >= length(props.bi) && return true
+  bCind = props.BtoC[props.Bustart]
+  for i in 1:length(props.bi)
+    if !contractedB(props, i)
+      props.BtoC[i] != bCind && return false
+      bCind += 1
+    end
+  end
+  return true
+end
+
+contractedA(props::ContractionProperties, i::Int) = (props.AtoC[i] < 1)
+contractedB(props::ContractionProperties, i::Int) = (props.BtoC[i] < 1)
+Atrans(props::ContractionProperties) = contractedA(props, 1)
+Btrans(props::ContractionProperties) = !contractedB(props, 1)
+Ctrans(props::ContractionProperties) = props.ctrans
+
+function compute_contraction_properties!(
+  props::ContractionProperties{NA,NB,NC}, A, B, C
+) where {NA,NB,NC}
+  compute_perms!(props)
+
+  #Use props.PC.size() as a check to see if we've already run this
+  #length(props.PC)!=0 && return
+
+  #ra = NA #length(props.ai)
+  #rb = NB #length(props.bi)
+  #rc = NC #length(props.ci)
+
+  #props.PC = fill(0,rc)
+
+  PC = props.PC
+  AtoC = props.AtoC
+  BtoC = props.BtoC
+
+  dleft = props.dleft
+  dmid = props.dmid
+  dright = props.dright
+
+  dleft = 1
+  dmid = 1
+  dright = 1
+  c = 1
+  for i in 1:NA
+    #if !contractedA(props,i)
+    if !(AtoC[i] < 1)
+      dleft *= size(A, i)
+      #props.PC[props.AtoC[i]] = c
+      PC = setindex(PC, c, AtoC[i])
+      c += 1
+    else
+      dmid *= size(A, i)
+    end
+  end
+  for j in 1:NB
+    #if !contractedB(props,j)
+    if !(BtoC[j] < 1)
+      dright *= size(B, j)
+      #props.PC[props.BtoC[j]] = c
+      PC = setindex(PC, c, BtoC[j])
+      c += 1
+    end
+  end
+  props.PC = PC
+  props.dleft = dleft
+  props.dmid = dmid
+  props.dright = dright
+
+  if !is_trivial_permutation(props.PC)
+    props.permuteC = true
+    if checkBCsameord(props) && checkACsameord(props)
+      #Can avoid permuting C by 
+      #computing Bt*At = Ct
+      props.ctrans = true
+      props.permuteC = false
+    end
+  end
+
+  #Check if A can be treated as a matrix without permuting
+  props.permuteA = false
+  if !(contractedA(props, 1) || contractedA(props, NA))
+    #If contracted indices are not all at front or back, 
+    #will have to permute A 
+    props.permuteA = true
+  else
+    #Contracted ind start at front or back, check if contiguous
+    #TODO: check that the limits are correct (1-indexed vs. 0-indexed)
+    for i in 1:(props.ncont)
+      if !contractedA(props, props.Acstart + i - 1)
+        #Contracted indices not contiguous, must permute
+        props.permuteA = true
+        break
+      end
+    end
+  end
+
+  #Check if B is matrix-like
+  props.permuteB = false
+  if !(contractedB(props, 1) || contractedB(props, NB))
+    #If contracted indices are not all at front or back, 
+    #will have to permute B
+    props.permuteB = true
+  else
+    #TODO: check that the limits are correct (1-indexed vs. 0-indexed)
+    for i in 1:(props.ncont)
+      if !contractedB(props, props.Bcstart + i - 1)
+        #Contracted inds not contiguous, permute
+        props.permuteB = true
+        break
+      end
+    end
+  end
+
+  if !props.permuteA && !props.permuteB
+    #Check if contracted inds. in same order
+    #TODO: check these limits are correct
+    for i in 1:(props.ncont)
+      if props.AtoB[props.Acstart + i - 1] != (props.Bcstart + i - 1)
+        #If not in same order, 
+        #must permute one of A or B
+        #so permute the smaller one
+        props.dleft < props.dright ? (props.permuteA = true) : (props.permuteB = true)
+        break
+      end
+    end
+  end
+
+  if props.permuteC && !(props.permuteA && props.permuteB)
+    PCost(d::Real) = d * d
+    #Could avoid permuting C if
+    #permute both A and B, worth it?
+    pCcost = PCost(props.dleft * props.dright)
+    extra_pABcost = 0
+    !props.permuteA && (extra_pABcost += PCost(props.dleft * props.dmid))
+    !props.permuteB && (extra_pABcost += PCost(props.dmid * props.dright))
+    if extra_pABcost < pCcost
+      props.permuteA = true
+      props.permuteB = true
+      props.permuteC = false
+    end
+  end
+
+  if props.permuteA
+    #props.PA = fill(0,ra)
+    #Permute contracted indices to the front,
+    #in the same order as on B
+
+    AtoC = props.AtoC
+    BtoC = props.BtoC
+    ai = props.ai
+    bi = props.bi
+    PA = props.PA
+
+    newi = 0
+    bind = props.Bcstart
+    for i in 1:(props.ncont)
+      while !(BtoC[bind] < 1)
+        bind += 1
+      end
+      j = findfirst(==(bi[bind]), ai)
+      #props.PA[newi + 1] = j
+      PA = setindex(PA, j, newi + 1)
+      bind += 1
+      newi += 1
+    end
+    #Reset p.AtoC:
+    #fill!(props.AtoC,0)
+    AtoC = ntuple(_ -> 0, Val(NA))
+    #Permute uncontracted indices to
+    #appear in same order as on C
+    #TODO: check this is correct for 1-indexing
+    for k in 1:NC
+      j = findfirst(==(props.ci[k]), props.ai)
+      if !isnothing(j)
+        #props.AtoC[newi+1] = k
+        AtoC = setindex(AtoC, k, newi + 1)
+        #props.PA[newi+1] = j
+        PA = setindex(PA, j, newi + 1)
+        newi += 1
+      end
+      newi == NA && break
+    end
+    props.PA = PA
+    props.AtoC = AtoC
+  end
+
+  ##Also update props.Austart,props.Acstart
+
+  Acstart = props.Acstart
+  Austart = props.Austart
+  newArange = props.newArange
+  PA = props.PA
+
+  Acstart = NA + 1
+  Austart = NA + 1
+  #TODO: check this is correct for 1-indexing
+  for i in 1:NA
+    #if contractedA(props,i)
+    if @inbounds AtoC[i] < 1
+      Acstart = min(i, Acstart)
+    else
+      Austart = min(i, Austart)
+    end
+    #props.newArange = permute_extents([size(A)...],props.PA)
+    newArange = permute(size(A), PA) #[size(A)...][props.PA]
+  end
+  props.Acstart = Acstart
+  props.Austart = Austart
+  props.newArange = newArange
+
+  if (props.permuteB)
+    PB = props.PB
+    AtoC = props.AtoC
+    BtoC = props.BtoC
+    ai = props.ai
+    bi = props.bi
+    ci = props.ci
+    Bcstart = props.Bcstart
+    Bustart = props.Bustart
+
+    #props.PB = fill(0,rb)
+    #TODO: check this is correct for 1-indexing
+    newi = 0 #1
+
+    if (props.permuteA)
+      #A's contracted indices already set to
+      #be in same order as B above, so just
+      #permute contracted indices to the front
+      #keeping relative order
+
+      i = props.Bcstart
+      while newi < props.ncont
+        while !(BtoC[i] < 1)
+          i += 1
+        end
+        #props.PB[newi+1] = i
+        PB = setindex(PB, i, newi + 1)
+        i += 1
+        newi += 1
+      end
+    else
+      #Permute contracted indices to the
+      #front and in same order as on A
+
+      aind = props.Acstart
+      for i in 0:(props.ncont - 1)
+        while !(AtoC[aind] < 1)
+          aind += 1
+        end
+        j = findfirst(==(ai[aind]), bi)
+        #props.PB[newi + 1] = j
+        PB = setindex(PB, j, newi + 1)
+        aind += 1
+        newi += 1
+      end
+    end
+
+    #Reset p.BtoC:
+    #fill!(props.BtoC,0)
+    BtoC = ntuple(_ -> 0, Val(NB))
+
+    #Permute uncontracted indices to
+    #appear in same order as on C
+    for k in 1:NC
+      j = findfirst(==(ci[k]), bi)
+      if !isnothing(j)
+        #props.BtoC[newi + 1] = k
+        BtoC = setindex(BtoC, k, newi + 1)
+        #props.PB[newi + 1] = j
+        PB = setindex(PB, j, newi + 1)
+        newi += 1
+      end
+      newi == NB && break
+    end
+    Bcstart = NB
+    Bustart = NB
+    for i in 1:NB
+      if BtoC[i] < 1
+        Bcstart = min(i, Bcstart)
+      else
+        Bustart = min(i, Bustart)
+      end
+    end
+    #props.newBrange = permute_extents([size(B)...],props.PB)
+    #props.newBrange = [size(B)...][props.PB]
+    props.newBrange = permute(size(B), PB)
+
+    props.BtoC = BtoC
+    props.PB = PB
+    props.Bcstart = Bcstart
+    props.Bustart = Bustart
+  end
+
+  if props.permuteA || props.permuteB
+    AtoC = props.AtoC
+    BtoC = props.BtoC
+    PC = props.PC
+
+    #Recompute props.PC
+    c = 1
+    #TODO: check this is correct for 1-indexing
+    for i in 1:NA
+      AtoC_i = AtoC[i]
+      if !(AtoC_i < 1)
+        #props.PC[props.AtoC[i]] = c
+        PC = setindex(PC, c, AtoC_i)
+        c += 1
+      end
+    end
+    #TODO: check this is correct for 1-indexing
+    for j in 1:NB
+      BtoC_j = BtoC[j]
+      if !(BtoC_j < 1)
+        #props.PC[props.BtoC[j]] = c
+        PC = setindex(PC, c, BtoC_j)
+        c += 1
+      end
+    end
+    props.PC = PC
+
+    props.ctrans = false
+    if (is_trivial_permutation(PC))
+      props.permuteC = false
+    else
+      props.permuteC = true
+      #Here we already know since pc_triv = false that
+      #at best indices from B precede those from A (on result C)
+      #so if both sets remain in same order on C 
+      #just need to transpose C, not permute it
+      if checkBCsameord(props) && checkACsameord(props)
+        props.ctrans = true
+        props.permuteC = false
+      end
+    end
+  end
+
+  if props.permuteC
+    Rb = MVector{NC,Int}(undef) #Int[]
+    k = 1
+    AtoC = props.AtoC
+    BtoC = props.BtoC
+    if !props.permuteA
+      #TODO: check this is correct for 1-indexing
+      for i in 1:NA
+        if !(AtoC[i] < 1)
+          #push!(Rb,size(A,i))
+          Rb[k] = size(A, i)
+          k = k + 1
+        end
+      end
+    else
+      #TODO: check this is correct for 1-indexing
+      for i in 1:NA
+        if !(AtoC[i] < 1)
+          #push!(Rb,size(props.newArange,i))
+          Rb[k] = props.newArange[i]
+          k = k + 1
+        end
+      end
+    end
+    if !props.permuteB
+      #TODO: check this is correct for 1-indexing
+      for j in 1:NB
+        if !(BtoC[j] < 1)
+          #push!(Rb,size(B,j))
+          Rb[k] = size(B, j)
+          k = k + 1
+        end
+      end
+    else
+      #TODO: check this is correct for 1-indexing
+      for j in 1:NB
+        if !(BtoC[j] < 1)
+          #push!(Rb,size(props.newBrange,j))
+          Rb[k] = props.newBrange[j]
+          k = k + 1
+        end
+      end
+    end
+    props.newCrange = Tuple(Rb)
+  end
+end

--- a/src/NDTensors/dense.jl
+++ b/src/NDTensors/dense.jl
@@ -1,0 +1,1093 @@
+#
+# Dense storage
+#
+using LinearAlgebra: BlasFloat
+
+struct Dense{ElT,VecT<:AbstractVector} <: TensorStorage{ElT}
+  data::VecT
+  function Dense{ElT,VecT}(data::AbstractVector) where {ElT,VecT<:AbstractVector{ElT}}
+    return new{ElT,VecT}(data)
+  end
+end
+
+function Dense(data::VecT) where {VecT<:AbstractVector{ElT}} where {ElT}
+  return Dense{ElT,VecT}(data)
+end
+
+function Dense{ElR}(data::AbstractVector{ElT}) where {ElR,ElT}
+  return ElT == ElR ? Dense(data) : Dense(ElR.(data))
+end
+
+# Construct from a set of indices
+function Dense{ElT,VecT}(inds) where {ElT,VecT<:AbstractVector{ElT}}
+  return Dense(VecT(dim(inds)))
+end
+
+Dense{ElT}(dim::Integer) where {ElT} = Dense(zeros(ElT, dim))
+
+Dense{ElT}(::UndefInitializer, dim::Integer) where {ElT} = Dense(Vector{ElT}(undef, dim))
+
+Dense(::Type{ElT}, dim::Integer) where {ElT} = Dense{ElT}(dim)
+
+Dense(x::ElT, dim::Integer) where {ElT<:Number} = Dense(fill(x, dim))
+
+Dense(dim::Integer) = Dense(Float64, dim)
+
+Dense(::Type{ElT}, ::UndefInitializer, dim::Integer) where {ElT} = Dense{ElT}(undef, dim)
+
+Dense(::UndefInitializer, dim::Integer) = Dense(Float64, undef, dim)
+
+Dense{ElT}() where {ElT} = Dense(ElT[])
+Dense(::Type{ElT}) where {ElT} = Dense{ElT}()
+
+setdata(D::Dense, ndata) = Dense(ndata)
+
+#
+# Random constructors
+#
+
+function randn(::Type{StoreT}, dim::Integer) where {StoreT<:Dense}
+  return Dense(randn(eltype(StoreT), dim))
+end
+
+copy(D::Dense) = Dense(copy(data(D)))
+
+Base.real(::Type{Dense{ElT,Vector{ElT}}}) where {ElT} = Dense{real(ElT),Vector{real(ElT)}}
+
+function complex(::Type{Dense{ElT,Vector{ElT}}}) where {ElT}
+  return Dense{complex(ElT),Vector{complex(ElT)}}
+end
+
+similar(D::Dense) = Dense(similar(data(D)))
+
+similar(D::Dense, length::Int) = Dense(similar(data(D), length))
+
+function similar(
+  ::Type{<:Dense{ElT,VecT}}, length::Int
+) where {ElT,VecT<:AbstractVector{ElT}}
+  return Dense(similar(Vector{ElT}, length))
+end
+
+function similartype(::Type{StoreT}, ::Type{ElT}) where {StoreT<:Dense,ElT}
+  return Dense{ElT,similartype(datatype(StoreT), ElT)}
+end
+
+# TODO: make these more general, move to tensorstorage.jl
+datatype(::Type{<:Dense{<:Any,DataT}}) where {DataT} = DataT
+
+function similar(::Type{StorageT}, ::Type{ElT}, length::Int) where {StorageT<:Dense,ElT}
+  return Dense(similar(datatype(StorageT), ElT, length))
+end
+
+similar(D::Dense, ::Type{T}) where {T<:Number} = Dense(similar(data(D), T))
+
+zeros(DenseT::Type{<:Dense{ElT}}, inds) where {ElT} = zeros(DenseT, dim(inds))
+
+# TODO: should this do something different for SubArray?
+zeros(::Type{<:Dense{ElT}}, dim::Int) where {ElT} = Dense{ElT}(dim)
+
+function promote_rule(
+  ::Type{<:Dense{ElT1,VecT1}}, ::Type{<:Dense{ElT2,VecT2}}
+) where {ElT1,VecT1,ElT2,VecT2}
+  ElR = promote_type(ElT1, ElT2)
+  VecR = promote_type(VecT1, VecT2)
+  return Dense{ElR,VecR}
+end
+
+# This is to get around the issue in Julia that:
+# promote_type(Vector{ComplexF32},Vector{Float64}) == Vector{T} where T
+function promote_rule(
+  ::Type{<:Dense{ElT1,Vector{ElT1}}}, ::Type{<:Dense{ElT2,Vector{ElT2}}}
+) where {ElT1,ElT2}
+  ElR = promote_type(ElT1, ElT2)
+  VecR = Vector{ElR}
+  return Dense{ElR,VecR}
+end
+
+# This is for type promotion for Scalar*Dense
+function promote_rule(
+  ::Type{<:Dense{ElT1,Vector{ElT1}}}, ::Type{ElT2}
+) where {ElT1,ElT2<:Number}
+  ElR = promote_type(ElT1, ElT2)
+  VecR = Vector{ElR}
+  return Dense{ElR,VecR}
+end
+
+function convert(::Type{<:Dense{ElR,VecR}}, D::Dense) where {ElR,VecR}
+  return Dense(convert(VecR, data(D)))
+end
+
+#
+# DenseTensor (Tensor using Dense storage)
+#
+
+const DenseTensor{ElT,N,StoreT,IndsT} = Tensor{ElT,N,StoreT,IndsT} where {StoreT<:Dense}
+
+DenseTensor(::Type{ElT}, inds) where {ElT} = tensor(Dense(ElT, dim(inds)), inds)
+
+# Special convenience function for Int
+# dimensions
+DenseTensor(::Type{ElT}, inds::Int...) where {ElT} = DenseTensor(ElT, inds)
+
+DenseTensor(inds) = tensor(Dense(dim(inds)), inds)
+
+DenseTensor(inds::Int...) = DenseTensor(inds)
+
+function DenseTensor(::Type{ElT}, ::UndefInitializer, inds) where {ElT}
+  return tensor(Dense(ElT, undef, dim(inds)), inds)
+end
+
+function DenseTensor(::Type{ElT}, ::UndefInitializer, inds::Int...) where {ElT}
+  return DenseTensor(ElT, undef, inds)
+end
+
+DenseTensor(::UndefInitializer, inds) = tensor(Dense(undef, dim(inds)), inds)
+
+DenseTensor(::UndefInitializer, inds::Int...) = DenseTensor(undef, inds)
+
+# For convenience, direct Tensor constructors default to Dense
+Tensor(::Type{ElT}, inds...) where {ElT} = DenseTensor(ElT, inds...)
+
+Tensor(inds...) = Tensor(Float64, inds...)
+
+function Tensor(::Type{ElT}, ::UndefInitializer, inds...) where {ElT}
+  return DenseTensor(ElT, undef, inds...)
+end
+
+Tensor(::UndefInitializer, inds...) = DenseTensor(undef, inds...)
+
+Tensor(A::Array{<:Number,N}, inds::Dims{N}) where {N} = tensor(Dense(vec(A)), inds)
+
+#
+# Random constructors
+#
+
+function randomDenseTensor(::Type{ElT}, inds) where {ElT}
+  return tensor(randn(Dense{ElT}, dim(inds)), inds)
+end
+
+function randomDenseTensor(::Type{ElT}, inds::Int...) where {ElT}
+  return randomDenseTensor(ElT, inds)
+end
+
+randomDenseTensor(inds) = randomDenseTensor(Float64, inds)
+
+randomDenseTensor(inds::Int...) = randomDenseTensor(Float64, inds)
+
+function randomTensor(::Type{ElT}, inds) where {ElT}
+  return randomDenseTensor(ElT, inds)
+end
+
+function randomTensor(::Type{ElT}, inds::Int...) where {ElT}
+  return randomDenseTensor(ElT, inds...)
+end
+
+randomTensor(inds) = randomDenseTensor(Float64, inds)
+
+randomTensor(inds::Int...) = randomDenseTensor(Float64, inds)
+
+# Basic functionality for AbstractArray interface
+IndexStyle(::Type{<:DenseTensor}) = IndexLinear()
+
+# Override CartesianIndices iteration to iterate
+# linearly through the Dense storage (faster)
+iterate(T::DenseTensor, args...) = iterate(storage(T), args...)
+
+function _zeros(TensorT::Type{<:DenseTensor}, inds)
+  return tensor(zeros(storagetype(TensorT), dim(inds)), inds)
+end
+
+function zeros(TensorT::Type{<:DenseTensor}, inds)
+  return _zeros(TensorT, inds)
+end
+
+# To fix method ambiguity with zeros(::Type, ::Tuple)
+function zeros(TensorT::Type{<:DenseTensor}, inds::Dims)
+  return _zeros(TensorT, inds)
+end
+
+function zeros(TensorT::Type{<:DenseTensor}, inds::Tuple{})
+  return _zeros(TensorT, inds)
+end
+
+# To fix method ambiguity with similar(::AbstractArray,::Type)
+function similar(T::DenseTensor, ::Type{ElT}) where {ElT}
+  return tensor(similar(storage(T), ElT), inds(T))
+end
+
+_similar(T::DenseTensor, inds) = similar(typeof(T), inds)
+
+similar(T::DenseTensor, inds) = _similar(T, inds)
+
+# To fix method ambiguity with similar(::AbstractArray,::Tuple)
+similar(T::DenseTensor, inds::Dims) = _similar(T, inds)
+
+#
+# Single index
+#
+
+@propagate_inbounds function getindex(
+  T::DenseTensor{<:Number,N}, I::Vararg{Integer,N}
+) where {N}
+  Base.@_inline_meta
+  return getindex(data(T), Base._sub2ind(T, I...))
+end
+
+@propagate_inbounds function getindex(
+  T::DenseTensor{<:Number,N}, I::CartesianIndex{N}
+) where {N}
+  Base.@_inline_meta
+  return getindex(T, I.I...)
+end
+
+@propagate_inbounds function setindex!(
+  T::DenseTensor{<:Number,N}, x::Number, I::Vararg{Integer,N}
+) where {N}
+  Base.@_inline_meta
+  setindex!(data(T), x, Base._sub2ind(T, I...))
+  return T
+end
+
+@propagate_inbounds function setindex!(
+  T::DenseTensor{<:Number,N}, x::Number, I::CartesianIndex{N}
+) where {N}
+  Base.@_inline_meta
+  setindex!(T, x, I.I...)
+  return T
+end
+
+#
+# Linear indexing
+#
+
+@propagate_inbounds @inline getindex(T::DenseTensor, i::Integer) = storage(T)[i]
+
+@propagate_inbounds @inline function setindex!(T::DenseTensor, v, i::Integer)
+  return (storage(T)[i] = v; T)
+end
+
+#
+# Slicing
+# TODO: this doesn't allow colon right now
+# Create a DenseView that stores a Dense and an offset?
+#
+
+@propagate_inbounds function _getindex(
+  T::DenseTensor{ElT,N}, I::CartesianIndices{N}
+) where {ElT,N}
+  storeR = Dense(vec(@view array(T)[I]))
+  indsR = Tuple(I[end] - I[1] + CartesianIndex(ntuple(_ -> 1, Val(N))))
+  return tensor(storeR, indsR)
+end
+
+@propagate_inbounds function getindex(T::DenseTensor{ElT,N}, I...) where {ElT,N}
+  return _getindex(T, CartesianIndices(I))
+end
+
+# Reshape a DenseTensor using the specified dimensions
+# This returns a view into the same Tensor data
+function reshape(T::DenseTensor, dims)
+  dim(T) == dim(dims) || error("Total new dimension must be the same as the old dimension")
+  return tensor(storage(T), dims)
+end
+
+# This version fixes method ambiguity with AbstractArray reshape
+function reshape(T::DenseTensor, dims::Dims)
+  dim(T) == dim(dims) || error("Total new dimension must be the same as the old dimension")
+  return tensor(storage(T), dims)
+end
+
+function reshape(T::DenseTensor, dims::Int...)
+  return tensor(storage(T), tuple(dims...))
+end
+
+convert(::Type{Array}, T::DenseTensor) = reshape(data(storage(T)), dims(inds(T)))
+
+# Create an Array that is a view of the Dense Tensor
+# Useful for using Base Array functions
+array(T::DenseTensor) = convert(Array, T)
+
+function Array{ElT,N}(T::DenseTensor{ElT,N}) where {ElT,N}
+  return copy(array(T))
+end
+
+function Array(T::DenseTensor{ElT,N}) where {ElT,N}
+  return Array{ElT,N}(T)
+end
+
+# If the storage data are regular Vectors, use Base.copyto!
+function copyto!(
+  R::Tensor{<:Number,N,<:Dense{<:Number,<:Vector}},
+  T::Tensor{<:Number,N,<:Dense{<:Number,<:Vector}},
+) where {N}
+  RA = array(R)
+  TA = array(T)
+  RA .= TA
+  return R
+end
+
+# If they are something more complicated like views, use Strided copyto!
+function copyto!(R::DenseTensor{<:Number,N}, T::DenseTensor{<:Number,N}) where {N}
+  RA = array(R)
+  TA = array(T)
+  @strided RA .= TA
+  return R
+end
+
+# TODO: call permutedims!(R,T,perm,(r,t)->t)?
+function permutedims!(
+  R::DenseTensor{<:Number,N}, T::DenseTensor{<:Number,N}, perm::NTuple{N,Int}
+) where {N}
+  RA = array(R)
+  TA = array(T)
+  @strided RA .= permutedims(TA, perm)
+  return R
+end
+
+function apply!(R::DenseTensor, T::DenseTensor, f::Function=(r, t) -> t)
+  RA = array(R)
+  TA = array(T)
+  @strided RA .= f.(RA, TA)
+  return R
+end
+
+# Version that may overwrite the result or promote
+# and return the result
+function permutedims!!(R::DenseTensor, T::DenseTensor, perm::Tuple, f::Function=(r, t) -> t)
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  #RA = array(R)
+  #TA = array(T)
+  RA = ReshapedArray(data(RR), dims(RR), ())
+  TA = ReshapedArray(data(T), dims(T), ())
+  if !is_trivial_permutation(perm)
+    @strided RA .= f.(RA, permutedims(TA, perm))
+  else
+    # TODO: specialize for specific functions
+    RA .= f.(RA, TA)
+  end
+  return RR
+end
+
+# TODO: move to tensor.jl?
+function permutedims(T::Tensor{<:Number,N}, perm::NTuple{N,Int}) where {N}
+  Tp = similar(T, permute(inds(T), perm))
+  Tp = permutedims!!(Tp, T, perm)
+  return Tp
+end
+
+function permutedims(::Tensor, ::Tuple{Vararg{Int}})
+  return error("Permutation size must match tensor order")
+end
+
+# TODO: move to tensor.jl?
+function (x::Number * T::Tensor)
+  return tensor(x * storage(T), inds(T))
+end
+(T::Tensor * x::Number) = x * T
+
+function permutedims!(
+  R::DenseTensor{<:Number,N}, T::DenseTensor{<:Number,N}, perm, f::Function
+) where {N}
+  if nnz(R) == 1 && nnz(T) == 1
+    R[1] = f(R[1], T[1])
+    return R
+  end
+  RA = array(R)
+  TA = array(T)
+  @strided RA .= f.(RA, permutedims(TA, perm))
+  return R
+end
+
+function outer!(
+  R::DenseTensor{ElR}, T1::DenseTensor{ElT1}, T2::DenseTensor{ElT2}
+) where {ElR,ElT1,ElT2}
+  if ElT1 != ElT2
+    # TODO: use promote instead
+    # T1,T2 = promote(T1,T2)
+
+    ElT1T2 = promote_type(ElT1, ElT2)
+    if ElT1 != ElT1T2
+      # TODO: get this working
+      # T1 = ElR.(T1)
+      T1 = one(ElT1T2) * T1
+    end
+    if ElT2 != ElT1T2
+      # TODO: get this working
+      # T2 = ElR.(T2)
+      T2 = one(ElT1T2) * T2
+    end
+  end
+
+  v1 = data(T1)
+  v2 = data(T2)
+  RM = reshape(R, length(v1), length(v2))
+  #RM .= v1 .* transpose(v2)
+  #mul!(RM, v1, transpose(v2))
+  _gemm!('N', 'T', one(ElR), v1, v2, zero(ElR), RM)
+  return R
+end
+
+export backend_auto, backend_blas, backend_generic
+
+@eval struct GemmBackend{T}
+  (f::Type{<:GemmBackend})() = $(Expr(:new, :f))
+end
+GemmBackend(s) = GemmBackend{Symbol(s)}()
+macro GemmBackend_str(s)
+  return :(GemmBackend{$(Expr(:quote, Symbol(s)))})
+end
+
+const gemm_backend = Ref(:Auto)
+function backend_auto()
+  return gemm_backend[] = :Auto
+end
+function backend_blas()
+  return gemm_backend[] = :BLAS
+end
+function backend_generic()
+  return gemm_backend[] = :Generic
+end
+
+@inline function auto_select_backend(
+  ::Type{<:StridedVecOrMat{<:BlasFloat}},
+  ::Type{<:StridedVecOrMat{<:BlasFloat}},
+  ::Type{<:StridedVecOrMat{<:BlasFloat}},
+)
+  return GemmBackend(:BLAS)
+end
+
+@inline function auto_select_backend(
+  ::Type{<:AbstractVecOrMat}, ::Type{<:AbstractVecOrMat}, ::Type{<:AbstractVecOrMat}
+)
+  return GemmBackend(:Generic)
+end
+
+function _gemm!(
+  tA, tB, alpha, A::TA, B::TB, beta, C::TC
+) where {TA<:AbstractVecOrMat,TB<:AbstractVecOrMat,TC<:AbstractVecOrMat}
+  if gemm_backend[] == :Auto
+    _gemm!(auto_select_backend(TA, TB, TC), tA, tB, alpha, A, B, beta, C)
+  else
+    _gemm!(GemmBackend(gemm_backend[]), tA, tB, alpha, A, B, beta, C)
+  end
+end
+
+# BLAS matmul
+function _gemm!(
+  ::GemmBackend{:BLAS},
+  tA,
+  tB,
+  alpha,
+  A::AbstractVecOrMat,
+  B::AbstractVecOrMat,
+  beta,
+  C::AbstractVecOrMat,
+)
+  #@timeit_debug timer "BLAS.gemm!" begin
+  return BLAS.gemm!(tA, tB, alpha, A, B, beta, C)
+  #end # @timeit
+end
+
+# generic matmul
+function _gemm!(
+  ::GemmBackend{:Generic},
+  tA,
+  tB,
+  alpha::AT,
+  A::AbstractVecOrMat,
+  B::AbstractVecOrMat,
+  beta::BT,
+  C::AbstractVecOrMat,
+) where {AT,BT}
+  mul!(C, tA == 'T' ? transpose(A) : A, tB == 'T' ? transpose(B) : B, alpha, beta)
+  return C
+end
+
+function outer!!(R::Tensor, T1::Tensor, T2::Tensor)
+  outer!(R, T1, T2)
+  return R
+end
+
+# TODO: call outer!!, make this generic
+function outer(T1::DenseTensor{ElT1}, T2::DenseTensor{ElT2}) where {ElT1,ElT2}
+  array_outer = vec(array(T1)) * transpose(vec(array(T2)))
+  inds_outer = unioninds(inds(T1), inds(T2))
+  return tensor(Dense{promote_type(ElT1, ElT2)}(vec(array_outer)), inds_outer)
+end
+const ⊗ = outer
+
+# TODO: move to tensor.jl?
+function contraction_output_type(
+  ::Type{TensorT1}, ::Type{TensorT2}, ::Type{IndsR}
+) where {TensorT1<:Tensor,TensorT2<:Tensor,IndsR}
+  return similartype(promote_type(TensorT1, TensorT2), IndsR)
+end
+
+function contraction_output(
+  ::TensorT1, ::TensorT2, indsR::IndsR
+) where {TensorT1<:DenseTensor,TensorT2<:DenseTensor,IndsR}
+  TensorR = contraction_output_type(TensorT1, TensorT2, IndsR)
+  return similar(TensorR, indsR)
+end
+
+# TODO: move to tensor.jl?
+function contraction_output(T1::Tensor, labelsT1, T2::Tensor, labelsT2, labelsR)
+  indsR = contract_inds(inds(T1), labelsT1, inds(T2), labelsT2, labelsR)
+  R = contraction_output(T1, T2, indsR)
+  return R
+end
+
+# TODO: move to tensor.jl?
+function contract(
+  T1::Tensor, labelsT1, T2::Tensor, labelsT2, labelsR=contract_labels(labelsT1, labelsT2)
+)
+  #@timeit_debug timer "dense contract" begin
+  # TODO: put the contract_inds logic into contraction_output,
+  # call like R = contraction_ouput(T1,labelsT1,T2,labelsT2)
+  #indsR = contract_inds(inds(T1),labelsT1,inds(T2),labelsT2,labelsR)
+  R = contraction_output(T1, labelsT1, T2, labelsT2, labelsR)
+  # contract!! version here since the output R may not
+  # be mutable (like UniformDiag)
+  R = contract!!(R, labelsR, T1, labelsT1, T2, labelsT2)
+  return R
+  #end @timeit
+end
+
+# Move to tensor.jl? Is this generic for all storage types?
+function contract!!(
+  R::Tensor, labelsR, T1::Tensor, labelsT1, T2::Tensor, labelsT2, α::Number=1, β::Number=0
+)
+  NR = ndims(R)
+  N1 = ndims(T1)
+  N2 = ndims(T2)
+  if (N1 ≠ 0) && (N2 ≠ 0) && (N1 + N2 == NR)
+    # Outer product
+    (α ≠ 1 || β ≠ 0) && error(
+      "contract!! not yet implemented for outer product tensor contraction with non-trivial α and β",
+    )
+    # TODO: permute T1 and T2 appropriately first (can be more efficient
+    # then permuting the result of T1⊗T2)
+    # TODO: implement the in-place version directly
+    R = outer!!(R, T1, T2)
+    labelsRp = (labelsT1..., labelsT2...)
+    perm = getperm(labelsR, labelsRp)
+    if !is_trivial_permutation(perm)
+      Rp = reshape(R, (inds(T1)..., inds(T2)...))
+      R = permutedims!!(R, copy(Rp), perm)
+    end
+  else
+    if α ≠ 1 || β ≠ 0
+      R = _contract!!(R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
+    else
+      R = _contract!!(R, labelsR, T1, labelsT1, T2, labelsT2)
+    end
+  end
+  return R
+end
+
+# Move to tensor.jl? Overload this function
+# for immutable storage types
+function _contract!!(
+  R::Tensor, labelsR, T1::Tensor, labelsT1, T2::Tensor, labelsT2, α::Number=1, β::Number=0
+)
+  if α ≠ 1 || β ≠ 0
+    contract!(R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
+  else
+    contract!(R, labelsR, T1, labelsT1, T2, labelsT2)
+  end
+  return R
+end
+
+Strided.StridedView(T::DenseTensor) = StridedView(convert(Array, T))
+
+# Both are scalar-like tensors
+function _contract_scalar!(
+  R::DenseTensor{ElR},
+  labelsR,
+  T1::Number,
+  labelsT1,
+  T2::Number,
+  labelsT2,
+  α=one(ElR),
+  β=zero(ElR),
+) where {ElR}
+  if iszero(β)
+    R[1] = α * T1 * T2
+  elseif iszero(α)
+    R[1] = β * R[1]
+  else
+    R[1] = α * T1 * T2 + β * R[1]
+  end
+  return R
+end
+
+# Trivial permutation
+# Version where R and T have different element types, so we can't call BLAS
+# Instead use Julia's broadcasting (maybe consider Strided in the future)
+function _contract_scalar_noperm!(
+  R::DenseTensor{ElR}, T::DenseTensor, α, β=zero(ElR)
+) where {ElR}
+  Rᵈ = data(R)
+  Tᵈ = data(T)
+  if iszero(β)
+    if iszero(α)
+      fill!(Rᵈ, 0)
+    else
+      Rᵈ .= α .* Tᵈ
+    end
+  elseif isone(β)
+    if iszero(α)
+      # No-op
+      # Rᵈ .= Rᵈ
+    else
+      Rᵈ .= α .* Tᵈ .+ Rᵈ
+    end
+  else
+    if iszero(α)
+      # Rᵈ .= β .* Rᵈ
+      BLAS.scal!(length(Rᵈ), β, Rᵈ, 1)
+    else
+      Rᵈ .= α .* Tᵈ .+ β .* Rᵈ
+    end
+  end
+  return R
+end
+
+# Trivial permutation
+# Version where R and T are the same element type, so we can
+# call BLAS
+function _contract_scalar_noperm!(
+  R::DenseTensor{ElR}, T::DenseTensor{ElR}, α, β=zero(ElR)
+) where {ElR}
+  Rᵈ = data(R)
+  Tᵈ = data(T)
+  if iszero(β)
+    if iszero(α)
+      fill!(Rᵈ, 0)
+    else
+      # Rᵈ .= α .* T₂ᵈ
+      BLAS.axpby!(α, Tᵈ, β, Rᵈ)
+    end
+  elseif isone(β)
+    if iszero(α)
+      # No-op
+      # Rᵈ .= Rᵈ
+    else
+      # Rᵈ .= α .* Tᵈ .+ Rᵈ
+      BLAS.axpy!(α, Tᵈ, Rᵈ)
+    end
+  else
+    if iszero(α)
+      # Rᵈ .= β .* Rᵈ
+      BLAS.scal!(length(Rᵈ), β, Rᵈ, 1)
+    else
+      # Rᵈ .= α .* Tᵈ .+ β .* Rᵈ
+      BLAS.axpby!(α, Tᵈ, β, Rᵈ)
+    end
+  end
+  return R
+end
+
+# Non-trivial permutation
+function _contract_scalar_perm!(
+  Rᵃ::AbstractArray{ElR}, Tᵃ::AbstractArray, perm, α, β=zero(ElR)
+) where {ElR}
+  if iszero(β)
+    if iszero(α)
+      fill!(Rᵃ, 0)
+    else
+      @strided Rᵃ .= α .* permutedims(Tᵃ, perm)
+    end
+  elseif isone(β)
+    if iszero(α)
+      # Rᵃ .= Rᵃ
+      # No-op
+    else
+      @strided Rᵃ .= α .* permutedims(Tᵃ, perm) .+ Rᵃ
+    end
+  else
+    if iszero(α)
+      # Rᵃ .= β .* Rᵃ
+      BLAS.scal!(length(Rᵃ), β, Rᵃ, 1)
+    else
+      Rᵃ .= α .* permutedims(Tᵃ, perm) .+ β .* Rᵃ
+    end
+  end
+  return Rᵃ
+end
+
+function drop_singletons(::Order{N}, labels, dims) where {N}
+  labelsᵣ = ntuple(zero, Val(N))
+  dimsᵣ = labelsᵣ
+  nkeep = 1
+  for n in 1:length(dims)
+    if dims[n] > 1
+      labelsᵣ = @inbounds setindex(labelsᵣ, labels[n], nkeep)
+      dimsᵣ = @inbounds setindex(dimsᵣ, dims[n], nkeep)
+      nkeep += 1
+    end
+  end
+  return labelsᵣ, dimsᵣ
+end
+
+function _contract_scalar_maybe_perm!(
+  ::Order{N}, R::DenseTensor{ElR,NR}, labelsR, T::DenseTensor, labelsT, α, β=zero(ElR)
+) where {ElR,NR,N}
+  labelsRᵣ, dimsRᵣ = drop_singletons(Order(N), labelsR, dims(R))
+  labelsTᵣ, dimsTᵣ = drop_singletons(Order(N), labelsT, dims(T))
+  perm = getperm(labelsRᵣ, labelsTᵣ)
+  if is_trivial_permutation(perm)
+    # trivial permutation
+    _contract_scalar_noperm!(R, T, α, β)
+  else
+    # non-trivial permutation
+    Rᵣ = ReshapedArray(data(R), dimsRᵣ, ())
+    Tᵣ = ReshapedArray(data(T), dimsTᵣ, ())
+    _contract_scalar_perm!(Rᵣ, Tᵣ, perm, α, β)
+  end
+  return R
+end
+
+function _contract_scalar_maybe_perm!(
+  R::DenseTensor{ElR,NR}, labelsR, T::DenseTensor, labelsT, α, β=zero(ElR)
+) where {ElR,NR}
+  N = count(≠(1), dims(R))
+  _contract_scalar_maybe_perm!(Order(N), R, labelsR, T, labelsT, α, β)
+  return R
+end
+
+# XXX: handle case of non-trivial permutation
+function _contract_scalar_maybe_perm!(
+  R::DenseTensor{ElR,NR},
+  labelsR,
+  T₁::DenseTensor,
+  labelsT₁,
+  T₂::DenseTensor,
+  labelsT₂,
+  α=one(ElR),
+  β=zero(ElR),
+) where {ElR,NR}
+  if nnz(T₁) == 1
+    _contract_scalar_maybe_perm!(R, labelsR, T₂, labelsT₂, α * T₁[1], β)
+  elseif nnz(T₂) == 1
+    _contract_scalar_maybe_perm!(R, labelsR, T₁, labelsT₁, α * T₂[1], β)
+  else
+    error("In _contract_scalar_perm!, one tensor must be a scalar")
+  end
+  return R
+end
+
+# At least one of the tensors is size 1
+function _contract_scalar!(
+  R::DenseTensor{ElR},
+  labelsR,
+  T1::DenseTensor,
+  labelsT1,
+  T2::DenseTensor,
+  labelsT2,
+  α=one(ElR),
+  β=zero(ElR),
+) where {ElR}
+  if nnz(T1) == nnz(T2) == 1
+    _contract_scalar!(R, labelsR, T1[1], labelsT1, T2[1], labelsT2, α, β)
+  else
+    _contract_scalar_maybe_perm!(R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
+  end
+  return R
+end
+
+function contract!(
+  R::DenseTensor{ElR,NR},
+  labelsR,
+  T1::DenseTensor{ElT1,N1},
+  labelsT1,
+  T2::DenseTensor{ElT2,N2},
+  labelsT2,
+  α::Elα=one(ElR),
+  β::Elβ=zero(ElR),
+) where {Elα,Elβ,ElR,ElT1,ElT2,NR,N1,N2}
+  # Special case for scalar tensors
+  if nnz(T1) == 1 || nnz(T2) == 1
+    _contract_scalar!(R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
+    return R
+  end
+
+  if using_tblis() && ElR <: LinearAlgebra.BlasReal && (ElR == ElT1 == ElT2 == Elα == Elβ)
+    #@timeit_debug timer "TBLIS contract!" begin
+    contract!(Val(:TBLIS), R, labelsR, T1, labelsT1, T2, labelsT2, α, β)
+    #end
+    return R
+  end
+
+  if N1 + N2 == NR
+    outer!(R, T1, T2)
+    labelsRp = (labelsT1..., labelsT2...)
+    perm = getperm(labelsR, labelsRp)
+    if !is_trivial_permutation(perm)
+      permutedims!(R, copy(R), perm)
+    end
+    return R
+  end
+
+  props = ContractionProperties(labelsT1, labelsT2, labelsR)
+  compute_contraction_properties!(props, T1, T2, R)
+
+  if ElT1 != ElT2
+    # TODO: use promote instead
+    # T1, T2 = promote(T1, T2)
+
+    ElT1T2 = promote_type(ElT1, ElT2)
+    if ElT1 != ElR
+      # TODO: get this working
+      # T1 = ElR.(T1)
+      T1 = one(ElT1T2) * T1
+    end
+    if ElT2 != ElR
+      # TODO: get this working
+      # T2 = ElR.(T2)
+      T2 = one(ElT1T2) * T2
+    end
+  end
+
+  _contract!(R, T1, T2, props, α, β)
+  return R
+  #end
+end
+
+function _contract!(
+  CT::DenseTensor{El,NC},
+  AT::DenseTensor{El,NA},
+  BT::DenseTensor{El,NB},
+  props::ContractionProperties,
+  α::Number=one(El),
+  β::Number=zero(El),
+) where {El,NC,NA,NB}
+  # TODO: directly use Tensor instead of Array
+  C = ReshapedArray(data(storage(CT)), dims(inds(CT)), ())
+  A = ReshapedArray(data(storage(AT)), dims(inds(AT)), ())
+  B = ReshapedArray(data(storage(BT)), dims(inds(BT)), ())
+
+  tA = 'N'
+  if props.permuteA
+    pA = NTuple{NA,Int}(props.PA)
+    #@timeit_debug timer "_contract!: permutedims A" begin
+    @strided Ap = permutedims(A, pA)
+    #end # @timeit
+    AM = ReshapedArray(Ap, (props.dmid, props.dleft), ())
+    tA = 'T'
+  else
+    #A doesn't have to be permuted
+    if Atrans(props)
+      AM = ReshapedArray(A.parent, (props.dmid, props.dleft), ())
+      tA = 'T'
+    else
+      AM = ReshapedArray(A.parent, (props.dleft, props.dmid), ())
+    end
+  end
+
+  tB = 'N'
+  if props.permuteB
+    pB = NTuple{NB,Int}(props.PB)
+    #@timeit_debug timer "_contract!: permutedims B" begin
+    @strided Bp = permutedims(B, pB)
+    #end # @timeit
+    BM = ReshapedArray(Bp, (props.dmid, props.dright), ())
+  else
+    if Btrans(props)
+      BM = ReshapedArray(B.parent, (props.dright, props.dmid), ())
+      tB = 'T'
+    else
+      BM = ReshapedArray(B.parent, (props.dmid, props.dright), ())
+    end
+  end
+
+  # TODO: this logic may be wrong
+  if props.permuteC
+    # Need to copy here since we will be permuting
+    # into C later
+    CM = ReshapedArray(copy(C), (props.dleft, props.dright), ())
+  else
+    if Ctrans(props)
+      CM = ReshapedArray(C.parent, (props.dright, props.dleft), ())
+      (AM, BM) = (BM, AM)
+      if tA == tB
+        tA = tB = (tA == 'T' ? 'N' : 'T')
+      end
+    else
+      CM = ReshapedArray(C.parent, (props.dleft, props.dright), ())
+    end
+  end
+
+  _gemm!(tA, tB, El(α), AM, BM, El(β), CM)
+
+  if props.permuteC
+    pC = NTuple{NC,Int}(props.PC)
+    Cr = ReshapedArray(CM.parent, props.newCrange, ())
+    # TODO: use invperm(pC) here?
+    #@timeit_debug timer "_contract!: permutedims C" begin
+    @strided C .= permutedims(Cr, pC)
+    #end # @timeit
+  end
+
+  return CT
+end
+
+"""
+    NDTensors.permute_reshape(T::Tensor,pos...)
+
+Takes a permutation that is split up into tuples. Index positions
+within the tuples are combined.
+
+For example:
+
+permute_reshape(T,(3,2),1)
+
+First T is permuted as `permutedims(3,2,1)`, then reshaped such
+that the original indices 3 and 2 are combined.
+"""
+function permute_reshape(
+  T::DenseTensor{ElT,NT,IndsT}, pos::Vararg{<:Any,N}
+) where {ElT,NT,IndsT,N}
+  perm = flatten(pos...)
+
+  length(perm) ≠ NT && error("Index positions must add up to order of Tensor ($N)")
+  isperm(perm) || error("Index positions must be a permutation")
+
+  dimsT = dims(T)
+  indsT = inds(T)
+  if !is_trivial_permutation(perm)
+    T = permutedims(T, perm)
+  end
+  if all(p -> length(p) == 1, pos) && N == NT
+    return T
+  end
+  newdims = MVector(ntuple(_ -> eltype(IndsT)(1), Val(N)))
+  for i in 1:N
+    if length(pos[i]) == 1
+      # No reshape needed, just use the
+      # original index
+      newdims[i] = indsT[pos[i][1]]
+    else
+      newdim_i = 1
+      for p in pos[i]
+        newdim_i *= dimsT[p]
+      end
+      newdims[i] = eltype(IndsT)(newdim_i)
+    end
+  end
+  newinds = similartype(IndsT, Val{N})(Tuple(newdims))
+  return reshape(T, newinds)
+end
+
+# svd of an order-n tensor according to positions Lpos
+# and Rpos
+function LinearAlgebra.svd(
+  T::DenseTensor{<:Number,N,IndsT}, Lpos::NTuple{NL,Int}, Rpos::NTuple{NR,Int}; kwargs...
+) where {N,IndsT,NL,NR}
+  M = permute_reshape(T, Lpos, Rpos)
+  UM, S, VM, spec = svd(M; kwargs...)
+  u = ind(UM, 2)
+  v = ind(VM, 2)
+
+  Linds = similartype(IndsT, Val{NL})(ntuple(i -> inds(T)[Lpos[i]], Val(NL)))
+  Uinds = push(Linds, u)
+
+  # TODO: do these positions need to be reversed?
+  Rinds = similartype(IndsT, Val{NR})(ntuple(i -> inds(T)[Rpos[i]], Val(NR)))
+  Vinds = push(Rinds, v)
+
+  U = reshape(UM, Uinds)
+  V = reshape(VM, Vinds)
+
+  return U, S, V, spec
+end
+
+# qr decomposition of an order-n tensor according to 
+# positions Lpos and Rpos
+function LinearAlgebra.qr(
+  T::DenseTensor{<:Number,N,IndsT}, Lpos::NTuple{NL,Int}, Rpos::NTuple{NR,Int}; kwargs...
+) where {N,IndsT,NL,NR}
+  M = permute_reshape(T, Lpos, Rpos)
+  QM, RM = qr(M; kwargs...)
+  q = ind(QM, 2)
+  r = ind(RM, 1)
+  # TODO: simplify this by permuting inds(T) by (Lpos,Rpos)
+  # then grab Linds,Rinds
+  Linds = similartype(IndsT, Val{NL})(ntuple(i -> inds(T)[Lpos[i]], Val(NL)))
+  Qinds = push(Linds, r)
+  Q = reshape(QM, Qinds)
+  Rinds = similartype(IndsT, Val{NR})(ntuple(i -> inds(T)[Rpos[i]], Val(NR)))
+  Rinds = pushfirst(Rinds, r)
+  R = reshape(RM, Rinds)
+  return Q, R
+end
+
+# polar decomposition of an order-n tensor according to positions Lpos
+# and Rpos
+function polar(
+  T::DenseTensor{<:Number,N,IndsT}, Lpos::NTuple{NL,Int}, Rpos::NTuple{NR,Int}
+) where {N,IndsT,NL,NR}
+  M = permute_reshape(T, Lpos, Rpos)
+  UM, PM = polar(M)
+
+  # TODO: turn these into functions
+  Linds = similartype(IndsT, Val{NL})(ntuple(i -> inds(T)[Lpos[i]], Val(NL)))
+  Rinds = similartype(IndsT, Val{NR})(ntuple(i -> inds(T)[Rpos[i]], Val(NR)))
+
+  # Use sim to create "similar" indices, in case
+  # the indices have identifiers. If not this should
+  # act as an identity operator
+  simRinds = sim(Rinds)
+  Uinds = (Linds..., simRinds...)
+  Pinds = (simRinds..., Rinds...)
+
+  U = reshape(UM, Uinds)
+  P = reshape(PM, Pinds)
+  return U, P
+end
+
+function LinearAlgebra.exp(
+  T::DenseTensor{ElT,N}, Lpos::NTuple{NL,Int}, Rpos::NTuple{NR,Int}; ishermitian::Bool=false
+) where {ElT,N,NL,NR}
+  M = permute_reshape(T, Lpos, Rpos)
+  indsTp = permute(inds(T), (Lpos..., Rpos...))
+  if ishermitian
+    expM = parent(exp(Hermitian(matrix(M))))
+    return tensor(Dense{ElT}(vec(expM)), indsTp)
+  else
+    expM = exp(M)
+    return reshape(expM, indsTp)
+  end
+end
+
+function HDF5.write(
+  parent::Union{HDF5.File,HDF5.Group}, name::String, D::Store
+) where {Store<:Dense}
+  g = create_group(parent, name)
+  attributes(g)["type"] = "Dense{$(eltype(Store))}"
+  attributes(g)["version"] = 1
+  if eltype(D) != Nothing
+    write(g, "data", D.data)
+  end
+end
+
+function HDF5.read(
+  parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, ::Type{Store}
+) where {Store<:Dense}
+  g = open_group(parent, name)
+  ElT = eltype(Store)
+  typestr = "Dense{$ElT}"
+  if read(attributes(g)["type"]) != typestr
+    error("HDF5 group or file does not contain $typestr data")
+  end
+  if ElT == Nothing
+    return Dense{Nothing}()
+  end
+  data = read(g, "data")
+  return Dense{ElT}(data)
+end
+
+function show(io::IO, mime::MIME"text/plain", T::DenseTensor)
+  summary(io, T)
+  return print_tensor(io, T)
+end

--- a/src/NDTensors/deprecated.jl
+++ b/src/NDTensors/deprecated.jl
@@ -1,0 +1,8 @@
+
+# NDTensors.jl
+@deprecate use_tblis() NDTensors.using_tblis()
+@deprecate enable_tblis!() NDTensors.enable_tblis()
+@deprecate disable_tblis!() NDTensors.disable_tblis()
+
+@deprecate addblock!! insertblock!!
+@deprecate addblock! insertblock!

--- a/src/NDTensors/diag.jl
+++ b/src/NDTensors/diag.jl
@@ -1,0 +1,564 @@
+
+# Diag can have either Vector storage, in which case
+# it is a general Diag tensor, or scalar storage,
+# in which case the diagonal has a uniform value
+struct Diag{ElT,VecT} <: TensorStorage{ElT}
+  data::VecT
+  function Diag{ElT,VecT}(data) where {ElT,VecT<:AbstractVector{ElT}}
+    return new{ElT,VecT}(data)
+  end
+  function Diag{ElT,ElT}(data) where {ElT}
+    return new{ElT,ElT}(data)
+  end
+end
+
+Diag(data::VecT) where {VecT<:AbstractVector{ElT}} where {ElT} = Diag{ElT,VecT}(data)
+
+Diag(data::ElT) where {ElT<:Number} = Diag{ElT,ElT}(data)
+
+function Diag{ElR}(data::AbstractVector{ElT}) where {ElR<:Number,ElT<:Number}
+  return ElT == ElR ? Diag(data) : Diag(ElR.(data))
+end
+
+Diag(::Type{ElT}, n::Integer) where {ElT<:Number} = Diag(zeros(ElT, n))
+
+Diag(x::ElT, n::Integer) where {ElT<:Number} = Diag(fill(x, n))
+
+copy(D::Diag) = Diag(copy(data(D)))
+
+const NonuniformDiag{ElT,VecT} = Diag{ElT,VecT} where {VecT<:AbstractVector}
+
+const UniformDiag{ElT,VecT} = Diag{ElT,VecT} where {VecT<:Number}
+
+getindex(D::UniformDiag, i::Int) = data(D)
+
+function setindex!(D::UniformDiag, val, i::Int)
+  return error("Cannot set elements of a uniform Diag storage")
+end
+
+Base.real(::Type{Diag{ElT,Vector{ElT}}}) where {ElT} = Diag{real(ElT),Vector{real(ElT)}}
+Base.real(::Type{Diag{ElT,ElT}}) where {ElT} = Diag{real(ElT),real(ElT)}
+
+complex(::Type{Diag{ElT,Vector{ElT}}}) where {ElT} = Diag{complex(ElT),Vector{complex(ElT)}}
+complex(::Type{Diag{ElT,ElT}}) where {ElT} = Diag{complex(ElT),complex(ElT)}
+
+# Deal with uniform Diag conversion
+convert(::Type{<:Diag{ElT,VecT}}, D::Diag) where {ElT,VecT} = Diag(convert(VecT, data(D)))
+
+# TODO: write in terms of ::Int, not inds
+similar(D::NonuniformDiag) = Diag(similar(data(D)))
+#similar(D::NonuniformDiag,inds) = Diag(similar(data(D),minimum(dims(inds))))
+#function similar(D::Type{<:NonuniformDiag{ElT,VecT}},inds) where {ElT,VecT}
+#  return Diag(similar(VecT,diaglength(inds)))
+#end
+
+similar(D::UniformDiag{ElT}) where {ElT} = Diag(zero(ElT))
+similar(D::UniformDiag, inds) = similar(D)
+similar(::Type{<:UniformDiag{ElT}}, inds) where {ElT} = Diag(zero(ElT))
+
+similar(D::Diag, n::Int) = Diag(similar(data(D), n))
+
+similar(D::Diag, ::Type{ElR}, n::Int) where {ElR} = Diag(similar(data(D), ElR, n))
+
+# TODO: make this work for other storage besides Vector
+zeros(::Type{<:NonuniformDiag{ElT}}, dim::Int64) where {ElT} = Diag(zeros(ElT, dim))
+zeros(::Type{<:UniformDiag{ElT}}, dim::Int64) where {ElT} = Diag(zero(ElT))
+
+setdata(D::Diag, ndata) = Diag(ndata)
+
+#
+# Type promotions involving Diag
+# Useful for knowing how conversions should work when adding and contracting
+#
+
+function promote_rule(
+  ::Type{<:UniformDiag{ElT1}}, ::Type{<:UniformDiag{ElT2}}
+) where {ElT1,ElT2}
+  ElR = promote_type(ElT1, ElT2)
+  return Diag{ElR,ElR}
+end
+
+function promote_rule(
+  ::Type{<:NonuniformDiag{ElT1,VecT1}}, ::Type{<:NonuniformDiag{ElT2,VecT2}}
+) where {ElT1,VecT1<:AbstractVector,ElT2,VecT2<:AbstractVector}
+  ElR = promote_type(ElT1, ElT2)
+  VecR = promote_type(VecT1, VecT2)
+  return Diag{ElR,VecR}
+end
+
+# This is an internal definition, is there a more general way?
+#promote_type(::Type{Vector{ElT1}},
+#                  ::Type{ElT2}) where {ElT1<:Number,
+#                                       ElT2<:Number} = Vector{promote_type(ElT1,ElT2)}
+#
+#promote_type(::Type{ElT1},
+#                  ::Type{Vector{ElT2}}) where {ElT1<:Number,
+#                                               ElT2<:Number} = promote_type(Vector{ElT2},ElT1)
+
+# TODO: how do we make this work more generally for T2<:AbstractVector{S2}?
+# Make a similartype(AbstractVector{S2},T1) -> AbstractVector{T1} function?
+function promote_rule(
+  ::Type{<:UniformDiag{ElT1,VecT1}}, ::Type{<:NonuniformDiag{ElT2,Vector{ElT2}}}
+) where {ElT1,VecT1<:Number,ElT2}
+  ElR = promote_type(ElT1, ElT2)
+  VecR = Vector{ElR}
+  return Diag{ElR,VecR}
+end
+
+function promote_rule(
+  ::Type{DenseT1}, ::Type{<:NonuniformDiag{ElT2,VecT2}}
+) where {DenseT1<:Dense,ElT2,VecT2<:AbstractVector}
+  return promote_type(DenseT1, Dense{ElT2,VecT2})
+end
+
+function promote_rule(
+  ::Type{DenseT1}, ::Type{<:UniformDiag{ElT2,VecT2}}
+) where {DenseT1<:Dense,ElT2,VecT2<:Number}
+  return promote_type(DenseT1, ElT2)
+end
+
+# Convert a Diag storage type to the closest Dense storage type
+dense(::Type{<:NonuniformDiag{ElT,VecT}}) where {ElT,VecT} = Dense{ElT,VecT}
+dense(::Type{<:UniformDiag{ElT}}) where {ElT} = Dense{ElT,Vector{ElT}}
+
+const DiagTensor{ElT,N,StoreT,IndsT} = Tensor{ElT,N,StoreT,IndsT} where {StoreT<:Diag}
+const NonuniformDiagTensor{ElT,N,StoreT,IndsT} =
+  Tensor{ElT,N,StoreT,IndsT} where {StoreT<:NonuniformDiag}
+const UniformDiagTensor{ElT,N,StoreT,IndsT} =
+  Tensor{ElT,N,StoreT,IndsT} where {StoreT<:UniformDiag}
+
+IndexStyle(::Type{<:DiagTensor}) = IndexCartesian()
+
+# TODO: this needs to be better (promote element type, check order compatibility,
+# etc.
+function convert(::Type{<:DenseTensor{ElT,N}}, T::DiagTensor{ElT,N}) where {ElT<:Number,N}
+  return dense(T)
+end
+
+convert(::Type{Diagonal}, D::DiagTensor{<:Number,2}) = Diagonal(data(D))
+
+# These are rules for determining the output of a pairwise contraction of NDTensors
+# (given the indices of the output tensors)
+function contraction_output_type(
+  TensorT1::Type{<:DiagTensor}, TensorT2::Type{<:DenseTensor}, IndsR::Type
+)
+  return similartype(promote_type(TensorT1, TensorT2), IndsR)
+end
+function contraction_output_type(
+  TensorT1::Type{<:DenseTensor}, TensorT2::Type{<:DiagTensor}, IndsR::Type
+)
+  return contraction_output_type(TensorT2, TensorT1, IndsR)
+end
+
+# This performs the logic that DiagTensor*DiagTensor -> DiagTensor if it is not an outer
+# product but -> DenseTensor if it is
+# TODO: if the tensors are both order 2 (or less), or if there is an Index replacement,
+# then they remain diagonal. Should we limit DiagTensor*DiagTensor to cases that
+# result in a DiagTensor, for efficiency and type stability? What about a general
+# SparseTensor result?
+function contraction_output_type(
+  TensorT1::Type{<:DiagTensor{<:Number,N1}},
+  TensorT2::Type{<:DiagTensor{<:Number,N2}},
+  IndsR::Type,
+) where {N1,N2}
+  if ValLength(IndsR) === Val{N1 + N2}
+    # Turn into is_outer(inds1,inds2,indsR) function?
+    # How does type inference work with arithmatic of compile time values?
+    return similartype(dense(promote_type(TensorT1, TensorT2)), IndsR)
+  end
+  return similartype(promote_type(TensorT1, TensorT2), IndsR)
+end
+
+# The output must be initialized as zero since it is sparse, cannot be undefined
+function contraction_output(T1::DiagTensor, T2::Tensor, indsR)
+  return zero_contraction_output(T1, T2, indsR)
+end
+contraction_output(T1::Tensor, T2::DiagTensor, indsR) = contraction_output(T2, T1, indsR)
+
+function contraction_output(T1::DiagTensor, T2::DiagTensor, indsR)
+  return zero_contraction_output(T1, T2, indsR)
+end
+
+function array(T::DiagTensor{ElT,N}) where {ElT,N}
+  return array(dense(T))
+end
+matrix(T::DiagTensor{<:Number,2}) = array(T)
+vector(T::DiagTensor{<:Number,1}) = array(T)
+
+function Array{ElT,N}(T::DiagTensor{ElT,N}) where {ElT,N}
+  return array(T)
+end
+
+function Array(T::DiagTensor{ElT,N}) where {ElT,N}
+  return Array{ElT,N}(T)
+end
+
+function zeros(TensorT::Type{<:DiagTensor}, inds)
+  return tensor(zeros(storagetype(TensorT), mindim(inds)), inds)
+end
+
+function zeros(TensorT::Type{<:DiagTensor}, inds::Tuple{})
+  return tensor(zeros(storagetype(TensorT), mindim(inds)), inds)
+end
+
+# Needed to get slice of DiagTensor like T[1:3,1:3]
+function similar(
+  T::DiagTensor{<:Number,N}, ::Type{ElR}, inds::Dims{N}
+) where {ElR<:Number,N}
+  return tensor(similar(storage(T), ElR, minimum(inds)), inds)
+end
+
+"""
+getdiagindex(T::DiagTensor,i::Int)
+
+Get the ith value along the diagonal of the tensor.
+"""
+getdiagindex(T::DiagTensor{<:Number}, ind::Int) = storage(T)[ind]
+
+"""
+setdiagindex!(T::DiagTensor,i::Int)
+
+Set the ith value along the diagonal of the tensor.
+"""
+setdiagindex!(T::DiagTensor{<:Number}, val, ind::Int) = (storage(T)[ind] = val)
+
+"""
+setdiag(T::UniformDiagTensor,val)
+
+Set the entire diagonal of a uniform DiagTensor.
+"""
+setdiag(T::UniformDiagTensor, val) = tensor(Diag(val), inds(T))
+
+@propagate_inbounds function getindex(
+  T::DiagTensor{ElT,N}, inds::Vararg{Int,N}
+) where {ElT,N}
+  if all(==(inds[1]), inds)
+    return getdiagindex(T, inds[1])
+  else
+    return zero(eltype(ElT))
+  end
+end
+@propagate_inbounds getindex(T::DiagTensor{<:Number,1}, ind::Int) = storage(T)[ind]
+@propagate_inbounds getindex(T::DiagTensor{<:Number,0}) = storage(T)[1]
+
+# Set diagonal elements
+# Throw error for off-diagonal
+@propagate_inbounds function setindex!(
+  T::DiagTensor{<:Number,N}, val, inds::Vararg{Int,N}
+) where {N}
+  all(==(inds[1]), inds) || error("Cannot set off-diagonal element of Diag storage")
+  setdiagindex!(T, val, inds[1])
+  return T
+end
+@propagate_inbounds function setindex!(T::DiagTensor{<:Number,1}, val, ind::Int)
+  return (storage(T)[ind] = val)
+end
+@propagate_inbounds setindex!(T::DiagTensor{<:Number,0}, val) = (storage(T)[1] = val)
+
+function setindex!(T::UniformDiagTensor{<:Number,N}, val, inds::Vararg{Int,N}) where {N}
+  return error("Cannot set elements of a uniform Diag storage")
+end
+
+# TODO: make a fill!! that works for uniform and non-uniform
+#fill!(T::DiagTensor,v) = fill!(storage(T),v)
+
+function dense(::Type{<:Tensor{ElT,N,StoreT,IndsT}}) where {ElT,N,StoreT<:Diag,IndsT}
+  return Tensor{ElT,N,dense(StoreT),IndsT}
+end
+
+# convert to Dense
+function dense(T::TensorT) where {TensorT<:DiagTensor}
+  R = zeros(dense(TensorT), inds(T))
+  for i in 1:diaglength(T)
+    setdiagindex!(R, getdiagindex(T, i), i)
+  end
+  return R
+end
+
+function outer!(
+  R::DenseTensor{<:Number,NR}, T1::DiagTensor{<:Number,N1}, T2::DiagTensor{<:Number,N2}
+) where {NR,N1,N2}
+  for i1 in 1:diaglength(T1), i2 in 1:diaglength(T2)
+    indsR = CartesianIndex{NR}(ntuple(r -> r ≤ N1 ? i1 : i2, Val(NR)))
+    R[indsR] = getdiagindex(T1, i1) * getdiagindex(T2, i2)
+  end
+  return R
+end
+
+# TODO: write an optimized version of this?
+function outer!(R::DenseTensor{ElR}, T1::DenseTensor, T2::DiagTensor) where {ElR}
+  R .= zero(ElR)
+  outer!(R, T1, dense(T2))
+  return R
+end
+
+function outer!(R::DenseTensor{ElR}, T1::DiagTensor, T2::DenseTensor) where {ElR}
+  R .= zero(ElR)
+  outer!(R, dense(T1), T2)
+  return R
+end
+
+# Right an in-place version
+function outer(T1::DiagTensor{ElT1,N1}, T2::DiagTensor{ElT2,N2}) where {ElT1,ElT2,N1,N2}
+  indsR = unioninds(inds(T1), inds(T2))
+  R = tensor(Dense(zeros(promote_type(ElT1, ElT2), dim(indsR))), indsR)
+  outer!(R, T1, T2)
+  return R
+end
+
+function permutedims!(
+  R::DiagTensor{<:Number,N},
+  T::DiagTensor{<:Number,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {N}
+  # TODO: check that inds(R)==permute(inds(T),perm)?
+  for i in 1:diaglength(R)
+    @inbounds setdiagindex!(R, f(getdiagindex(R, i), getdiagindex(T, i)), i)
+  end
+  return R
+end
+
+function permutedims(
+  T::DiagTensor{<:Number,N}, perm::NTuple{N,Int}, f::Function=identity
+) where {N}
+  R = similar(T, permute(inds(T), perm))
+  g(r, t) = f(t)
+  permutedims!(R, T, perm, g)
+  return R
+end
+
+function permutedims(
+  T::UniformDiagTensor{<:Number,N}, perm::NTuple{N,Int}, f::Function=identity
+) where {N}
+  R = tensor(Diag(f(getdiagindex(T, 1))), permute(inds(T), perm))
+  return R
+end
+
+# Version that may overwrite in-place or may return the result
+function permutedims!!(
+  R::NonuniformDiagTensor{<:Number,N},
+  T::NonuniformDiagTensor{<:Number,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {N}
+  R = convert(promote_type(typeof(R), typeof(T)), R)
+  permutedims!(R, T, perm, f)
+  return R
+end
+
+function permutedims!!(
+  R::UniformDiagTensor{ElR,N},
+  T::UniformDiagTensor{ElT,N},
+  perm::NTuple{N,Int},
+  f::Function=(r, t) -> t,
+) where {ElR,ElT,N}
+  R = convert(promote_type(typeof(R), typeof(T)), R)
+  R = tensor(Diag(f(getdiagindex(R, 1), getdiagindex(T, 1))), inds(R))
+  return R
+end
+
+function permutedims!(
+  R::DenseTensor{ElR,N}, T::DiagTensor{ElT,N}, perm::NTuple{N,Int}, f::Function=(r, t) -> t
+) where {ElR,ElT,N}
+  for i in 1:diaglength(T)
+    @inbounds setdiagindex!(R, f(getdiagindex(R, i), getdiagindex(T, i)), i)
+  end
+  return R
+end
+
+function permutedims!!(
+  R::DenseTensor{ElR,N}, T::DiagTensor{ElT,N}, perm::NTuple{N,Int}, f::Function=(r, t) -> t
+) where {ElR,ElT,N}
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  permutedims!(RR, T, perm, f)
+  return RR
+end
+
+# TODO: make a single implementation since this is
+# the same as the version with the input types
+# swapped.
+function permutedims!!(
+  R::DiagTensor{ElR,N}, T::DenseTensor{ElT,N}, perm::NTuple{N,Int}, f::Function=(r, t) -> t
+) where {ElR,ElT,N}
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  permutedims!(RR, T, perm, f)
+  return RR
+end
+
+function _contract!!(
+  R::UniformDiagTensor{ElR,NR},
+  labelsR,
+  T1::UniformDiagTensor{<:Number,N1},
+  labelsT1,
+  T2::UniformDiagTensor{<:Number,N2},
+  labelsT2,
+) where {ElR,NR,N1,N2}
+  if NR == 0  # If all indices of A and B are contracted
+    # all indices are summed over, just add the product of the diagonal
+    # elements of A and B
+    R = setdiag(R, diaglength(T1) * getdiagindex(T1, 1) * getdiagindex(T2, 1))
+  else
+    # not all indices are summed over, set the diagonals of the result
+    # to the product of the diagonals of A and B
+    R = setdiag(R, getdiagindex(T1, 1) * getdiagindex(T2, 1))
+  end
+  return R
+end
+
+function contract!(
+  R::DiagTensor{ElR,NR},
+  labelsR,
+  T1::DiagTensor{<:Number,N1},
+  labelsT1,
+  T2::DiagTensor{<:Number,N2},
+  labelsT2,
+) where {ElR,NR,N1,N2}
+  if NR == 0  # If all indices of A and B are contracted
+    # all indices are summed over, just add the product of the diagonal
+    # elements of A and B
+    Rdiag = zero(ElR)
+    for i in 1:diaglength(T1)
+      Rdiag += getdiagindex(T1, i) * getdiagindex(T2, i)
+    end
+    setdiagindex!(R, Rdiag, 1)
+  else
+    min_dim = min(diaglength(T1), diaglength(T2))
+    # not all indices are summed over, set the diagonals of the result
+    # to the product of the diagonals of A and B
+    for i in 1:min_dim
+      setdiagindex!(R, getdiagindex(T1, i) * getdiagindex(T2, i), i)
+    end
+  end
+  return R
+end
+
+function contract!(
+  C::DenseTensor{ElC,NC},
+  Clabels,
+  A::DiagTensor{ElA,NA},
+  Alabels,
+  B::DenseTensor{ElB,NB},
+  Blabels,
+  α::Number=one(ElC),
+  β::Number=zero(ElC);
+  convert_to_dense::Bool=true,
+) where {ElA,NA,ElB,NB,ElC,NC}
+  #@timeit_debug timer "diag-dense contract!" begin 
+  if all(i -> i < 0, Blabels)
+    # If all of B is contracted
+    # TODO: can also check NC+NB==NA
+    min_dim = minimum(dims(B))
+    if length(Clabels) == 0
+      # all indices are summed over, just add the product of the diagonal
+      # elements of A and B
+      # Assumes C starts set to 0
+      c₁ = zero(ElC)
+      for i in 1:min_dim
+        c₁ += getdiagindex(A, i) * getdiagindex(B, i)
+      end
+      setdiagindex!(C, α * c₁ + β * getdiagindex(C, 1), 1)
+    else
+      # not all indices are summed over, set the diagonals of the result
+      # to the product of the diagonals of A and B
+      # TODO: should we make this return a Diag storage?
+      for i in 1:min_dim
+        setdiagindex!(
+          C, α * getdiagindex(A, i) * getdiagindex(B, i) + β * getdiagindex(C, i), i
+        )
+      end
+    end
+  else
+    # Most general contraction
+    if convert_to_dense
+      contract!(C, Clabels, dense(A), Alabels, B, Blabels, α, β)
+    else
+      if !isone(α) || !iszero(β)
+        error(
+          "`contract!(::DenseTensor, ::DiagTensor, ::DenseTensor, α, β; convert_to_dense = false)` with `α ≠ 1` or `β ≠ 0` is not currently supported. You can call it with `convert_to_dense = true` instead.",
+        )
+      end
+      astarts = zeros(Int, length(Alabels))
+      bstart = 0
+      cstart = 0
+      b_cstride = 0
+      nbu = 0
+      for ib in 1:length(Blabels)
+        ia = findfirst(==(Blabels[ib]), Alabels)
+        if !isnothing(ia)
+          b_cstride += stride(B, ib)
+          bstart += astarts[ia] * stride(B, ib)
+        else
+          nbu += 1
+        end
+      end
+
+      c_cstride = 0
+      for ic in 1:length(Clabels)
+        ia = findfirst(==(Clabels[ic]), Alabels)
+        if !isnothing(ia)
+          c_cstride += stride(C, ic)
+          cstart += astarts[ia] * stride(C, ic)
+        end
+      end
+
+      # strides of the uncontracted dimensions of
+      # B
+      bustride = zeros(Int, nbu)
+      custride = zeros(Int, nbu)
+      # size of the uncontracted dimensions of
+      # B, to be used in CartesianIndices
+      busize = zeros(Int, nbu)
+      n = 1
+      for ib in 1:length(Blabels)
+        if Blabels[ib] > 0
+          bustride[n] = stride(B, ib)
+          busize[n] = size(B, ib)
+          ic = findfirst(==(Blabels[ib]), Clabels)
+          custride[n] = stride(C, ic)
+          n += 1
+        end
+      end
+
+      boffset_orig = 1 - sum(strides(B))
+      coffset_orig = 1 - sum(strides(C))
+      cartesian_inds = CartesianIndices(Tuple(busize))
+      for inds in cartesian_inds
+        boffset = boffset_orig
+        coffset = coffset_orig
+        for i in 1:nbu
+          ii = inds[i]
+          boffset += ii * bustride[i]
+          coffset += ii * custride[i]
+        end
+        c = zero(ElC)
+        for j in 1:diaglength(A)
+          # With α == 0 && β == 1
+          C[cstart + j * c_cstride + coffset] +=
+            getdiagindex(A, j) * B[bstart + j * b_cstride + boffset]
+          # XXX: not sure if this is correct
+          #C[cstart+j*c_cstride+coffset] += α * getdiagindex(A, j)* B[bstart+j*b_cstride+boffset] + β * C[cstart+j*c_cstride+coffset]
+        end
+      end
+    end
+  end
+  #end # @timeit
+end
+
+function contract!(
+  C::DenseTensor,
+  Clabels,
+  A::DenseTensor,
+  Alabels,
+  B::DiagTensor,
+  Blabels,
+  α::Number=one(eltype(C)),
+  β::Number=zero(eltype(C)),
+)
+  return contract!(C, Clabels, B, Blabels, A, Alabels, α, β)
+end
+
+function show(io::IO, mime::MIME"text/plain", T::DiagTensor)
+  summary(io, T)
+  return print_tensor(io, T)
+end

--- a/src/NDTensors/dims.jl
+++ b/src/NDTensors/dims.jl
@@ -1,0 +1,88 @@
+export dense, dims, dim, mindim, diaglength
+
+# dim and dims are used in the Tensor interface, overload 
+# base Dims here
+dims(ds::Dims) = ds
+
+# Generic dims function
+dims(inds::Tuple) = ntuple(i -> dim(@inbounds inds[i]), Val(length(inds)))
+
+# Generic dim function
+dim(inds::Tuple) = prod(dims(inds))
+
+dims(::Tuple{}) = ()
+
+dim(::Tuple{}) = 1
+
+dense(ds::Dims) = ds
+
+dense(::Type{DimsT}) where {DimsT<:Dims} = DimsT
+
+dim(ds::Dims) = prod(ds)
+
+dim(ds::Dims, i::Int) = dims(ds)[i]
+
+mindim(inds::Tuple) = minimum(dims(inds))
+
+mindim(::Tuple{}) = 1
+
+diaglength(inds::Tuple) = mindim(inds)
+
+"""
+    dim_to_strides(ds)
+
+Get the strides from the dimensions.
+
+This is unexported, call with NDTensors.dim_to_strides.
+"""
+dim_to_strides(ds) = Base.size_to_strides(1, dims(ds)...)
+
+"""
+    dim_to_stride(ds, k::Int)
+
+Get the stride of the dimension k from the dimensions.
+
+This is unexported, call with NDTensors.stride.
+"""
+dim_to_stride(ds, k::Int) = dim_to_strides(ds)[k]
+
+# This is to help with some generic programming in the Tensor
+# code (it helps to construct a Tuple(::NTuple{N,Int}) where the 
+# only known thing for dispatch is a concrete type such
+# as Dims{4})
+similartype(::Type{<:Dims}, ::Type{Val{N}}) where {N} = Dims{N}
+
+# This is to help with ITensor compatibility
+dim(i::Int) = i
+
+# This is to help with ITensor compatibility
+dir(::Int) = 0
+
+# This is to help with ITensor compatibility
+dag(i::Int) = i
+
+# This is to help with ITensor compatibility
+sim(i::Int) = i
+
+#
+# Order value type
+#
+
+# More complicated definition makes Order(Ref(2)[]) faster
+@eval struct Order{N}
+  (OrderT::Type{<:Order})() = $(Expr(:new, :OrderT))
+end
+
+@doc """
+    Order{N}
+
+A value type representing the order of an ITensor.
+""" Order
+
+"""
+    Order(N) = Order{N}()
+
+Create an instance of the value type Order representing
+the order of an ITensor.
+"""
+Order(N) = Order{N}()

--- a/src/NDTensors/empty.jl
+++ b/src/NDTensors/empty.jl
@@ -1,0 +1,319 @@
+
+#
+# Represents a tensor order that could be set to any order.
+#
+
+struct EmptyOrder end
+
+#
+# Represents a number that can be set to any type.
+#
+
+struct EmptyNumber <: Number end
+
+# This is a backup definition to make:
+# A = ITensor(i, j)
+# complex!(A)
+# work. It acts as if the "default" type is `Float64`
+complex(::Type{EmptyNumber}) = ComplexF64
+
+function similartype(::Type{StoreT}, ::Type{ElT}) where {StoreT<:Dense{EmptyNumber},ElT}
+  return Dense{ElT,similartype(datatype(StoreT), ElT)}
+end
+
+function similartype(
+  ::Type{StoreT}, ::Type{ElT}
+) where {StoreT<:BlockSparse{EmptyNumber},ElT}
+  return BlockSparse{ElT,similartype(datatype(StoreT), ElT),ndims(StoreT)}
+end
+
+#
+# Empty storage
+#
+
+struct EmptyStorage{ElT,StoreT<:TensorStorage} <: TensorStorage{ElT} end
+
+# Get the EmptyStorage version of the TensorStorage
+function emptytype(::Type{StoreT}) where {StoreT}
+  return EmptyStorage{eltype(StoreT),StoreT}
+end
+
+empty(::Type{StoreT}) where {StoreT} = emptytype(StoreT)()
+
+# Defaults to Dense
+function EmptyStorage(::Type{ElT}) where {ElT}
+  return emptytype(Dense{ElT,Vector{ElT}})()
+end
+
+EmptyStorage() = EmptyStorage(Float64)
+
+similar(S::EmptyStorage) = S
+similar(S::EmptyStorage, ::Type{ElT}) where {ElT} = empty(similartype(fulltype(S), ElT))
+
+copy(S::EmptyStorage) = S
+
+isempty(::EmptyStorage) = true
+
+nnzblocks(::EmptyStorage) = 0
+
+nnz(::EmptyStorage) = 0
+
+function Base.real(::Type{<:EmptyStorage{ElT,StoreT}}) where {ElT,StoreT}
+  return EmptyStorage{real(ElT),real(StoreT)}
+end
+
+Base.real(S::EmptyStorage) = real(typeof(S))()
+
+function complex(::Type{<:EmptyStorage{ElT,StoreT}}) where {ElT,StoreT}
+  return EmptyStorage{complex(ElT),complex(StoreT)}
+end
+
+complex(S::EmptyStorage) = complex(typeof(S))()
+
+#size(::EmptyStorage) = 0
+
+function show(io::IO, mime::MIME"text/plain", S::EmptyStorage)
+  return println(io, typeof(S))
+end
+
+#
+# EmptyTensor (Tensor using EmptyStorage storage)
+#
+
+const EmptyTensor{ElT,N,StoreT,IndsT} =
+  Tensor{ElT,N,StoreT,IndsT} where {StoreT<:EmptyStorage}
+
+function emptytype(::Type{TensorT}) where {TensorT<:Tensor}
+  return Tensor{
+    eltype(TensorT),ndims(TensorT),emptytype(storagetype(TensorT)),indstype(TensorT)
+  }
+end
+
+# XXX TODO: add bounds checking
+getindex(T::EmptyTensor, I::Integer...) = zero(eltype(T))
+getindex(T::EmptyTensor{EmptyNumber}, I::Integer...) = zero(Float64)
+
+similar(T::EmptyTensor, inds::Tuple) = setinds(T, inds)
+function similar(T::EmptyTensor, ::Type{ElT}) where {ElT<:Number}
+  return tensor(similar(storage(T), ElT), inds(T))
+end
+
+function randn!!(T::EmptyTensor)
+  Tf = similar(fulltype(T), inds(T))
+  randn!(Tf)
+  return Tf
+end
+
+# Default to Float64
+function randn!!(T::EmptyTensor{EmptyNumber})
+  return randn!!(similar(T, Float64))
+end
+
+function _fill!!(::Type{ElT}, T::EmptyTensor, α::Number) where {ElT}
+  Tf = similar(fulltype(T), ElT, inds(T))
+  fill!(Tf, α)
+  return Tf
+end
+
+fill!!(T::EmptyTensor, α::Number) = _fill!!(eltype(T), T, α)
+
+# Determine the element type from the number you are filling with
+fill!!(T::EmptyTensor{EmptyNumber}, α::Number) = _fill!!(eltype(α), T, α)
+
+isempty(::EmptyTensor) = true
+
+function EmptyTensor(::Type{ElT}, inds) where {ElT<:Number}
+  return tensor(EmptyStorage(ElT), inds)
+end
+
+function EmptyTensor(::Type{StoreT}, inds) where {StoreT<:TensorStorage}
+  return tensor(empty(StoreT), inds)
+end
+
+function EmptyBlockSparseTensor(::Type{ElT}, inds) where {ElT<:Number}
+  StoreT = BlockSparse{ElT,Vector{ElT},length(inds)}
+  return EmptyTensor(StoreT, inds)
+end
+
+fulltype(::Type{EmptyStorage{ElT,StoreT}}) where {ElT,StoreT} = StoreT
+fulltype(T::EmptyStorage) = fulltype(typeof(T))
+
+fulltype(T::Tensor) = fulltype(typeof(T))
+
+# From an EmptyTensor, return the closest Tensor type
+function fulltype(::Type{TensorT}) where {TensorT<:Tensor}
+  return Tensor{
+    eltype(TensorT),ndims(TensorT),fulltype(storetype(TensorT)),indstype(TensorT)
+  }
+end
+
+function fulltype(
+  ::Type{ElR}, ::Type{<:Tensor{ElT,N,EStoreT,IndsT}}
+) where {ElR,ElT<:Number,N,EStoreT<:EmptyStorage{ElT,StoreT},IndsT} where {StoreT}
+  return Tensor{ElR,N,similartype(StoreT, ElR),IndsT}
+end
+
+function zeros(T::TensorT) where {TensorT<:EmptyTensor}
+  TensorR = fulltype(TensorT)
+  return zeros(TensorR, inds(T))
+end
+
+function zeros(::Type{ElT}, T::TensorT) where {ElT,TensorT<:EmptyTensor}
+  TensorR = fulltype(ElT, TensorT)
+  return zeros(TensorR, inds(T))
+end
+
+function insertblock(T::EmptyTensor{<:Number,N}, block) where {N}
+  R = zeros(T)
+  insertblock!(R, Block(block))
+  return R
+end
+
+insertblock!!(T::EmptyTensor{<:Number,N}, block) where {N} = insertblock(T, block)
+
+# Special case with element type of EmptyNumber: storage takes the type
+# of the input
+@propagate_inbounds function _setindex(T::EmptyTensor{EmptyNumber}, x, I...)
+  R = zeros(typeof(x), T)
+  R[I...] = x
+  return R
+end
+
+@propagate_inbounds function _setindex(T::EmptyTensor, x, I...)
+  R = zeros(T)
+  R[I...] = x
+  return R
+end
+
+@propagate_inbounds function setindex(T::EmptyTensor, x, I...)
+  return _setindex(T, x, I...)
+end
+
+# This is needed to fix an ambiguity error with ArrayInterface.jl
+# https://github.com/ITensor/NDTensors.jl/issues/62
+@propagate_inbounds function setindex(T::EmptyTensor, x, I::Int...)
+  return _setindex(T, x, I...)
+end
+
+setindex!!(T::EmptyTensor, x, I...) = setindex(T, x, I...)
+
+# Version of contraction where output storage is empty
+function contract!!(R::EmptyTensor, labelsR, T1::Tensor, labelsT1, T2::Tensor, labelsT2)
+  RR = contract(T1, labelsT1, T2, labelsT2, labelsR)
+  return RR
+end
+
+# When one of the tensors is empty, return an empty
+# tensor.
+# XXX: make sure `R` is actually correct!
+function contract!!(
+  R::EmptyTensor, labelsR, T1::EmptyTensor, labelsT1, T2::Tensor, labelsT2
+)
+  return R
+end
+
+# When one of the tensors is empty, return an empty
+# tensor.
+# XXX: make sure `R` is actually correct!
+function contract!!(
+  R::EmptyTensor, labelsR, T1::Tensor, labelsT1, T2::EmptyTensor, labelsT2
+)
+  return R
+end
+
+function contract!!(
+  R::EmptyTensor, labelsR, T1::EmptyTensor, labelsT1, T2::EmptyTensor, labelsT2
+)
+  return R
+end
+
+# For ambiguity with versions in combiner.jl
+function contract!!(
+  R::EmptyTensor, labelsR, T1::CombinerTensor, labelsT1, T2::Tensor, labelsT2
+)
+  RR = contract(T1, labelsT1, T2, labelsT2, labelsR)
+  return RR
+end
+
+# For ambiguity with versions in combiner.jl
+function contract!!(
+  R::EmptyTensor, labelsR, T1::Tensor, labelsT1, T2::CombinerTensor, labelsT2
+)
+  RR = contract(T1, labelsT1, T2, labelsT2, labelsR)
+  return RR
+end
+
+promote_rule(::Type{EmptyNumber}, ::Type{T}) where {T<:Number} = T
+
+function promote_rule(
+  ::Type{T1}, ::Type{T2}
+) where {T1<:EmptyStorage{EmptyNumber},T2<:TensorStorage}
+  return T2
+end
+function promote_rule(::Type{T1}, ::Type{T2}) where {T1<:EmptyStorage,T2<:TensorStorage}
+  return promote_type(similartype(T2, eltype(T1)), T2)
+end
+
+function contraction_output(T1::EmptyTensor, T2::EmptyTensor, is)
+  fulltypeR = contraction_output_type(fulltype(T1), fulltype(T2), typeof(is))
+  storagetypeR = storagetype(fulltypeR)
+  emptystoragetypeR = emptytype(storagetypeR)
+  return Tensor(emptystoragetypeR(), is)
+end
+
+function contraction_output(T1::Tensor, T2::EmptyTensor, is)
+  fulltypeR = contraction_output_type(typeof(T1), fulltype(T2), typeof(is))
+  storagetypeR = storagetype(fulltypeR)
+  emptystoragetypeR = emptytype(storagetypeR)
+  return Tensor(emptystoragetypeR(), is)
+end
+
+function contraction_output(T1::EmptyTensor, T2::Tensor, is)
+  fulltypeR = contraction_output_type(fulltype(T1), typeof(T2), typeof(is))
+  storagetypeR = storagetype(fulltypeR)
+  emptystoragetypeR = emptytype(storagetypeR)
+  return Tensor(emptystoragetypeR(), is)
+end
+
+function permutedims!!(R::Tensor, T::EmptyTensor, perm::Tuple, f::Function=(r, t) -> t)
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  RR = permutedims!!(RR, RR, ntuple(identity, Val(ndims(R))), (r, t) -> f(r, false))
+  return RR
+end
+
+function permutedims!!(R::EmptyTensor, T::Tensor, perm::Tuple, f::Function=(r, t) -> t)
+  RR = similar(promote_type(typeof(R), typeof(T)), inds(R))
+  RR = permutedims!!(RR, T, perm, (r, t) -> f(false, t))
+  return RR
+end
+
+function permutedims!!(R::EmptyTensor, T::EmptyTensor, perm::Tuple, f::Function=(r, t) -> t)
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  return RR
+end
+
+function show(io::IO, mime::MIME"text/plain", T::EmptyTensor)
+  summary(io, T)
+  return println(io)
+end
+
+# XXX: this seems a bit strange and fragile?
+# Takes the type very literally.
+function HDF5.read(
+  parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, ::Type{StoreT}
+) where {StoreT<:EmptyStorage}
+  g = open_group(parent, name)
+  typestr = string(StoreT)
+  if read(attributes(g)["type"]) != typestr
+    error("HDF5 group or file does not contain $typestr data")
+  end
+  return StoreT()
+end
+
+function HDF5.write(
+  parent::Union{HDF5.File,HDF5.Group}, name::String, ::StoreT
+) where {StoreT<:EmptyStorage}
+  g = create_group(parent, name)
+  attributes(g)["type"] = string(StoreT)
+  return attributes(g)["version"] = 1
+end

--- a/src/NDTensors/exports.jl
+++ b/src/NDTensors/exports.jl
@@ -1,0 +1,79 @@
+export
+  # NDTensors.jl
+  insertblock!!,
+  setindex,
+  setindex!!,
+
+  # blocksparse/blockdims.jl
+  BlockDims,
+  blockdim,
+  blockdims,
+  nblocks,
+  blockindex,
+
+  # blocksparse/blocksparse.jl
+  # Types
+  Block,
+  BlockOffset,
+  BlockOffsets,
+  BlockSparse,
+  # Methods
+  blockoffsets,
+  blockview,
+  eachnzblock,
+  findblock,
+  isblocknz,
+  nnzblocks,
+  nnz,
+  nzblock,
+  nzblocks,
+
+  # blocksparse/blocksparsetensor.jl
+  # Types
+  BlockSparseTensor,
+  # Methods
+  blockview,
+  insertblock!,
+  randomBlockSparseTensor,
+
+  # dense.jl
+  # Types
+  Dense,
+  DenseTensor,
+  # Symbols
+  ⊗,
+  # Methods
+  randomTensor,
+  randomDenseTensor,
+  array,
+  contract,
+  matrix,
+  outer,
+  permutedims!!,
+  read,
+  vector,
+  write,
+
+  # diag.jl
+  # Types
+  Diag,
+  DiagTensor,
+
+  # empty.jl
+  EmptyStorage,
+  EmptyTensor,
+  EmptyBlockSparseTensor,
+
+  # tensorstorage.jl
+  data,
+  TensorStorage,
+  randn!,
+  scale!,
+  norm,
+
+  # tensor.jl
+  Tensor,
+  tensor,
+  inds,
+  ind,
+  store

--- a/src/NDTensors/imports.jl
+++ b/src/NDTensors/imports.jl
@@ -1,0 +1,47 @@
+import Base:
+  # Types
+  Array,
+  CartesianIndex,
+  IndexStyle,
+  Tuple,
+  # Symbols
+  +,
+  *,
+  # Methods
+  checkbounds,
+  complex,
+  convert,
+  conj,
+  copy,
+  copyto!,
+  eachindex,
+  eltype,
+  fill,
+  fill!,
+  getindex,
+  hash,
+  isempty,
+  isless,
+  iterate,
+  length,
+  ndims,
+  permutedims,
+  permutedims!,
+  promote_rule,
+  randn,
+  reshape,
+  setindex,
+  setindex!,
+  show,
+  size,
+  stride,
+  strides,
+  summary,
+  to_indices,
+  unsafe_convert,
+  view,
+  zeros
+
+import Base.Broadcast: Broadcasted, BroadcastStyle
+
+import TupleTools: isperm

--- a/src/NDTensors/linearalgebra.jl
+++ b/src/NDTensors/linearalgebra.jl
@@ -1,0 +1,399 @@
+export eigs, entropy, polar, random_orthog, random_unitary, Spectrum, svd, truncerror
+
+#
+# Linear Algebra of order 2 NDTensors
+#
+# Even though DenseTensor{_,2} is strided
+# and passable to BLAS/LAPACK, it cannot
+# be made <: StridedArray
+
+function (
+  T1::Tensor{ElT1,2,StoreT1} * T2::Tensor{ElT2,2,StoreT2}
+) where {ElT1,StoreT1<:Dense,IndsT1,ElT2,StoreT2<:Dense,IndsT2}
+  RM = matrix(T1) * matrix(T2)
+  indsR = (ind(T1, 1), ind(T2, 2))
+  return tensor(Dense(vec(RM)), indsR)
+end
+
+function LinearAlgebra.exp(T::DenseTensor{ElT,2}) where {ElT<:Union{Real,Complex}}
+  expTM = exp(matrix(T))
+  return tensor(Dense(vec(expTM)), inds(T))
+end
+
+function LinearAlgebra.exp(
+  T::Hermitian{ElT,<:DenseTensor{ElT,2}}
+) where {ElT<:Union{Real,Complex}}
+  # exp(::Hermitian/Symmetric) returns Hermitian/Symmetric,
+  # so extract the parent matrix
+  expTM = parent(exp(matrix(T)))
+  return tensor(Dense(vec(expTM)), inds(T))
+end
+
+"""
+  Spectrum
+contains the (truncated) density matrix eigenvalue spectrum which is computed during a
+decomposition done by `svd` or `eigen`. In addition stores the truncation error.
+"""
+struct Spectrum{VecT<:Union{AbstractVector,Nothing}}
+  eigs::VecT
+  truncerr::Float64
+end
+
+eigs(s::Spectrum) = s.eigs
+truncerror(s::Spectrum) = s.truncerr
+
+function entropy(s::Spectrum)
+  S = 0.0
+  eigs_s = eigs(s)
+  isnothing(eigs_s) &&
+    error("Spectrum does not contain any eigenvalues, cannot compute the entropy")
+  for p in eigs_s
+    p > 1e-13 && (S -= p * log(p))
+  end
+  return S
+end
+
+function svd_catch_error(A; kwargs...)
+  USV = try
+    svd(A; kwargs...)
+  catch
+    return nothing
+  end
+  return USV
+end
+
+function lapack_svd_error_message(alg)
+  return "The SVD algorithm `\"$alg\"` has thrown an error,\n" *
+         "likely because of a convergance failure. You can try\n" *
+         "other SVD algorithms that may converge better using the\n" *
+         "`alg` (or `svd_alg` if called through `factorize` or MPS/MPO functionality) keyword argument:\n\n" *
+         " - \"divide_and_conquer\" is a divide-and-conquer algorithm\n" *
+         "   (LAPACK's `gesdd`). It is fast, but may lead to some innacurate\n" *
+         "   singular values for very ill-conditioned matrices.\n" *
+         "   It also may sometimes fail to converge, leading to errors\n" *
+         "   (in which case `\"qr_iteration\"` or `\"recursive\"` can be tried).\n\n" *
+         " - `\"qr_iteration\"` (LAPACK's `gesvd`) is typically slower \n" *
+         "   than \"divide_and_conquer\", especially for large matrices,\n" *
+         "   but is more accurate for very ill-conditioned matrices \n" *
+         "   compared to `\"divide_and_conquer\"`.\n\n" *
+         " - `\"recursive\"` is ITensor's custom SVD algorithm. It is very\n" *
+         "   reliable, but may be slow if high precision is needed.\n" *
+         "   To get an `svd` of a matrix `A`, an eigendecomposition of\n" *
+         "   ``A^{\\dagger} A`` is used to compute `U` and then a `qr` of\n" *
+         "   ``A^{\\dagger} U`` is used to compute `V`. This is performed\n" *
+         "   recursively to compute small singular values.\n\n" *
+         "Returning `nothing`. For an output `F = svd(A, ...)` you can check if\n" *
+         "`isnothing(F)` in your code and try a different algorithm.\n\n" *
+         "To suppress this message in the future, you can wrap the `svd` call in the\n" *
+         "`@suppress` macro from the `Suppressor` package.\n"
+end
+
+"""
+    svd(T::DenseTensor{<:Number,2}; kwargs...)
+
+svd of an order-2 DenseTensor
+"""
+function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT}; kwargs...) where {ElT,IndsT}
+  truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
+
+  #
+  # Keyword argument deprecations
+  #
+  use_absolute_cutoff = false
+  if haskey(kwargs, :absoluteCutoff)
+    @warn "In svd, keyword argument absoluteCutoff is deprecated in favor of use_absolute_cutoff"
+    use_absolute_cutoff = get(kwargs, :absoluteCutoff, use_absolute_cutoff)
+  end
+
+  use_relative_cutoff = true
+  if haskey(kwargs, :doRelCutoff)
+    @warn "In svd, keyword argument doRelCutoff is deprecated in favor of use_relative_cutoff"
+    use_relative_cutoff = get(kwargs, :doRelCutoff, use_relative_cutoff)
+  end
+
+  if haskey(kwargs, :fastsvd) || haskey(kwargs, :fastSVD)
+    error(
+      "In svd, fastsvd/fastSVD keyword arguments are removed in favor of alg, see documentation for more details.",
+    )
+  end
+
+  maxdim::Int = get(kwargs, :maxdim, minimum(dims(T)))
+  mindim::Int = get(kwargs, :mindim, 1)
+  cutoff::Float64 = get(kwargs, :cutoff, 0.0)
+  use_absolute_cutoff::Bool = get(kwargs, :use_absolute_cutoff, use_absolute_cutoff)
+  use_relative_cutoff::Bool = get(kwargs, :use_relative_cutoff, use_relative_cutoff)
+  alg::String = get(kwargs, :alg, "divide_and_conquer")
+
+  #@timeit_debug timer "dense svd" begin
+  if alg == "divide_and_conquer"
+    MUSV = svd_catch_error(matrix(T); alg=LinearAlgebra.DivideAndConquer())
+  elseif alg == "qr_iteration"
+    MUSV = svd_catch_error(matrix(T); alg=LinearAlgebra.QRIteration())
+  elseif alg == "recursive"
+    MUSV = svd_recursive(matrix(T))
+  else
+    error(
+      "svd algorithm $alg is not currently supported. Please see the documentation for currently supported algorithms.",
+    )
+  end
+  if isnothing(MUSV)
+    if any(isnan, T)
+      println("SVD failed, the matrix you were trying to SVD contains NaNs.")
+    else
+      println(lapack_svd_error_message(alg))
+    end
+    return nothing
+  end
+  MU, MS, MV = MUSV
+  conj!(MV)
+  #end # @timeit_debug
+
+  P = MS .^ 2
+  if truncate
+    truncerr, _ = truncate!(
+      P;
+      mindim=mindim,
+      maxdim=maxdim,
+      cutoff=cutoff,
+      use_absolute_cutoff=use_absolute_cutoff,
+      use_relative_cutoff=use_relative_cutoff,
+    )
+  else
+    truncerr = 0.0
+  end
+  spec = Spectrum(P, truncerr)
+  dS = length(P)
+  if dS < length(MS)
+    MU = MU[:, 1:dS]
+    resize!(MS, dS)
+    MV = MV[:, 1:dS]
+  end
+
+  # Make the new indices to go onto U and V
+  u = eltype(IndsT)(dS)
+  v = eltype(IndsT)(dS)
+  Uinds = IndsT((ind(T, 1), u))
+  Sinds = IndsT((u, v))
+  Vinds = IndsT((ind(T, 2), v))
+  U = tensor(Dense(vec(MU)), Uinds)
+  S = tensor(Diag(MS), Sinds)
+  V = tensor(Dense(vec(MV)), Vinds)
+  return U, S, V, spec
+end
+
+function LinearAlgebra.eigen(
+  T::Hermitian{ElT,<:DenseTensor{ElT,2,IndsT}}; kwargs...
+) where {ElT<:Union{Real,Complex},IndsT}
+  # Keyword argument deprecations
+  use_absolute_cutoff = false
+  if haskey(kwargs, :absoluteCutoff)
+    @warn "In svd, keyword argument absoluteCutoff is deprecated in favor of use_absolute_cutoff"
+    use_absolute_cutoff = get(kwargs, :absoluteCutoff, use_absolute_cutoff)
+  end
+  use_relative_cutoff = true
+  if haskey(kwargs, :doRelCutoff)
+    @warn "In svd, keyword argument doRelCutoff is deprecated in favor of use_relative_cutoff"
+    use_relative_cutoff = get(kwargs, :doRelCutoff, use_relative_cutoff)
+  end
+
+  truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
+  maxdim::Int = get(kwargs, :maxdim, minimum(dims(T)))
+  mindim::Int = get(kwargs, :mindim, 1)
+  cutoff::Float64 = get(kwargs, :cutoff, 0.0)
+  use_absolute_cutoff::Bool = get(kwargs, :use_absolute_cutoff, use_absolute_cutoff)
+  use_relative_cutoff::Bool = get(kwargs, :use_relative_cutoff, use_relative_cutoff)
+
+  DM, VM = eigen(matrix(T))
+
+  # Sort by largest to smallest eigenvalues
+  p = sortperm(DM; rev=true)
+  DM = DM[p]
+  VM = VM[:, p]
+
+  if truncate
+    truncerr, _ = truncate!(
+      DM;
+      maxdim=maxdim,
+      cutoff=cutoff,
+      use_absolute_cutoff=use_absolute_cutoff,
+      use_relative_cutoff=use_relative_cutoff,
+    )
+    dD = length(DM)
+    if dD < size(VM, 2)
+      VM = VM[:, 1:dD]
+    end
+  else
+    dD = length(DM)
+    truncerr = 0.0
+  end
+  spec = Spectrum(DM, truncerr)
+
+  # Make the new indices to go onto V
+  l = eltype(IndsT)(dD)
+  r = eltype(IndsT)(dD)
+  Vinds = IndsT((dag(ind(T, 2)), dag(r)))
+  Dinds = IndsT((l, dag(r)))
+  V = tensor(Dense(vec(VM)), Vinds)
+  D = tensor(Diag(DM), Dinds)
+  return D, V, spec
+end
+
+"""
+    random_unitary(n::Int,m::Int)::Matrix{ComplexF64}
+    random_unitary(::Type{ElT},n::Int,m::Int)::Matrix{ElT}
+
+Return a random matrix U of dimensions (n,m)
+such that if n >= m, U'*U is the identity, or if 
+m > n U*U' is the identity. Optionally can pass a numeric
+type as the first argument to obtain a matrix of that type.
+
+Sampling is based on https://arxiv.org/abs/math-ph/0609050
+such that in the case `n==m`, the unitary matrix will be sampled
+according to the Haar measure.
+"""
+function random_unitary(::Type{ElT}, n::Int, m::Int) where {ElT<:Number}
+  if n < m
+    return Matrix(random_unitary(ElT, m, n)')
+  end
+  F = qr(randn(ElT, n, m))
+  Q = Matrix(F.Q)
+  # The upper triangle of F.factors 
+  # are the elements of R.
+  # Multiply cols of Q by the signs
+  # that would make diagonal of R 
+  # non-negative:
+  for c in 1:size(Q, 2)
+    Q[:, c] .*= sign(F.factors[c, c])
+  end
+  return Q
+end
+
+random_unitary(n::Int, m::Int) = random_unitary(ComplexF64, n, m)
+
+"""
+    random_orthog(n::Int,m::Int)::Matrix{Float64}
+    random_orthog(::Type{ElT},n::Int,m::Int)::Matrix{ElT}
+
+Return a random, real matrix O of dimensions (n,m)
+such that if n >= m, transpose(O)*O is the 
+identity, or if m > n O*transpose(O) is the
+identity. Optionally can pass a real number type
+as the first argument to obtain a matrix of that type.
+"""
+random_orthog(::Type{ElT}, n::Int, m::Int) where {ElT<:Real} = random_unitary(ElT, n, m)
+
+random_orthog(n::Int, m::Int) = random_orthog(Float64, n, m)
+
+"""
+    qr_positive(M::AbstractMatrix)
+
+Compute the QR decomposition of a matrix M
+such that the diagonal elements of R are
+non-negative. Such a QR decomposition of a
+matrix is unique. Returns a tuple (Q,R).
+"""
+function qr_positive(M::AbstractMatrix)
+  sparseQ, R = qr(M)
+  Q = convert(Matrix, sparseQ)
+  nc = size(Q, 2)
+  for c in 1:nc
+    if real(R[c, c]) < 0.0
+      R[c, c:end] *= -1
+      Q[:, c] *= -1
+    end
+  end
+  return (Q, R)
+end
+
+function LinearAlgebra.eigen(
+  T::DenseTensor{ElT,2,IndsT}; kwargs...
+) where {ElT<:Union{Real,Complex},IndsT}
+  # Keyword argument deprecations
+  use_absolute_cutoff = false
+  if haskey(kwargs, :absoluteCutoff)
+    @warn "In svd, keyword argument absoluteCutoff is deprecated in favor of use_absolute_cutoff"
+    use_absolute_cutoff = get(kwargs, :absoluteCutoff, use_absolute_cutoff)
+  end
+  use_relative_cutoff = true
+  if haskey(kwargs, :doRelCutoff)
+    @warn "In svd, keyword argument doRelCutoff is deprecated in favor of use_relative_cutoff"
+    use_relative_cutoff = get(kwargs, :doRelCutoff, use_relative_cutoff)
+  end
+
+  truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
+  maxdim::Int = get(kwargs, :maxdim, minimum(dims(T)))
+  mindim::Int = get(kwargs, :mindim, 1)
+  cutoff::Float64 = get(kwargs, :cutoff, 0.0)
+  use_absolute_cutoff::Bool = get(kwargs, :use_absolute_cutoff, use_absolute_cutoff)
+  use_relative_cutoff::Bool = get(kwargs, :use_relative_cutoff, use_relative_cutoff)
+
+  DM, VM = eigen(matrix(T))
+
+  # Sort by largest to smallest eigenvalues
+  #p = sortperm(DM; rev = true)
+  #DM = DM[p]
+  #VM = VM[:,p]
+
+  if truncate
+    truncerr, _ = truncate!(
+      DM;
+      maxdim=maxdim,
+      cutoff=cutoff,
+      use_absolute_cutoff=use_absolute_cutoff,
+      use_relative_cutoff=use_relative_cutoff,
+    )
+    dD = length(DM)
+    if dD < size(VM, 2)
+      VM = VM[:, 1:dD]
+    end
+  else
+    dD = length(DM)
+    truncerr = 0.0
+  end
+  spec = Spectrum(abs.(DM), truncerr)
+
+  i1, i2 = inds(T)
+
+  # Make the new indices to go onto D and V
+  l = typeof(i1)(dD)
+  r = dag(sim(l))
+  Dinds = (l, r)
+  Vinds = (dag(i2), r)
+  D = complex(tensor(Diag(DM), Dinds))
+  V = complex(tensor(Dense(vec(VM)), Vinds))
+  return D, V, spec
+end
+
+function LinearAlgebra.qr(T::DenseTensor{ElT,2,IndsT}; kwargs...) where {ElT,IndsT}
+  positive = get(kwargs, :positive, false)
+  # TODO: just call qr on T directly (make sure
+  # that is fast)
+  if positive
+    QM, RM = qr_positive(matrix(T))
+  else
+    QM, RM = qr(matrix(T))
+  end
+  # Make the new indices to go onto Q and R
+  q, r = inds(T)
+  q = dim(q) < dim(r) ? sim(q) : sim(r)
+  Qinds = IndsT((ind(T, 1), q))
+  Rinds = IndsT((q, ind(T, 2)))
+  Q = tensor(Dense(vec(Matrix(QM))), Qinds)
+  R = tensor(Dense(vec(RM)), Rinds)
+  return Q, R
+end
+
+# TODO: support alg keyword argument to choose the svd algorithm
+function polar(T::DenseTensor{ElT,2,IndsT}) where {ElT,IndsT}
+  QM, RM = polar(matrix(T))
+  dim = size(QM, 2)
+  # Make the new indices to go onto Q and R
+  q = eltype(IndsT)(dim)
+  # TODO: use push/pushfirst instead of a constructor
+  # call here
+  Qinds = IndsT((ind(T, 1), q))
+  Rinds = IndsT((q, ind(T, 2)))
+  Q = tensor(Dense(vec(QM)), Qinds)
+  R = tensor(Dense(vec(RM)), Rinds)
+  return Q, R
+end

--- a/src/NDTensors/octavian.jl
+++ b/src/NDTensors/octavian.jl
@@ -1,0 +1,22 @@
+using .Octavian
+
+export backend_octavian
+
+function backend_octavian()
+  return gemm_backend[] = :Octavian
+end
+
+function _gemm!(
+  ::GemmBackend{:Octavian},
+  tA,
+  tB,
+  alpha,
+  A::AbstractVecOrMat,
+  B::AbstractVecOrMat,
+  beta,
+  C::AbstractVecOrMat,
+)
+  return Octavian.matmul!(
+    C, tA == 'T' ? transpose(A) : A, tB == 'T' ? transpose(B) : B, alpha, beta
+  )
+end

--- a/src/NDTensors/similar.jl
+++ b/src/NDTensors/similar.jl
@@ -1,0 +1,64 @@
+
+#
+# Custom NDTensors.similar implementation
+# More extensive than Base.similar
+#
+
+# TODO: define
+# Base.similar(t::Tensor, args...) = similar(t, args...)
+
+# In general define NDTensors.similar = Base.similar
+similar(a::Array, args...) = Base.similar(a, args...)
+
+# XXX: this is type piracy but why doesn't base have something like this?
+# This type piracy is pretty bad, consider making an internal `NDTensors.similar` function.
+# Currently Base gives:
+# julia> similar(Matrix{Float64}, 2)
+# ERROR: MethodError: no method matching Matrix{Float64}(::UndefInitializer, ::Tuple{Int64})
+# [...]
+similar(::Type{<:Array{T}}, dims) where {T} = Array{T,length(dims)}(undef, dims)
+
+# XXX: this is type piracy but why doesn't base have something like this?
+function similar(::Type{ArrayT}, ::Type{ElT}, size) where {ArrayT<:AbstractArray,ElT}
+  return similar(similartype(ArrayT, ElT), size)
+end
+
+#
+# similartype returns the type of the object that would be returned by `similar`
+#
+
+# TODO: extend to AbstractVector, returning the same type as `Base.similar` would
+# (make sure it handles views, CuArrays, etc. correctly)
+# This is to help with code that is generic to different storage types.
+similartype(::Type{<:Array{<:Any,N}}, eltype::Type) where {N} = Array{eltype,N}
+
+#similartype(::Type{LinearAlgebra.Adjoint{Float64, Matrix{Float64}}}, ::Type{Float64})
+
+# A union type of AbstractArrays that are wrappers that define `Base.parent`.
+#const WrappedArray = Union{ReshapedArray,Adjoint,Transpose,SubArray}
+const WrappedArray{T,AW} = Union{
+  ReshapedArray{T,<:Any,AW},
+  Transpose{T,AW},
+  Adjoint{T,AW},
+  Symmetric{T,AW},
+  Hermitian{T,AW},
+  UpperTriangular{T,AW},
+  LowerTriangular{T,AW},
+  UnitUpperTriangular{T,AW},
+  UnitLowerTriangular{T,AW},
+  Diagonal{T,AW},
+}
+
+parenttype(::Type{<:WrappedArray{<:Any,P}}) where {P} = P
+
+function similartype(::Type{ArrayT}, eltype::Type, dims::Tuple) where {ArrayT<:WrappedArray}
+  return similartype(parenttype(ArrayT), eltype, dims)
+end
+
+function similartype(::Type{ArrayT}, eltype::Type) where {ArrayT<:WrappedArray}
+  return similartype(parenttype(ArrayT), eltype)
+end
+
+function similartype(::Type{ArrayT}) where {ArrayT<:WrappedArray}
+  return similartype(parenttype(ArrayT))
+end

--- a/src/NDTensors/svd.jl
+++ b/src/NDTensors/svd.jl
@@ -1,0 +1,61 @@
+
+function checkSVDDone(S::Vector, thresh::Float64)
+  N = length(S)
+  (N <= 1 || thresh < 0.0) && return (true, 1)
+  S1t = S[1] * thresh
+  start = 2
+  while start <= N
+    (S[start] < S1t) && break
+    start += 1
+  end
+  if start >= N
+    return (true, N)
+  end
+  return (false, start)
+end
+
+function svd_recursive(M::AbstractMatrix; thresh::Float64=1E-3, north_pass::Int=2)
+  Mr, Mc = size(M)
+  if Mr > Mc
+    V, S, U = svd_recursive(transpose(M))
+    conj!(U)
+    conj!(V)
+    return U, S, V
+  end
+
+  #rho = BLAS.gemm('N','T',-1.0,M,M) #negative to sort eigenvalues greatest to smallest
+  rho = -M * M' #negative to sort eigenvalues in decreasing order
+  D, U = eigen(Hermitian(rho), 1:size(rho, 1))
+
+  Nd = length(D)
+
+  V = M' * U
+
+  V, R = qr_positive(V)
+  for n in 1:Nd
+    D[n] = R[n, n]
+  end
+
+  (done, start) = checkSVDDone(D, thresh)
+
+  done && return U, D, V
+
+  u = view(U, :, start:Nd)
+  v = view(V, :, start:Nd)
+
+  b = u' * (M * v)
+  bu, bd, bv = svd_recursive(b; thresh=thresh, north_pass=north_pass)
+
+  u .= u * bu
+  v .= v * bv
+  view(D, start:Nd) .= bd
+
+  return U, D, V
+end
+
+# TODO: maybe move to another location?
+# Include options for other svd algorithms
+function polar(M::AbstractMatrix)
+  U, S, V = svd(M) # calls LinearAlgebra.svd(_)
+  return U * V', V * Diagonal(S) * V'
+end

--- a/src/NDTensors/symmetric.jl
+++ b/src/NDTensors/symmetric.jl
@@ -1,0 +1,27 @@
+
+# XXX Should this permute the dimensions?
+dims(H::Hermitian{<:Number,<:Tensor}) = dims(parent(H))
+
+# XXX Should this permute the dimensions?
+dim(H::Hermitian{<:Number,<:Tensor}, i::Int) = dim(parent(H), i)
+
+matrix(H::Hermitian{<:Number,<:Tensor}) = Hermitian(matrix(parent(H)))
+
+# XXX Should this permute the indices?
+inds(H::Hermitian{<:Number,<:Tensor}) = inds(parent(H))
+
+# XXX Should this permute the indices?
+ind(H::Hermitian{<:Number,<:Tensor}, i::Int) = ind(parent(H), i)
+
+# XXX Should this tranpose the block locations?
+nnzblocks(H::Hermitian{<:Number,<:Tensor}) = nnzblocks(parent(H))
+
+# XXX Should this tranpose the block locations?
+nzblocks(H::Hermitian{<:Number,<:Tensor}) = nzblocks(parent(H))
+
+# XXX Should this tranpose the block locations?
+eachnzblock(H::Hermitian{<:Number,<:Tensor}) = eachnzblock(parent(H))
+
+nblocks(H::Hermitian{<:Number,<:Tensor}) = nblocks(parent(H))
+
+blockview(H::Hermitian{<:Number,<:Tensor}, block) = Hermitian(blockview(parent(H), block))

--- a/src/NDTensors/tblis.jl
+++ b/src/NDTensors/tblis.jl
@@ -1,0 +1,43 @@
+
+function contract!(
+  ::Val{:TBLIS},
+  R::DenseTensor{ElT},
+  labelsR,
+  T1::DenseTensor{ElT},
+  labelsT1,
+  T2::DenseTensor{ElT},
+  labelsT2,
+  α::ElT,
+  β::ElT,
+) where {ElT<:LinearAlgebra.BlasReal}
+  # TBLIS Tensors
+  R_tblis = TBLIS.TTensor{ElT}(array(R), β)
+  T1_tblis = TBLIS.TTensor{ElT}(array(T1), α)
+  T2_tblis = TBLIS.TTensor{ElT}(array(T2))
+
+  function label_to_char(label)
+    # Start at 'a'
+    char_start = Char(96)
+    if label < 0
+      # Start at 'z'
+      char_start = Char(123)
+    end
+    return char_start + label
+  end
+
+  function labels_to_tblis(labels)
+    if isempty(labels)
+      return ""
+    end
+    str = prod(label_to_char.(labels))
+    return str
+  end
+
+  labelsT1_tblis = labels_to_tblis(labelsT1)
+  labelsT2_tblis = labels_to_tblis(labelsT2)
+  labelsR_tblis = labels_to_tblis(labelsR)
+
+  TBLIS.mul!(R_tblis, T1_tblis, T2_tblis, labelsT1_tblis, labelsT2_tblis, labelsR_tblis)
+
+  return R
+end

--- a/src/NDTensors/tensor.jl
+++ b/src/NDTensors/tensor.jl
@@ -1,0 +1,372 @@
+
+"""
+Tensor{StoreT,IndsT}
+
+A plain old tensor (with order independent
+interface and no assumption of labels)
+"""
+struct Tensor{ElT,N,StoreT<:TensorStorage,IndsT} <: AbstractArray{ElT,N}
+  storage::StoreT
+  inds::IndsT
+
+  """
+      Tensor{ElT,N,StoreT,IndsT}(inds, store::StorageType)
+
+  Internal constructor for creating a Tensor from the 
+  storage and indices.
+
+  The Tensor is a view of the tensor storage.
+
+  For normal usage, use the Tensor(store::TensorStorage, inds)
+  and tensor(store::TensorStorage, inds) constructors.
+  """
+  function Tensor{ElT,N,StoreT,IndsT}(
+    ::AllowAlias, storage::TensorStorage, inds
+  ) where {ElT,N,StoreT<:TensorStorage,IndsT}
+    return new{ElT,N,StoreT,IndsT}(storage, inds)
+  end
+end
+
+function Tensor{ElT,N,StoreT,IndsT}(
+  vs::NeverAlias, storage::TensorStorage, inds
+) where {ElT,N,StoreT<:TensorStorage,IndsT}
+  return Tensor{ElT,N,StoreT,IndsT}(AllowAlias(), copy(storage), inds)
+end
+
+# Allow the storage and indices to be input in opposite ordering
+(T::Type{<:Tensor})(vs::AliasStyle, inds, storage::TensorStorage) = T(vs, storage, inds)
+
+"""
+    Tensor(store::TensorStorage, inds)
+
+Construct a Tensor from a tensor storage and indices.
+The Tensor holds a view of the storage data.
+"""
+function Tensor(
+  vs::AliasStyle, store::StoreT, inds::IndsT
+) where {StoreT<:TensorStorage,IndsT}
+  return Tensor{eltype(store),length(inds),StoreT,IndsT}(vs, inds, store)
+end
+
+tensor(args...; kwargs...) = Tensor(AllowAlias(), args...; kwargs...)
+Tensor(storage::TensorStorage, inds) = Tensor(NeverAlias(), storage, inds)
+Tensor(inds, storage::TensorStorage) = Tensor(storage, inds)
+
+storage(T::Tensor) = T.storage
+
+# TODO: deprecate
+store(T::Tensor) = storage(T)
+
+data(T::Tensor) = data(storage(T))
+
+datatype(T::Tensor) = datatype(storage(T))
+
+indstype(::Type{<:Tensor{<:Any,<:Any,<:Any,IndsT}}) where {IndsT} = IndsT
+indstype(T::Tensor) = indstype(typeof(T))
+
+storagetype(::Type{<:Tensor{<:Any,<:Any,StoreT}}) where {StoreT} = StoreT
+storagetype(T::Tensor) = storagetype(typeof(T))
+
+# TODO: deprecate
+storetype(args...) = storagetype(args...)
+
+inds(T::Tensor) = T.inds
+
+ind(T::Tensor, j::Integer) = inds(T)[j]
+
+eachindex(T::Tensor) = CartesianIndices(dims(inds(T)))
+
+eltype(::Tensor{ElT}) where {ElT} = ElT
+
+strides(T::Tensor) = dim_to_strides(inds(T))
+
+setstorage(T, nstore) = tensor(nstore, inds(T))
+
+setinds(T, ninds) = tensor(storage(T), ninds)
+
+#
+# Generic Tensor functions
+#
+
+# The size is obtained from the indices
+dims(T::Tensor) = dims(inds(T))
+dim(T::Tensor) = dim(inds(T))
+dim(T::Tensor, i::Int) = dim(inds(T), i)
+maxdim(T::Tensor) = maxdim(inds(T))
+mindim(T::Tensor) = mindim(inds(T))
+diaglength(T::Tensor) = mindim(T)
+size(T::Tensor) = dims(T)
+size(T::Tensor, i::Int) = dim(T, i)
+
+# Needed for passing Tensor{T,2} to BLAS/LAPACK
+# TODO: maybe this should only be for DenseTensor?
+function unsafe_convert(::Type{Ptr{ElT}}, T::Tensor{ElT}) where {ElT}
+  return unsafe_convert(Ptr{ElT}, storage(T))
+end
+
+copy(T::Tensor) = setstorage(T, copy(storage(T)))
+
+copyto!(R::Tensor, T::Tensor) = (copyto!(storage(R), storage(T)); R)
+
+complex(T::Tensor) = setstorage(T, complex(storage(T)))
+
+Base.real(T::Tensor) = setstorage(T, real(storage(T)))
+
+Base.imag(T::Tensor) = setstorage(T, imag(storage(T)))
+
+#
+# Necessary to overload since the generic fallbacks are
+# slow
+#
+
+LinearAlgebra.norm(T::Tensor) = norm(storage(T))
+
+conj(vs::AliasStyle, T::Tensor) = setstorage(T, conj(vs, storage(T)))
+conj(T::Tensor) = conj(AllowAlias(), T)
+
+randn!!(T::Tensor) = (randn!(T); T)
+Random.randn!(T::Tensor) = (randn!(storage(T)); T)
+
+LinearAlgebra.rmul!(T::Tensor, α::Number) = (rmul!(storage(T), α); T)
+scale!(T::Tensor, α::Number) = rmul!(storage(T), α)
+
+fill!!(T::Tensor, α::Number) = fill!(T, α)
+fill!(T::Tensor, α::Number) = (fill!(storage(T), α); T)
+
+#function similar(::Type{<:Tensor{ElT,N,StoreT}},dims) where {ElT,N,StoreT}
+#  return tensor(similar(StoreT,dim(dims)),dims)
+#end
+
+# TODO: make sure these are implemented correctly
+#similar(T::Type{<:Tensor},::Type{S}) where {S} = tensor(similar(storage(T),S),inds(T))
+#similar(T::Type{<:Tensor},::Type{S},dims) where {S} = tensor(similar(storage(T),S),dims)
+
+similar(T::Tensor) = setstorage(T, similar(storage(T)))
+
+# TODO: for BlockSparse, this needs to include the offsets
+# TODO: for Diag, the storage is not just the total dimension
+similar(T::Tensor, dims::Tuple) = _similar_from_dims(T, dims)
+function similar(::Type{TensorT}, dims::Tuple) where {TensorT<:Tensor}
+  return _similar_from_dims(TensorT, dims)
+end
+function similar(::Type{TensorT}, dims::Tuple{}) where {TensorT<:Tensor}
+  return _similar_from_dims(TensorT, dims)
+end
+
+# To handle method ambiguity with AbstractArray
+#similar(T::Tensor,dims::Dims) = _similar_from_dims(T,dims)
+
+similar(T::Tensor, ::Type{S}) where {S} = setstorage(T, similar(storage(T), S))
+
+function similar(::Type{TensorT}, ::Type{S}, dims) where {TensorT<:Tensor,S<:Number}
+  return _similar_from_dims(TensorT, S, dims)
+end
+
+similar(T::Tensor, ::Type{S}, dims) where {S<:Number} = _similar_from_dims(T, S, dims)
+
+# To handle method ambiguity with AbstractArray
+similar(T::Tensor, ::Type{S}, dims::Dims) where {S<:Number} = _similar_from_dims(T, S, dims)
+
+_similar_from_dims(T::Tensor, dims) = tensor(similar(storage(T), dim(dims)), dims)
+
+function _similar_from_dims(T::Tensor, ::Type{S}, dims) where {S<:Number}
+  return tensor(similar(storage(T), S, dim(dims)), dims)
+end
+
+function _similar_from_dims(::Type{TensorT}, dims) where {TensorT<:Tensor}
+  return _similar_from_dims(TensorT, eltype(TensorT), dims)
+end
+
+function _similar_from_dims(
+  ::Type{TensorT}, ::Type{S}, dims
+) where {TensorT<:Tensor,S<:Number}
+  return tensor(similar(storagetype(TensorT), S, dim(dims)), dims)
+end
+
+function convert(
+  ::Type{<:Tensor{<:Number,N,StoreR,Inds}}, T::Tensor{<:Number,N,<:Any,Inds}
+) where {N,Inds,StoreR}
+  return setstorage(T, convert(StoreR, storage(T)))
+end
+
+function zeros(TensorT::Type{<:Tensor{ElT,N,StoreT}}, inds) where {ElT,N,StoreT}
+  return error("zeros(::Type{$TensorT}, inds) not implemented yet")
+end
+
+function promote_rule(
+  ::Type{<:Tensor{ElT1,N1,StoreT1,IndsT1}}, ::Type{<:Tensor{ElT2,N2,StoreT2,IndsT2}}
+) where {ElT1,ElT2,N1,N2,StoreT1,StoreT2,IndsT1,IndsT2}
+  StoreR = promote_type(StoreT1, StoreT2)
+  ElR = eltype(StoreR)
+  return Tensor{ElR,N3,StoreR,IndsR} where {N3,IndsR}
+end
+
+function promote_rule(
+  ::Type{<:Tensor{ElT1,N,StoreT1,Inds}}, ::Type{<:Tensor{ElT2,N,StoreT2,Inds}}
+) where {ElT1,ElT2,N,StoreT1,StoreT2,Inds}
+  StoreR = promote_type(StoreT1, StoreT2)
+  ElR = eltype(StoreR)
+  return Tensor{ElR,N,StoreR,Inds}
+end
+
+# Convert the tensor type to the closest dense
+# type
+function dense(::Type{<:Tensor{ElT,NT,StoreT,IndsT}}) where {ElT,NT,StoreT,IndsT}
+  return Tensor{ElT,NT,dense(StoreT),IndsT}
+end
+
+dense(T::Tensor) = setstorage(T, dense(storage(T)))
+
+function similartype(
+  ::Type{<:Tensor{ElT,<:Any,StoreT,<:Any}}, ::Type{IndsR}
+) where {ElT,StoreT,IndsR}
+  return Tensor{ElT,length(IndsR),StoreT,IndsR}
+end
+
+function similartype(
+  ::Type{<:Tensor{ElT,<:Any,StoreT,<:Any}}, ::Type{IndsR}
+) where {ElT,StoreT,IndsR<:NTuple{NR}} where {NR}
+  return Tensor{ElT,NR,StoreT,IndsR}
+end
+
+# Convert to Array, avoiding copying if possible
+array(T::Tensor) = array(dense(T))
+matrix(T::Tensor{<:Number,2}) = array(T)
+vector(T::Tensor{<:Number,1}) = array(T)
+
+isempty(T::Tensor) = isempty(storage(T))
+
+#
+# Helper functions for BlockSparse-type storage
+#
+
+"""
+nzblocks(T::Tensor)
+
+Return a vector of the non-zero blocks of the BlockSparseTensor.
+"""
+nzblocks(T::Tensor) = nzblocks(storage(T))
+
+eachnzblock(T::Tensor) = eachnzblock(storage(T))
+
+blockoffsets(T::Tensor) = blockoffsets(storage(T))
+nnzblocks(T::Tensor) = nnzblocks(storage(T))
+nnz(T::Tensor) = nnz(storage(T))
+nblocks(T::Tensor) = nblocks(inds(T))
+blockdims(T::Tensor, block) = blockdims(inds(T), block)
+blockdim(T::Tensor, block) = blockdim(inds(T), block)
+
+"""
+offset(T::Tensor, block::Block)
+
+Get the linear offset in the data storage for the specified block.
+If the specified block is not non-zero structurally, return nothing.
+
+offset(T::Tensor,pos::Int)
+
+Get the offset of the block at position pos
+in the block-offsets list.
+"""
+offset(T::Tensor, block) = offset(storage(T), block)
+
+"""
+isblocknz(T::Tensor,
+          block::Block)
+
+Check if the specified block is non-zero
+"""
+isblocknz(T::Tensor, block) = isblocknz(storage(T), block)
+
+function blockstart(T::Tensor{<:Number,N}, block) where {N}
+  start_index = @MVector ones(Int, N)
+  for j in 1:N
+    ind_j = ind(T, j)
+    for block_j in 1:(block[j] - 1)
+      start_index[j] += blockdim(ind_j, block_j)
+    end
+  end
+  return Tuple(start_index)
+end
+
+function blockend(T::Tensor{<:Number,N}, block) where {N}
+  end_index = @MVector zeros(Int, N)
+  for j in 1:N
+    ind_j = ind(T, j)
+    for block_j in 1:block[j]
+      end_index[j] += blockdim(ind_j, block_j)
+    end
+  end
+  return Tuple(end_index)
+end
+
+#
+# Some generic getindex and setindex! functionality
+#
+
+@propagate_inbounds @inline setindex!!(T::Tensor, x, I...) = setindex!(T, x, I...)
+
+insertblock!!(T::Tensor, block) = insertblock!(T, block)
+
+"""
+getdiagindex
+
+Get the specified value on the diagonal
+"""
+function getdiagindex(T::Tensor{<:Number,N}, ind::Int) where {N}
+  return getindex(T, CartesianIndex(ntuple(_ -> ind, Val(N))))
+end
+
+"""
+setdiagindex!
+
+Set the specified value on the diagonal
+"""
+function setdiagindex!(T::Tensor{<:Number,N}, val, ind::Int) where {N}
+  setindex!(T, val, CartesianIndex(ntuple(_ -> ind, Val(N))))
+  return T
+end
+
+#
+# Some generic contraction functionality
+#
+
+function zero_contraction_output(
+  T1::TensorT1, T2::TensorT2, indsR::IndsR
+) where {TensorT1<:Tensor,TensorT2<:Tensor,IndsR}
+  return zeros(contraction_output_type(TensorT1, TensorT2, IndsR), indsR)
+end
+
+#
+# Broadcasting
+#
+
+BroadcastStyle(::Type{T}) where {T<:Tensor} = Broadcast.ArrayStyle{T}()
+
+function Base.similar(
+  bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{T}}, ::Type{ElT}
+) where {T<:Tensor,ElT}
+  A = find_tensor(bc)
+  return similar(A, ElT)
+end
+
+"`A = find_tensor(As)` returns the first Tensor among the arguments."
+find_tensor(bc::Broadcast.Broadcasted) = find_tensor(bc.args)
+find_tensor(args::Tuple) = find_tensor(find_tensor(args[1]), Base.tail(args))
+find_tensor(x) = x
+find_tensor(a::Tensor, rest) = a
+find_tensor(::Any, rest) = find_tensor(rest)
+
+function summary(io::IO, T::Tensor)
+  for (dim, ind) in enumerate(inds(T))
+    println(io, "Dim $dim: ", ind)
+  end
+  println(io, typeof(storage(T)))
+  return println(io, " ", Base.dims2string(dims(T)))
+end
+
+#
+# Printing
+#
+
+print_tensor(io::IO, T::Tensor) = Base.print_array(io, T)
+print_tensor(io::IO, T::Tensor{<:Number,1}) = Base.print_array(io, reshape(T, (dim(T), 1)))

--- a/src/NDTensors/tensorstorage.jl
+++ b/src/NDTensors/tensorstorage.jl
@@ -1,0 +1,90 @@
+abstract type TensorStorage{ElT} <: AbstractVector{ElT} end
+
+data(S::TensorStorage) = S.data
+
+datatype(S::TensorStorage) = typeof(data(S))
+
+Base.eltype(::TensorStorage{ElT}) where {ElT} = ElT
+
+Base.eltype(::Type{<:TensorStorage{ElT}}) where {ElT} = ElT
+
+Base.iterate(S::TensorStorage, args...) = iterate(data(S), args...)
+
+dense(S::TensorStorage) = S
+
+# This is necessary since for some reason inference doesn't work
+# with the more general definition (eltype(Nothing) === Any)
+Base.eltype(::TensorStorage{Nothing}) = Nothing
+
+Base.length(S::TensorStorage) = length(data(S))
+
+Base.size(S::TensorStorage) = size(data(S))
+
+Base.@propagate_inbounds Base.getindex(S::TensorStorage, i::Integer) = data(S)[i]
+Base.@propagate_inbounds function Base.setindex!(S::TensorStorage, v, i::Integer)
+  return (setindex!(data(S), v, i); S)
+end
+
+(S::TensorStorage * x::Number) = setdata(S, x * data(S))
+(x::Number * S::TensorStorage) = S * x
+
+# To be added, but make sure these covers all the cases, such
+# as different kinds of DiagBlockSparse:
+#similar(S::TensorStorage) = setdata(S,similar(data(S)))
+#similar(S::TensorStorage,::Type{ElT}) where {ElT} = setdata(S,similar(data(S),ElT))
+
+# Needed for passing Tensor{T,2} to BLAS/LAPACK
+function Base.unsafe_convert(::Type{Ptr{ElT}}, T::TensorStorage{ElT}) where {ElT}
+  return Base.unsafe_convert(Ptr{ElT}, data(T))
+end
+
+# This may need to be overloaded, since storage types
+# often have other fields besides data
+
+Base.conj!(S::TensorStorage) = (conj!(data(S)); return S)
+
+Base.conj(S::TensorStorage) = conj(AllowAlias(), S)
+
+function Base.conj(::AllowAlias, S::TensorStorage)
+  return setdata(S, conj(data(S)))
+end
+
+function Base.conj(::NeverAlias, S::TensorStorage)
+  return conj!(copy(S))
+end
+
+Base.complex(S::TensorStorage) = setdata(S, complex(data(S)))
+
+Base.real(S::TensorStorage) = setdata(S, real(data(S)))
+
+Base.imag(S::TensorStorage) = setdata(S, imag(data(S)))
+
+Base.copyto!(S1::TensorStorage, S2::TensorStorage) = (copyto!(data(S1), data(S2)); S1)
+
+Random.randn!(S::TensorStorage) = (randn!(data(S)); S)
+
+Base.fill!(S::TensorStorage, v) = (fill!(data(S), v); S)
+
+LinearAlgebra.rmul!(S::TensorStorage, v::Number) = (rmul!(data(S), v); S)
+
+scale!(S::TensorStorage, v::Number) = rmul!(S, v)
+
+LinearAlgebra.norm(S::TensorStorage) = norm(data(S))
+
+Base.convert(::Type{T}, S::T) where {T<:TensorStorage} = S
+
+blockoffsets(S::TensorStorage) = S.blockoffsets
+
+"""
+nzblocks(T::TensorStorage)
+
+Return a vector of the non-zero blocks of the BlockSparse storage.
+"""
+nzblocks(T::TensorStorage) = nzblocks(blockoffsets(T))
+
+eachnzblock(T::TensorStorage) = eachnzblock(blockoffsets(T))
+
+nnzblocks(S::TensorStorage) = length(blockoffsets(S))
+nnz(S::TensorStorage) = length(S)
+
+offset(S::TensorStorage, block) = offset(blockoffsets(S), block)

--- a/src/NDTensors/truncate.jl
+++ b/src/NDTensors/truncate.jl
@@ -1,0 +1,87 @@
+export truncate!
+
+function truncate!(P::Vector{Float64}; kwargs...)::Tuple{Float64,Float64}
+  # Keyword argument deprecations
+  use_absolute_cutoff = false
+  if haskey(kwargs, :absoluteCutoff)
+    @warn "In truncate!, keyword argument absoluteCutoff is deprecated in favor of use_absolute_cutoff"
+    use_absolute_cutoff = get(kwargs, :absoluteCutoff, use_absolute_cutoff)
+  end
+  use_relative_cutoff = true
+  if haskey(kwargs, :doRelCutoff)
+    @warn "In truncate!, keyword argument doRelCutoff is deprecated in favor of use_relative_cutoff"
+    use_relative_cutoff = get(kwargs, :doRelCutoff, use_relative_cutoff)
+  end
+
+  maxdim::Int = min(get(kwargs, :maxdim, length(P)), length(P))
+  mindim::Int = max(get(kwargs, :mindim, 1), 1)
+  cutoff::Float64 = max(get(kwargs, :cutoff, 0.0), 0.0)
+  use_absolute_cutoff::Bool = get(kwargs, :use_absolute_cutoff, use_absolute_cutoff)
+  use_relative_cutoff::Bool = get(kwargs, :use_relative_cutoff, use_relative_cutoff)
+
+  origm = length(P)
+  docut = 0.0
+
+  if P[1] <= 0.0
+    P[1] = 0.0
+    resize!(P, 1)
+    return 0.0, 0.0
+  end
+
+  if origm == 1
+    docut = P[1] / 2
+    return 0.0, docut
+  end
+
+  #Zero out any negative weight
+  for n in origm:-1:1
+    (P[n] >= 0.0) && break
+    P[n] = 0.0
+  end
+
+  n = origm
+  truncerr = 0.0
+  while n > maxdim
+    truncerr += P[n]
+    n -= 1
+  end
+
+  if use_absolute_cutoff
+    #Test if individual prob. weights fall below cutoff
+    #rather than using *sum* of discarded weights
+    while P[n] <= cutoff && n > mindim
+      truncerr += P[n]
+      n -= 1
+    end
+  else
+    scale = 1.0
+    if use_relative_cutoff
+      scale = sum(P)
+      (scale == 0.0) && (scale = 1.0)
+    end
+
+    #Continue truncating until *sum* of discarded probability 
+    #weight reaches cutoff reached (or m==mindim)
+    while (truncerr + P[n] <= cutoff * scale) && (n > mindim)
+      truncerr += P[n]
+      n -= 1
+    end
+
+    truncerr /= scale
+  end
+
+  if n < 1
+    n = 1
+  end
+
+  if n < origm
+    docut = (P[n] + P[n + 1]) / 2
+    if abs(P[n] - P[n + 1]) < 1E-3 * P[n]
+      docut += 1E-3 * P[n]
+    end
+  end
+
+  resize!(P, n)
+
+  return truncerr, docut
+end

--- a/src/NDTensors/tupletools.jl
+++ b/src/NDTensors/tupletools.jl
@@ -1,0 +1,294 @@
+
+"""
+    ValLength(::Type{NTuple{N}}) = Val{N}
+"""
+ValLength(::Type{NTuple{N,T}}) where {N,T} = Val{N}
+
+"""
+    ValLength(::NTuple{N}) = Val(N)
+"""
+ValLength(::NTuple{N}) where {N} = Val(N)
+
+ValLength(::Tuple{Vararg{<:Any,N}}) where {N} = Val(N)
+
+ValLength(::Type{<:Tuple{Vararg{<:Any,N}}}) where {N} = Val{N}
+
+ValLength(::CartesianIndex{N}) where {N} = Val(N)
+ValLength(::Type{CartesianIndex{N}}) where {N} = Val{N}
+
+push(s::Tuple, val) = (s..., val)
+
+pushfirst(s::Tuple, val) = (val, s...)
+
+pop(s::NTuple{N}) where {N} = ntuple(i -> s[i], Val(N - 1))
+
+popfirst(s::NTuple{N}) where {N} = ntuple(i -> s[i + 1], Val(N - 1))
+
+# Permute some other type by perm
+# (for example, tuple, MVector, etc.)
+# as long as the constructor accepts a tuple
+@inline function _permute(s, perm)
+  return ntuple(i -> s[perm[i]], ValLength(perm))
+end
+
+permute(s::Tuple, perm) = _permute(s, perm)
+
+# TODO: is this needed?
+function permute(s::T, perm) where {T<:NTuple}
+  return T(_permute(s, perm))
+end
+
+function permute(s::T, perm) where {T}
+  return T(_permute(Tuple(s), perm))
+end
+
+# TODO: This is to handle Vector, is this correct?
+permute(s::AbstractVector, perm) = _permute(s, perm)
+
+sim(s::NTuple) = s
+
+# type stable findfirst
+@inline _findfirst(args...) = (i = findfirst(args...); i === nothing ? 0 : i)
+
+"""
+    getperm(col1,col2)
+
+Get the permutation that takes collection 2 to collection 1,
+such that col2[p].==col1
+"""
+@inline function getperm(s1, s2)
+  return ntuple(i -> _findfirst(==(@inbounds s1[i]), s2), length(s1))
+end
+
+"""
+    getperms(col1,col2,col3)
+
+Get the permutations that takes collections 2 and 3 to collection 1.
+"""
+function getperms(s, s1, s2)
+  N = length(s)
+  N1 = length(s1)
+  N2 = length(s2)
+  N1 + N2 ≠ N && error("Size of partial sets don't match with total set")
+  perm1 = ntuple(i -> findfirst(==(s1[i]), s), Val(N1))
+  perm2 = ntuple(i -> findfirst(==(s2[i]), s), Val(N2))
+  isperm((perm1..., perm2...)) ||
+    error("Combined permutations are $((perm1...,perm2...)), not a valid permutation")
+  return perm1, perm2
+end
+
+function invperm!(permres, perm)
+  for i in 1:length(perm)
+    permres[perm[i]] = i
+  end
+  return permres
+end
+
+function invperm(perm::NTuple{N,Int}) where {N}
+  mpermres = MVector{N,Int}(undef)
+  invperm!(mpermres, perm)
+  return Tuple(mpermres)
+end
+
+function invperm(perm)
+  permres = similar(perm)
+  invperm!(permres, perm)
+  return permres
+end
+
+# Override TupleTools.isperm to speed up
+# Strided.permutedims a bit (see:
+# https://github.com/Jutho/Strided.jl/issues/15)
+function isperm(p::NTuple{N}) where {N}
+  N < 6 && return Base.isperm(p)
+  used = @MVector zeros(Bool, N)
+  for a in p
+    (0 < a <= N) && (used[a] ⊻= true) || return false
+  end
+  return true
+end
+
+"""
+    is_trivial_permutation(P)
+
+Determine if P is a trivial permutation.
+"""
+function is_trivial_permutation(P)
+  #isperm(P) || error("Input is not a permutation")
+  # TODO: use `all(n->P[n]==n,1:length(P))`?
+  N = length(P)
+  for n in 1:N
+    @inbounds P[n] != n && return false
+  end
+  return true
+end
+
+# Combine a bunch of tuples
+@inline flatten(x) = x
+@inline flatten(x, y) = (x..., y...)
+@inline flatten(x, y, z...) = (x..., flatten(y, z...)...)
+
+function _deleteat(t, pos, i)
+  i < pos && return t[i]
+  return t[i + 1]
+end
+
+function deleteat(t::NTuple{N}, pos::Integer) where {N}
+  return ntuple(i -> _deleteat(t, pos, i), Val(N - 1))
+end
+
+deleteat(t::Tuple, I::Tuple{Int}) = deleteat(t, I[1])
+function deleteat(t::Tuple, I::Tuple{Int,Int,Vararg{Int}})
+  return deleteat_sorted(t, sort(I; rev=true))
+end
+
+deleteat_sorted(t::Tuple, pos::Int64) = deleteat(t, pos[1])
+deleteat_sorted(t::Tuple, pos::Tuple{Int}) = deleteat(t, pos[1])
+function deleteat_sorted(t::Tuple, pos::NTuple{N,Int}) where {N}
+  return deleteat_sorted(deleteat_sorted(t, pos[1]), Base.tail(pos))
+end
+
+# Make a slice of the block on the specified dimensions
+# Make this a generic tupletools function (TupleTools.jl calls it getindices)
+function getindices(t::Tuple, I::NTuple{N,Int}) where {N}
+  return ntuple(i -> t[I[i]], Val(N))
+end
+
+# Taken from TupleTools.jl
+"""
+    sort(t::Tuple; lt=isless, by=identity, rev::Bool=false) -> ::Tuple
+Sorts the tuple `t`.
+"""
+Base.sort(t::Tuple; lt=isless, by=identity, rev::Bool=false) = _sort(t, lt, by, rev)
+@inline function _sort(t::Tuple, lt=isless, by=identity, rev::Bool=false)
+  t1, t2 = _split(t)
+  t1s = _sort(t1, lt, by, rev)
+  t2s = _sort(t2, lt, by, rev)
+  return _merge(t1s, t2s, lt, by, rev)
+end
+_sort(t::Tuple{Any}, lt=isless, by=identity, rev::Bool=false) = t
+_sort(t::Tuple{}, lt=isless, by=identity, rev::Bool=false) = t
+
+function _split(t::NTuple{N}) where {N}
+  M = N >> 1
+  return ntuple(i -> t[i], M), ntuple(i -> t[i + M], N - M)
+end
+
+function _merge(t1::Tuple, t2::Tuple, lt, by, rev)
+  if lt(by(first(t1)), by(first(t2))) != rev
+    return (first(t1), _merge(Base.tail(t1), t2, lt, by, rev)...)
+  else
+    return (first(t2), _merge(t1, Base.tail(t2), lt, by, rev)...)
+  end
+end
+_merge(t1::Tuple{}, t2::Tuple, lt, by, rev) = t2
+_merge(t1::Tuple, t2::Tuple{}, lt, by, rev) = t1
+
+#function tail(t::NTuple{N})
+#  return ntuple(i -> t[i+1],Val(N-1))
+#end
+
+function _insertat(t, pos, n_insert, val, i)
+  if i < pos
+    return t[i]
+  elseif i > pos + n_insert - 1
+    return t[i - n_insert + 1]
+  end
+  return val[i - pos + 1]
+end
+
+"""
+    insertat
+
+Remove the value at pos and insert the elements in val
+"""
+function insertat(t::NTuple{N}, val::NTuple{M}, pos::Integer) where {N,M}
+  return ntuple(i -> _insertat(t, pos, M, val, i), Val(N + M - 1))
+end
+
+function insertat(t::NTuple{N}, val, pos::Integer) where {N}
+  return insertat(t, tuple(val), pos)
+end
+
+function _insertafter(t, pos, n_insert, val, i)
+  if i <= pos
+    return t[i]
+  elseif i > pos + n_insert
+    return t[i - n_insert]
+  end
+  return val[i - pos]
+end
+
+"""
+    insertafter(t, val, pos)
+
+Insert the elements in val after the position pos
+"""
+function insertafter(t::NTuple{N}, val::NTuple{M}, pos::Integer) where {N,M}
+  return ntuple(i -> _insertafter(t, pos, M, val, i), Val(N + M))
+end
+
+function insertafter(t::NTuple{N}, val, pos::Integer) where {N}
+  return insertafter(t, tuple(val), pos)
+end
+
+"""
+    isdisjoint(s1, s2)
+
+Determine if s1 and s2 have no overlapping elements.
+"""
+function isdisjoint(s1, s2)
+  for i1 in 1:length(s1)
+    for i2 in 1:length(s2)
+      s1[i1] == s2[i2] && return false
+    end
+  end
+  return true
+end
+
+"""
+    diff(t::Tuple)
+
+For a tuple of length N, return a tuple of length N-1
+where element i is t[i+1] - t[i].
+"""
+diff(t::NTuple{N}) where {N} = ntuple(i -> t[i + 1] - t[i], Val(N - 1))
+
+function count_unique(labelsT1, labelsT2)
+  count = 0
+  for l1 in labelsT1
+    l1 ∉ labelsT2 && (count += 1)
+  end
+  return count
+end
+
+function count_common(labelsT1, labelsT2)
+  count = 0
+  for l1 in labelsT1
+    l1 ∈ labelsT2 && (count += 1)
+  end
+  return count
+end
+
+function intersect_positions(labelsT1, labelsT2)
+  for i1 in 1:length(labelsT1)
+    for i2 in 1:length(labelsT2)
+      if labelsT1[i1] == labelsT2[i2]
+        return i1, i2
+      end
+    end
+  end
+  return nothing
+end
+
+function is_replacement(labelsT1, labelsT2)
+  return count_unique(labelsT1, labelsT2) == 1 && count_common(labelsT1, labelsT2) == 1
+end
+
+function is_combiner(labelsT1, labelsT2)
+  return count_unique(labelsT1, labelsT2) == 1 && count_common(labelsT1, labelsT2) > 1
+end
+
+function is_uncombiner(labelsT1, labelsT2)
+  return count_unique(labelsT1, labelsT2) > 1 && count_common(labelsT1, labelsT2) == 1
+end

--- a/src/global_variables.jl
+++ b/src/global_variables.jl
@@ -129,20 +129,6 @@ macro reset_warn_order(block)
 end
 
 #
-# A global timer used with TimerOutputs.jl
-#
-
-using NDTensors: timer
-
-#
-# Get the current number of BLAS threads
-# For VERSION >= v"1.6" this will become
-# using LinearAlgebra; BLAS.get_num_threads()
-#
-
-using NDTensors: blas_get_num_threads
-
-#
 # Block sparse multithreading
 #
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -95,9 +95,10 @@ import LinearAlgebra:
   svd,
   tr
 
-using NDTensors: EmptyNumber, fill!!, randn!!
+using ITensors.NDTensors:
+  EmptyNumber, blas_get_num_threads, fill!!, randn!!, timer
 
-import NDTensors:
+import ITensors.NDTensors:
   # Modules
   Strided, # to control threading
   # Types
@@ -134,13 +135,14 @@ import NDTensors:
   setinds,
   setstorage,
   sim,
-  store,
+  storage,
   sum,
   tensor,
   truncate!,
   using_tblis,
   vector,
   # Deprecated
-  addblock!
+  addblock!,
+  store
 
 import Random: randn!

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -87,7 +87,7 @@ all of the arrow directions).
 dag(is::Indices) = map(i -> dag(i), is)
 
 # TODO: move to NDTensors
-NDTensors.dim(is::Tuple, pos::Int) = dim(is[pos])
+NDTensors.dim(is::Tuple, pos::Integer) = dim(is[pos])
 
 # TODO: this fixes an ambiguity error with base, move to NDTensors
 NDTensors.similar(T::NDTensors.DenseTensor, inds::Tuple) = NDTensors._similar(T, inds)

--- a/test/NDTensors/Project.toml
+++ b/test/NDTensors/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/NDTensors/blocksparse.jl
+++ b/test/NDTensors/blocksparse.jl
@@ -1,0 +1,323 @@
+using ITensors.NDTensors, Test
+using LinearAlgebra
+
+@testset "BlockSparseTensor basic functionality" begin
+
+  # Indices
+  indsA = ([2, 3], [4, 5])
+
+  # Locations of non-zero blocks
+  locs = [(1, 2), (2, 1)]
+
+  A = BlockSparseTensor(locs, indsA...)
+  randn!(A)
+
+  @test blockdims(A, (1, 2)) == (2, 5)
+  @test blockdims(A, (2, 1)) == (3, 4)
+  @test nnzblocks(A) == 2
+  @test nnz(A) == 2 * 5 + 3 * 4
+  @test inds(A) == ([2, 3], [4, 5])
+  @test isblocknz(A, (2, 1))
+  @test isblocknz(A, (1, 2))
+  @test !isblocknz(A, (1, 1))
+  @test !isblocknz(A, (2, 2))
+
+  # Test different ways of getting nnz
+  @test nnz(blockoffsets(A), inds(A)) == nnz(A)
+
+  A[1, 5] = 15
+  A[2, 5] = 25
+
+  @test A[1, 1] == 0
+  @test A[1, 5] == 15
+  @test A[2, 5] == 25
+
+  D = dense(A)
+
+  @test D == A
+
+  for I in eachindex(A)
+    @test D[I] == A[I]
+  end
+
+  A12 = blockview(A, (1, 2))
+
+  @test dims(A12) == (2, 5)
+
+  for I in eachindex(A12)
+    @test A12[I] == A[I + CartesianIndex(0, 4)]
+  end
+
+  B = BlockSparseTensor(undef, locs, indsA)
+  randn!(B)
+
+  C = A + B
+
+  for I in eachindex(C)
+    @test C[I] == A[I] + B[I]
+  end
+
+  Ap = permutedims(A, (2, 1))
+
+  @test blockdims(Ap, (1, 2)) == (4, 3)
+  @test blockdims(Ap, (2, 1)) == (5, 2)
+  @test nnz(A) == nnz(Ap)
+  @test nnzblocks(A) == nnzblocks(Ap)
+
+  for I in eachindex(C)
+    @test A[I] == Ap[NDTensors.permute(I, (2, 1))]
+  end
+
+  A = BlockSparseTensor(ComplexF64, locs, indsA)
+  randn!(A)
+  @test conj(data(store(A))) == data(store(conj(A)))
+  @test typeof(conj(A)) <: BlockSparseTensor
+
+  @testset "Random constructor" begin
+    T = randomBlockSparseTensor([(1, 1), (2, 2)], ([2, 2], [2, 2]))
+    @test nnzblocks(T) == 2
+    @test nnz(T) == 8
+    @test eltype(T) == Float64
+    @test norm(T) ≉ 0
+
+    Tc = randomBlockSparseTensor(ComplexF64, [(1, 1), (2, 2)], ([2, 2], [2, 2]))
+    @test nnzblocks(Tc) == 2
+    @test nnz(Tc) == 8
+    @test eltype(Tc) == ComplexF64
+    @test norm(Tc) ≉ 0
+  end
+
+  @testset "Complex Valued Operations" begin
+    T = randomBlockSparseTensor(ComplexF64, [(1, 1), (2, 2)], ([2, 2], [2, 2]))
+    rT = real(T)
+    @test eltype(rT) == Float64
+    @test nnzblocks(rT) == nnzblocks(T)
+    iT = imag(T)
+    @test eltype(iT) == Float64
+    @test nnzblocks(iT) == nnzblocks(T)
+    @test norm(rT)^2 + norm(iT)^2 ≈ norm(T)^2
+
+    cT = conj(T)
+    @test eltype(cT) == ComplexF64
+    @test nnzblocks(cT) == nnzblocks(T)
+  end
+
+  @testset "BlockSparseTensor setindex! add block" begin
+    T = BlockSparseTensor([2, 3], [4, 5])
+
+    for I in eachindex(C)
+      @test T[I] == 0.0
+    end
+    @test nnz(T) == 0
+    @test nnzblocks(T) == 0
+    @test !isblocknz(T, (1, 1))
+    @test !isblocknz(T, (2, 1))
+    @test !isblocknz(T, (1, 2))
+    @test !isblocknz(T, (2, 2))
+
+    T[1, 1] = 1.0
+
+    @test T[1, 1] == 1.0
+    @test nnz(T) == 8
+    @test nnzblocks(T) == 1
+    @test isblocknz(T, (1, 1))
+    @test !isblocknz(T, (2, 1))
+    @test !isblocknz(T, (1, 2))
+    @test !isblocknz(T, (2, 2))
+
+    T[4, 8] = 2.0
+
+    @test T[4, 8] == 2.0
+    @test nnz(T) == 8 + 15
+    @test nnzblocks(T) == 2
+    @test isblocknz(T, (1, 1))
+    @test !isblocknz(T, (2, 1))
+    @test !isblocknz(T, (1, 2))
+    @test isblocknz(T, (2, 2))
+
+    T[1, 6] = 3.0
+
+    @test T[1, 6] == 3.0
+    @test nnz(T) == 8 + 15 + 10
+    @test nnzblocks(T) == 3
+    @test isblocknz(T, (1, 1))
+    @test !isblocknz(T, (2, 1))
+    @test isblocknz(T, (1, 2))
+    @test isblocknz(T, (2, 2))
+
+    T[4, 2] = 4.0
+
+    @test T[4, 2] == 4.0
+    @test nnz(T) == 8 + 15 + 10 + 12
+    @test nnzblocks(T) == 4
+    @test isblocknz(T, (1, 1))
+    @test isblocknz(T, (2, 1))
+    @test isblocknz(T, (1, 2))
+    @test isblocknz(T, (2, 2))
+  end
+
+  @testset "Add with different blocks" begin
+    # Indices
+    inds = ([2, 3], [4, 5])
+
+    # Locations of non-zero blocks
+    locsA = [(1, 1), (1, 2), (2, 2)]
+    A = BlockSparseTensor(locsA, inds...)
+    randn!(A)
+
+    locsB = [(1, 2), (2, 1)]
+    B = BlockSparseTensor(locsB, inds...)
+    randn!(B)
+
+    R = A + B
+
+    @test nnz(R) == dim(R)
+    for I in eachindex(R)
+      @test R[I] == A[I] + B[I]
+    end
+  end
+
+  @testset "permutedims!! with different blocks" begin
+    # Indices
+    indsA = ([2, 3], [4, 5])
+
+    # Locations of non-zero blocks
+    locsA = [(1, 2), (2, 1)]
+    A = BlockSparseTensor(locsA, indsA...)
+    randn!(A)
+
+    perm = (2, 1)
+
+    locsB = [(2, 1)]
+    indsB = NDTensors.permute(indsA, perm)
+    B = BlockSparseTensor(locsB, indsB...)
+    randn!(B)
+
+    R = permutedims!!(B, A, perm)
+
+    @test nnz(R) == nnz(A)
+    for I in eachindex(A)
+      @test R[NDTensors.permute(I, perm)] == A[I]
+    end
+  end
+
+  @testset "Contract" begin
+    indsA = ([2, 3], [4, 5])
+    locsA = [(1, 1), (2, 2), (2, 1), (1, 2)]
+    A = BlockSparseTensor(locsA, indsA...)
+    randn!(A)
+
+    indsB = ([4, 5], [3, 2])
+    locsB = [(1, 2), (2, 1), (1, 1)]
+    B = BlockSparseTensor(locsB, indsB...)
+    randn!(B)
+
+    R = contract(A, (1, -1), B, (-1, 2))
+
+    DA = dense(A)
+    DB = dense(B)
+    DR = contract(DA, (1, -1), DB, (-1, 2))
+
+    for I in eachindex(R)
+      @test R[I] ≈ DR[I]
+    end
+  end
+
+  @testset "reshape" begin
+    indsA = ([2, 3], [4, 5])
+    locsA = [(2, 1), (1, 2)]
+    A = BlockSparseTensor(locsA, indsA...)
+    randn!(A)
+
+    indsB = ([8, 12, 10, 15],)
+    B = reshape(A, indsB)
+
+    @test nnzblocks(A) == nnzblocks(B)
+    @test nnz(A) == nnz(B)
+    for (bA, bB) in zip(eachnzblock(A), eachnzblock(B))
+      blockA = blockview(A, bA)
+      blockB = blockview(B, bB)
+      @test reshape(blockA, size(blockB)) == blockB
+    end
+  end
+
+  @testset "permute_combine" begin
+    indsA = ([2, 3], [4, 5], [6, 7, 8])
+    locsA = [(2, 1, 1), (1, 2, 1), (2, 2, 3)]
+    A = BlockSparseTensor(locsA, indsA...)
+    randn!(A)
+
+    B = NDTensors.permute_combine(A, 3, (2, 1))
+
+    @test nnzblocks(A) == nnzblocks(B)
+    @test nnz(A) == nnz(B)
+
+    Ap = permutedims(A, (3, 2, 1))
+
+    for (bAp, bB) in zip(eachnzblock(Ap), eachnzblock(B))
+      blockAp = blockview(Ap, bAp)
+      blockB = blockview(B, bB)
+      @test reshape(blockAp, size(blockB)) == blockB
+    end
+  end
+
+  @testset "svd" begin
+    @testset "svd example 1" begin
+      A = BlockSparseTensor([(2, 1), (1, 2)], [2, 2], [2, 2])
+      randn!(A)
+      U, S, V = svd(A)
+      @test isapprox(norm(array(U) * array(S) * array(V)' - array(A)), 0; atol=1e-14)
+    end
+
+    @testset "svd example 2" begin
+      A = BlockSparseTensor([(1, 2), (2, 3)], [2, 2], [3, 2, 3])
+      randn!(A)
+      U, S, V = svd(A)
+      @test isapprox(norm(array(U) * array(S) * array(V)' - array(A)), 0.0; atol=1e-14)
+    end
+
+    @testset "svd example 3" begin
+      A = BlockSparseTensor([(2, 1), (3, 2)], [3, 2, 3], [2, 2])
+      randn!(A)
+      U, S, V = svd(A)
+      @test isapprox(norm(array(U) * array(S) * array(V)' - array(A)), 0.0; atol=1e-14)
+    end
+
+    @testset "svd example 4" begin
+      A = BlockSparseTensor([(2, 1), (3, 2)], [2, 3, 4], [5, 6])
+      randn!(A)
+      U, S, V = svd(A)
+      @test isapprox(norm(array(U) * array(S) * array(V)' - array(A)), 0.0; atol=1e-13)
+    end
+
+    @testset "svd example 5" begin
+      A = BlockSparseTensor([(1, 2), (2, 3)], [5, 6], [2, 3, 4])
+      randn!(A)
+      U, S, V = svd(A)
+      @test isapprox(norm(array(U) * array(S) * array(V)' - array(A)), 0.0; atol=1e-13)
+    end
+  end
+
+  @testset "exp" begin
+    A = BlockSparseTensor([(1, 1), (2, 2)], [2, 4], [2, 4])
+    randn!(A)
+    expT = exp(A)
+    @test isapprox(norm(array(expT) - exp(array(A))), 0.0; atol=1e-13)
+
+    # Hermitian case
+    A = BlockSparseTensor(ComplexF64, [(1, 1), (2, 2)], ([2, 2], [2, 2]))
+    randn!(A)
+    Ah = BlockSparseTensor(ComplexF64, undef, [(1, 1), (2, 2)], ([2, 2], [2, 2]))
+    for bA in eachnzblock(A)
+      b = blockview(A, bA)
+      blockview(Ah, bA) .= b + b'
+    end
+    expTh = exp(Hermitian(Ah))
+    @test array(expTh) ≈ exp(Hermitian(array(Ah))) rtol = 1e-13
+
+    A = BlockSparseTensor([(2, 1), (1, 2)], [2, 2], [2, 2])
+    @test_throws ErrorException exp(A)
+  end
+end
+
+nothing

--- a/test/NDTensors/dense.jl
+++ b/test/NDTensors/dense.jl
@@ -1,0 +1,249 @@
+using ITensors.NDTensors, Test
+
+@static if VERSION >= v"1.5"
+  using Pkg
+  Pkg.add("Octavian")
+  using Octavian
+end
+
+@testset "Dense Tensors" begin
+  @testset "DenseTensor basic functionality" begin
+    A = Tensor(3, 4)
+
+    for I in eachindex(A)
+      @test A[I] == 0
+    end
+
+    randn!(A)
+
+    for I in eachindex(A)
+      @test A[I] != 0
+    end
+
+    for I in eachindex(A)
+      @test A[I] != 0
+    end
+
+    @test ndims(A) == 2
+    @test dims(A) == (3, 4)
+    @test inds(A) == (3, 4)
+
+    A[1, 1] = 11
+
+    @test A[1, 1] == 11
+
+    Aview = A[2:3, 2:3]
+
+    @test dims(Aview) == (2, 2)
+    @test A[2, 2] == Aview[1, 1]
+
+    @test A * 2.0 == 2.0 * A
+
+    Asim = similar(data(A), 10)
+    @test eltype(Asim) == Float64
+    @test length(Asim) == 10
+
+    B = Tensor(undef, 3, 4)
+    randn!(B)
+
+    C = A + B
+
+    for I in eachindex(C)
+      @test C[I] == A[I] + B[I]
+    end
+
+    Ap = permutedims(A, (2, 1))
+
+    for I in eachindex(A)
+      @test A[I] == Ap[NDTensors.permute(I, (2, 1))]
+    end
+
+    t = Tensor(ComplexF64, 100, 100)
+    randn!(t)
+    @test conj(data(store(t))) == data(store(conj(t)))
+    @test typeof(conj(t)) <: DenseTensor
+
+    @test Dense(ComplexF64) == Dense{ComplexF64}()
+    @test Dense(ComplexF64) == complex(Dense(Float64))
+
+    D = Tensor(ComplexF64, (100, 100))
+    @test eltype(D) == ComplexF64
+    @test ndims(D) == 2
+    @test dim(D) == 100^2
+
+    E = Tensor(ComplexF64, undef, (100, 100))
+    @test eltype(E) == ComplexF64
+    @test ndims(E) == 2
+    @test dim(E) == 100^2
+
+    F = Tensor((100, 100))
+    @test eltype(F) == Float64
+    @test ndims(F) == 2
+    @test dim(F) == 100^2
+
+    G = Tensor(undef, (100, 100))
+    @test eltype(G) == Float64
+    @test ndims(G) == 2
+    @test dim(G) == 100^2
+
+    H = Tensor(ComplexF64, undef, 100, 100)
+    @test eltype(H) == ComplexF64
+    @test ndims(H) == 2
+    @test dim(H) == 100^2
+
+    I_arr = rand(10, 10, 10)
+    I = Tensor(I_arr, (10, 10, 10))
+    @test eltype(I) == Float64
+    @test dim(I) == 1000
+    @test Array(I) == I_arr
+
+    J = Tensor(2, 2)
+    K = Tensor(2, 2)
+    @test Array(J * K) ≈ Array(J) * Array(K)
+  end
+
+  @testset "Random constructor" begin
+    T = randomTensor(2, 2)
+    @test dims(T) == (2, 2)
+    @test eltype(T) == Float64
+    @test T[1, 1] ≉ 0
+    @test norm(T) ≉ 0
+
+    Tc = randomTensor(ComplexF64, 2, 2)
+    @test dims(Tc) == (2, 2)
+    @test eltype(Tc) == ComplexF64
+    @test Tc[1, 1] ≉ 0
+    @test norm(Tc) ≉ 0
+  end
+
+  @testset "Complex Valued Tensors" begin
+    d1, d2, d3 = 2, 3, 4
+    T = randomTensor(ComplexF64, d1, d2, d3)
+
+    rT = real(T)
+    iT = imag(T)
+    cT = conj(T)
+
+    for n1 in 1:d1, n2 in 1:d2, n3 in 1:d3
+      @test rT[n1, n2, n3] ≈ real(T[n1, n2, n3])
+      @test iT[n1, n2, n3] ≈ imag(T[n1, n2, n3])
+      @test cT[n1, n2, n3] ≈ conj(T[n1, n2, n3])
+    end
+  end
+
+  @testset "Custom inds types" begin
+    struct MyInd
+      dim::Int
+    end
+    NDTensors.dim(i::MyInd) = i.dim
+
+    T = Tensor((MyInd(2), MyInd(3), MyInd(4)))
+    @test store(T) isa Dense
+    @test eltype(T) == Float64
+    @test norm(T) == 0
+    @test dims(T) == (2, 3, 4)
+    @test ndims(T) == 3
+    @test inds(T) == (MyInd(2), MyInd(3), MyInd(4))
+    T[2, 1, 2] = 1.21
+    @test T[2, 1, 2] == 1.21
+    @test norm(T) == 1.21
+
+    T = randomTensor(ComplexF64, (MyInd(4), MyInd(3)))
+    @test store(T) isa Dense
+    @test eltype(T) == ComplexF64
+    @test norm(T) > 0
+    @test dims(T) == (4, 3)
+    @test ndims(T) == 2
+    @test inds(T) == (MyInd(4), MyInd(3))
+
+    T2 = 2 * T
+    @test eltype(T2) == ComplexF64
+    @test store(T2) isa Dense
+    @test norm(T2) > 0
+    @test norm(T2) / norm(T) ≈ 2
+    @test dims(T2) == (4, 3)
+    @test ndims(T2) == 2
+    @test inds(T2) == (MyInd(4), MyInd(3))
+  end
+
+  @testset "generic contraction" begin
+    # correctness of _gemm!
+    for alpha in [0.0, 1.0, 2.0]
+      for beta in [0.0, 1.0, 2.0]
+        for tA in ['N', 'T']
+          for tB in ['N', 'T']
+            A = randn(4, 4)
+            B = randn(4, 4)
+            C = randn(4, 4)
+            A = BigFloat.(A)
+            B = BigFloat.(B)
+            C2 = BigFloat.(C)
+            NDTensors._gemm!(tA, tB, alpha, A, B, beta, C)
+            NDTensors._gemm!(tA, tB, alpha, A, B, beta, C2)
+            @test C ≈ C2
+          end
+        end
+      end
+    end
+  end
+
+  @testset "Contraction with size 1 block and NaN" begin
+    @testset "No permutation" begin
+      R = Tensor(ComplexF64, 2, 2, 1)
+      fill!(R, NaN)
+      @test any(isnan, R)
+      T1 = randomTensor(2, 2, 1)
+      T2 = randomTensor(ComplexF64, 1, 1)
+      NDTensors.contract!(R, (1, 2, 3), T1, (1, 2, -1), T2, (-1, 1))
+      @test !any(isnan, R)
+      @test convert(Array, R) ≈ convert(Array, T1) * T2[1]
+    end
+
+    @testset "Permutation" begin
+      R = Tensor(ComplexF64, 2, 2, 1)
+      fill!(R, NaN)
+      @test any(isnan, R)
+      T1 = randomTensor(2, 2, 1)
+      T2 = randomTensor(ComplexF64, 1, 1)
+      NDTensors.contract!(R, (2, 1, 3), T1, (1, 2, -1), T2, (-1, 1))
+      @test !any(isnan, R)
+      @test convert(Array, R) ≈ permutedims(convert(Array, T1), (2, 1, 3)) * T2[1]
+    end
+  end
+
+  @testset "change backends" begin
+    a, b, c = [randn(5, 5) for i in 1:3]
+    backend_auto()
+    @test NDTensors.gemm_backend[] == :Auto
+    @test NDTensors.auto_select_backend(typeof.((a, b, c))...) ==
+          NDTensors.GemmBackend(:BLAS)
+    res1 = NDTensors._gemm!('N', 'N', 2.0, a, b, 0.2, copy(c))
+    backend_blas()
+    @test NDTensors.gemm_backend[] == :BLAS
+    res2 = NDTensors._gemm!('N', 'N', 2.0, a, b, 0.2, copy(c))
+    backend_generic()
+    @test NDTensors.gemm_backend[] == :Generic
+    res3 = NDTensors._gemm!('N', 'N', 2.0, a, b, 0.2, copy(c))
+    @test res1 == res2
+    @test res1 ≈ res3
+    backend_auto()
+  end
+
+  @static if VERSION >= v"1.5"
+    @testset "change backends" begin
+      a, b, c = [randn(5, 5) for i in 1:3]
+      backend_auto()
+      @test NDTensors.gemm_backend[] == :Auto
+      @test NDTensors.auto_select_backend(typeof.((a, b, c))...) ==
+            NDTensors.GemmBackend(:BLAS)
+      res1 = NDTensors._gemm!('N', 'N', 2.0, a, b, 0.2, copy(c))
+      backend_octavian()
+      @test NDTensors.gemm_backend[] == :Octavian
+      res4 = NDTensors._gemm!('N', 'N', 2.0, a, b, 0.2, copy(c))
+      @test res1 ≈ res4
+      backend_auto()
+    end
+  end
+end
+
+nothing

--- a/test/NDTensors/diag.jl
+++ b/test/NDTensors/diag.jl
@@ -1,0 +1,30 @@
+using ITensors.NDTensors, Test
+
+@testset "DiagTensor basic functionality" begin
+  t = tensor(Diag(rand(ComplexF64, 100)), (100, 100))
+  @test conj(data(store(t))) == data(store(conj(t)))
+  @test typeof(conj(t)) <: DiagTensor
+
+  d = rand(Float32, 10)
+  D = Diag{ComplexF64}(d)
+  @test eltype(D) == ComplexF64
+  @test Array(dense(D)) == convert.(ComplexF64, d)
+  simD = similar(D)
+  @test length(simD) == length(D)
+  @test eltype(simD) == eltype(D)
+  D = Diag(1.0)
+  @test eltype(D) == Float64
+  @test complex(D) == Diag(one(ComplexF64))
+  @test similar(D) == Diag(0.0)
+
+  d = 3
+  vr = rand(d)
+  D = tensor(Diag(vr), (d, d))
+  @test Array(D) == NDTensors.LinearAlgebra.diagm(0 => vr)
+  @test matrix(D) == NDTensors.LinearAlgebra.diagm(0 => vr)
+  # fails because of missing similar method for NonuniformDiag :(
+  #@test permutedims(D, (2, 1)) == tensor(diagITensor(vr, j, i))
+  #@test permutedims(tensor(diagITensor(2.0, j, i)), (2, 1)) == tensor(diagITensor(2.0, j, i))
+end
+
+nothing

--- a/test/NDTensors/linearalgebra.jl
+++ b/test/NDTensors/linearalgebra.jl
@@ -1,0 +1,22 @@
+using ITensors.NDTensors, Test
+using LinearAlgebra
+
+@testset "random_orthog" begin
+  n, m = 10, 4
+  O1 = random_orthog(n, m)
+  @test eltype(O1) == Float64
+  @test norm(transpose(O1) * O1 - Diagonal(fill(1.0, m))) < 1E-14
+  O2 = random_orthog(m, n)
+  @test norm(O2 * transpose(O2) - Diagonal(fill(1.0, m))) < 1E-14
+end
+
+@testset "random_unitary" begin
+  n, m = 10, 4
+  U1 = random_unitary(n, m)
+  @test eltype(U1) == ComplexF64
+  @test norm(U1' * U1 - Diagonal(fill(1.0, m))) < 1E-14
+  U2 = random_unitary(m, n)
+  @test norm(U2 * U2' - Diagonal(fill(1.0, m))) < 1E-14
+end
+
+nothing

--- a/test/NDTensors/readwrite.jl
+++ b/test/NDTensors/readwrite.jl
@@ -1,0 +1,73 @@
+using ITensors.NDTensors, Test
+using HDF5
+
+@testset "Write to Disk and Read from Disk" begin
+  @testset "HDF5 readwrite Dense storage" begin
+    # Real case
+
+    D = randomTensor(3, 4)
+
+    fo = h5open("data.h5", "w")
+    write(fo, "D", D.store)
+    close(fo)
+
+    fi = h5open("data.h5", "r")
+    rDstore = read(fi, "D", Dense{Float64})
+    close(fi)
+    @test rDstore ≈ D.store
+
+    # Complex case
+
+    D = randomTensor(ComplexF64, 3, 4)
+
+    fo = h5open("data.h5", "w")
+    write(fo, "D", D.store)
+    close(fo)
+
+    fi = h5open("data.h5", "r")
+    rDstore = read(fi, "D", Dense{ComplexF64})
+    close(fi)
+    @test rDstore ≈ D.store
+  end
+
+  @testset "HDF5 readwrite BlockSparse storage" begin
+    # Indices
+    indsA = ([2, 3], [4, 5])
+
+    # Locations of non-zero blocks
+    locs = [(1, 2), (2, 1)]
+
+    # Real case
+
+    B = randomBlockSparseTensor(locs, indsA)
+
+    fo = h5open("data.h5", "w")
+    write(fo, "B", B.store)
+    close(fo)
+
+    fi = h5open("data.h5", "r")
+    rBstore = read(fi, "B", BlockSparse{Float64})
+    close(fi)
+    @test rBstore ≈ B.store
+
+    # Complex case
+
+    B = randomBlockSparseTensor(ComplexF64, locs, indsA)
+
+    fo = h5open("data.h5", "w")
+    write(fo, "B", B.store)
+    close(fo)
+
+    fi = h5open("data.h5", "r")
+    rBstore = read(fi, "B", BlockSparse{ComplexF64})
+    close(fi)
+    @test rBstore ≈ B.store
+  end
+
+  #
+  # Clean up the test hdf5 file
+  #
+  rm("data.h5"; force=true)
+end
+
+nothing

--- a/test/NDTensors/runtests.jl
+++ b/test/NDTensors/runtests.jl
@@ -1,0 +1,12 @@
+using Test
+
+@testset "ITensors.NDTensors" begin
+  @testset "$filename" for filename in [
+    "linearalgebra.jl", "dense.jl", "blocksparse.jl", "diag.jl"
+   ]
+    println("Running $filename")
+    include(filename)
+  end
+end
+
+nothing

--- a/test/NDTensors/tupletools.jl
+++ b/test/NDTensors/tupletools.jl
@@ -1,0 +1,9 @@
+using Test
+using ITensors.NDTensors
+
+@testset "Test non-exported tuple tools" begin
+  @test NDTensors.diff((1, 3, 6, 4)) == (2, 3, -2)
+  @test NDTensors.diff((1, 2, 3)) == (1, 1)
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 
 @testset "ITensors.jl" begin
   @testset "$filename" for filename in [
+    "NDTensors/runtests.jl",
     "tagset.jl",
     "smallstring.jl",
     "symmetrystyle.jl",


### PR DESCRIPTION
This moves the `NDTensors` module and tests from https://github.com/ITensor/NDTensors.jl. That repository will still exist in its current form, but at least for the time being development will happen here. This will make development as well as CI testing and benchmarking easier.

Once `NDTensors` is more stable we can move development back to the separate repository.