### PR TITLE
Deprecate `MPO(::MPS)` in favor of `outer(::MPS, ::MPS)`

### DIFF
--- a/benchmark/bench_autompo.jl
+++ b/benchmark/bench_autompo.jl
@@ -1,4 +1,4 @@
-module BenchAutoMPO
+module BenchOpSum
 
 using BenchmarkTools
 using ITensors
@@ -7,7 +7,7 @@ suite = BenchmarkGroup()
 
 let N = 30
   s = siteinds("S=1/2", N; conserve_qns=false)
-  a = AutoMPO()
+  a = OpSum()
   for k in 1:N, l in 1:N, m in 1:N, n in 1:N
     a .+= "projDn", k, "projDn", l, "projDn", m, "projDn", n
   end
@@ -20,7 +20,7 @@ end
 
 let N = 30
   s = siteinds("S=1/2", N; conserve_qns=true)
-  a = AutoMPO()
+  a = OpSum()
   for k in 1:N, l in 1:N, m in 1:N, n in 1:N
     a .+= "projDn", k, "projDn", l, "projDn", m, "projDn", n
   end
@@ -33,4 +33,4 @@ end
 
 end
 
-BenchAutoMPO.suite
+BenchOpSum.suite

--- a/benchmark/bench_dmrg.jl
+++ b/benchmark/bench_dmrg.jl
@@ -7,7 +7,7 @@ suite = BenchmarkGroup()
 
 let N = 100
   sites = siteinds("S=1", N)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j in 1:(N - 1)
     ampo .+= ("Sz", j, "Sz", j + 1)
     ampo .+= (0.5, "S+", j, "S-", j + 1)
@@ -28,7 +28,7 @@ end
 
 let N = 100
   sites = siteinds("S=1", N; conserve_qns=true)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j in 1:(N - 1)
     ampo .+= ("Sz", j, "Sz", j + 1)
     ampo .+= (0.5, "S+", j, "S-", j + 1)
@@ -52,7 +52,7 @@ end
 #  N = Nx * Ny
 #  sites = siteinds("S=1/2", N)
 #  lattice = square_lattice(Nx, Ny; yperiodic = false)
-#  ampo = AutoMPO()
+#  ampo = OpSum()
 #  for b in lattice
 #    ampo .+= (0.5, "S+", b.s1, "S-", b.s2)
 #    ampo .+= (0.5, "S-", b.s1, "S+", b.s2)

--- a/docs/settings.jl
+++ b/docs/settings.jl
@@ -36,7 +36,7 @@ settings = Dict(
         "Observer.md",
         "DMRGObserver.md",
       ],
