### PR TITLE
Fix bug when computing flux where index and Block were getting mixed up

### DIFF
--- a/src/NDTensors/blocksparse/blockdims.jl
+++ b/src/NDTensors/blocksparse/blockdims.jl
@@ -153,7 +153,12 @@ end
 
 # Given a CartesianIndex in the range dims(T), get the block it is in
 # and the index within that block
-function blockindex(T, i::Vararg{Int,N}) where {ElT,N}
+function blockindex(T, i::Vararg{Integer,N}) where {ElT,N}
+  # Bounds check.
+  # Do something more robust like:
+  # @boundscheck Base.checkbounds_indices(Bool, map(Base.oneto, dims(T)), i) || throw_boundserror(T, i)
+  @boundscheck any(iszero, i) && Base.throw_boundserror(T, i)
+
   # Start in the (1,1,...,1) block
   current_block_loc = @MVector ones(Int, N)
   current_block_dims = blockdims(T, Tuple(current_block_loc))

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -48,6 +48,17 @@
 @deprecate simlinks!(args...; kwargs...) ITensors.sim_linkinds!(args...; kwargs...)
 @deprecate mul(A::AbstractMPS, B::AbstractMPS; kwargs...) contract(A, B; kwargs...)
 
+# mps/mps.jl
+@deprecate randomMPS(sites::Vector{<:Index}, linkdims::Integer) randomMPS(
+  sites; linkdims=linkdims
+)
+@deprecate randomMPS(ElType::Type, sites::Vector{<:Index}, linkdims::Integer) randomMPS(
+  ElType, sites; linkdims=linkdims
+)
+@deprecate randomMPS(sites::Vector{<:Index}, state, linkdims::Integer) randomMPS(
+  sites, state; linkdims=linkdims
+)
+
 # physics/autompo.jl
 @deprecate toMPO(args...; kwargs...) MPO(args...; kwargs...)
 

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -721,7 +721,7 @@ ndiagblocks(inds) = minimum(nblocks(inds))
 
 # TODO: generic to Indices and BlockDims
 function eachblock(inds::Indices)
-  return CartesianIndices(_Tuple(nblocks(inds)))
+  return (Block(b) for b in CartesianIndices(_Tuple(nblocks(inds))))
 end
 
 # TODO: turn this into an iterator instead

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -737,13 +737,13 @@ Get the flux of the specified block, for example:
 ```
 i = Index(QN(0)=>2, QN(1)=>2)
 is = (i, dag(i'))
-flux(is, (1,1)) == QN(0)
-flux(is, (2,1)) == QN(1)
-flux(is, (1,2)) == QN(-1)
-flux(is, (2,2)) == QN(0)
+flux(is, Block(1, 1)) == QN(0)
+flux(is, Block(2, 1)) == QN(1)
+flux(is, Block(1, 2)) == QN(-1)
+flux(is, Block(2, 2)) == QN(0)
 ```
 """
-function flux(inds::Indices, block)
+function flux(inds::Indices, block::Block)
   qntot = QN()
   for n in 1:length(inds)
     ind = inds[n]
@@ -753,7 +753,7 @@ function flux(inds::Indices, block)
 end
 
 """
-    flux(inds::Indices, I::Int...)
+    flux(inds::Indices, I::Integer...)
 
 Get the flux of the block that the specified
 index falls in.
@@ -764,10 +764,10 @@ flux(is, 3, 1) == QN(1)
 flux(is, 1, 2) == QN(0)
 ```
 """
-flux(inds, vals...) = flux(inds, block(inds, vals...))
+flux(inds::Indices, vals::Integer...) = flux(inds, block(inds, vals...))
 
 """
-    ITensors.block(inds::Indices, I::Int...)
+    ITensors.block(inds::Indices, I::Integer...)
 
 Get the block that the specified index falls in.
 
@@ -780,7 +780,7 @@ ITensors.block(is, 3, 1) == (2,1)
 ITensors.block(is, 1, 2) == (1,1)
 ```
 """
-block(inds::Indices, vals::Int...) = blockindex(inds, vals...)[2]
+block(inds::Indices, vals::Integer...) = blockindex(inds, vals...)[2]
 
 function show(io::IO, is::IndexSet)
   print(io, "IndexSet{$(length(is))} ")

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -727,7 +727,7 @@ end
 # TODO: turn this into an iterator instead
 # of returning a Vector
 function eachdiagblock(inds::Indices)
-  return [fill(i, length(inds)) for i in 1:ndiagblocks(inds)]
+  return (Block(ntuple(_ -> i, length(inds))) for i in 1:ndiagblocks(inds))
 end
 
 """

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1661,7 +1661,7 @@ s = siteinds("S=1/2", N)
 gates = ops(os, s)
 
 # Starting state |↑↑↑⟩
