### PR TITLE
Allow constructing a `Tensor` from a `Vector` of `Index`

### DIFF
--- a/src/NDTensors/blocksparse/blockdims.jl
+++ b/src/NDTensors/blocksparse/blockdims.jl
@@ -99,7 +99,9 @@ function blockdim(ind::BlockDim, i::Integer)
 end
 
 function blockdim(ind::Integer, i)
-  error("`blockdim(i::Integer, b)` not currently defined for non-block index $i of type `$(typeof(i))`. In the future this may be defined for `b == Block(1)` or `b == 1` as `dim(i)` and error otherwise.")
+  return error(
+    "`blockdim(i::Integer, b)` not currently defined for non-block index $i of type `$(typeof(i))`. In the future this may be defined for `b == Block(1)` or `b == 1` as `dim(i)` and error otherwise.",
+  )
 end
 
 """

--- a/src/NDTensors/blocksparse/blockdims.jl
+++ b/src/NDTensors/blocksparse/blockdims.jl
@@ -98,6 +98,10 @@ function blockdim(ind::BlockDim, i::Integer)
   return ind[i]
 end
 
+function blockdim(ind::Integer, i)
+  error("`blockdim(i::Integer, b)` not currently defined for non-block index $i of type `$(typeof(i))`. In the future this may be defined for `b == Block(1)` or `b == 1` as `dim(i)` and error otherwise.")
+end
+
 """
     blockdim(::BlockDims,block,::Integer)
 

--- a/src/NDTensors/tensor.jl
+++ b/src/NDTensors/tensor.jl
@@ -27,35 +27,35 @@ struct Tensor{ElT,N,StoreT<:TensorStorage,IndsT} <: AbstractArray{ElT,N}
   end
 end
 
-# Automatically convert to Tuple if the indices are not a Tuple
-# already (like a Vector). In the future this may be lifted
-# to allow for very large tensor orders in which case Tuple
-# operations may become too slow.
 function Tensor{ElT,N,StoreT,IndsT}(
-  as::AllowAlias, storage::TensorStorage, inds
-) where {ElT,N,StoreT<:TensorStorage,IndsT}
-  return Tensor{ElT,N,StoreT,IndsT}(as, storage, Tuple(inds))
-end
-
-function Tensor{ElT,N,StoreT,IndsT}(
-  vs::NeverAlias, storage::TensorStorage, inds
+  ::NeverAlias, storage::TensorStorage, inds
 ) where {ElT,N,StoreT<:TensorStorage,IndsT}
   return Tensor{ElT,N,StoreT,IndsT}(AllowAlias(), copy(storage), inds)
 end
 
 # Allow the storage and indices to be input in opposite ordering
-(T::Type{<:Tensor})(vs::AliasStyle, inds, storage::TensorStorage) = T(vs, storage, inds)
+(T::Type{<:Tensor})(as::AliasStyle, inds, storage::TensorStorage) = T(as, storage, inds)
 
 """
-    Tensor(store::TensorStorage, inds)
+    Tensor(storage::TensorStorage, inds)
 
 Construct a Tensor from a tensor storage and indices.
-The Tensor holds a view of the storage data.
+The Tensor holds a copy of the storage data.
+
+The indices `inds` will be converted to a `Tuple`.
 """
-function Tensor(
-  vs::AliasStyle, store::StoreT, inds::IndsT
-) where {StoreT<:TensorStorage,IndsT}
-  return Tensor{eltype(store),length(inds),StoreT,IndsT}(vs, inds, store)
+function Tensor(as::AliasStyle, storage::TensorStorage, inds::Tuple)
+  return Tensor{eltype(storage),length(inds),typeof(storage),typeof(inds)}(
+    as, storage, inds
+  )
+end
+
+# Automatically convert to Tuple if the indices are not a Tuple
+# already (like a Vector). In the future this may be lifted
+# to allow for very large tensor orders in which case Tuple
+# operations may become too slow.
+function Tensor(as::AliasStyle, storage::TensorStorage, inds)
+  return Tensor(as, storage, Tuple(inds))
 end
 
 tensor(args...; kwargs...) = Tensor(AllowAlias(), args...; kwargs...)
@@ -134,7 +134,7 @@ Base.similar(T::Tensor, args...) = similar(T, args...)
 
 LinearAlgebra.norm(T::Tensor) = norm(storage(T))
 
-conj(vs::AliasStyle, T::Tensor) = setstorage(T, conj(vs, storage(T)))
+conj(as::AliasStyle, T::Tensor) = setstorage(T, conj(as, storage(T)))
 conj(T::Tensor) = conj(AllowAlias(), T)
 
 randn!!(T::Tensor) = (randn!(T); T)

