### PR TITLE
Add `denseblocks` to convert from `DiagBlockSparse` to `BlockSparse` tensor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,12 @@ Note that as of Julia v1.5, in order to see deprecation warnings you will need t
 
 After we release v1 of the package, we will start following [semantic versioning](https://semver.org).
 
+ITensor v0.2.3 Release Notes
+==============================
+
+- Add `denseblocks` to convert from `DiagBlockSparse` to `BlockSparse` storage (PR #693).
+- Make A == B return false if ITensors A and B have different indices (PR #690).
+
 ITensor v0.2.2 Release Notes
 ==============================
 

--- a/src/NDTensors/blocksparse/diagblocksparse.jl
+++ b/src/NDTensors/blocksparse/diagblocksparse.jl
@@ -391,6 +391,18 @@ function dense(T::TensorT) where {TensorT<:DiagBlockSparseTensor}
   return R
 end
 
+# convert to BlockSparse
+function denseblocks(D::Tensor)
+  nzblocksD = nzblocks(D)
+  T = BlockSparseTensor(eltype(D), nzblocksD, inds(D))
+  for b in nzblocksD
+    for n in 1:diaglength(D)
+      setdiagindex!(T, getdiagindex(D, n), n)
+    end
+  end
+  return T
+end
+
 function outer!(
   R::DenseTensor{<:Number,NR},
   T1::DiagBlockSparseTensor{<:Number,N1},

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -117,6 +117,7 @@ export
   complex!,
   delta,
   dense,
+  denseblocks,
   δ,
   diagitensor,
   diagITensor,

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -121,6 +121,7 @@ import ITensors.NDTensors:
   blockoffsets,
   contract,
   dense,
+  denseblocks,
   dim,
   dims,
   disable_tblis,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -619,9 +619,10 @@ For example, an ITensor with Diag storage will become Dense storage,
 filled with zeros except for the diagonal values.
 """
 function dense(A::ITensor)
-  T = dense(tensor(A))
-  return ITensor(storage(T), removeqns(inds(A)))
+  return setinds(itensor(dense(tensor(A))), removeqns(inds(A)))
 end
+
+denseblocks(D::ITensor) = itensor(denseblocks(tensor(D)))
 
 """
     complex(T::ITensor)

--- a/test/qndiagitensor.jl
+++ b/test/qndiagitensor.jl
@@ -65,6 +65,17 @@ using ITensors, Test
     end
   end
 
+  @testset "denseblocks: convert DiagBlockSparse to BlockSparse" begin
+    i = Index([QN(0) => 2, QN(1) => 3])
+    A = diagITensor(i', dag(i))
+    randn!(ITensors.data(A))
+    B = denseblocks(A)
+    for n in 1:dim(i)
+      @test A[n, n] == B[n, n]
+    end
+    @test dense(A) == dense(B)
+  end
+
   @testset "Regression test for QN delta contraction bug" begin
     # http://itensor.org/support/2814/block-sparse-itensor-wrong-results-multiplying-delta-tensor
     s = Index([QN(("N", i, 1)) => 1 for i in 1:2])


### PR DESCRIPTION
Implements `denseblocks` as proposed in issue #344.

For example:
```julia
julia> i = Index([QN(0) => 2, QN(1) => 3])
(dim=5|id=682) <Out>
 1: QN(0) => 2
 2: QN(1) => 3

julia> @show A = diagITensor(2.0, i', dag(i));
A = diagITensor(2.0, i', dag(i)) = ITensor ord=2
Dim 1: (dim=5|id=682)' <Out>
 1: QN(0) => 2
 2: QN(1) => 3
Dim 2: (dim=5|id=682) <In>
 1: QN(0) => 2
 2: QN(1) => 3
DiagBlockSparse{Float64, Vector{Float64}, 2}
 5×5
Block(1, 1)
 [1:2, 1:2]
 2.0  0.0
 0.0  2.0

Block(2, 2)
 [3:5, 3:5]
 2.0  0.0  0.0
 0.0  2.0  0.0
 0.0  0.0  2.0

julia> @show denseblocks(A);
denseblocks(A) = ITensor ord=2
Dim 1: (dim=5|id=682)' <Out>
 1: QN(0) => 2
 2: QN(1) => 3
Dim 2: (dim=5|id=682) <In>
 1: QN(0) => 2
 2: QN(1) => 3
BlockSparse{Float64, Vector{Float64}, 2}
 5×5
Block(1, 1)
 [1:2, 1:2]
 2.0  0.0
 0.0  2.0

Block(2, 2)
 [3:5, 3:5]
 2.0  0.0  0.0
 0.0  2.0  0.0
 0.0  0.0  2.0
```