-ψ0 = productMPS(s, "↑")
+ψ0 = MPS(s, "↑")
 
 # Apply the gates.
 ψ = apply(gates, ψ0; cutoff = 1e-15)
@@ -1672,7 +1672,7 @@ prodψ = apply(gates, prod(ψ0))
 
 # The result is:
 # σz₃ σz₂ σz₁ σx₃ σx₂ σx₁ |↑↑↑⟩ = -|↓↓↓⟩
-@show inner(ψ, productMPS(s, "↓")) == -1
+@show inner(ψ, MPS(s, "↓")) == -1
 ```
 Apply nonlocal two-site gates and one-site gates to an MPS:
 ```julia
@@ -1690,12 +1690,12 @@ os = [("CX", 1, 3), ("σz", 3)]
 @show os
 
 # Start with the state |↓↑↑⟩
-ψ0 = productMPS(s, n -> n == 1 ? "↓" : "↑")
+ψ0 = MPS(s, n -> n == 1 ? "↓" : "↑")
 
 # The result is:
 # σz₃ CX₁₃ |↓↑↑⟩ = -|↓↑↓⟩
 ψ = apply(ops(os, s), ψ0; cutoff = 1e-15)
-@show inner(ψ, productMPS(s, n -> n == 1 || n == 3 ? "↓" : "↑")) == -1
+@show inner(ψ, MPS(s, n -> n == 1 || n == 3 ? "↓" : "↑")) == -1
 ```
 Perform TEBD-like time evolution:
 ```julia
@@ -1711,7 +1711,7 @@ end
 τ = -0.1im
 os = [("expS⋅S", (1, 2), (τ = τ,)),
       ("expS⋅S", (2, 3), (τ = τ,))]