-      "AutoMPO" => "AutoMPO.md",
+      "OpSum" => "OpSum.md",
     ],
     "Advanced usage guide" => [
       "Advanced usage guide" => "AdvancedUsageGuide.md",

--- a/docs/src/AdvancedUsageGuide.md
+++ b/docs/src/AdvancedUsageGuide.md
@@ -134,13 +134,13 @@ NDTensors.Dense{Float64,Array{Float64,1}}
 ```
 
 A common place you might accidentally come across this is when
-you are creating a Hamiltonian with `AutoMPO`:
+you are creating a Hamiltonian with `OpSum`:
 ```julia
 julia> N = 4;
 
 julia> sites = siteinds("S=1/2",N);
 
-julia> ampo = AutoMPO();
+julia> ampo = OpSum();
 
 julia> for j=1:N-1
          ampo += "Sz", j, "Sz", j+1
@@ -304,7 +304,7 @@ julia> names(ITensors)
  Symbol("@set_warn_order")
  Symbol("@ts_str")
  :AbstractObserver
- :AutoMPO
+ :OpSum
  :DMRGObserver
  :ITensor
  :ITensors

--- a/docs/src/MPSandMPO.md
+++ b/docs/src/MPSandMPO.md
@@ -27,7 +27,6 @@ productMPS(::Type{<:Number}, ::Vector{<:IndexVal})
 MPO(::Int)
 MPO(::Type{<:Number}, ::Vector{<:Index}, ::Vector{String})
 MPO(::Type{<:Number}, ::Vector{<:Index}, ::String)
-MPO(::MPS)
 ```
 
 ## Properties
@@ -134,6 +133,9 @@ logdot(::MPST, ::MPST) where {MPST <: ITensors.AbstractMPS}
 norm(::ITensors.AbstractMPS)
 lognorm(::ITensors.AbstractMPS)
 +(::MPS, ::MPS)
-*(::MPO, ::MPS)
+contract(::MPO, ::MPS)
+contract(::MPO, ::MPO)
+outer(::MPS, ::MPS)
+projector(::MPS)
 ```
 

--- a/docs/src/Observer.md
+++ b/docs/src/Observer.md
@@ -174,7 +174,7 @@ let
 
   s = siteinds("S=1/2",N)
 
-  a = AutoMPO()
+  a = OpSum()
   for n=1:N-1
     a += "Sz",n,"Sz",n+1
     a += 0.5,"S+",n,"S-",n+1

--- a/docs/src/OpSum.md
+++ b/docs/src/OpSum.md
@@ -1,14 +1,14 @@
-# AutoMPO
+# OpSum
 
 ## Description
 
 ```@docs
-AutoMPO
+OpSum
 ```
 
 ## Methods
 
 ```@docs
 add!
-MPO(::AutoMPO,::Vector{<:Index})
+MPO(::OpSum,::Vector{<:Index})
 ```

--- a/docs/src/examples/DMRG.md
+++ b/docs/src/examples/DMRG.md
@@ -16,12 +16,12 @@ denotes a special Index tag which hooks into a system that knows "S=1" indices h
 a dimension of 3 and how to create common physics operators like "Sz" for them.
 
 Next we'll make our Hamiltonian matrix product operator (MPO). A very 
-convenient way to do this is to use the AutoMPO helper type which lets 
+convenient way to do this is to use the OpSum helper type which lets 
 us input a Hamiltonian (or any sum of local operators) in similar notation
 to pencil-and-paper notation:
 
 ```julia
-ampo = AutoMPO()
+ampo = OpSum()
 for j=1:N-1
   ampo += 0.5,"S+",j,"S-",j+1
   ampo += 0.5,"S-",j,"S+",j+1
@@ -30,7 +30,7 @@ end
 H = MPO(ampo,sites)
 ```
 
-In the last line above we convert the AutoMPO helper object to an actual MPO.
+In the last line above we convert the OpSum helper object to an actual MPO.
 
 Before beginning the calculation, we need to specify how many DMRG sweeps to do and
 what schedule we would like for the parameters controlling the accuracy.
@@ -72,7 +72,7 @@ let
   N = 100
   sites = siteinds("S=1",N)
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j=1:N-1
     ampo += 0.5,"S+",j,"S-",j+1
     ampo += 0.5,"S-",j,"S+",j+1
@@ -104,7 +104,7 @@ Note that the only difference from a regular ITensor DMRG calculation
 is that the `sites` array has Index objects which alternate in dimension
 and in which physical tag type they carry, whether `"S=1/2"` or `"S=1"`.
 (Try printing out the sites array to see!)
-These tags tell the AutoMPO system which local operators to use for these
+These tags tell the OpSum system which local operators to use for these
 sites when building the Hamiltonian MPO.
 
 ```julia
@@ -125,7 +125,7 @@ let
   Jhh = 0.5 # half-half coupling
   Joo = 0.5 # one-one coupling
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j=1:N-1
     ampo += 0.5*Jho,"S+",j,"S-",j+1
     ampo += 0.5*Jho,"S-",j,"S+",j+1
@@ -157,10 +157,10 @@ end
 
 ## Make a 2D Hamiltonian for DMRG
 
-You can use the AutoMPO system to make 2D Hamiltonians
+You can use the OpSum system to make 2D Hamiltonians
 much in the same way you make 1D Hamiltonians: by looping over
 all of the bonds and adding the interactions on these bonds to
-the AutoMPO. 
+the OpSum. 
 
 To help with the logic of 2D lattices, ITensor pre-defines
 some helper functions which
@@ -200,7 +200,7 @@ let
   lattice = square_lattice(Nx, Ny; yperiodic = false)
 
   # Define the Heisenberg spin Hamiltonian on this lattice
-  ampo = AutoMPO()
+  ampo = OpSum()
   for b in lattice
     ampo .+= 0.5, "S+", b.s1, "S-", b.s2
     ampo .+= 0.5, "S-", b.s1, "S+", b.s2
@@ -275,13 +275,13 @@ let
 
 
   #
-  # Use the AutoMPO feature to create the
+  # Use the OpSum feature to create the
   # transverse field Ising model
   #
   # Factors of 4 and 2 are to rescale
   # spin operators into Pauli matrices
   #
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j=1:N-1
     ampo += -4,"Sz",j,"Sz",j+1
   end

--- a/docs/src/examples/MPSandMPO.md
+++ b/docs/src/examples/MPSandMPO.md
@@ -320,16 +320,16 @@ psi = read(f,"psi",MPS)
 close(f)
 ```
 
-Many functions which involve MPS, such as the `dmrg` function or the `AutoMPO` system
+Many functions which involve MPS, such as the `dmrg` function or the `OpSum` system
 require that you use an array of site indices which match the MPS. So when reading in
 an MPS from disk, do not construct a new array of site indices. Instead, you can
 obtain them like this: `sites = siteinds(psi)`.
 
-So for example, to create an MPO from an AutoMPO which has the same site indices
+So for example, to create an MPO from an OpSum which has the same site indices
 as your MPS `psi`, do the following:
 
 ```julia
-ampo = AutoMPO()
+ampo = OpSum()
 # Then put operators into ampo...
 
 sites = siteinds(psi) # Get site indices from your MPS

--- a/docs/src/examples/Physics.md
+++ b/docs/src/examples/Physics.md
@@ -161,8 +161,8 @@ putting other Index tags that are conventional for site indices.
 The `op` function is really the heart of the `SiteType` system. This is
 the function that lets you define custom local operators associated
 to the physical degrees of freedom of your `SiteType`. Then for example 
-you can use indices carrying your custom tag with AutoMPO and the 
-AutoMPO system will know how to automatically convert names of operators
+you can use indices carrying your custom tag with OpSum and the 
+OpSum system will know how to automatically convert names of operators
 such as `"Sz"` or `"S+"` into ITensors so that it can make an actual MPO.
 
 In our example above, we defined this function for the case of the `"Sz"`
@@ -219,9 +219,9 @@ Sp3 = op("S+",sites[3])
 Alternatively, you can write the lines of code above in the style
 of `Sz1 = op("Sz",sites,1)`.
 
-This same `op` function is used inside of AutoMPO when it converts its input into
+This same `op` function is used inside of OpSum when it converts its input into
 an actual MPO. So by defining custom operator names you can pass any of these
-operator names into AutoMPO and it will know how to use these operators.
+operator names into OpSum and it will know how to use these operators.
 
 **Further Steps**
 
@@ -377,7 +377,7 @@ Sz = op("Sz",s)
 
 to automatically create the ``S^z`` operator for an Index `s` based on the 
 `"S=1/2"` tag it carries. A major reason to define such `op` overloads
-is to allow the AutoMPO system to recognize new operator names, as
+is to allow the OpSum system to recognize new operator names, as
 discussed more below.
 
 Let's see how to introduce a new operator name into the ITensor `SiteType`
@@ -438,20 +438,20 @@ Pup3 = op("Pup",s[3])
 ```
 
 
-**Using Custom Operators in AutoMPO**
+**Using Custom Operators in OpSum**
 
 A key use of these `op` system extensions is allowing additional operator names to
-be recognized by the AutoMPO system for constructing matrix product operator (MPO)
+be recognized by the OpSum system for constructing matrix product operator (MPO)
 tensor networks. With the code above defining the `"Pup"` operator, we are now 
-allowed to use this operator name in any AutoMPO code involving `"S=1/2"` site 
+allowed to use this operator name in any OpSum code involving `"S=1/2"` site 
 indices.
 
-For example, we could now make an AutoMPO such as:
+For example, we could now make an OpSum such as:
 
 ```julia
 N = 100
 sites = siteinds("S=1/2",N)
-ampo = AutoMPO()
+ampo = OpSum()
 for n=1:N
   ampo += "Pup",n
 end

--- a/docs/src/getting_started/Tutorials.md
+++ b/docs/src/getting_started/Tutorials.md
@@ -32,7 +32,7 @@ let
   N = 100
   sites = siteinds("S=1",N)
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j=1:N-1
     ampo += "Sz",j,"Sz",j+1
     ampo += 1/2,"S+",j,"S-",j+1
@@ -77,7 +77,7 @@ Try printing out some of these indices to verify their properties:
 The next part of the code builds the Hamiltonian:
 
 ```julia
-ampo = AutoMPO()
+ampo = OpSum()
 for j=1:N-1
   ampo += "Sz",j,"Sz",j+1
   ampo += 1/2,"S+",j,"S-",j+1
@@ -86,7 +86,7 @@ end
 H = MPO(ampo,sites)
 ```
 
-An `AutoMPO` is an object which accumulates Hamiltonian terms such as `"Sz",1,"Sz",2`
+An `OpSum` is an object which accumulates Hamiltonian terms such as `"Sz",1,"Sz",2`
 so that they can be summed afterward into a matrix product operator (MPO) tensor network. 
 The line of code `H = MPO(ampo,sites)` constructs the Hamiltonian in the MPO format, with
 physical indices given by the array `sites`.
@@ -285,7 +285,7 @@ let
   N = 100
   sites = siteinds("S=1",N;conserve_qns=true)
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j=1:N-1
     ampo += "Sz",j,"Sz",j+1
     ampo += 1/2,"S+",j,"S-",j+1

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -323,7 +323,7 @@ let
   # a Hamiltonian matrix, and convert
   # these terms to an MPO tensor network
   # (here we make the 1D Heisenberg model)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j=1:N-1
     ampo += "Sz",j,"Sz",j+1
     ampo += 0.5,"S+",j,"S-",j+1

--- a/examples/TBLIS/1d_heisenberg.jl
+++ b/examples/TBLIS/1d_heisenberg.jl
@@ -11,7 +11,7 @@ let
 
   N = 100
   sites = siteinds("S=1", N)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j in 1:(N - 1)
     ampo += 0.5, "S+", j, "S-", j + 1
     ampo += 0.5, "S-", j, "S+", j + 1

--- a/examples/dmrg/1d_heisenberg.jl
+++ b/examples/dmrg/1d_heisenberg.jl
@@ -13,7 +13,7 @@ let
   #sites = siteinds("S=1/2",N)
 
   # Input operator terms which define a Hamiltonian
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j in 1:(N - 1)
     ampo += "Sz", j, "Sz", j + 1
     ampo += 0.5, "S+", j, "S-", j + 1

--- a/examples/dmrg/1d_heisenberg_conserve_spin.jl
+++ b/examples/dmrg/1d_heisenberg_conserve_spin.jl
@@ -15,7 +15,7 @@ let
 
   sites = siteinds("S=1", N; conserve_qns=true)
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j in 1:(N - 1)
     ampo .+= 0.5, "S+", j, "S-", j + 1
     ampo .+= 0.5, "S-", j, "S+", j + 1

--- a/examples/dmrg/1d_hubbard_extended.jl
+++ b/examples/dmrg/1d_hubbard_extended.jl
@@ -15,7 +15,7 @@ let
 
   sites = siteinds("Electron", N; conserve_qns=true)
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for b in 1:(N - 1)
     ampo += -t1, "Cdagup", b, "Cup", b + 1
     ampo += -t1, "Cdagup", b + 1, "Cup", b

--- a/examples/dmrg/1d_ising_with_observer.jl
+++ b/examples/dmrg/1d_ising_with_observer.jl
@@ -9,7 +9,7 @@ using ITensors
 function tfimMPO(sites, h::Float64)
   # Input operator terms which define a Hamiltonian
   N = length(sites)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j in 1:(N - 1)
     ampo += -1, "Z", j, "Z", j + 1
   end

--- a/examples/dmrg/2d_heisenberg_conserve_spin.jl
+++ b/examples/dmrg/2d_heisenberg_conserve_spin.jl
@@ -10,7 +10,7 @@ let
 
   lattice = square_lattice(Nx, Ny; yperiodic=false)
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for b in lattice
     ampo .+= 0.5, "S+", b.s1, "S-", b.s2
     ampo .+= 0.5, "S-", b.s1, "S+", b.s2

--- a/examples/dmrg/2d_hubbard_conserve_particles.jl
+++ b/examples/dmrg/2d_hubbard_conserve_particles.jl
@@ -13,7 +13,7 @@ function main(; Nx=6, Ny=3, U=4.0, t=1.0)
 
   lattice = square_lattice(Nx, Ny; yperiodic=true)
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for b in lattice
     ampo += -t, "Cdagup", b.s1, "Cup", b.s2
     ampo += -t, "Cdagup", b.s2, "Cup", b.s1

--- a/examples/dmrg/input_files/ArgParse/1d_hubbard_extended.jl
+++ b/examples/dmrg/input_files/ArgParse/1d_hubbard_extended.jl
@@ -89,7 +89,7 @@ noise!(sweeps, noise...)
 
 sites = siteinds("Electron", N; conserve_qns=true)
 
-ampo = AutoMPO()
+ampo = OpSum()
 for i in 1:N
   ampo .+= U, "Nupdn", i
 end

--- a/examples/dmrg/input_files/argsdict/1d_hubbard_extended.jl
+++ b/examples/dmrg/input_files/argsdict/1d_hubbard_extended.jl
@@ -82,7 +82,7 @@ noise!(sweeps, noise...)
 
 sites = siteinds("Electron", N; conserve_qns=true)
 
-ampo = AutoMPO()
+ampo = OpSum()
 for i in 1:N
   ampo .+= U, "Nupdn", i
 end

--- a/examples/dmrg/input_files/script/1d_hubbard_extended.jl
+++ b/examples/dmrg/input_files/script/1d_hubbard_extended.jl
@@ -25,7 +25,7 @@ sweeps = Sweeps(nsweep, sweeps_args)
 
 sites = siteinds("Electron", N; conserve_qns=true)
 
-ampo = AutoMPO()
+ampo = OpSum()
 for i in 1:N
   ampo .+= U, "Nupdn", i
 end

--- a/examples/dmrg/write_to_disk/1d_heisenberg.jl
+++ b/examples/dmrg/write_to_disk/1d_heisenberg.jl
@@ -12,7 +12,7 @@ let
 
   sites = siteinds("S=1", N; conserve_qns=true)
 
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j in 1:(N - 1)
     ampo .+= 0.5, "S+", j, "S-", j + 1
     ampo .+= 0.5, "S-", j, "S+", j + 1

--- a/examples/src/hubbard.jl
+++ b/examples/src/hubbard.jl
@@ -1,6 +1,6 @@
 
 function hubbard_1d(; N::Int, t=1.0, U=0.0)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for b in 1:(N - 1)
     ampo .+= -t, "Cdagup", b, "Cup", b + 1
     ampo .+= -t, "Cdagup", b + 1, "Cup", b
@@ -18,7 +18,7 @@ end
 function hubbard_2d(; Nx::Int, Ny::Int, t=1.0, U=0.0, yperiodic::Bool=true)
   N = Nx * Ny
   lattice = square_lattice(Nx, Ny; yperiodic=yperiodic)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for b in lattice
     ampo .+= -t, "Cdagup", b.s1, "Cup", b.s2
     ampo .+= -t, "Cdagup", b.s2, "Cup", b.s1
@@ -34,7 +34,7 @@ function hubbard_2d(; Nx::Int, Ny::Int, t=1.0, U=0.0, yperiodic::Bool=true)
 end
 
 function hubbard_2d_ky(; Nx::Int, Ny::Int, t=1.0, U=0.0)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for x in 0:(Nx - 1)
     for ky in 0:(Ny - 1)
       s = x * Ny + ky + 1

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -48,6 +48,9 @@
 @deprecate simlinks!(args...; kwargs...) ITensors.sim_linkinds!(args...; kwargs...)
 @deprecate mul(A::AbstractMPS, B::AbstractMPS; kwargs...) contract(A, B; kwargs...)
 
+# mps/mpo.jl
+@deprecate MPO(A::MPS; kwargs...) outer(A, A; kwargs...)
+
 # mps/mps.jl
 @deprecate randomMPS(sites::Vector{<:Index}, linkdims::Integer) randomMPS(
   sites; linkdims=linkdims

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -309,6 +309,7 @@ export
 
   # physics/autompo.jl
   AutoMPO,
+  OpSum,
   add!,
 
   # physics/lattices.jl

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -213,6 +213,8 @@ export
   movesite,
   movesites,
   ortho_lims,
+  reset_ortho_lims!,
+  set_ortho_lims!,
   siteinds,
 
   # mps/mpo.jl
@@ -223,6 +225,8 @@ export
   maxlinkdim,
   orthogonalize,
   orthogonalize!,
+  outer,
+  projector,
   randomMPO,
   truncate,
   truncate!,

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -36,6 +36,7 @@ import Base:
   intersect,
   intersect!,
   isapprox,
+  isassigned,
   isempty,
   isless,
   iterate,

--- a/src/index.jl
+++ b/src/index.jl
@@ -443,14 +443,20 @@ function Base.iterate(i::Index, state::Int=1)
 end
 
 # This is a trivial definition for use in NDTensors
+# XXX: rename tensorproduct with ⊗ alias
 function NDTensors.outer(i::Index; dir=dir(i), tags="", plev::Int=0)
   return sim(i; tags=tags, plev=plev, dir=dir)
 end
 
 # This is for use in NDTensors
+# XXX: rename tensorproduct with ⊗ alias
 function NDTensors.outer(i1::Index, i2::Index; tags="")
   return Index(dim(i1) * dim(i2), tags)
 end
+
+# Non-qn Index
+# TODO: add ⊕ alias
+directsum(i::Index, j::Index; tags="sum") = Index(dim(i) + dim(j); tags=tags)
 
 #
 # QN related functions

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -773,7 +773,10 @@ Get the block that the specified index falls in.
 
 This is mostly an internal function, and the interface
 is subject to change.
-```
+
+# Examples
+
+```julia
 i = Index(QN(0)=>2, QN(1)=>2)
 is = (i, dag(i'))
 ITensors.block(is, 3, 1) == (2,1)
@@ -782,16 +785,7 @@ ITensors.block(is, 1, 2) == (1,1)
 """
 block(inds::Indices, vals::Integer...) = blockindex(inds, vals...)[2]
 
-function show(io::IO, is::IndexSet)
-  print(io, "IndexSet{$(length(is))} ")
-  for n in eachindex(is)
-    i = is[n]
-    print(io, i)
-    if n < lastindex(is)
-      print(io, " ")
-    end
-  end
-end
+#show(io::IO, is::IndexSet) = show(io, MIME"text/plain"(), is)
 
 #
 # Read and write

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -2000,6 +2000,89 @@ end
 
 ⊙(A::ITensor, B::ITensor) = hadamard_product(A, B)
 
+# Helper tensors for performing a partial direct sum
+function directsum_itensors(i::Index, j::Index, ij::Index)
+  S1 = zeros(dim(i), dim(ij))
+  for ii in 1:dim(i)
+    S1[ii, ii] = 1
+  end
+  S2 = zeros(dim(j), dim(ij))
+  for jj in 1:dim(j)
+    S2[jj, dim(i) + jj] = 1
+  end
+  D1 = itensor(S1, dag(i), ij)
+  D2 = itensor(S2, dag(j), ij)
+  return D1, D2
+end
+
+function directsum(A_and_I::Pair{ITensor}, B_and_J::Pair{ITensor}; kwargs...)
+  A, I = A_and_I
+  B, J = B_and_J
+  return directsum(A, B, I, J; kwargs...)
+end
+
+"""
+    directsum(A::Pair{ITensor}, B::Pair{ITensor}, ...; tags)
+
+Given a list of pairs of ITensors and collections of indices, perform a partial
+direct sum of the tensors over the specified indices. Indices that are
+not specified to be summed must match between the tensors.
+
+If all indices are specified then the operation is equivalent to creating
+a block diagonal tensor.
+
+Returns the ITensor representing the partial direct sum as well as the new
+direct summed indices. The tags of the direct summed indices are specified
+by the keyword arguments.
+
+See Section 2.3 of https://arxiv.org/abs/1405.7786 for a definition of a partial
+direct sum of tensors.
+
+# Examples
+```julia
+x = Index(2, "x")
+i1 = Index(3, "i1")
+j1 = Index(4, "j1")
+i2 = Index(5, "i2")
+j2 = Index(6, "j2")
+
+A1 = randomITensor(i1, x, j1)
+A2 = randomITensor(x, j2, i2)
+S, s = ITensors.directsum(A1 => (i1, j1), A2 => (i2, j2); tags = ["sum_i", "sum_j"])
+```
+"""
+function directsum(
+  A_and_I::Pair{ITensor},
+  B_and_J::Pair{ITensor},
+  C_and_K::Pair{ITensor},
+  itensor_and_inds...;
+  tags=["sum$i" for i in 1:length(last(A_and_I))],
+)
+  return directsum(
+    Pair(directsum(A_and_I, B_and_J; kwargs...)...), C_and_K, itensor_and_inds...; tags=tags
+  )
+end
+
+function directsum(A::ITensor, B::ITensor, I, J; tags)
+  N = length(I)
+  (N != length(J)) &&
+    error("In directsum(::ITensor, ::ITensor, ...), must sum equal number of indices")
+  IJ = Vector{Base.promote_eltype(I, J)}(undef, N)
+  for n in 1:N
+    In = I[n]
+    Jn = J[n]
+    In = dir(A, In) != dir(In) ? dag(In) : In
+    Jn = dir(B, Jn) != dir(Jn) ? dag(Jn) : Jn
+    IJn = directsum(In, Jn; tags=tags[n])
+    D1, D2 = directsum_itensors(In, Jn, IJn)
+    IJ[n] = IJn
+    A *= D1
+    B *= D2
+  end
+  C = A + B
+  return C, IJ
+end
+
 """
     product(A::ITensor, B::ITensor)
 

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -99,7 +99,7 @@ function set_ortho_lims!(ψ::AbstractMPS, r::UnitRange{Int})
   return ψ
 end
 
-reset_ortho_lims!(ψ::AbstractMPS) = set_ortho_lims!(ψ, 1:length(N))
+reset_ortho_lims!(ψ::AbstractMPS) = set_ortho_lims!(ψ, 1:length(ψ))
 
 isortho(m::AbstractMPS) = leftlim(m) + 1 == rightlim(m) - 1
 

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1870,15 +1870,11 @@ function copyto!(ψ::AbstractMPS, b::Broadcasted)
   return ψ
 end
 
-function similar(
-  bc::Broadcasted{Style{MPST}}, ElType::Type
-) where {MPST<:AbstractMPS}
+function similar(bc::Broadcasted{Style{MPST}}, ElType::Type) where {MPST<:AbstractMPS}
   return similar(Array{ElType}, axes(bc))
 end
 
-function similar(
-  bc::Broadcasted{Style{MPST}}, ::Type{ITensor}
-) where {MPST<:AbstractMPS}
+function similar(bc::Broadcasted{Style{MPST}}, ::Type{ITensor}) where {MPST<:AbstractMPS}
   # In general, we assume the broadcast operation
   # will mess up the orthogonality so we use
   # a generic constructor where we don't specify
@@ -1894,7 +1890,6 @@ function Base.show(io::IO, M::AbstractMPS)
   print(io, "$(typeof(M))")
   (length(M) > 0) && print(io, "\n")
   for i in eachindex(M)
-  #for (i, A) in enumerate(data(M))
     if !isassigned(M, i)
       println(io, "#undef")
     else

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -66,10 +66,10 @@ and operators `ops` on each site.
 """
 function MPO(::Type{ElT}, sites::Vector{<:Index}, ops::Vector{String}) where {ElT<:Number}
   N = length(sites)
-  ampo = AutoMPO() + [ops[n] => n for n in 1:N]
+  ampo = OpSum() + [ops[n] => n for n in 1:N]
   M = MPO(ampo, sites)
 
-  # Currently, AutoMPO does not output the optimally truncated
+  # Currently, OpSum does not output the optimally truncated
   # MPO (see https://github.com/ITensor/ITensors.jl/issues/526)
   # So here, we need to first normalize, then truncate, then
   # return the normalization.

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -113,21 +113,48 @@ function MPO(A::ITensor, sites::Vector{<:Index}; kwargs...)
   return MPO(A, IndexSet.(prime.(sites), dag.(sites)); kwargs...)
 end
 
-# TODO: write this in a better way with density matrices instead
-# of contracting the MPS tensors individually at the beginning
 """
-    MPO(A::MPS; kwargs...)
+    outer(x::MPS, y::MPS; <keyword argument>) -> MPO
 
-For an MPS `|A>`, make the MPO `|A><A|`.
-Keyword arguments like `cutoff` can be used to
-truncate the resulting MPO.
+Compute the outer product of `MPS` `x` and `MPS` `y`,
+returning an `MPO` approximation.
+
+Note that `y` will be conjugated, and the site indices
+of `x` will be primed.
+
+In Dirac notation, this is the operation `|x⟩⟨y|`.
+
+The keyword arguments determine the truncation, and accept
+the same arguments as `contract(::MPO, ::MPO; kw...)`.
+
+See also [`product`](@ref), [`contract`](@ref).
 """
-function MPO(A::MPS; kwargs...)
-  M = MPO(prime.(A) .* dag.(A))
-  if !hasnolinkinds(M)
-    truncate!(M; kwargs...)
+function outer(ψ::MPS, ϕ::MPS; kw...)
+  ψmat = convert(MPO, ψ')
+  ϕmat = convert(MPO, dag(ϕ))
+  return contract(ψmat, ϕmat; kw...)
+end
+
+"""
+    projector(x::MPS; <keyword argument>) -> MPO
+
+Computes the projector onto the state `x`. In Dirac notation, this is the operation `|x⟩⟨x|/|⟨x|x⟩|²`.
+
+Use keyword arguments to control the level of truncation, which are
+the same as those accepted by `contract(::MPO, ::MPO; kw...)`.
+
+# Keywords
+- `normalize::Bool=true`: whether or not to normalize the input MPS before forming the projector. If `normalize==false` and the input MPS is not already normalized, this function will not output a proper project, and simply outputs `outer(x, x) = |x⟩⟨x|`, i.e. the projector scaled by `norm(x)^2`.
+- truncation keyword arguments accepted by `contract(::MPO, ::MPO; kw...)`.
+
+See also [`outer`](@ref), [`contract`](@ref).
+"""
+function projector(ψ::MPS; normalize::Bool=true, kw...)
+  ψψᴴ = outer(ψ, ψ; kw...)
+  if normalize
+    normalize!(ψψᴴ[orthocenter(ψψᴴ)])
   end
-  return M
+  return ψψᴴ
 end
 
 # XXX: rename originalsiteind?
@@ -350,20 +377,7 @@ end
 
 error_contract(y::MPS, x::MPS, A::MPO) = error_contract(y, A, x)
 
-"""
-    contract(::MPS, ::MPO; kwargs...)
-    *(::MPS, ::MPO; kwargs...)
-
-    contract(::MPO, ::MPS; kwargs...)
-    *(::MPO, ::MPS; kwargs...)
-
-Contract the MPO with the MPS, returning an MPS with the unique
-site indices of the MPO.
-
-Choose the method with the `method` keyword, for example
-"densitymatrix" and "naive".
-"""
-function *(A::MPO, ψ::MPS; kwargs...)
+function contract(A::MPO, ψ::MPS; kwargs...)
   method = get(kwargs, :method, "densitymatrix")
 
   # Keyword argument deprecations
@@ -387,7 +401,43 @@ function *(A::MPO, ψ::MPS; kwargs...)
   return Aψ
 end
 
-Base.:*(ψ::MPS, A::MPO; kwargs...) = *(A, ψ; kwargs...)
+contract_mpo_mps_doc = """
+    contract(ψ::MPS, A::MPO; kwargs...) -> MPS
+    *(::MPS, ::MPO; kwargs...) -> MPS
+
+    contract(A::MPO, ψ::MPS; kwargs...) -> MPS
+    *(::MPO, ::MPS; kwargs...) -> MPS
+
+Contract the `MPO` `A` with the `MPS` `ψ`, returning an `MPS` with the unique
+site indices of the `MPO`.
+
+Choose the method with the `method` keyword, for example
+`"densitymatrix"` and `"naive"`.
+
+# Keywords
+- `cutoff::Float64=1e-13`: the cutoff value for truncating the density matrix eigenvalues. Note that the default is somewhat arbitrary and subject to change, in general you should set a `cutoff` value.
+- `maxdim::Int=maxlinkdim(A) * maxlinkdim(ψ))`: the maximal bond dimension of the results MPS.
+- `mindim::Int=1`: the minimal bond dimension of the resulting MPS.
+- `normalize::Bool=false`: whether or not to normalize the resulting MPS.
+- `method::String="densitymatrix"`: the algorithm to use for the contraction.
+"""
+
+@doc """
+$contract_mpo_mps_doc
+""" contract(::MPO, ::MPS)
+
+contract(ψ::MPS, A::MPO; kwargs...) = contract(A, ψ; kwargs...)
+
+*(A::MPO, B::MPS; kwargs...) = contract(A, B; kwargs...)
+*(A::MPS, B::MPO; kwargs...) = contract(A, B; kwargs...)
+
+# TODO: try this to copy the docstring
+# Causing an error in Revise
+#@doc """
+#$contract_mpo_mps_doc
+#""" *(::MPO, ::MPS)
+
+#@doc (@doc contract(::MPO, ::MPS)) *(::MPO, ::MPS)
 
 function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
   n = length(A)
@@ -399,7 +449,7 @@ function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
 
   ψ_out = similar(ψ)
   cutoff::Float64 = get(kwargs, :cutoff, 1e-13)
-  maxdim::Int = get(kwargs, :maxdim, maxlinkdim(ψ))
+  maxdim::Int = get(kwargs, :maxdim, maxlinkdim(A) * maxlinkdim(ψ))
   mindim::Int = max(get(kwargs, :mindim, 1), 1)
   normalize::Bool = get(kwargs, :normalize, false)
 
@@ -492,8 +542,7 @@ function _contract_naive(A::MPO, ψ::MPS; kwargs...)::MPS
   return ψ_out
 end
 
-# TODO: form density matrices using a trace
-function Base.:*(A::MPO, B::MPO; kwargs...)
+function contract(A::MPO, B::MPO; kwargs...)
   cutoff::Float64 = get(kwargs, :cutoff, 1e-14)
   resp_degen::Bool = get(kwargs, :respect_degenerate, true)
   maxdim::Int = get(kwargs, :maxdim, maxlinkdim(A) * maxlinkdim(B))
@@ -509,13 +558,14 @@ function Base.:*(A::MPO, B::MPO; kwargs...)
   sA = siteinds(uniqueinds, A, B)
   sB = siteinds(uniqueinds, B, A)
   C = MPO(N)
-  lCᵢ = IndexSet()
+  lCᵢ = Index[]
   R = ITensor(1)
   for i in 1:(N - 2)
     RABᵢ = R * A[i] * B[i]
+    left_inds = [sA[i]..., sB[i]..., lCᵢ...]
     C[i], R = factorize(
       RABᵢ,
-      (sA[i]..., sB[i]..., lCᵢ...);
+      left_inds;
       ortho="left",
       tags=commontags(linkinds(A, i)),
       cutoff=cutoff,
@@ -526,9 +576,10 @@ function Base.:*(A::MPO, B::MPO; kwargs...)
   end
   i = N - 1
   RABᵢ = R * A[i] * B[i] * A[i + 1] * B[i + 1]
+  left_inds = [sA[i]..., sB[i]..., lCᵢ...]
   C[N - 1], C[N] = factorize(
     RABᵢ,
-    (sA[i]..., sB[i]..., lCᵢ...);
+    left_inds;
     ortho="right",
     tags=commontags(linkinds(A, i)),
     cutoff=cutoff,
@@ -538,6 +589,33 @@ function Base.:*(A::MPO, B::MPO; kwargs...)
   truncate!(C; kwargs...)
   return C
 end
+
+contract_mpo_mpo_doc = """
+    contract(A::MPO, B::MPO; kwargs...) -> MPO
+    *(::MPO, ::MPO; kwargs...) -> MPO
+
+Contract the `MPO` `A` with the `MPO` `B`, returning an `MPO` with the 
+site indices that are not shared between `A` and `B`.
+
+# Keywords
+- `cutoff::Float64=1e-13`: the cutoff value for truncating the density matrix eigenvalues. Note that the default is somewhat arbitrary and subject to change, in general you should set a `cutoff` value.
+- `maxdim::Int=maxlinkdim(A) * maxlinkdim(B))`: the maximal bond dimension of the results MPS.
+- `mindim::Int=1`: the minimal bond dimension of the resulting MPS.
+"""
+
+@doc """
+$contract_mpo_mpo_doc
+""" contract(::MPO, ::MPO)
+
+*(A::MPO, B::MPO; kwargs...) = contract(A, B; kwargs...)
+
+# TODO: try this to copy the docstring
+# Causing an error in Revise
+#@doc """
+#$contract_mpo_mpo_doc
+#""" *(::MPO, ::MPO)
+
+#@doc (@doc contract(::MPO, ::MPO)) *(::MPO, ::MPO)
 
 """
     sample(M::MPO)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -646,7 +646,7 @@ updens,dndens = expect(psi,"Nup","Ndn")
 function expect(psi::MPS, ops::AbstractString...; kwargs...)
   psi = copy(psi)
   N = length(psi)
-  ElT = real(eltype(psi))
+  ElT = real(promote_itensor_eltype(psi))
   Nops = length(ops)
   s = siteinds(psi)
 

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -549,7 +549,7 @@ Cuu = correlator(psi,"Cdagup","Cup";site_range=2:8)
 """
 function correlation_matrix(psi::MPS, Op1::AbstractString, Op2::AbstractString; kwargs...)
   N = length(psi)
-  ElT = eltype(psi)
+  ElT = promote_itensor_eltype(psi)
 
   site_range::UnitRange{Int} = get(kwargs, :site_range, 1:N)
   start_site = first(site_range)

--- a/src/packagecompile/precompile_itensors.jl
+++ b/src/packagecompile/precompile_itensors.jl
@@ -14,7 +14,7 @@ sweeps = Sweeps(3)
 maxdim!(sweeps, 10)
 cutoff!(sweeps, 1E-13)
 
-ampo = AutoMPO()
+ampo = OpSum()
 for j in 1:(N - 1)
   ampo .+= "Sz", j, "Sz", j + 1
   ampo .+= 0.5, "S+", j, "S-", j + 1

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -168,46 +168,46 @@ const AutoMPO = OpSum
     
 Construct an empty `OpSum`.
 """
-AutoMPO() = AutoMPO(Vector{MPOTerm}())
+OpSum() = OpSum(Vector{MPOTerm}())
 
-data(ampo::AutoMPO) = ampo.data
-setdata!(ampo::AutoMPO, ndata) = (ampo.data = ndata)
+data(ampo::OpSum) = ampo.data
+setdata!(ampo::OpSum, ndata) = (ampo.data = ndata)
 
-push!(ampo::AutoMPO, term) = push!(data(ampo), term)
+push!(ampo::OpSum, term) = push!(data(ampo), term)
 
-Base.:(==)(ampo1::AutoMPO, ampo2::AutoMPO) = data(ampo1) == data(ampo2)
+Base.:(==)(ampo1::OpSum, ampo2::OpSum) = data(ampo1) == data(ampo2)
 
-Base.copy(ampo::AutoMPO) = AutoMPO(copy(data(ampo)))
+Base.copy(ampo::OpSum) = OpSum(copy(data(ampo)))
 
-function Base.deepcopy(ampo::AutoMPO)
-  return AutoMPO(map(copy, data(ampo)))
+function Base.deepcopy(ampo::OpSum)
+  return OpSum(map(copy, data(ampo)))
 end
 
-Base.size(ampo::AutoMPO) = size(data(ampo))
+Base.size(ampo::OpSum) = size(data(ampo))
 
 """
-    add!(ampo::AutoMPO,
+    add!(ampo::OpSum,
          op1::String, i1::Int)
 
-    add!(ampo::AutoMPO,
+    add!(ampo::OpSum,
          coef::Number,
          op1::String, i1::Int)
 
-    add!(ampo::AutoMPO,
+    add!(ampo::OpSum,
          op1::String, i1::Int,
          op2::String, i2::Int,
          ops...)
 
-    add!(ampo::AutoMPO,
+    add!(ampo::OpSum,
          coef::Number,
          op1::String, i1::Int,
          op2::String, i2::Int,
          ops...)
 
-    +(ampo:AutoMPO, term::Tuple)
+    +(ampo:OpSum, term::Tuple)
 
 Add a single- or multi-site operator 
-term to the AutoMPO `ampo`. Each operator
+term to the OpSum `ampo`. Each operator
 is specified by a name (String) and a
 site number (Int). The second version
 accepts a real or complex coefficient.
@@ -219,14 +219,14 @@ accepts a tuple with entries either
 where these tuple values are the same
 as valid inputs to the `add!` function.
 For inputting a very large number of
-terms (tuples) to an AutoMPO, consider
+terms (tuples) to an OpSum, consider
 using the broadcasted operator `.+=`
-which avoids reallocating the AutoMPO
+which avoids reallocating the OpSum
 after each addition.
 
 # Examples
 ```julia
