### PR TITLE
Fix bug in indexing with end for order-1 ITensor

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -753,6 +753,7 @@ Same as `T[]`.
 scalar(T::ITensor)::Any = T[]
 
 lastindex(A::ITensor, n::Int64) = LastVal()
+lastindex(A::ITensor) = LastVal()
 
 """
     getindex(T::ITensor, I::Int...)

--- a/src/lastval.jl
+++ b/src/lastval.jl
@@ -17,9 +17,6 @@ LastVal() = LastVal(identity)
 (-l::LastVal) = LastVal(x -> -l.f(x))
 ^(l::LastVal, n::Integer) = LastVal(x -> l.f(x)^n)
 
-# Implement when ITensors can be indexed by a single integer
-#lastindex(A::ITensor) = dim(A)
-
 lastval_to_int(n::Int, l::LastVal) = l.f(n)
 lastval_to_int(::Int, n::Int) = n
 lastval_to_int(dimsT::Tuple, I::Tuple) = lastval_to_int.(dimsT, I)

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -81,6 +81,12 @@ end
       @test A[b => end, a => 1] == A[a => 1, b => 3]
       @test A[b => end - 2, a => 1] == A[a => 1, b => 1]
       @test A[b => end^2 - 7, a => 1] == A[a => 1, b => 2]
+
+      B = randomITensor(i)
+      @test B[i => end] == B[i => dim(i)]
+      @test B[i => end-1] == B[i => dim(i)-1]
+      @test B[end] == B[dim(i)]
+      @test B[end-1] == B[dim(i)-1]
     end
 
     @testset "Set element with end (lastindex, LastIndex)" begin


### PR DESCRIPTION
This fixes a bug when doing: `i = Index(2); A = randomITensor(i); A[i => end]` or `A[end]`.