-ψ0 = productMPS(s, n -> n == 1 ? "↓" : "↑")
+ψ0 = MPS(s, n -> n == 1 ? "↓" : "↑")
 expτH = ops(os, s)
 ψτ = apply(expτH, ψ0)
 ```

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -171,57 +171,60 @@ function randomCircuitMPS(
   return M
 end
 
-function randomCircuitMPS(sites::Vector{<:Index}, linkdim::Int; kwargs...)
+function randomCircuitMPS(sites::Vector{<:Index}, linkdim::Integer; kwargs...)
   return randomCircuitMPS(Float64, sites, linkdim; kwargs...)
 end
 
 """
-    randomMPS(::Type{ElT<:Number}, sites::Vector{<:Index}, linkdim=1)
+    randomMPS(::Type{ElT<:Number}, sites::Vector{<:Index}; linkdims=1)
 
-Construct a random MPS with link dimension `linkdim` of 
+Construct a random MPS with link dimension `linkdims` of 
 type `ElT`.
 """
-function randomMPS(::Type{ElT}, sites::Vector{<:Index}, linkdim::Int=1) where {ElT<:Number}
-  if hasqns(sites[1])
+function randomMPS(
+  ::Type{ElT}, sites::Vector{<:Index}; linkdims::Integer=1
+) where {ElT<:Number}
+  if any(hasqns, sites)
     error("initial state required to use randomMPS with QNs")
   end
 
   # For non-QN-conserving MPS, instantiate
   # the random MPS directly as a circuit:
-  return randomCircuitMPS(ElT, sites, linkdim)
+  return randomCircuitMPS(ElT, sites, linkdims)
 end
 
 """
-    randomMPS(sites::Vector{<:Index}, linkdim=1)
+    randomMPS(sites::Vector{<:Index}; linkdims=1)
 
 Construct a random MPS with link dimension `linkdim` of 
 type `Float64`.
 """
-randomMPS(sites::Vector{<:Index}, linkdim::Int=1) = randomMPS(Float64, sites, linkdim)
+function randomMPS(sites::Vector{<:Index}; linkdims::Integer=1)
+  return randomMPS(Float64, sites; linkdims=linkdims)
+end
 
-#! format: off
-# JuliaFormatter tries to change this line to:
-# randomMPS(sites::Vector{<:Index}, state; linkdim::Int=1)
-# so turn it off for this line.
-function randomMPS(sites::Vector{<:Index}, state, linkdim::Int=1)::MPS
-#! format: on
-  M = MPS(sites, state)
-  if linkdim > 1
-    randomizeMPS!(M, sites, linkdim)
+function randomMPS(sites::Vector{<:Index}, state; linkdims::Integer=1)
+  return randomMPS(Float64, sites, state; linkdims=linkdims)
+end
+
+function randomMPS(ElType::Type, sites::Vector{<:Index}, state; linkdims::Integer=1)::MPS
+  M = MPS(ElType, sites, state)
+  if linkdims > 1
+    randomizeMPS!(M, sites, linkdims)
   end
   return M
 end
 
 @doc """
-    randomMPS(sites::Vector{<:Index}, state, linkdim=1)
+    randomMPS(sites::Vector{<:Index}, state; linkdims=1)
 
-Construct a real, random MPS with link dimension `linkdim`,
+Construct a real, random MPS with link dimension `linkdims`,
 made by randomizing an initial product state specified by
 `state`. This version of `randomMPS` is necessary when creating
 QN-conserving random MPS (consisting of QNITensors). The initial
 `state` array provided determines the total QN of the resulting
 random MPS.
-""" randomMPS(::Vector{<:Index}, ::Any, ::Int)
+""" randomMPS(::Vector{<:Index}, ::Any)
 
 """
     MPS(::Type{T<:Number}, ivals::Vector{<:IndexVal})
@@ -536,11 +539,11 @@ N = 30
 m = 4
 
 s = siteinds("S=1/2",N)
-psi = randomMPS(s,m)
+psi = randomMPS(s; linkdims=m)
 Czz = correlator(psi,"Sz","Sz")
 
 s = siteinds("Electron",N; conserve_qns=true)
-psi = randomMPS(s,n->isodd(n) ? "Up" : "Dn",m)
+psi = randomMPS(s, n->isodd(n) ? "Up" : "Dn"; linkdims=m)
 Cuu = correlator(psi,"Cdagup","Cup";site_range=2:8)
 ```
 """
@@ -631,11 +634,11 @@ provided, returns a tuple of expectation value vectors.
 N = 10
 
 s = siteinds("S=1/2",N)
-psi = randomMPS(s,8)
+psi = randomMPS(s; linkdims=8)
 Z = expect(psi,"Sz";site_range=2:6)
 
 s = siteinds("Electron",N)
-psi = randomMPS(s,8)
+psi = randomMPS(s; linkdims=8)
 dens = expect(psi,"Ntot")
 updens,dndens = expect(psi,"Nup","Ndn")
 ```

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -39,16 +39,16 @@ function MPS(N::Int; ortho_lims::UnitRange=1:N)
 end
 
 """
-    MPS([::Type{ElT} = Float64, ]sites; linkdim=1)
+    MPS([::Type{ElT} = Float64, ]sites; linkdims=1)
 
 Construct an MPS filled with Empty ITensors of type `ElT` from a collection of indices.
 
-Optionally specify the link dimension with the keyword argument `linkdim`, which by default is 1.
+Optionally specify the link dimension with the keyword argument `linkdims`, which by default is 1.
 
-In the future we may generalize `linkdim` to allow specifying each individual link dimension as a vector,
+In the future we may generalize `linkdims` to allow specifying each individual link dimension as a vector,
 and additionally allow specifying quantum numbers.
 """
-function MPS(::Type{T}, sites::Vector{<:Index}; linkdim::Integer=1) where {T<:Number}
+function MPS(::Type{T}, sites::Vector{<:Index}; linkdims::Integer=1) where {T<:Number}
   N = length(sites)
   v = Vector{ITensor}(undef, N)
   if N == 1
@@ -57,9 +57,9 @@ function MPS(::Type{T}, sites::Vector{<:Index}; linkdim::Integer=1) where {T<:Nu
   end
 
   space = if hasqns(sites)
-    [QN() => linkdim]
+    [QN() => linkdims]
   else
-    linkdim
+    linkdims
   end
 
   l = [Index(space, "Link,l=$ii") for ii in 1:(N - 1)]

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -355,13 +355,13 @@ function op(
   return op(opname, ntuple(n -> s[ns[n]], Val(N))...; kwargs...)
 end
 
-function op(
-  opname::AbstractString, s::Vector{<:Index}, ns::Vararg{Integer}; kwargs...
-)
+function op(opname::AbstractString, s::Vector{<:Index}, ns::Vararg{Integer}; kwargs...)
   return op(opname, s, ns; kwargs...)
 end
 
-function op(s::Vector{<:Index}, opname::AbstractString, ns::Tuple{Vararg{Integer}}; kwargs...)
+function op(
+  s::Vector{<:Index}, opname::AbstractString, ns::Tuple{Vararg{Integer}}; kwargs...
+)
   return op(opname, s, ns...; kwargs...)
 end
 

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -350,36 +350,62 @@ Sz2 = op("Sz", s, 2)
 ```
 """
 function op(
-  opname::AbstractString, s::Vector{<:Index}, ns::Vararg{Int,N}; kwargs...
+  opname::AbstractString, s::Vector{<:Index}, ns::NTuple{N,Integer}; kwargs...
 ) where {N}
   return op(opname, ntuple(n -> s[ns[n]], Val(N))...; kwargs...)
 end
 
