### PR TITLE
Make ITensors evaluate as unequal if they have different indices

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1355,6 +1355,7 @@ adjoint(A::ITensor) = prime(A)
 dirs(A::ITensor, is) = dirs(inds(A), is)
 
 function (A::ITensor == B::ITensor)
+  !hassameinds(A, B) && return false
   return norm(A - B) == zero(promote_type(eltype(A), eltype(B)))
 end
 

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -88,7 +88,16 @@ end
       @test B[end] == B[dim(i)]
       @test B[end - 1] == B[dim(i) - 1]
     end
-
+    @testset "ITensor equality" begin
+      Aij = randomITensor(i, j)
+      Aji = permute(Aij, j, i)
+      Bij′ = randomITensor(i, j')
+      Cij′ = randomITensor(i, j')
+      @test Aij == Aij
+      @test Aij == Aji
+      @test Bij′ != Cij′
+      @test Bij′ != Aij
+    end
     @testset "Set element with end (lastindex, LastIndex)" begin
       _i = Index(2, "i")
       _j = Index(3, "j")


### PR DESCRIPTION
For example now:
```julia
i = Index(2)
A = randomITensor(i)
@show A == A'
```
will return `false` instead of throwing an error, which is the current behavior.

This is in line with the general Julia convention that things don't error when evaluating equality, and instead fall back to returning `false` which is helpful for generic code. You can always check `norm(A - B)` if you want to check equality that would error if the indices are different.