### PR TITLE
Make Index non-broadcastable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@ Note that as of Julia v1.5, in order to see deprecation warnings you will need t
 
 After we release v1 of the package, we will start following [semantic versioning](https://semver.org).
 
+ITensor v0.2.2 Release Notes
+==============================
+
+- Make Index non-broadcastable so you can do: `i = Index(2); i .^ (0, 1, 2)` (PR #689).
+
 ITensor v0.2.1 Release Notes
 ==============================
 

--- a/src/index.jl
+++ b/src/index.jl
@@ -442,6 +442,20 @@ function Base.iterate(i::Index, state::Int=1)
   return (i => state, state + 1)
 end
 
+# Treat Index as a scalar for the sake of broadcast.
+# This allows:
+#
+# i = Index(2)
+# ps = (n - 1 for n in 1:4)
+# is = prime.(i, ps)
+#
+# or
+#
+# ts = ("i$n" for n in 1:4)
+# is = settags.(i, ts)
+#
+Base.broadcastable(i::Index) = Ref(i)
+
 """
     eachval(i::Index)
 

--- a/test/index.jl
+++ b/test/index.jl
@@ -73,6 +73,20 @@ import ITensors: In, Out, Neither
       c += 1
     end
   end
+  @testset "Broadcasting" begin
+    N = 3
+    i = Index(2)
+    ps = (n - 1 for n in 1:4)
+    is = prime.(i, ps)
+    @test is[1] == i
+    @test is[2] == i'
+    @test is[3] == i''
+    ts = ("i$n" for n in 1:4)
+    is = settags.(i, ts)
+    @test is[1] == addtags(i, "i1")
+    @test is[2] == addtags(i, "i2")
+    @test is[3] == addtags(i, "i3")
+  end
   @testset "Index ID random seed" begin
     Random.seed!(index_id_rng(), 1234)
     i = Index(2)


### PR DESCRIPTION
Make `Index` non-broadcastable, so we can do:
```julia
i = Index(2)
ps = (n - 1 for n in 1:4)
is = prime.(i, ps)
# Alternatively:
# is = i .^ ps
```
or
```julia
ts = ("i$n" for n in 1:4)
is = settags.(i, ts)
```
Previously these errored since broadcast would try to iterate through the `Index` itself, which would fail.