-function op(s::Vector{<:Index}, opname::AbstractString, ns::Int...; kwargs...)
+function op(
+  opname::AbstractString, s::Vector{<:Index}, ns::Vararg{Integer}; kwargs...
+)
+  return op(opname, s, ns; kwargs...)
+end
+
+function op(s::Vector{<:Index}, opname::AbstractString, ns::Tuple{Vararg{Integer}}; kwargs...)
   return op(opname, s, ns...; kwargs...)
+end
+
+function op(s::Vector{<:Index}, opname::AbstractString, ns::Integer...; kwargs...)
+  return op(opname, s, ns; kwargs...)
 end
 
 function op(
-  s::Vector{<:Index}, opname::AbstractString, ns::Tuple{Vararg{Int}}, kwargs::NamedTuple
+  s::Vector{<:Index}, opname::AbstractString, ns::Tuple{Vararg{Integer}}, kwargs::NamedTuple
 )
-  return op(opname, s, ns...; kwargs...)
+  return op(opname, s, ns; kwargs...)
 end
 
-function op(s::Vector{<:Index}, opname::AbstractString, ns::Int, kwargs::NamedTuple)
-  return op(opname, s, ns; kwargs...)
+function op(s::Vector{<:Index}, opname::AbstractString, ns::Integer, kwargs::NamedTuple)
+  return op(opname, s, (ns,); kwargs...)
 end
 
 # This version helps with call like `op.(Ref(s), os)` where `os`
 # is a vector of tuples.
-op(s::Vector{<:Index}, os::Tuple{String,Vararg}) = op(s, os...)
+op(s::Vector{<:Index}, os::Tuple{AbstractString,Vararg}) = op(s, os...)
+op(os::Tuple{AbstractString,Vararg}, s::Vector{<:Index}) = op(s, os...)
 
 # Here, Ref is used to not broadcast over the vector of indices
 # TODO: consider overloading broadcast for `op` with the example
 # here: https://discourse.julialang.org/t/how-to-broadcast-over-only-certain-function-arguments/19274/5
 # so that `Ref` isn't needed.
-ops(s::Vector{<:Index}, os::AbstractArray{<:Tuple}) = op.(Ref(s), os)
+ops(s::Vector{<:Index}, os::AbstractArray) = op.(Ref(s), os)
+ops(os::AbstractVector, s::Vector{<:Index}) = op.(Ref(s), os)
 
-ops(os::Vector{<:Tuple}, s::Vector{<:Index}) = op.(Ref(s), os)
+@doc """
+    ops(s::Vector{<:Index}, os::Vector)
+    ops(os::Vector, s::Vector{<:Index})
+
+Given a list of operators, create ITensors using the collection
+of indices.
+
+# Examples
+```julia
+s = siteinds("Qubit", 4)
+os = [("H", 1), ("X", 2), ("CX", 2, 4)]
+# gates = ops(s, os)
+gates = ops(os, s)
+```
+""" ops(::Vector{<:Index}, ::AbstractArray)
 
 #---------------------------------------
 #

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -1047,10 +1047,8 @@ end
     @test prod(product(X[1], ψ)) ≈ prod(MPS(s, n -> n == 1 ? "1" : "0"))
     @test prod(product(X[1], product(X[2], ψ))) ≈
           prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
-    @test prod(product(X[1] * X[2], ψ)) ≈
-          prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
-    @test prod(product([X[2], X[1]], ψ)) ≈
-          prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
+    @test prod(product(X[1] * X[2], ψ)) ≈ prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
+    @test prod(product([X[2], X[1]], ψ)) ≈ prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
     @test prod(product(CX[1, 2], ψ)) ≈ prod(MPS(s, "0"))
     @test prod(product(CX[1, 2], product(X[1], ψ))) ≈
           prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -17,7 +17,7 @@ include("util.jl")
   @test linkdims(psi) == fill(1, N - 1)
   @test isnothing(flux(psi))
 