--- a/src/NDTensors/tensor.jl
+++ b/src/NDTensors/tensor.jl
@@ -21,10 +21,20 @@ struct Tensor{ElT,N,StoreT<:TensorStorage,IndsT} <: AbstractArray{ElT,N}
   and tensor(store::TensorStorage, inds) constructors.
   """
   function Tensor{ElT,N,StoreT,IndsT}(
-    ::AllowAlias, storage::TensorStorage, inds
+    ::AllowAlias, storage::TensorStorage, inds::Tuple
   ) where {ElT,N,StoreT<:TensorStorage,IndsT}
     return new{ElT,N,StoreT,IndsT}(storage, inds)
   end
+end
+
+# Automatically convert to Tuple if the indices are not a Tuple
+# already (like a Vector). In the future this may be lifted
+# to allow for very large tensor orders in which case Tuple
+# operations may become too slow.
+function Tensor{ElT,N,StoreT,IndsT}(
+  as::AllowAlias, storage::TensorStorage, inds
+) where {ElT,N,StoreT<:TensorStorage,IndsT}
+  return Tensor{ElT,N,StoreT,IndsT}(as, storage, Tuple(inds))
 end
 
 function Tensor{ElT,N,StoreT,IndsT}(

--- a/src/NDTensors/tupletools.jl
+++ b/src/NDTensors/tupletools.jl
@@ -9,6 +9,10 @@ ValLength(::Type{NTuple{N,T}}) where {N,T} = Val{N}
 """
 ValLength(::NTuple{N}) where {N} = Val(N)
 
+# Only to help with backwards compatibility, this
+# is not type stable and therefore not efficient.
+ValLength(v::Vector) = Val(length(v))
+
 ValLength(::Tuple{Vararg{<:Any,N}}) where {N} = Val(N)
 
 ValLength(::Type{<:Tuple{Vararg{<:Any,N}}}) where {N} = Val{N}

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -190,7 +190,9 @@ qnblocks(i::QNIndex) = space(i)
 blockdim(i::QNIndex, b::Block) = blockdim(space(i), b)
 blockdim(i::QNIndex, b::Integer) = blockdim(i, Block(b))
 function blockdim(i::Index, b::Union{Block,Integer})
-  error("`blockdim(i::Index, b)` not currently defined for non-QN Index $i of type `$(typeof(i))`. In the future this may be defined for `b == Block(1)` or `b == 1` as `dim(i)` and error otherwise.")
+  return error(
+    "`blockdim(i::Index, b)` not currently defined for non-QN Index $i of type `$(typeof(i))`. In the future this may be defined for `b == Block(1)` or `b == 1` as `dim(i)` and error otherwise.",
+  )
 end
 
 eachblock(i::Index) = (Block(n) for n in 1:nblocks(i))

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -189,6 +189,9 @@ qnblocks(i::QNIndex) = space(i)
 # XXX: deprecate the Integer version
 blockdim(i::QNIndex, b::Block) = blockdim(space(i), b)
 blockdim(i::QNIndex, b::Integer) = blockdim(i, Block(b))
+function blockdim(i::Index, b::Union{Block,Integer})
+  error("`blockdim(i::Index, b)` not currently defined for non-QN Index $i of type `$(typeof(i))`. In the future this may be defined for `b == Block(1)` or `b == 1` as `dim(i)` and error otherwise.")
+end
 
 eachblock(i::Index) = (Block(n) for n in 1:nblocks(i))
 

--- a/test/ndtensors.jl
+++ b/test/ndtensors.jl
@@ -1,0 +1,28 @@
+using ITensors
+using ITensors.NDTensors
+using Test
+
+@testset "NDTensors compatibility" begin
+  i = Index([QN(0) => 1, QN(1) => 1])
+
+  T = BlockSparseTensor(Float64, [Block(1, 1)], (i', dag(i)))
+  @test nnzblocks(T) == 1
+  @test nzblocks(T) == [Block(1, 1)]
+
+  T = BlockSparseTensor(Float64, [Block(1, 1)], [i', dag(i)])
+  @test nnzblocks(T) == 1
+  @test nzblocks(T) == [Block(1, 1)]
+
+  T = BlockSparseTensor(Float64, [Block(1, 1)], IndexSet(i', dag(i)))
+  @test nnzblocks(T) == 1
+  @test nzblocks(T) == [Block(1, 1)]
+
+  @testset "blockdim" begin
+    i = Index(2)
+    @test_throws ErrorException blockdim(i, Block(1))
+    @test_throws ErrorException blockdim(i, 1)
+    @test_throws ErrorException blockdim(1, Block(1))
+    @test_throws ErrorException blockdim(1, 1)
+  end
+end
+

--- a/test/ndtensors.jl
+++ b/test/ndtensors.jl
@@ -25,4 +25,3 @@ using Test
     @test_throws ErrorException blockdim(1, 1)
   end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Test
     "symmetrystyle.jl",
     "index.jl",
     "indexset.jl",
+    "ndtensors.jl",
     "not.jl",
     "itensor_scalar.jl",
     "itensor.jl",


### PR DESCRIPTION
Allow constructing a `Tensor` from a `Vector` of `Index` to help with backwards compatibility (they get converted to `Tuple` before construction). Also add better error message for trying to construct a block sparse tensor from indices that don't have blocks, like `Int` or `Index{Int}`.