-ampo = AutoMPO()
+ampo = OpSum()
 
 add!(ampo,"Sz",2,"Sz",3)
 
@@ -237,62 +237,62 @@ ampo += (0.5,"S+",4,"S-",5)
 ampo .+= (0.5,"S+",5,"S-",6)
 ```
 """
-function add!(ampo::AutoMPO, coef::Number, op::String, i::Int)
+function add!(ampo::OpSum, coef::Number, op::String, i::Int)
   push!(data(ampo), MPOTerm(coef, op, i))
   return nothing
 end
 
-add!(ampo::AutoMPO, op::String, i::Int) = add!(ampo, 1.0, op, i)
+add!(ampo::OpSum, op::String, i::Int) = add!(ampo, 1.0, op, i)
 
-function add!(ampo::AutoMPO, coef::Number, op1::String, i1::Int, op2::String, i2::Int)
+function add!(ampo::OpSum, coef::Number, op1::String, i1::Int, op2::String, i2::Int)
   push!(data(ampo), MPOTerm(coef, op1, i1, op2, i2))
   return nothing
 end
 
-function add!(ampo::AutoMPO, op1::String, i1::Int, op2::String, i2::Int)
+function add!(ampo::OpSum, op1::String, i1::Int, op2::String, i2::Int)
   return add!(ampo, 1.0, op1, i1, op2, i2)
 end
 
 function add!(
-  ampo::AutoMPO, coef::Number, op1::String, i1::Int, op2::String, i2::Int, ops...
+  ampo::OpSum, coef::Number, op1::String, i1::Int, op2::String, i2::Int, ops...
 )
   push!(ampo, MPOTerm(coef, op1, i1, op2, i2, ops...))
   return ampo
 end
 
-function add!(ampo::AutoMPO, op1::String, i1::Int, op2::String, i2::Int, ops...)
+function add!(ampo::OpSum, op1::String, i1::Int, op2::String, i2::Int, ops...)
   return add!(ampo, 1.0, op1, i1, op2, i2, ops...)
 end
 
-function add!(ampo::AutoMPO, ops::Vector{Pair{String,Int64}})
+function add!(ampo::OpSum, ops::Vector{Pair{String,Int64}})
   push!(ampo, MPOTerm(1.0, ops))
   return ampo
 end
 
 """
-    subtract!(ampo::AutoMPO,
+    subtract!(ampo::OpSum,
               op1::String, i1::Int,
               op2::String, i2::Int,
               ops...)
 
-    subtract!(ampo::AutoMPO,
+    subtract!(ampo::OpSum,
               coef::Number,
               op1::String, i1::Int,
               op2::String, i2::Int,
               ops...)
 
 Subtract a multi-site operator term
-from the AutoMPO `ampo`. Each operator
+from the OpSum `ampo`. Each operator
 is specified by a name (String) and a
 site number (Int). The second version
 accepts a real or complex coefficient.
 """
-function subtract!(ampo::AutoMPO, op1::String, i1::Int, op2::String, i2::Int, ops...)
+function subtract!(ampo::OpSum, op1::String, i1::Int, op2::String, i2::Int, ops...)
   return add!(ampo, -1.0, op1, i1, op2, i2, ops...)
 end
 
 function subtract!(
-  ampo::AutoMPO, coef::Number, op1::String, i1::Int, op2::String, i2::Int, ops...
+  ampo::OpSum, coef::Number, op1::String, i1::Int, op2::String, i2::Int, ops...
 )
   push!(ampo, -MPOTerm(coef, op1, i1, op2, i2, ops...))
   return ampo
@@ -300,19 +300,19 @@ end
 
 -(t::MPOTerm) = MPOTerm(-coef(t), ops(t))
 
-function (ampo::AutoMPO + term::Tuple)
+function (ampo::OpSum + term::Tuple)
   ampo_plus_term = copy(ampo)
   add!(ampo_plus_term, term...)
   return ampo_plus_term
 end
 
-function (ampo::AutoMPO + term::Vector{Pair{String,Int64}})
+function (ampo::OpSum + term::Vector{Pair{String,Int64}})
   ampo_plus_term = copy(ampo)
   add!(ampo_plus_term, term)
   return ampo_plus_term
 end
 
-function (ampo::AutoMPO - term::Tuple)
+function (ampo::OpSum - term::Tuple)
   ampo_plus_term = copy(ampo)
   subtract!(ampo_plus_term, term...)
   return ampo_plus_term
@@ -322,18 +322,18 @@ end
 # ampo .+= ("Sz",1) syntax using broadcasting
 #
 
-struct AutoMPOStyle <: Broadcast.BroadcastStyle end
-Base.BroadcastStyle(::Type{<:AutoMPO}) = AutoMPOStyle()
+struct OpSumStyle <: Broadcast.BroadcastStyle end
+Base.BroadcastStyle(::Type{<:OpSum}) = OpSumStyle()
 
-struct AutoMPOAddTermStyle <: Broadcast.BroadcastStyle end
+struct OpSumAddTermStyle <: Broadcast.BroadcastStyle end
 
-Base.broadcastable(ampo::AutoMPO) = ampo
+Base.broadcastable(ampo::OpSum) = ampo
 
-Base.BroadcastStyle(::AutoMPOStyle, ::Broadcast.Style{Tuple}) = AutoMPOAddTermStyle()
+Base.BroadcastStyle(::OpSumStyle, ::Broadcast.Style{Tuple}) = OpSumAddTermStyle()
 
-Broadcast.instantiate(bc::Broadcast.Broadcasted{AutoMPOAddTermStyle}) = bc
+Broadcast.instantiate(bc::Broadcast.Broadcasted{OpSumAddTermStyle}) = bc
 
-function Base.copyto!(ampo, bc::Broadcast.Broadcasted{AutoMPOAddTermStyle,<:Any,typeof(+)})
+function Base.copyto!(ampo, bc::Broadcast.Broadcasted{OpSumAddTermStyle,<:Any,typeof(+)})
   add!(ampo, bc.args[2]...)
   return ampo
 end
@@ -342,13 +342,13 @@ end
 # ampo .-= ("Sz",1) syntax using broadcasting
 #
 
-function Base.copyto!(ampo, bc::Broadcast.Broadcasted{AutoMPOAddTermStyle,<:Any,typeof(-)})
+function Base.copyto!(ampo, bc::Broadcast.Broadcasted{OpSumAddTermStyle,<:Any,typeof(-)})
   subtract!(ampo, bc.args[2]...)
   return ampo
 end
 
-function Base.show(io::IO, ampo::AutoMPO)
-  println(io, "AutoMPO:")
+function Base.show(io::IO, ampo::OpSum)
+  println(io, "OpSum:")
   for term in data(ampo)
     println(io, "  $term")
   end
@@ -478,7 +478,7 @@ function remove_dups!(v::Vector{T}) where {T}
   return nothing
 end #remove_dups!
 
-function svdMPO(ampo::AutoMPO, sites; kwargs...)::MPO
+function svdMPO(ampo::OpSum, sites; kwargs...)::MPO
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, 10000)
   cutoff::Float64 = get(kwargs, :cutoff, 1E-13)
@@ -632,7 +632,7 @@ function svdMPO(ampo::AutoMPO, sites; kwargs...)::MPO
   return H
 end #svdMPO
 
-function qn_svdMPO(ampo::AutoMPO, sites; kwargs...)::MPO
+function qn_svdMPO(ampo::OpSum, sites; kwargs...)::MPO
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, 10000)
   cutoff::Float64 = get(kwargs, :cutoff, 1E-13)
@@ -852,7 +852,7 @@ function qn_svdMPO(ampo::AutoMPO, sites; kwargs...)::MPO
   return H
 end #qn_svdMPO
 
-function sorteachterm!(ampo::AutoMPO, sites)
+function sorteachterm!(ampo::OpSum, sites)
   ampo = copy(ampo)
   isless_site(o1::SiteOp, o2::SiteOp) = site(o1) < site(o2)
   N = length(sites)
@@ -893,7 +893,7 @@ function sorteachterm!(ampo::AutoMPO, sites)
       end
     end
     if rhs_parity == -1
-      error("Total parity-odd fermionic terms not yet supported by AutoMPO")
+      error("Total parity-odd fermionic terms not yet supported by OpSum")
     end
     # Keep only fermionic op positions (non-zero entries)
     filter!(!iszero, perm)
@@ -905,7 +905,7 @@ function sorteachterm!(ampo::AutoMPO, sites)
   return ampo
 end
 
-function sortmergeterms!(ampo::AutoMPO)
+function sortmergeterms!(ampo::OpSum)
   sort!(data(ampo))
 
   # Merge (add) terms with same operators
@@ -927,20 +927,20 @@ function sortmergeterms!(ampo::AutoMPO)
 end
 
 """
-    MPO(ampo::AutoMPO,sites::Vector{<:Index};kwargs...)
+    MPO(ampo::OpSum,sites::Vector{<:Index};kwargs...)
        
-Convert an AutoMPO object `ampo` to an
+Convert an OpSum object `ampo` to an
 MPO, with indices given by `sites`. The
 resulting MPO will have the indices
 `sites[1], sites[1]', sites[2], sites[2]'`
 etc. The conversion is done by an algorithm
 that compresses the MPO resulting from adding
-the AutoMPO terms together, often achieving
+the OpSum terms together, often achieving
 the minimum possible bond dimension.
 
 # Examples
 ```julia