-  psi = MPS(sites, 3)
+  psi = MPS(sites; linkdims=3)
   @test length(psi) == N
   @test length(MPS()) == 0
   @test linkdims(psi) == fill(3, N - 1)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -67,16 +67,27 @@ include("util.jl")
       for j in 1:N
         state[j] = isodd(j) ? "Up" : "Dn"
       end
+      psi = MPS(sites, state)
+      for j in 1:N
+        sign = isodd(j) ? +1.0 : -1.0
+        @test (psi[j] * op(sites, "Sz", j) * dag(prime(psi[j], "Site")))[] ≈ sign / 2
+      end
       psi = productMPS(sites, state)
       for j in 1:N
         sign = isodd(j) ? +1.0 : -1.0
         @test (psi[j] * op(sites, "Sz", j) * dag(prime(psi[j], "Site")))[] ≈ sign / 2
       end
+      @test_throws DimensionMismatch MPS(sites, fill("", N - 1))
       @test_throws DimensionMismatch productMPS(sites, fill("", N - 1))
     end
 
     @testset "String input" begin
       sites = siteinds("S=1/2", N)
+      psi = MPS(sites, "Dn")
+      for j in 1:N
+        sign = -1.0
+        @test (psi[j] * op(sites, "Sz", j) * dag(prime(psi[j], "Site")))[] ≈ sign / 2
+      end
       psi = productMPS(sites, "Dn")
       for j in 1:N
         sign = -1.0
@@ -86,6 +97,11 @@ include("util.jl")
 
     @testset "Int input" begin
       sites = siteinds("S=1/2", N)
+      psi = MPS(sites, 2)
+      for j in 1:N
+        sign = -1.0
+        @test (psi[j] * op(sites, "Sz", j) * dag(prime(psi[j], "Site")))[] ≈ sign / 2
+      end
       psi = productMPS(sites, 2)
       for j in 1:N
         sign = -1.0
@@ -98,6 +114,11 @@ include("util.jl")
       state = fill(0, N)
       for j in 1:N
         state[j] = isodd(j) ? 1 : 2
+      end
+      psi = MPS(sites, state)
+      for j in 1:N
+        sign = isodd(j) ? +1.0 : -1.0
+        @test (psi[j] * op(sites, "Sz", j) * dag(prime(psi[j], "Site")))[] ≈ sign / 2
       end
       psi = productMPS(sites, state)
       for j in 1:N
@@ -113,6 +134,11 @@ include("util.jl")
         states[j] = isodd(j) ? 1 : 2
       end
       ivals = [state(sites[n], states[n]) for n in 1:length(sites)]
+      psi = MPS(ivals)
+      for j in 1:N
+        sign = isodd(j) ? +1.0 : -1.0
+        @test (psi[j] * op(sites, "Sz", j) * dag(prime(psi[j], "Site")))[] ≈ sign / 2
+      end
       psi = productMPS(ivals)
       for j in 1:N
         sign = isodd(j) ? +1.0 : -1.0
@@ -121,6 +147,10 @@ include("util.jl")
 
       @testset "ComplexF64 eltype" begin
         sites = siteinds("S=1/2", N)
+        psi = MPS(ComplexF64, sites, fill(1, N))
+        for j in 1:N
+          @test eltype(psi[j]) <: ComplexF64
+        end
         psi = productMPS(ComplexF64, sites, fill(1, N))
         for j in 1:N
           @test eltype(psi[j]) <: ComplexF64
@@ -130,9 +160,15 @@ include("util.jl")
 
     @testset "N=1 case" begin
       site = Index(2, "Site,n=1")
+      psi = MPS([site], [1])
+      @test psi[1][1] ≈ 1.0
+      @test psi[1][2] ≈ 0.0
       psi = productMPS([site], [1])
       @test psi[1][1] ≈ 1.0
       @test psi[1][2] ≈ 0.0
+      psi = MPS([site], [2])
+      @test psi[1][1] ≈ 0.0
+      @test psi[1][2] ≈ 1.0
       psi = productMPS([site], [2])
       @test psi[1][1] ≈ 0.0
       @test psi[1][2] ≈ 1.0
@@ -362,7 +398,7 @@ end
   N = 8
   sites = siteinds("S=1/2", N; conserve_qns=true)
   init_state = [isodd(n) ? "Up" : "Dn" for n in 1:N]
