### PR TITLE
Fix bug when taking the exponential of a QN ITensor with missing diagonal blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ Deprecations:
 Bug fixes and new features:
 -----------------
 
+- Fix bug when taking the exponential of a QN ITensor with missing diagonal blocks (PR #682).
 - Generalize indexing to with `end` to allow arithmetic such as `A[i => end - 1, j => 2]` (PR #679).
 - Allow Pair inputs in `swaptags` and `swapinds`, i.e. `swaptags(A, "i" => "j")` and `swapinds(A, i => j)` (PR #676).
 - Fix negating of QN ITensor (PR #672) (@emstoudenmire).

--- a/docs/settings.jl
+++ b/docs/settings.jl
@@ -37,9 +37,7 @@ settings = Dict(
       ],
       "OpSum" => "OpSum.md",
     ],
-    "Upgrade guides" => [
-      "Upgrading from 0.1 to 0.2" => "UpgradeGuide_0.1_to_0.2.md",
-    ],
+    "Upgrade guides" => ["Upgrading from 0.1 to 0.2" => "UpgradeGuide_0.1_to_0.2.md"],
     "ITensor indices and Einstein notation" => "Einsum.md",
     "Advanced usage guide" => [
       "Advanced usage guide" => "AdvancedUsageGuide.md",

--- a/docs/src/AdvancedUsageGuide.md
+++ b/docs/src/AdvancedUsageGuide.md
@@ -28,10 +28,16 @@ replace the current BLAS and LAPACK implementation used by Julia with
 MKL by using the MKL.jl package. Please follow the instructions 
 [here](https://github.com/JuliaComputing/MKL.jl).
 
-To use the latest version of ITensors.jl, use `update ITensors`. 
-We will commonly release new minor versions with bug fixes and 
-improvements. However, make sure to double check before doing this, 
-because new releases may be breaking.
+To use the latest registered (stable) version of ITensors.jl, use `update ITensors`
+in `Pkg` mode or `import Pkg; Pkg.update("ITensors")`.
+We will commonly release new patch versions (such as updating from `v0.1.12` to 
+`v0.1.13`) with bug fixes and improvements. However, make sure to double check before
+updating between minor versions (such as from `v0.1.41` to `v0.2.0`) because new minor
+releases may be breaking.
+
+Remember that if you are compiling system images of ITensors.jl, such as with the
+`ITensors.compile()` command, you will need to rerurn this command to compile
+the new version of ITensor after an update.
 
 To try the "development branch" of ITensors.jl (for example, if 
 there is a feature or fix we added that hasn't been released yet), 

--- a/examples/dmrg/1d_ising_with_observer.jl
+++ b/examples/dmrg/1d_ising_with_observer.jl
@@ -23,7 +23,7 @@ end
 let
   N = 100
   sites = siteinds("S=1/2", N)
-  psi0 = randomMPS(sites, 10)
+  psi0 = randomMPS(sites; linkdims=10)
 
   # define parameters for DMRG sweeps
   sweeps = Sweeps(15)

--- a/src/NDTensors/blocksparse/blockdims.jl
+++ b/src/NDTensors/blocksparse/blockdims.jl
@@ -1,5 +1,5 @@
 """
-BlockDim
+    BlockDim
 
 An index for a BlockSparseTensor.
 """
@@ -9,7 +9,7 @@ const BlockDim = Vector{Int}
 dim(d::BlockDim) = sum(d)
 
 """
-BlockDims{N}
+    BlockDims{N}
 
 Dimensions used for BlockSparse NDTensors.
 Each entry lists the block sizes in each dimension.
@@ -52,7 +52,7 @@ function dim(ds::BlockDims{N}) where {N}
 end
 
 """
-nblocks(::BlockDim)
+    nblocks(::BlockDim)
 
 The number of blocks of the BlockDim.
 """
@@ -61,7 +61,16 @@ function nblocks(ind::BlockDim)
 end
 
 """
-nblocks(::BlockDims,i::Integer)
+    ndiagblocks(::Any)
+
+The number of blocks along the diagonal.
+"""
+function ndiagblocks(x)
+  return minimum(nblocks(x))
+end
+
+"""
+    nblocks(::BlockDims,i::Integer)
 
 The number of blocks in the specified dimension.
 """
@@ -70,7 +79,7 @@ function nblocks(inds::Tuple, i::Integer)
 end
 
 """
-nblocks(::BlockDims,is)
+    nblocks(::BlockDims,is)
 
 The number of blocks in the specified dimensions.
 """
@@ -79,13 +88,21 @@ function nblocks(inds::Tuple, is::NTuple{N,Int}) where {N}
 end
 
 """
-nblocks(::BlockDims)
+    nblocks(::BlockDims)
 
 A tuple of the number of blocks in each
 dimension.
 """
 function nblocks(inds::NTuple{N,<:Any}) where {N}
   return ntuple(i -> nblocks(inds, i), Val(N))
+end
+
+function eachblock(inds::Tuple)
+  return (Block(b) for b in CartesianIndices(_Tuple(nblocks(inds))))
+end
+
+function eachdiagblock(inds::Tuple)
+  return (Block(ntuple(_ -> i, length(inds))) for i in 1:ndiagblocks(inds))
 end
 
 """
@@ -133,7 +150,7 @@ function blockdim(inds, block)
 end
 
 """
-blockdiaglength(inds::BlockDims,block)
+    blockdiaglength(inds::BlockDims,block)
 
 The length of the diagonal of the specified block.
 """

--- a/src/NDTensors/blocksparse/blocksparsetensor.jl
+++ b/src/NDTensors/blocksparse/blocksparsetensor.jl
@@ -274,7 +274,16 @@ getindex(T::BlockSparseTensor, block::Block) = blockview(T, block)
 to_indices(T::Tensor{<:Any,N}, b::Tuple{Block{N}}) where {N} = blockindices(T, b...)
 
 function blockview(T::BlockSparseTensor, block::Block)
-  return blockview(T, BlockOffset(block, offset(T, block)))
+  return blockview(T, block, offset(T, block))
+end
+
+function blockview(T::BlockSparseTensor, block::Block, offset::Integer)
+  return blockview(T, BlockOffset(block, offset))
+end
+
+# Case where the block isn't found, return nothing
+function blockview(T::BlockSparseTensor, block::Block, ::Nothing)
+  return nothing
 end
 
 blockview(T::BlockSparseTensor, block) = blockview(T, Block(block))

--- a/src/NDTensors/blocksparse/linearalgebra.jl
+++ b/src/NDTensors/blocksparse/linearalgebra.jl
@@ -302,14 +302,23 @@ function LinearAlgebra.eigen(
   return D, V, Spectrum(d, truncerr)
 end
 
-function LinearAlgebra.exp(
+function exp(
   T::Union{BlockSparseMatrix{ElT},Hermitian{ElT,<:BlockSparseMatrix{ElT}}}
 ) where {ElT<:Union{Real,Complex}}
   expT = BlockSparseTensor(ElT, undef, nzblocks(T), inds(T))
   for b in eachnzblock(T)
     all(==(b[1]), b) || error("exp currently supports only block-diagonal matrices")
+  end
+  for b in eachdiagblock(T)
     blockT = blockview(T, b)
-    blockview(expT, b) .= exp(blockT)
+    if isnothing(blockT)
+      # Block was not found in the list, treat as 0
+      id_block = Matrix{ElT}(I, blockdims(T, b))
+      insertblock!(expT, b)
+      blockview(expT, b) .= id_block
+    else
+      blockview(expT, b) .= exp(blockT)
+    end
   end
   return expT
 end

--- a/src/NDTensors/empty.jl
+++ b/src/NDTensors/empty.jl
@@ -243,6 +243,14 @@ function contract!!(
   return RR
 end
 
+# For ambiguity with versions in combiner.jl
+function contract!!(
+  R::EmptyTensor, labelsR, T1::EmptyTensor, labelsT1, T2::CombinerTensor, labelsT2
+)
+  RR = contraction_output(T1, labelsT1, T2, labelsT2, labelsR)
+  return RR
+end
+
 promote_rule(::Type{EmptyNumber}, ::Type{T}) where {T<:Number} = T
 
 function promote_rule(

--- a/src/NDTensors/imports.jl
+++ b/src/NDTensors/imports.jl
@@ -45,4 +45,6 @@ import Base:
 
 import Base.Broadcast: Broadcasted, BroadcastStyle
 
+import LinearAlgebra: exp
+
 import TupleTools: isperm

--- a/src/NDTensors/symmetric.jl
+++ b/src/NDTensors/symmetric.jl
@@ -1,27 +1,29 @@
 
-# XXX Should this permute the dimensions?
 dims(H::Hermitian{<:Number,<:Tensor}) = dims(parent(H))
 
-# XXX Should this permute the dimensions?
+blockdims(H::Hermitian{<:Number,<:Tensor}, b) = blockdims(parent(H), b)
+
 dim(H::Hermitian{<:Number,<:Tensor}, i::Int) = dim(parent(H), i)
 
 matrix(H::Hermitian{<:Number,<:Tensor}) = Hermitian(matrix(parent(H)))
 
-# XXX Should this permute the indices?
 inds(H::Hermitian{<:Number,<:Tensor}) = inds(parent(H))
 
-# XXX Should this permute the indices?
 ind(H::Hermitian{<:Number,<:Tensor}, i::Int) = ind(parent(H), i)
 
-# XXX Should this tranpose the block locations?
 nnzblocks(H::Hermitian{<:Number,<:Tensor}) = nnzblocks(parent(H))
 
-# XXX Should this tranpose the block locations?
 nzblocks(H::Hermitian{<:Number,<:Tensor}) = nzblocks(parent(H))
 
-# XXX Should this tranpose the block locations?
 eachnzblock(H::Hermitian{<:Number,<:Tensor}) = eachnzblock(parent(H))
+
+eachblock(H::Hermitian{<:Number,<:Tensor}) = eachblock(parent(H))
+
+eachdiagblock(H::Hermitian{<:Number,<:Tensor}) = eachdiagblock(parent(H))
 
 nblocks(H::Hermitian{<:Number,<:Tensor}) = nblocks(parent(H))
 
-blockview(H::Hermitian{<:Number,<:Tensor}, block) = Hermitian(blockview(parent(H), block))
+blockview(H::Hermitian{<:Number,<:Tensor}, block) = _blockview(H, blockview(parent(H), block))
+_blockview(::Hermitian{<:Number,<:Tensor}, blockviewH) = Hermitian(blockviewH)
+_blockview(::Hermitian{<:Number,<:Tensor}, ::Nothing) = nothing
+

--- a/src/NDTensors/symmetric.jl
+++ b/src/NDTensors/symmetric.jl
@@ -23,7 +23,8 @@ eachdiagblock(H::Hermitian{<:Number,<:Tensor}) = eachdiagblock(parent(H))
 
 nblocks(H::Hermitian{<:Number,<:Tensor}) = nblocks(parent(H))
 
-blockview(H::Hermitian{<:Number,<:Tensor}, block) = _blockview(H, blockview(parent(H), block))
+function blockview(H::Hermitian{<:Number,<:Tensor}, block)
+  return _blockview(H, blockview(parent(H), block))
+end
 _blockview(::Hermitian{<:Number,<:Tensor}, blockviewH) = Hermitian(blockviewH)
 _blockview(::Hermitian{<:Number,<:Tensor}, ::Nothing) = nothing
-

--- a/src/NDTensors/tensor.jl
+++ b/src/NDTensors/tensor.jl
@@ -86,6 +86,10 @@ ind(T::Tensor, j::Integer) = inds(T)[j]
 
 eachindex(T::Tensor) = CartesianIndices(dims(inds(T)))
 
+eachblock(T::Tensor) = eachblock(inds(T))
+
+eachdiagblock(T::Tensor) = eachdiagblock(inds(T))
+
 eltype(::Tensor{ElT}) where {ElT} = ElT
 
 strides(T::Tensor) = dim_to_strides(inds(T))

--- a/src/NDTensors/tupletools.jl
+++ b/src/NDTensors/tupletools.jl
@@ -1,4 +1,12 @@
 
+# This is a cache of [Val(1), Val(2), ...]
+# Hard-coded for now to only handle tensors up to order 100
+const ValCache = Val[Val(n) for n in 0:100]
+# Faster conversions of collection to tuple than `Tuple(::AbstractVector)`
+_NTuple(::Val{N}, v::Vector{T}) where {N,T} = ntuple(n -> v[n], Val(N))
+_Tuple(v::Vector{T}) where {T} = _NTuple(ValCache[length(v) + 1], v)
+_Tuple(t::Tuple) = t
+
 """
     ValLength(::Type{NTuple{N}}) = Val{N}
 """

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -97,7 +97,16 @@ import LinearAlgebra:
   svd,
   tr
 
-using ITensors.NDTensors: EmptyNumber, blas_get_num_threads, fill!!, randn!!, timer
+using ITensors.NDTensors:
+  EmptyNumber,
+  _Tuple,
+  _NTuple,
+  blas_get_num_threads,
+  eachblock,
+  eachdiagblock,
+  fill!!,
+  randn!!,
+  timer
 
 import ITensors.NDTensors:
   # Modules

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -31,13 +31,6 @@ IndexSet(inds::Index...) = collect(inds)
 IndexSet(f::Function, N::Int) = map(f, 1:N)
 IndexSet(f::Function, ::Order{N}) where {N} = IndexSet(f, N)
 
-# This is a cache of [Val(1), Val(2), ...]
-# Hard-coded for now to only handle tensors up to order 100
-const ValCache = Val[Val(n) for n in 0:100]
-# Faster conversions of collection to tuple than `Tuple(::AbstractVector)`
-_NTuple(::Val{N}, v::Vector{T}) where {N,T} = ntuple(n -> v[n], Val(N))
-_Tuple(v::Vector{T}) where {T} = _NTuple(ValCache[length(v) + 1], v)
-_Tuple(t::Tuple) = t
 Tuple(is::IndexSet) = _Tuple(is)
 NTuple{N}(is::IndexSet) where {N} = _NTuple(Val(N), is)
 
@@ -765,17 +758,6 @@ function NDTensors.nblocks(inds::NTuple{N,<:Index}) where {N}
 end
 
 ndiagblocks(inds) = minimum(nblocks(inds))
-
-# TODO: generic to Indices and BlockDims
-function eachblock(inds::Indices)
-  return (Block(b) for b in CartesianIndices(_Tuple(nblocks(inds))))
-end
-
-# TODO: turn this into an iterator instead
-# of returning a Vector
-function eachdiagblock(inds::Indices)
-  return (Block(ntuple(_ -> i, length(inds))) for i in 1:ndiagblocks(inds))
-end
 
 """
     flux(inds::Indices, block::Tuple{Vararg{Int}})

--- a/src/packagecompile/precompile_itensors.jl
+++ b/src/packagecompile/precompile_itensors.jl
@@ -23,7 +23,7 @@ end
 
 sites = siteinds("S=1", N)
 H = MPO(ampo, sites)
-psi0 = randomMPS(sites, 2)
+psi0 = randomMPS(sites; linkdims=2)
 dmrg(H, psi0, sweeps)
 
 sites_qn = siteinds("S=1", N; conserve_qns=true)
@@ -31,5 +31,5 @@ if !hasqns(sites_qn[1])
   throw(ErrorException("Index does not have QNs in part of precompile script"))
 end
 H_qn = MPO(ampo, sites_qn)
-psi0_qn = randomMPS(sites_qn, [isodd(n) ? "Up" : "Dn" for n in 1:N], 2)
+psi0_qn = randomMPS(sites_qn, [isodd(n) ? "Up" : "Dn" for n in 1:N]; linkdims=2)
 dmrg(H_qn, psi0_qn, sweeps)

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -195,7 +195,7 @@ end
 
 dim(i::QNIndex, b::Block) = blockdim(space(i), b)
 
-eachblock(i::Index) = (Block(n) for n in 1:nblocks(i))
+NDTensors.eachblock(i::Index) = (Block(n) for n in 1:nblocks(i))
 
 # Return the first block of the QNIndex with the flux q
 function block(::typeof(first), ind::QNIndex, q::QN)

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -84,9 +84,9 @@ end
 
       B = randomITensor(i)
       @test B[i => end] == B[i => dim(i)]
-      @test B[i => end-1] == B[i => dim(i)-1]
+      @test B[i => end - 1] == B[i => dim(i) - 1]
       @test B[end] == B[dim(i)]
-      @test B[end-1] == B[dim(i)-1]
+      @test B[end - 1] == B[dim(i) - 1]
     end
 
     @testset "Set element with end (lastindex, LastIndex)" begin

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -269,11 +269,11 @@ include("util.jl")
     @test psi²[] ≈ psi ⋅ psi
     @test sqrt(psi²[]) ≈ norm(psi)
 
-    psi = randomMPS(sites, 10)
+    psi = randomMPS(sites; linkdims=10)
     psi .*= 1:N
     @test norm(psi) ≈ factorial(N)
 
-    psi = randomMPS(sites, 10)
+    psi = randomMPS(sites; linkdims=10)
     for j in 1:N
       psi[j] .*= j
     end
@@ -586,7 +586,7 @@ end
     end
 
     # Complex case
-    Mc = randomMPS(sites, chi)
+    Mc = randomMPS(sites; linkdims=chi)
     @test inner(Mc, Mc) ≈ 1.0 + 0.0im
   end
 
@@ -597,7 +597,7 @@ end
 
     # Make flux-zero random MPS
     state = [isodd(n) ? 1 : 2 for n in 1:N]
-    M = randomMPS(sites, state, chi)
+    M = randomMPS(sites, state; linkdims=chi)
     @test flux(M) == QN("Sz", 0)
 
     @test ITensors.leftlim(M) == 0
@@ -610,10 +610,10 @@ end
 
     # Test making random MPS with different flux
     state[1] = 2
-    M = randomMPS(sites, state, chi)
+    M = randomMPS(sites, state; linkdims=chi)
     @test flux(M) == QN("Sz", -2)
     state[3] = 2
-    M = randomMPS(sites, state, chi)
+    M = randomMPS(sites, state; linkdims=chi)
     @test flux(M) == QN("Sz", -4)
   end
 
@@ -623,7 +623,7 @@ end
 
     # Non-fermionic case - spin system
     s = siteinds("S=1/2", N; conserve_qns=true)
-    psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn", m)
+    psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn"; linkdims=m)
     Cpm = correlation_matrix(psi, "S+", "S-")
     # Check using OpSum:
     for i in 1:N, j in i:N
@@ -639,7 +639,7 @@ end
 
     # With start_site, end_site arguments:
     s = siteinds("S=1/2", N)
-    psi = randomMPS(ComplexF64, s, m)
+    psi = randomMPS(ComplexF64, s; linkdims=m)
     ss, es = 3, 6
     Nb = es - ss + 1
     Cpm = correlation_matrix(psi, "S+", "S-"; site_range=ss:es)
@@ -654,7 +654,7 @@ end
 
     # Fermionic case
     s = siteinds("Electron", N)
-    psi = randomMPS(s, m)
+    psi = randomMPS(s; linkdims=m)
     Cuu = correlation_matrix(psi, "Cdagup", "Cup")
     # Check using OpSum:
     for i in 1:N, j in i:N
@@ -874,7 +874,7 @@ end
     @test ITensors.orthocenter(ψ) == N
     @test maxlinkdim(ψ) == 1
 
-    ψ0 = randomMPS(s, 2)
+    ψ0 = randomMPS(s; linkdims=2)
     A = prod(ψ0)
     ψ = MPS(A, s; cutoff=1e-15, orthocenter=2)
     @test prod(ψ) ≈ A
@@ -914,7 +914,7 @@ end
   @testset "Set range of MPS tensors" begin
     N = 5
     s = siteinds("S=1/2", N)
-    ψ0 = randomMPS(s, 3)
+    ψ0 = randomMPS(s; linkdims=3)
 
     ψ = orthogonalize(ψ0, 2)
     A = prod(ITensors.data(ψ)[2:(N - 1)])
@@ -1545,7 +1545,7 @@ end
   @testset "dense conversion of MPS" begin
     N = 4
     s = siteinds("S=1/2", N; conserve_qns=true)
-    QM = randomMPS(s, ["Up", "Dn", "Up", "Dn"], 4)
+    QM = randomMPS(s, ["Up", "Dn", "Up", "Dn"]; linkdims=4)
     qsz1 = scalar(QM[1] * op("Sz", s[1]) * dag(prime(QM[1], "Site")))
 
     M = dense(QM)
@@ -1579,7 +1579,7 @@ end
       a .+= "Sz", j, "Sz", j + 1
     end
     H = MPO(a, s)
-    ψ = randomMPS(s, n -> isodd(n) ? "↑" : "↓", 10)
+    ψ = randomMPS(s, n -> isodd(n) ? "↑" : "↓"; linkdims=10)
     # Create MPO/MPS with pairs of sites merged
     H2 = MPO([H[b] * H[b + 1] for b in 1:2:N])
     ψ2 = MPS([ψ[b] * ψ[b + 1] for b in 1:2:N])

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -1563,6 +1563,21 @@ Random.seed!(1234)
       @test Array(Aexp, i1, i1') ≈ Amatexp rtol = 5e-14
     end
 
+    @testset "Regression test for exp of QN ITensor with missing diagonal blocks" begin
+      i = Index([QN(0) => 2, QN(1) => 3])
+      A[1, 1] = 1.2
+      expA = exp(A; ishermitian=false)
+      for n in 1:mindim(A)
+        @test expA[n, n] == exp(A[n, n])
+      end
+      @test expA ≈ exp(dense(A))
+      expA = exp(A; ishermitian=true)
+      for n in 1:mindim(A)
+        @test expA[n, n] == exp(A[n, n])
+      end
+      @test expA ≈ exp(dense(A))
+    end
+
     @testset "Mixed arrows" begin
       i1 = Index([QN(0) => 1, QN(1) => 2], "i1")
       i2 = Index([QN(0) => 1, QN(1) => 2], "i2")

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -1565,6 +1565,7 @@ Random.seed!(1234)
 
     @testset "Regression test for exp of QN ITensor with missing diagonal blocks" begin
       i = Index([QN(0) => 2, QN(1) => 3])
+      A = ITensor(i', dag(i))
       A[1, 1] = 1.2
       expA = exp(A; ishermitian=false)
       for n in 1:mindim(A)


### PR DESCRIPTION
For example:
```julia
julia> i = Index([QN(0) => 2, QN(1) => 3])
(dim=5|id=13) <Out>
 1: QN(0) => 2
 2: QN(1) => 3

julia> A = ITensor(i', dag(i));

julia> A[1, 1] = 1.2
1.2

julia> @show exp(A);
exp(A) = ITensor ord=2
Dim 1: (dim=5|id=13)' <Out>
 1: QN(0) => 2
 2: QN(1) => 3
Dim 2: (dim=5|id=13) <In>
 1: QN(0) => 2
 2: QN(1) => 3
ITensors.NDTensors.BlockSparse{Float64, Vector{Float64}, 2}
 5×5
Block(1, 1)
 [1:2, 1:2]
 3.3201169227365472  0.0
 0.0                 1.0

Block(2, 2)
 [3:5, 3:5]
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0
```
Previously it was leaving out the `(2, 2)` block instead of treating it as zero.