-ampo = AutoMPO()
+ampo = OpSum()
 ampo += ("Sz",1,"Sz",2)
 ampo += ("Sz",2,"Sz",3)
 ampo += ("Sz",3,"Sz",4)
@@ -949,8 +949,8 @@ sites = siteinds("S=1/2",4)
 H = MPO(ampo,sites)
 ```
 """
-function MPO(ampo::AutoMPO, sites::Vector{<:Index}; kwargs...)::MPO
-  length(data(ampo)) == 0 && error("AutoMPO has no terms")
+function MPO(ampo::OpSum, sites::Vector{<:Index}; kwargs...)::MPO
+  length(data(ampo)) == 0 && error("OpSum has no terms")
 
   ampo = deepcopy(ampo)
   sorteachterm!(ampo, sites)

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -253,9 +253,7 @@ function add!(ampo::OpSum, op1::String, i1::Int, op2::String, i2::Int)
   return add!(ampo, 1.0, op1, i1, op2, i2)
 end
 
-function add!(
-  ampo::OpSum, coef::Number, op1::String, i1::Int, op2::String, i2::Int, ops...
-)
+function add!(ampo::OpSum, coef::Number, op1::String, i1::Int, op2::String, i2::Int, ops...)
   push!(ampo, MPOTerm(coef, op1, i1, op2, i2, ops...))
   return ampo
 end

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -135,34 +135,38 @@ function Base.show(io::IO, op::MPOTerm)
 end
 
 ############################
-## AutoMPO                 #
+## OpSum                 #
 ############################
 
 """
-An AutoMPO stores a collection of
-operator terms, to be later summed
-together into an MPO by calling
-the function `MPO` on the AutoMPO object. 
+An `OpSum` represents a sum of operator
+terms.
+
+Often it is used to create matrix
+product operator (`MPO`) approximation
+of the sum of the terms in the `OpSum` oject.
 Each term is a product of local operators
-specified by names such as "Sz" or "N",
+specified by names such as `"Sz"` or `"N"`,
 times an optional coefficient which
 can be real or complex.
 
 Which local operator names are available
 is determined by the function `op`
-associated with the TagType defined by
-special Index tags, such as "S=1/2","S=1",
-"Fermion", and "Electron".
+associated with the `TagType` defined by
+special Index tags, such as `"S=1/2"`, `"S=1"`,
+`"Fermion"`, and `"Electron"`.
 """
-mutable struct AutoMPO
+mutable struct OpSum
   data::Vector{MPOTerm}
-  AutoMPO(terms::Vector{MPOTerm}) = new(terms)
+  OpSum(terms::Vector{MPOTerm}) = new(terms)
 end
 
+const AutoMPO = OpSum
+
 """
-    AutoMPO()
+    OpSum()
     
-Construct an empty AutoMPO
+Construct an empty `OpSum`.
 """
 AutoMPO() = AutoMPO(Vector{MPOTerm}())
 

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -206,7 +206,7 @@ The result is an ITensor made by forming each operator
 then contracting them together in a way corresponding
 to the usual operator product or matrix multiplication.
 
-The `op` system is used by the AutoMPO
+The `op` system is used by the OpSum
 system to convert operator names into ITensors,
 and can be used directly such as for applying
 operators to MPS.

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -195,6 +195,8 @@ function blockdim(i::Index, b::Union{Block,Integer})
   )
 end
 
+dim(i::QNIndex, b::Block) = blockdim(space(i), b)
+
 eachblock(i::Index) = (Block(n) for n in 1:nblocks(i))
 
 # Return the first block of the QNIndex with the flux q
@@ -269,6 +271,7 @@ end
 
 (qn1::QNBlock * qn2::QNBlock) = QNBlock(qn(qn1) + qn(qn2), blockdim(qn1) * blockdim(qn2))
 
+# TODO: rename tensorproduct with ⊗ alias
 function outer(qn1::QNBlocks, qn2::QNBlocks)
   qnR = ITensors.QNBlocks(undef, nblocks(qn1) * nblocks(qn2))
   for (i, t) in enumerate(Iterators.product(qn1, qn2))
@@ -277,6 +280,7 @@ function outer(qn1::QNBlocks, qn2::QNBlocks)
   return qnR
 end
 
+# TODO: rename tensorproduct with ⊗ alias
 function outer(i1::QNIndex, i2::QNIndex; dir=nothing, tags="", plev::Integer=0)
   if isnothing(dir)
     if ITensors.dir(i1) == ITensors.dir(i2)
@@ -289,12 +293,23 @@ function outer(i1::QNIndex, i2::QNIndex; dir=nothing, tags="", plev::Integer=0)
   return Index(newspace; dir=dir, tags=tags, plev=plev)
 end
 
+# TODO: rename tensorproduct with ⊗ alias
 function outer(i::QNIndex; dir=nothing, tags="", plev::Integer=0)
   if isnothing(dir)
     dir = ITensors.dir(i)
   end
   newspace = dir * (ITensors.dir(i) * space(i))
   return Index(newspace; dir=dir, tags=tags, plev=plev)
+end
+
+# TODO: add ⊕ alias
+function directsum(
+  i::Index{Vector{Pair{QN,Int}}}, j::Index{Vector{Pair{QN,Int}}}; tags="sum"
+)
+  dir(i) ≠ dir(j) && error(
+    "To direct sum two indices, they must have the same direction. Trying to direct sum indices $i and $j.",
+  )
+  return Index(vcat(space(i), space(j)); dir=dir(i), tags=tags)
 end
 
 isless(qnb1::QNBlock, qnb2::QNBlock) = isless(qn(qnb1), qn(qnb2))

--- a/src/qn/qnindexset.jl
+++ b/src/qn/qnindexset.jl
@@ -34,12 +34,3 @@ removeqns(is::QNIndices) = map(i -> removeqns(i), is)
 anyfermionic(is::Indices) = any(isfermionic, is)
 
 allfermionic(is::Indices) = all(isfermionic, is)
-
-# TODO: specialize for Vector vs. Tuple
-function Base.show(io::IO, is::QNIndices)
-  print(io, "$(length(is)) Indices\n")
-  for i in is
-    print(io, i)
-    println(io)
-  end
-end

--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -143,24 +143,24 @@ function fourSiteIsingMPO(sites)::MPO
   return H
 end
 
-@testset "AutoMPO" begin
+@testset "OpSum" begin
   N = 10
 
   @testset "Show MPOTerm" begin
-    ampo = AutoMPO()
+    ampo = OpSum()
     add!(ampo, "Sz", 1, "Sz", 2)
     @test length(sprint(show, ITensors.data(ampo)[1])) > 1
   end
 
-  @testset "Show AutoMPO" begin
-    ampo = AutoMPO()
+  @testset "Show OpSum" begin
+    ampo = OpSum()
     add!(ampo, "Sz", 1, "Sz", 2)
     add!(ampo, "Sz", 2, "Sz", 3)
     @test length(sprint(show, ampo)) > 1
   end
 
   @testset "Single creation op" begin
-    ampo = AutoMPO()
+    ampo = OpSum()
     add!(ampo, "Adagup", 3)
     sites = siteinds("Electron", N)
     W = MPO(ampo, sites)
@@ -171,7 +171,7 @@ end
   end
 
   @testset "Ising" begin
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       ampo += "Sz", j, "Sz", j + 1
     end
@@ -185,7 +185,7 @@ end
   end
 
   @testset "Ising-Different Order" begin
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       ampo += "Sz", j, "Sz", j + 1
     end
@@ -199,7 +199,7 @@ end
   end
 
   @testset "Heisenberg" begin
-    ampo = AutoMPO()
+    ampo = OpSum()
     h = rand(N) #random magnetic fields
     for j in 1:(N - 1)
       ampo += "Sz", j, "Sz", j + 1
@@ -221,7 +221,7 @@ end
 
   @testset "Multiple Onsite Ops" begin
     sites = siteinds("S=1", N)
-    ampo1 = AutoMPO()
+    ampo1 = OpSum()
     for j in 1:(N - 1)
       ampo1 += "Sz", j, "Sz", j + 1
       ampo1 += 0.5, "S+", j, "S-", j + 1
@@ -232,7 +232,7 @@ end
     end
     Ha1 = MPO(ampo1, sites)
 
-    ampo2 = AutoMPO()
+    ampo2 = OpSum()
     for j in 1:(N - 1)
       ampo2 += "Sz", j, "Sz", j + 1
       ampo2 += 0.5, "S+", j, "S-", j + 1
@@ -253,7 +253,7 @@ end
   end
 
   @testset "Three-site ops" begin
-    ampo = AutoMPO()
+    ampo = OpSum()
     # To test version of add! taking a coefficient
     add!(ampo, 1.0, "Sz", 1, "Sz", 2, "Sz", 3)
     @test length(ITensors.data(ampo)) == 1
@@ -274,7 +274,7 @@ end
   end
 
   @testset "Four-site ops" begin
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 3)
       add!(ampo, "Sz", j, "Sz", j + 1, "Sz", j + 2, "Sz", j + 3)
     end
@@ -288,7 +288,7 @@ end
   end
 
   @testset "Next-neighbor Heisenberg" begin
-    ampo = AutoMPO()
+    ampo = OpSum()
     J1 = 1.0
     J2 = 0.5
     for j in 1:(N - 1)
@@ -314,7 +314,7 @@ end
 
   @testset "Onsite Regression Test" begin
     sites = siteinds("S=1", 4)
-    ampo = AutoMPO()
+    ampo = OpSum()
     add!(ampo, 0.5, "Sx", 1)
     add!(ampo, 0.5, "Sy", 1)
     H = MPO(ampo, sites)
@@ -324,7 +324,7 @@ end
     @test norm(T - 0.5 * O) < 1E-8
 
     sites = siteinds("S=1", 2)
-    ampo = AutoMPO()
+    ampo = OpSum()
     add!(ampo, 0.5im, "Sx", 1)
     add!(ampo, 0.5, "Sy", 1)
     H = MPO(ampo, sites)
@@ -336,7 +336,7 @@ end
 
   @testset "+ syntax" begin
     @testset "Single creation op" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       ampo += "Adagup", 3
       sites = siteinds("Electron", N)
       W = MPO(ampo, sites)
@@ -347,7 +347,7 @@ end
     end
 
     @testset "Ising" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       for j in 1:(N - 1)
         ampo += "Sz", j, "Sz", j + 1
       end
@@ -361,7 +361,7 @@ end
     end
 
     @testset "Ising-Different Order" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       for j in 1:(N - 1)
         ampo += "Sz", j + 1, "Sz", j
       end
@@ -375,7 +375,7 @@ end
     end
 
     @testset "Heisenberg" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       h = rand(N) #random magnetic fields
       for j in 1:(N - 1)
         ampo += "Sz", j, "Sz", j + 1
@@ -397,7 +397,7 @@ end
 
     @testset "Multiple Onsite Ops" begin
       sites = siteinds("S=1", N)
-      ampo1 = AutoMPO()
+      ampo1 = OpSum()
       for j in 1:(N - 1)
         ampo1 += "Sz", j, "Sz", j + 1
         ampo1 += 0.5, "S+", j, "S-", j + 1
@@ -408,7 +408,7 @@ end
       end
       Ha1 = MPO(ampo1, sites)
 
-      ampo2 = AutoMPO()
+      ampo2 = OpSum()
       for j in 1:(N - 1)
         ampo2 += "Sz", j, "Sz", j + 1
         ampo2 += 0.5, "S+", j, "S-", j + 1
@@ -429,7 +429,7 @@ end
     end
 
     @testset "Three-site ops" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       # To test version of add! taking a coefficient
       ampo += 1.0, "Sz", 1, "Sz", 2, "Sz", 3
       @test length(ITensors.data(ampo)) == 1
@@ -450,7 +450,7 @@ end
     end
 
     @testset "Four-site ops" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       for j in 1:(N - 3)
         ampo += "Sz", j, "Sz", j + 1, "Sz", j + 2, "Sz", j + 3
       end
@@ -464,7 +464,7 @@ end
     end
 
     @testset "Next-neighbor Heisenberg" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       J1 = 1.0
       J2 = 0.5
       for j in 1:(N - 1)
@@ -489,16 +489,16 @@ end
     end
 
     #@testset "-= syntax" begin
-    #  ampo = AutoMPO()
+    #  ampo = OpSum()
     #  ampo += (-1,"Sz",1,"Sz",2)
-    #  ampo2 = AutoMPO()
+    #  ampo2 = OpSum()
     #  ampo2 -= ("Sz",1,"Sz",2)
     #  @test ampo == ampo2
     #end
 
     @testset "Onsite Regression Test" begin
       sites = siteinds("S=1", 4)
-      ampo = AutoMPO()
+      ampo = OpSum()
       ampo += 0.5, "Sx", 1
       ampo += 0.5, "Sy", 1
       H = MPO(ampo, sites)
@@ -508,7 +508,7 @@ end
       @test norm(T - 0.5 * O) < 1E-8
 
       sites = siteinds("S=1", 2)
-      ampo = AutoMPO()
+      ampo = OpSum()
       ampo += 0.5im, "Sx", 1
       ampo += 0.5, "Sy", 1
       H = MPO(ampo, sites)
@@ -523,15 +523,15 @@ end
   @testset ".+= and .-= syntax" begin
 
     #@testset ".-= syntax" begin
-    #  ampo = AutoMPO()
+    #  ampo = OpSum()
     #  ampo .+= (-1,"Sz",1,"Sz",2)
-    #  ampo2 = AutoMPO()
+    #  ampo2 = OpSum()
     #  ampo2 .-= ("Sz",1,"Sz",2)
     #  @test ampo == ampo2
     #end
 
     @testset "Single creation op" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       ampo .+= "Adagup", 3
       sites = siteinds("Electron", N)
       W = MPO(ampo, sites)
@@ -542,7 +542,7 @@ end
     end
 
     @testset "Ising" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       for j in 1:(N - 1)
         ampo .+= "Sz", j, "Sz", j + 1
       end
@@ -556,7 +556,7 @@ end
     end
 
     @testset "Ising-Different Order" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       for j in 1:(N - 1)
         ampo .+= "Sz", j + 1, "Sz", j
       end
@@ -570,7 +570,7 @@ end
     end
 
     @testset "Heisenberg" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       h = rand(N) #random magnetic fields
       for j in 1:(N - 1)
         ampo .+= "Sz", j, "Sz", j + 1
@@ -592,7 +592,7 @@ end
 
     @testset "Multiple Onsite Ops" begin
       sites = siteinds("S=1", N)
-      ampo1 = AutoMPO()
+      ampo1 = OpSum()
       for j in 1:(N - 1)
         ampo1 .+= "Sz", j, "Sz", j + 1
         ampo1 .+= 0.5, "S+", j, "S-", j + 1
@@ -603,7 +603,7 @@ end
       end
       Ha1 = MPO(ampo1, sites)
 
-      ampo2 = AutoMPO()
+      ampo2 = OpSum()
       for j in 1:(N - 1)
         ampo2 .+= "Sz", j, "Sz", j + 1
         ampo2 .+= 0.5, "S+", j, "S-", j + 1
@@ -624,7 +624,7 @@ end
     end
 
     @testset "Three-site ops" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       # To test version of add! taking a coefficient
       ampo .+= 1.0, "Sz", 1, "Sz", 2, "Sz", 3
       @test length(ITensors.data(ampo)) == 1
@@ -645,7 +645,7 @@ end
     end
 
     @testset "Four-site ops" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       for j in 1:(N - 3)
         ampo .+= "Sz", j, "Sz", j + 1, "Sz", j + 2, "Sz", j + 3
       end
@@ -659,7 +659,7 @@ end
     end
 
     @testset "Next-neighbor Heisenberg" begin
-      ampo = AutoMPO()
+      ampo = OpSum()
       J1 = 1.0
       J2 = 0.5
       for j in 1:(N - 1)
@@ -685,7 +685,7 @@ end
 
     @testset "Onsite Regression Test" begin
       sites = siteinds("S=1", 4)
-      ampo = AutoMPO()
+      ampo = OpSum()
       ampo .+= 0.5, "Sx", 1
       ampo .+= 0.5, "Sy", 1
       H = MPO(ampo, sites)
@@ -695,7 +695,7 @@ end
       @test norm(T - 0.5 * O) < 1E-8
 
       sites = siteinds("S=1", 2)
-      ampo = AutoMPO()
+      ampo = OpSum()
       ampo .+= 0.5im, "Sx", 1
       ampo .+= 0.5, "Sy", 1
       H = MPO(ampo, sites)
@@ -711,15 +711,15 @@ end
     N = 5
     s = siteinds("Fermion", N)
 
-    a1 = AutoMPO()
+    a1 = OpSum()
     a1 += "Cdag", 1, "C", 3
     M1 = MPO(a1, s)
 
-    a2 = AutoMPO()
+    a2 = OpSum()
     a2 += -1, "C", 3, "Cdag", 1
     M2 = MPO(a2, s)
 
-    a3 = AutoMPO()
+    a3 = OpSum()
     a3 += "Cdag", 1, "N", 2, "C", 3
     M3 = MPO(a3, s)
 
@@ -744,11 +744,11 @@ end
 
     s = siteinds("Electron", N; conserve_qns=true)
 
-    a1 = AutoMPO()
+    a1 = OpSum()
     a1 += "Cdagup", 1, "Cup", 3
     M1 = MPO(a1, s)
 
-    a2 = AutoMPO()
+    a2 = OpSum()
     a2 += -1, "Cdn", 3, "Cdagdn", 1
     M2 = MPO(a2, s)
 
@@ -767,12 +767,12 @@ end
     @test inner(pd00, M2, p00d) ≈ +1.0
   end
 
-  @testset "Complex AutoMPO Coefs" begin
+  @testset "Complex OpSum Coefs" begin
     N = 4
 
     for use_qn in [false, true]
       sites = siteinds("S=1/2", N; conserve_qns=use_qn)
-      ampo = AutoMPO()
+      ampo = OpSum()
       for i in 1:(N - 1)
         ampo += +1im, "S+", i, "S-", i + 1
         ampo += -1im, "S-", i, "S+", i + 1
@@ -785,11 +785,11 @@ end
     end
   end
 
-  @testset "Fermion AutoMPO Issue 514 Regression Test" begin
+  @testset "Fermion OpSum Issue 514 Regression Test" begin
     N = 4
     s = siteinds("Electron", N; conserve_qns=true)
-    ampo1 = AutoMPO()
-    ampo2 = AutoMPO()
+    ampo1 = OpSum()
+    ampo2 = OpSum()
 
     ampo1 += "Nup", 1
     ampo2 += "Cdagup", 1, "Cup", 1
@@ -803,10 +803,10 @@ end
     @test norm(H1 - H2) ≈ 0.0
   end
 
-  @testset "AutoMPO in-place modification regression test" begin
+  @testset "OpSum in-place modification regression test" begin
     N = 2
     t = 1.0
-    ampo = AutoMPO()
+    ampo = OpSum()
     for n in 1:(N - 1)
       ampo .+= -t, "Cdag", n, "C", n + 1
       ampo .+= -t, "Cdag", n + 1, "C", n

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -5,7 +5,7 @@ using ITensors, Test, Random
     N = 10
     sites = siteinds("S=1", N)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       add!(ampo, "Sz", j, "Sz", j + 1)
       add!(ampo, 0.5, "S+", j, "S-", j + 1)
@@ -31,7 +31,7 @@ using ITensors, Test, Random
     N = 10
     sites = siteinds("S=1", N; conserve_qns=true)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       ampo += "Sz", j, "Sz", j + 1
       ampo += 0.5, "S+", j, "S-", j + 1
@@ -58,7 +58,7 @@ using ITensors, Test, Random
     N = 10
     sites = siteinds("S=1", N; conserve_qns=true)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       ampo += "Sz", j, "Sz", j + 1
       ampo += 0.5, "S+", j, "S-", j + 1
@@ -85,7 +85,7 @@ using ITensors, Test, Random
     N = 10
     sites = siteinds("S=1", N; conserve_qns=true)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       ampo += "Sz", j, "Sz", j + 1
       ampo += 0.5, "S+", j, "S-", j + 1
@@ -122,7 +122,7 @@ using ITensors, Test, Random
     Random.seed!(432)
     psi0 = randomMPS(sites)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:N
       j < N && add!(ampo, -1.0, "Z", j, "Z", j + 1)
       add!(ampo, -1.0, "X", j)
@@ -149,7 +149,7 @@ using ITensors, Test, Random
     state = [isodd(j) ? "↑" : "↓" for j in 1:N]
     psi0 = randomMPS(sites, state)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:N
       j < N && add!(ampo, -1.0, "X", j, "X", j + 1)
       add!(ampo, -1.0, "Z", j)
@@ -180,7 +180,7 @@ using ITensors, Test, Random
     Random.seed!(42)
     psi0 = randomMPS(sites)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       ampo += -1, "Sz", j, "Sz", j + 1
     end
@@ -214,13 +214,13 @@ using ITensors, Test, Random
     N = 10
     sites = siteinds("S=1", N)
 
-    ampoZ = AutoMPO()
+    ampoZ = OpSum()
     for j in 1:(N - 1)
       ampoZ += "Sz", j, "Sz", j + 1
     end
     HZ = MPO(ampoZ, sites)
 
-    ampoXY = AutoMPO()
+    ampoXY = OpSum()
     for j in 1:(N - 1)
       ampoXY += 0.5, "S+", j, "S-", j + 1
       ampoXY += 0.5, "S-", j, "S+", j + 1
@@ -246,7 +246,7 @@ using ITensors, Test, Random
     sites[1] = Index(2, "S=1/2,n=1,Site")
     sites[N] = Index(2, "S=1/2,n=$N,Site")
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       ampo += "Sz", j, "Sz", j + 1
       ampo += 0.5, "S+", j, "S-", j + 1
@@ -287,7 +287,7 @@ using ITensors, Test, Random
     state[7] = 2
     psi0 = productMPS(s, state)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       ampo += -t1, "Cdag", j, "C", j + 1
       ampo += -t1, "Cdag", j + 1, "C", j
@@ -315,7 +315,7 @@ using ITensors, Test, Random
     U = 1.0
     V1 = 0.5
     sites = siteinds("Electron", N; conserve_qns=true)
-    ampo = AutoMPO()
+    ampo = OpSum()
     for i in 1:N
       ampo += (U, "Nupdn", i)
     end
@@ -340,7 +340,7 @@ using ITensors, Test, Random
     N = 6
     sites = siteinds("S=1", N)
 
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       add!(ampo, "Sz", j, "Sz", j + 1)
       add!(ampo, 0.5, "S+", j, "S-", j + 1)
@@ -382,7 +382,7 @@ using ITensors, Test, Random
     noise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
     sites = siteinds("Electron", N; conserve_qns=true)
     lattice = square_lattice(Nx, Ny; yperiodic=true)
-    ampo = AutoMPO()
+    ampo = OpSum()
     for b in lattice
       ampo .+= -t, "Cdagup", b.s1, "Cup", b.s2
       ampo .+= -t, "Cdagup", b.s2, "Cup", b.s1

--- a/test/index.jl
+++ b/test/index.jl
@@ -147,6 +147,13 @@ import ITensors: In, Out, Neither
     @test all(tensor(A) .== tensor(Ã))
     @test all(tensor(A) .≠ tensor(Ã′))
   end
+  @testset "directsum" begin
+    i = Index(2, "i")
+    j = Index(3, "j")
+    ij = ITensors.directsum(i, j; tags="test")
+    @test dim(ij) == 5
+    @test hastags(ij, "test")
+  end
 end
 
 nothing

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -599,8 +599,8 @@ end
     s2 = siteinds("S=1/2", N)
     psi1 = randomMPS(s1)
     psi2 = randomMPS(s2)
-    H1 = MPO(AutoMPO() + ("Id", 1), s1)
-    H2 = MPO(AutoMPO() + ("Id", 1), s2)
+    H1 = MPO(OpSum() + ("Id", 1), s1)
+    H2 = MPO(OpSum() + ("Id", 1), s2)
 
     @test_throws ErrorException inner(psi1, H2, psi1)
     @test_throws ErrorException inner(psi1, H2, psi2; make_inds_match=false)
@@ -616,7 +616,7 @@ end
   @testset "MPO*MPO contraction with multiple site indices" begin
     N = 8
     s = siteinds("S=1/2", N)
-    a = AutoMPO()
+    a = OpSum()
     for j in 1:(N - 1)
       a .+= 0.5, "S+", j, "S-", j + 1
       a .+= 0.5, "S-", j, "S+", j + 1
@@ -634,7 +634,7 @@ end
   @testset "MPO*MPO contraction with multiple and combined site indices" begin
     N = 8
     s = siteinds("S=1/2", N)
-    a = AutoMPO()
+    a = OpSum()
     for j in 1:(N - 1)
       a .+= 0.5, "S+", j, "S-", j + 1
       a .+= 0.5, "S-", j, "S+", j + 1

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -71,6 +71,7 @@ end
     for j in 1:N
       A[j] ./= j
     end
+    reset_ortho_lims!(A)
     @test norm(A) ≈ 1 / factorial(N)
   end
 
@@ -79,6 +80,7 @@ end
     for j in 1:N
       A[j] .*= j
     end
+    reset_ortho_lims!(A)
     Adag = sim(linkinds, dag(A))
     A² = ITensor(1)
     for j in 1:N

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -230,6 +230,7 @@ include("util.jl")
     psi .*= 1:N
     @test norm(psi) ≈ factorial(N)
 
+    psi = randomMPS(sites, 10)
     for j in 1:N
       psi[j] .*= j
     end

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -56,7 +56,7 @@ include("util.jl")
     @test isnothing(linkind(psi, 1))
     @test isnothing(linkind(psi, 5))
     @test isnothing(linkind(psi, N))
-    @test maxlinkdim(psi) == 0
+    @test maxlinkdim(psi) == 1
     @test psi ⋅ psi ≈ *(dag(psi)..., psi...)[]
   end
 
@@ -764,7 +764,7 @@ end
       @test ns′ == perm
       ψ′ = movesites(ψ, 1:N .=> ns′; cutoff=1e-15)
       if N == 1
-        @test maxlinkdim(ψ′) == 0
+        @test maxlinkdim(ψ′) == 1
       else
         @test maxlinkdim(ψ′) == 1
       end
@@ -1532,13 +1532,13 @@ end
     s = siteinds("S=1/2", N)
     ψ = MPS([itensor(randn(ComplexF64, 2), s[n]) for n in 1:N])
     ρ = outer(ψ, ψ)
-    @test ITensors.hasnolinkinds(ρ)
+    @test !ITensors.hasnolinkinds(ρ)
     @test inner(ρ, ρ) ≈ inner(ψ, ψ)^2
     @test inner(ψ, ρ, ψ) ≈ inner(ψ, ψ)^2
 
     # Deprecated syntax
     ρ = MPO(ψ)
-    @test ITensors.hasnolinkinds(ρ)
+    @test !ITensors.hasnolinkinds(ρ)
     @test inner(ρ, ρ) ≈ inner(ψ, ψ)^2
     @test inner(ψ, ρ, ψ) ≈ inner(ψ, ψ)^2
   end

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -582,9 +582,9 @@ end
     s = siteinds("S=1/2", N; conserve_qns=true)
     psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn", m)
     Cpm = correlation_matrix(psi, "S+", "S-")
-    # Check using AutoMPO:
+    # Check using OpSum:
     for i in 1:N, j in i:N
-      a = AutoMPO()
+      a = OpSum()
       a += "S+", i, "S-", j
       @test inner(psi, MPO(a, s), psi) ≈ Cpm[i, j]
     end
@@ -602,9 +602,9 @@ end
     Cpm = correlation_matrix(psi, "S+", "S-"; site_range=ss:es)
     Czz = correlation_matrix(psi, "Sz", "Sz"; site_range=ss:es)
     @test size(Cpm) == (Nb, Nb)
-    # Check using AutoMPO:
+    # Check using OpSum:
     for i in ss:es, j in i:es
-      a = AutoMPO()
+      a = OpSum()
       a += "S+", i, "S-", j
       @test inner(psi, MPO(a, s), psi) ≈ Cpm[i - ss + 1, j - ss + 1]
     end
@@ -613,9 +613,9 @@ end
     s = siteinds("Electron", N)
     psi = randomMPS(s, m)
     Cuu = correlation_matrix(psi, "Cdagup", "Cup")
-    # Check using AutoMPO:
+    # Check using OpSum:
     for i in 1:N, j in i:N
-      a = AutoMPO()
+      a = OpSum()
       a += "Cdagup", i, "Cup", j
       @test inner(psi, MPO(a, s), psi) ≈ Cuu[i, j]
     end
@@ -1329,7 +1329,7 @@ end
 
       @test inner(ψ1, ψ110) == -1
 
-      a = AutoMPO()
+      a = OpSum()
       a += "Cdag", 1, "C", 3
       H = MPO(a, s)
 
@@ -1349,7 +1349,7 @@ end
 
       t = 1.0
       U = 1.0
-      ampo = AutoMPO()
+      ampo = OpSum()
       for b in 1:(N - 1)
         ampo .+= -t, "Cdag", b, "C", b + 1
         ampo .+= -t, "Cdag", b + 1, "C", b
@@ -1383,7 +1383,7 @@ end
           G2 *= op("C", s, j)
         end
 
-        ampo = AutoMPO()
+        ampo = OpSum()
         ampo += "Cdag", i, "C", j
         G3 = MPO(ampo, s)
 
@@ -1414,7 +1414,7 @@ end
           end
           G2 *= op("C", s, l)
 
-          ampo = AutoMPO()
+          ampo = OpSum()
           ampo += "Cdag", i, "Cdag", j, "C", k, "C", l
           G3 = MPO(ampo, s)
 
@@ -1435,7 +1435,7 @@ end
       ψ0 = randomMPS(s, n -> isodd(n) ? "↑" : "↓")
       t = 1.0
       U = 1.0
-      ampo = AutoMPO()
+      ampo = OpSum()
       for b in 1:(N - 1)
         ampo .+= -t, "Cdagup", b, "Cup", b + 1
         ampo .+= -t, "Cdagup", b + 1, "Cup", b
@@ -1456,7 +1456,7 @@ end
       end
 
       for i in 1:(N - 1), j in (i + 1):N
-        ampo = AutoMPO()
+        ampo = OpSum()
         ampo += "Cdagup", i, "Cup", j
         G1 = MPO(ampo, s)
         G2 = op("CCup", s, i, j)
@@ -1497,7 +1497,7 @@ end
   @testset "inner(::MPS, ::MPO, ::MPS) with more than one site Index" begin
     N = 8
     s = siteinds("S=1/2", N)
-    a = AutoMPO()
+    a = OpSum()
     for j in 1:(N - 1)
       a .+= 0.5, "S+", j, "S-", j + 1
       a .+= 0.5, "S-", j, "S+", j + 1

--- a/test/qnindex.jl
+++ b/test/qnindex.jl
@@ -52,6 +52,23 @@ import ITensors: In, Out, Neither
     @test qn(i => Block(1)) == QN(0)
     @test qn(i => Block(2)) == QN(1)
   end
+
+  @testset "directsum" begin
+    i = Index([QN(0) => 1, QN(1) => 2], "i")
+    j = Index([QN(2) => 3, QN(3) => 4], "j")
+    ij = ITensors.directsum(i, j; tags="test")
+    @test dim(ij) == dim(i) + dim(j)
+    @test hastags(ij, "test")
+    @test flux(ij, Block(1)) == QN(0)
+    @test flux(ij, Block(2)) == QN(1)
+    @test flux(ij, Block(3)) == QN(2)
+    @test flux(ij, Block(4)) == QN(3)
+    @test dim(ij, Block(1)) == 1
+    @test dim(ij, Block(2)) == 2
+    @test dim(ij, Block(3)) == 3
+    @test dim(ij, Block(4)) == 4
+    @test_throws ErrorException ITensors.directsum(i, dag(j))
+  end
 end
 
 nothing

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -1619,6 +1619,38 @@ Random.seed!(1234)
       @test A2 ≈ A
     end
   end
+
+  @testset "directsum" begin
+    x = Index([QN(0) => 1, QN(1) => 1], "x")
+    i1 = Index([QN(0) => 1, QN(1) => 2], "i1")
+    j1 = Index([QN(0) => 2, QN(1) => 2], "j1")
+    i2 = Index([QN(0) => 2, QN(1) => 3], "i2")
+    j2 = Index([QN(0) => 3, QN(1) => 3], "j2")
+
+    A1 = randomITensor(i1, x, j1)
+    A2 = randomITensor(x, j2, i2)
+    S, s = ITensors.directsum(A1 => (i1, j1), A2 => (i2, j2); tags=["sum_i", "sum_j"])
+
+    @test hassameinds(S, (x, s...))
+    @test hastags(s[1], "sum_i")
+    @test hastags(s[2], "sum_j")
+
+    for vx in 1:dim(x)
+      proj = dag(onehot(x => vx))
+      A1_vx = A1 * proj
+      A2_vx = A2 * proj
+      S_vx = S * proj
+      for m in 1:dim(s[1]), n in 1:dim(s[2])
+        if m ≤ dim(i1) && n ≤ dim(j1)
+          @test S_vx[s[1] => m, s[2] => n] == A1_vx[i1 => m, j1 => n]
+        elseif m > dim(i1) && n > dim(j1)
+          @test S_vx[s[1] => m, s[2] => n] == A2_vx[i2 => m - dim(i1), j2 => n - dim(j1)]
+        else
+          @test S_vx[s[1] => m, s[2] => n] == 0
+        end
+      end
+    end
+  end
 end
 
 nothing

--- a/test/qnmpo.jl
+++ b/test/qnmpo.jl
@@ -171,7 +171,7 @@ end
 @testset "splitblocks" begin
   N = 4
   sites = siteinds("S=1", N; conserve_qns=true)
-  ampo = AutoMPO()
+  ampo = OpSum()
   for j in 1:(N - 1)
     ampo .+= 0.5, "S+", j, "S-", j + 1
     ampo .+= 0.5, "S-", j, "S+", j + 1
@@ -204,7 +204,7 @@ end
 @testset "MPO operations with one or two sites" begin
   for N in 1:4, conserve_szparity in (true, false)
     s = siteinds("S=1/2", N; conserve_szparity=conserve_szparity)
-    a = AutoMPO()
+    a = OpSum()
     h = 0.5
     for j in 1:(N - 1)
       a .+= -1, "Sx", j, "Sx", j + 1

--- a/test/readme.jl
+++ b/test/readme.jl
@@ -76,7 +76,7 @@ using ITensors, Test
     # Input operator terms which define
     # a Hamiltonian matrix, and convert
     # these terms to an MPO tensor network
-    ampo = AutoMPO()
+    ampo = OpSum()
     for j in 1:(N - 1)
       add!(ampo, "Sz", j, "Sz", j + 1)
       add!(ampo, 0.5, "S+", j, "S-", j + 1)


### PR DESCRIPTION
Closes #581.

 - Add `outer(::MPS, ::MPS)` and `projector(::MPS)`, deprecate `MPO(::MPS)` in favor of these.
 - Fix bug in `contract(::MPO, ::MPO)` when either of the MPOs has no link indices.
 - Add `OpSum` as alternative (preferred) name to `AutoMPO`.
 - Makes `maxlinkdim(::MPO/MPS)` return a minimum of `1`. Previously it returned `0` for `MPO`/`MPS` without any link indices, which caused problems when passed to functions that used `maxlinkdim` as defaults, such as contractions of MPO with MPS. Conceptually I think it makes sense for "missing" indices to implicitly have a dimension of `1`.
 - Change `norm(::MPO/MPS)` to special case when there is a well defined orthogonality center and only compute the `norm` of the ITensor at the center site.
 - Fix a bug in broadcasting an MPS such as `psi .*= 2` where previously it wasn't expanding the orthogonality limits to the edge of the system. Also now out-of-place broadcasting like `2 .* psi` will return an MPS (previously it returned a `Vector{ITensor}`).
 - Redefine `eltype(::MPS)` as `ITensor`, i.e. the actual element type of the storage data, thinking about the `MPS` as a `Vector{ITensor}`. This matches better with how `eltype` is used in general in Julia, and therefore helps `MPS` by more compatible with what generic Julia code expects (like broadcasting, where an issue related to this came up). A new function `promote_itensor_eltype(::MPS)` returns the promoted element types of the ITensors of the `MPS` to replace the old functionality.
 - Add a prototype function `ITensors.directsum(A => (i, j), B => (k, l))` that performs the partial direct sum of `A` and `B`, direct summing over the specified indices.

This PR brought up an issue in the orthogonality limits system of MPS, which is that if you do something like the following:
```julia
An = psi[n]
An .*= 2
```
can mess up the orthogonality of the MPS but it is not "caught" because there is no call to `setindex!`. The simplest way I could imagine fixing this situation generically is to design `getindex` the same way we design `setindex!`, where by default `getindex` expands the orthogonality limits but you can turn that off with a macro `@preserve_ortho`. That might get a bit annoying though.