-  psi0 = productMPS(sites, init_state)
+  psi0 = MPS(sites, init_state)
   orthogonalize!(psi0, 4)
   @test ITensors.leftlim(psi0) == 3
   @test ITensors.rightlim(psi0) == 5
@@ -596,7 +632,7 @@ end
   @testset "map!" begin
     N = 5
     s = siteinds("S=½", N)
-    M0 = productMPS(s, "↑")
+    M0 = MPS(s, "↑")
 
     # Test map! with limits getting set
     M = orthogonalize(M0, 1)
@@ -631,14 +667,14 @@ end
     N = 4
     s = siteinds("S=½", N)
     ψ = randomMPS(s)
-    ϕ = productMPS(s, "↑")
+    ϕ = MPS(s, "↑")
     orthogonalize!(ϕ, 1)
     ψ[:] = ϕ
     @test ITensors.orthocenter(ψ) == 1
     @test inner(ψ, ϕ) ≈ 1
 
     ψ = randomMPS(s)
-    ϕ = productMPS(s, "↑")
+    ϕ = MPS(s, "↑")
     orthogonalize!(ϕ, 1)
     ψ[:] = ITensors.data(ϕ)
     @test ITensors.leftlim(ψ) == 0
@@ -709,7 +745,7 @@ end
     s0 = siteinds("S=1/2", N)
     for perm in permutations(1:N)
       s = s0[perm]
-      ψ = productMPS(s, rand(("↑", "↓"), N))
+      ψ = MPS(s, rand(("↑", "↓"), N))
       ns′ = [findfirst(==(i), s0) for i in s]
       @test ns′ == perm
       ψ′ = movesites(ψ, 1:N .=> ns′; cutoff=1e-15)
@@ -741,7 +777,7 @@ end
     @test ITensors.orthocenter(ψ) == N
     @test maxlinkdim(ψ) == 4
 
-    ψ0 = productMPS(s, "↑")
+    ψ0 = MPS(s, "↑")
     A = prod(ψ0)
     ψ = MPS(A, s; cutoff=1e-15)
     @test prod(ψ) ≈ A
@@ -1007,35 +1043,35 @@ end
     # Apply to an MPS
     #
 
-    ψ = productMPS(s, "0")
-    @test prod(product(X[1], ψ)) ≈ prod(productMPS(s, n -> n == 1 ? "1" : "0"))
+    ψ = MPS(s, "0")
+    @test prod(product(X[1], ψ)) ≈ prod(MPS(s, n -> n == 1 ? "1" : "0"))
     @test prod(product(X[1], product(X[2], ψ))) ≈
