### PR TITLE
Fix bug in `MPO(::AutoMPO, ...)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ITensor v0.2.0 Release Notes
 ==============================
+- Fix bug in `MPO(::AutoMPO, ::Vector{<:Index})` where for fermionic models the AutoMPO was being modified in-place (PR #659) (@mtfishman).
 - Remove size type parameter from ITensor and IndexSet (PR #591) (@kshyatt).
 - Add support for using end in setindex! for ITensors (PR #596) (@mtfishman).
 - Contraction sequence optimization (PR #589) (@mtfishman).
@@ -15,6 +16,13 @@ ITensor v0.2.0 Release Notes
 
 Deprecations:
 - `store` is deprecated in favor of `storage` for getting the storage of an ITensor. Similarly `ITensors.setstore[!]` -> `ITensors.setstorage[!]`.
+
+Breaking changes:
+- The tensor order type paramater has been removed from the `ITensor` type, so you can no longer write `ITensor{3}` to specify an order 3 ITensor (PR #591).
+- ITensors now store a `Tuple` of `Index` instead of an `IndexSet` (PR #).
+- The `IndexSet{T}` type has been redefined as a type alias for `Vector{T<:Index}` (which is subject to change). Therefore it no longer has a type parameter for the number of indices, similar to the change to the `ITensor` type. If you were using the plain `IndexSet` type, code should generally still work properly. In general you should not have to use `IndexSet`, and can just use `Tuple` or `Vector` of `Index` instead, such as `is = (i, j, k)` or `is = [i, j, k]`. Priming, tagging, and set operations now work generically on those types.
+- `ITensor` constructors from collections of `Index`, such as `ITensor(i, j, k)`, now return an `ITensor` with `EmptyStorage` (previously called `Empty`) storage instead of `Dense` or `BlockSparse` storage filled with 0 values. Most operations should still work that worked previously, but please contact us if there are issues.
+- The `NDTensors` module has been moved into the `ITensors` package, so `ITensors` no longer depends on the standalone `NDTensors` package. This should only effect users who were using both `NDTensors` and `ITensors` seperately. If you want to use the latest `NDTensors` library, you should do `using ITensors.NDTensors`. Note the current `NDTensors.jl` packge will still exist, but for now developmentof `NDTensors` will occur within `ITensors.jl`.
 
 ITensors v0.1.41 Release Notes
 ==============================

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 [compat]
 Compat = "2.1, 3"
 Dictionaries = "0.3.5"
-HDF5 = "0.14,0.15"
+HDF5 = "0.14, 0.15"
 KrylovKit = "0.4.2, 0.5"
 PackageCompiler = "1.0.0"
 Requires = "1.1"

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -175,6 +175,10 @@ Base.:(==)(ampo1::AutoMPO, ampo2::AutoMPO) = data(ampo1) == data(ampo2)
 
 Base.copy(ampo::AutoMPO) = AutoMPO(copy(data(ampo)))
 
+function Base.deepcopy(ampo::AutoMPO)
+  return AutoMPO(map(copy, data(ampo)))
+end
+
 Base.size(ampo::AutoMPO) = size(data(ampo))
 
 """

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -944,6 +944,7 @@ H = MPO(ampo,sites)
 function MPO(ampo::AutoMPO, sites::Vector{<:Index}; kwargs...)::MPO
   length(data(ampo)) == 0 && error("AutoMPO has no terms")
 
+  ampo = deepcopy(ampo)
   sorteachterm!(ampo, sites)
   sortmergeterms!(ampo)
 

--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -802,6 +802,22 @@ end
 
     @test norm(H1 - H2) ≈ 0.0
   end
+
+  @testset "AutoMPO in-place modification regression test" begin
+    N = 2
+    t = 1.0
+    ampo = AutoMPO()
+    for n in 1:(N - 1)
+      ampo .+= -t, "Cdag", n, "C", n + 1
+      ampo .+= -t, "Cdag", n + 1, "C", n
+    end
+    s = siteinds("Fermion", N; conserve_qns=true)
+    ampo_original = deepcopy(ampo)
+    for i in 1:4
+      MPO(ampo, s)
+      @test ampo == ampo_original
+    end
+  end
 end
 
 nothing


### PR DESCRIPTION
Fix bug in `MPO(::AutoMPO, ...)` where the input `AutoMPO` gets modified in-place for fermionic models. Minimal example of the issue:
```julia
function main(N = 2)
  t = 1.0
  ampo = AutoMPO()
  for n in 1:(N - 1)
    ampo .+= -t, "Cdag", n, "C", n + 1
    ampo .+= -t, "Cdag", n + 1, "C", n
  end
  s = siteinds("Fermion", N; conserve_qns=true)
  for i in 1:4
    MPO(ampo, s)
    @show ampo
  end
end
```
gives:
```julia
julia> main()
ampo = AutoMPO:
  1.0 "C*F"(1) "Cdag"(2) 
  -1.0 "Cdag*F"(1) "C"(2) 
ampo = AutoMPO:
  1.0 "C*F*F"(1) "Cdag"(2) 
  -1.0 "Cdag*F*F"(1) "C"(2) 
ampo = AutoMPO:
  1.0 "C*F*F*F"(1) "Cdag"(2) 
  -1.0 "Cdag*F*F*F"(1) "C"(2) 
ampo = AutoMPO:
  1.0 "C*F*F*F*F"(1) "Cdag"(2) 
  -1.0 "Cdag*F*F*F*F"(1) "C"(2) 
```
After the fix it gives:
```julia
julia> main()
ampo = AutoMPO:
  -1.0 "Cdag"(1) "C"(2) 
  -1.0 "Cdag"(2) "C"(1) 

ampo = AutoMPO:
  -1.0 "Cdag"(1) "C"(2) 
  -1.0 "Cdag"(2) "C"(1) 

ampo = AutoMPO:
  -1.0 "Cdag"(1) "C"(2) 
  -1.0 "Cdag"(2) "C"(1) 

ampo = AutoMPO:
  -1.0 "Cdag"(1) "C"(2) 
  -1.0 "Cdag"(2) "C"(1) 
```
as expected.