-          prod(productMPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
+          prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
     @test prod(product(X[1] * X[2], ψ)) ≈
-          prod(productMPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
+          prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
     @test prod(product([X[2], X[1]], ψ)) ≈
-          prod(productMPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
-    @test prod(product(CX[1, 2], ψ)) ≈ prod(productMPS(s, "0"))
+          prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
+    @test prod(product(CX[1, 2], ψ)) ≈ prod(MPS(s, "0"))
     @test prod(product(CX[1, 2], product(X[1], ψ))) ≈
-          prod(productMPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
+          prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
     @test prod(product(product(CX[1, 2], X[1]), ψ)) ≈
-          prod(productMPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
+          prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
     @test prod(product([X[1], CX[1, 2]], ψ)) ≈
-          prod(productMPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
+          prod(MPS(s, n -> n == 1 || n == 2 ? "1" : "0"))
 
     for i in 1:N, j in 1:N
       !allunique((i, j)) && continue
       # Don't move sites back
       CXij_ψ = product([X[i], CX[i, j]], ψ; move_sites_back=false, cutoff=1e-15)
       @test maxlinkdim(CXij_ψ) == 1
-      @test prod(CXij_ψ) ≈ prod(productMPS(s, n -> n == i || n == j ? "1" : "0"))
+      @test prod(CXij_ψ) ≈ prod(MPS(s, n -> n == i || n == j ? "1" : "0"))
 
       # Move sites back
       CXij_ψ = product([X[i], CX[i, j]], ψ)
       for n in 1:N
         @test siteind(CXij_ψ, n) == siteind(ψ, n)
       end
-      @test prod(CXij_ψ) ≈ prod(productMPS(s, n -> n == i || n == j ? "1" : "0"))
+      @test prod(CXij_ψ) ≈ prod(MPS(s, n -> n == i || n == j ? "1" : "0"))
     end
 
     for i in 1:N, j in 1:N, k in 1:N
@@ -1046,7 +1082,7 @@ end
         [X[j], X[i], CCNOT[ns...]], ψ; move_sites_back=false, cutoff=1e-15
       )
       @test maxlinkdim(CCNOTijk_ψ) == 1
-      @test prod(CCNOTijk_ψ) ≈ prod(productMPS(s, n -> n ∈ ns ? "1" : "0"))
+      @test prod(CCNOTijk_ψ) ≈ prod(MPS(s, n -> n ∈ ns ? "1" : "0"))
 
       # Move sites back
       CCNOTijk_ψ = product([X[j], X[i], CCNOT[ns...]], ψ; cutoff=1e-15)
@@ -1054,7 +1090,7 @@ end
       for n in 1:N
         @test siteind(CCNOTijk_ψ, n) == siteind(ψ, n)
       end
-      @test prod(CCNOTijk_ψ) ≈ prod(productMPS(s, n -> n ∈ ns ? "1" : "0"))
+      @test prod(CCNOTijk_ψ) ≈ prod(MPS(s, n -> n ∈ ns ? "1" : "0"))
     end
 
     for i in 1:N, j in i:N, k in 1:N, l in k:N
@@ -1065,7 +1101,7 @@ end
         [X[i], X[j], X[k], CCCNOT[ns...]], ψ; move_sites_back=false, cutoff=1e-15
       )
       @test maxlinkdim(CCCNOTijkl_ψ) == 1
-      @test prod(CCCNOTijkl_ψ) ≈ prod(productMPS(s, n -> n ∈ ns ? "1" : "0"))
+      @test prod(CCCNOTijkl_ψ) ≈ prod(MPS(s, n -> n ∈ ns ? "1" : "0"))
 
       # Move sites back
       CCCNOTijkl_ψ = product([X[i], X[j], X[k], CCCNOT[ns...]], ψ; cutoff=1e-15)
@@ -1073,7 +1109,7 @@ end
       for n in 1:N
         @test siteind(CCCNOTijkl_ψ, n) == siteind(ψ, n)
       end
-      @test prod(CCCNOTijkl_ψ) ≈ prod(productMPS(s, n -> n ∈ ns ? "1" : "0"))
+      @test prod(CCCNOTijkl_ψ) ≈ prod(MPS(s, n -> n ∈ ns ? "1" : "0"))
     end
   end
 
@@ -1096,7 +1132,7 @@ end
 
       s = siteinds("Qubit", N)
       gates = ops(s, pos)
-      ψ0 = productMPS(s, "0")
+      ψ0 = MPS(s, "0")
 
       # Apply the gates
       ψ = product(gates, ψ0)
@@ -1140,7 +1176,7 @@ end
       gates = ops(os, s)
 
       @testset "Pure state evolution" begin
-        ψ0 = productMPS(s, "0")
+        ψ0 = MPS(s, "0")
         ψ = product(gates, ψ0; cutoff=1e-15)
         @test maxlinkdim(ψ) == 8
         prodψ = product(gates, prod(ψ0))
@@ -1245,7 +1281,7 @@ end
       s = siteinds("Qubit", N)
       gates = ops(os, s)
 
-      ψ0 = productMPS(s, "0")
+      ψ0 = MPS(s, "0")
 
       # Apply the gates
       ψ = apply(gates, ψ0; cutoff=1e-15, maxdim=100)
@@ -1260,13 +1296,13 @@ end
       s = siteinds("Fermion", N; conserve_qns=true)
 
       # Ground state |000⟩
-      ψ000 = productMPS(s, "0")
+      ψ000 = MPS(s, "0")
 
       # Start state |011⟩
-      ψ011 = productMPS(s, n -> n == 2 || n == 3 ? "1" : "0")
+      ψ011 = MPS(s, n -> n == 2 || n == 3 ? "1" : "0")
 
       # Reference state |110⟩
-      ψ110 = productMPS(s, n -> n == 1 || n == 2 ? "1" : "0")
+      ψ110 = MPS(s, n -> n == 1 || n == 2 ? "1" : "0")
 
       function ITensors.op(::OpName"CdagC", ::SiteType, s1::Index, s2::Index)
         return op("Cdag", s1) * op("C", s2)
@@ -1296,7 +1332,7 @@ end
       s = siteinds("Fermion", N; conserve_qns=true)
 
       # Starting state
-      ψ0 = productMPS(s, n -> isodd(n) ? "0" : "1")
+      ψ0 = MPS(s, n -> isodd(n) ? "0" : "1")
 
       t = 1.0
       U = 1.0

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -94,6 +94,29 @@ Random.seed!(1234)
     @test_throws ErrorException ITensor(A, i', dag(i); tol=1e-8)
   end
 
+  @testset "Construct from Array regression test" begin
+    i = Index([QN(0) => 2, QN(1) => 2])
+    T = itensor([0, 0, 1, 2], i)
+    @test flux(T) == QN(1)
+    @test nnzblocks(T) == 1
+    @test !(Block(1) in nzblocks(T))
+    @test Block(2) in nzblocks(T)
+    @test T[1] == 0
+    @test T[2] == 0
+    @test T[3] == 1
+    @test T[4] == 2
+    @test flux(T, 1) == QN(0)
+    @test flux(T, 2) == QN(0)
+    @test flux(T, 3) == QN(1)
+    @test flux(T, 4) == QN(1)
+    @test_throws BoundsError flux(T, 5)
+    @test_throws BoundsError flux(T, 0)
+    @test flux(T, Block(1)) == QN(0)
+    @test flux(T, Block(2)) == QN(1)
+    @test_throws BoundsError flux(T, Block(0))
+    @test_throws BoundsError flux(T, Block(3))
+  end
+
   @testset "QN ITensor Array constructor view behavior" begin
     d = 2
     i = Index([QN(0) => d ÷ 2, QN(1) => d ÷ 2])

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -1,4 +1,7 @@
-using ITensors, Test, Random
+using ITensors
+using LinearAlgebra
+using Random
+using Test
 
 Random.seed!(1234)
 
@@ -1382,9 +1385,9 @@ Random.seed!(1234)
 
       A = emptyITensor(ElT, l, s, dag(r))
 
-      insertblock!(A, (2, 1, 2))
-      insertblock!(A, (1, 2, 2))
-      insertblock!(A, (2, 2, 3))
+      insertblock!(A, Block(2, 1, 2))
+      insertblock!(A, Block(1, 2, 2))
+      insertblock!(A, Block(2, 2, 3))
 
       for b in nzblocks(A)
         @test flux(A, b) == QN()
@@ -1413,10 +1416,10 @@ Random.seed!(1234)
         QN("Sz", 4) => 1,
       )
       A = emptyITensor(ElT, s, s')
-      insertblock!(A, (5, 2))
-      insertblock!(A, (4, 3))
-      insertblock!(A, (3, 4))
-      insertblock!(A, (2, 5))
+      insertblock!(A, Block(5, 2))
+      insertblock!(A, Block(4, 3))
+      insertblock!(A, Block(3, 4))
+      insertblock!(A, Block(2, 5))
       randn!(A)
       U, S, V = svd(A, s)
       @test U * S * V ≈ A
@@ -1431,11 +1434,11 @@ Random.seed!(1234)
         QN("Sz", 4) => 1,
       )
       A = emptyITensor(ElT, s, s')
-      insertblock!(A, (5, 1))
-      insertblock!(A, (4, 2))
-      insertblock!(A, (3, 3))
-      insertblock!(A, (2, 4))
-      insertblock!(A, (1, 5))
+      insertblock!(A, Block(5, 1))
+      insertblock!(A, Block(4, 2))
+      insertblock!(A, Block(3, 3))
+      insertblock!(A, Block(2, 4))
+      insertblock!(A, Block(1, 5))
       U, S, V = svd(A, s)
       @test dims(S) == dims(A)
       @test U * S * V ≈ A
@@ -1450,11 +1453,11 @@ Random.seed!(1234)
         QN("Sz", 4) => 1,
       )
       A = emptyITensor(ElT, s, s')
-      insertblock!(A, (5, 1))
-      insertblock!(A, (4, 2))
-      insertblock!(A, (3, 3))
-      insertblock!(A, (2, 4))
-      insertblock!(A, (1, 5))
+      insertblock!(A, Block(5, 1))
+      insertblock!(A, Block(4, 2))
+      insertblock!(A, Block(3, 3))
+      insertblock!(A, Block(2, 4))
+      insertblock!(A, Block(1, 5))
       U, S, V = svd(A, s; cutoff=0)
       @test dims(S) == (0, 0)
       @test U * S * V ≈ A


### PR DESCRIPTION
Fixes a bug when computing flux where the index and Block were getting mixed up (an input `flux(i, 3)` was being treated as `flux(i, Block(3))`.

Also adds `MPS` as alternative syntax for `productMPS`.

Also adds more allowed inputs to `ops` and `op`, like `op(("H", 1), s)`.