### PR TITLE
Add `denseblocks` definition for `Diag` storage

### DIFF
--- a/src/NDTensors/diag.jl
+++ b/src/NDTensors/diag.jl
@@ -275,6 +275,8 @@ function dense(T::TensorT) where {TensorT<:DiagTensor}
   return R
 end
 
+denseblocks(T::DiagTensor) = dense(T)
+
 function outer!(
   R::DenseTensor{<:Number,NR}, T1::DiagTensor{<:Number,N1}, T2::DiagTensor{<:Number,N2}
 ) where {NR,N1,N2}

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -583,7 +583,7 @@ function compute_contraction_labels(Ais::Tuple, Bis::Tuple)
     if Ais_i == Bis_j
       if have_qns && (dir(Ais_i) ≠ -dir(Bis_j))
         error(
-          "Attempting to contract IndexSet:\n$(Ais)with IndexSet:\n$(Bis)QN indices must have opposite direction to contract.",
+          "Attempting to contract IndexSet:\n\n$(Ais)\n\nwith IndexSet:\n\n$(Bis)\n\nQN indices must have opposite direction to contract, but indices:\n\n$(Ais_i)\n\nand:\n\n$(Bis_j)\n\ndo not have opposite directions.",
         )
       end
       Alabels[i] = Blabels[j] = -(1 + ncont)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -2382,7 +2382,7 @@ function insertblock!(T::ITensor, args...)
   (!isnothing(flux(T)) && flux(T) ≠ flux(T, args...)) &&
     error("Block does not match current flux")
   TR = insertblock!!(tensor(T), args...)
-  setstorage!(T, storage(TR))
+  settensor!(T, TR)
   return T
 end
 

--- a/test/diagitensor.jl
+++ b/test/diagitensor.jl
@@ -207,6 +207,20 @@ using ITensors, Test
       end
     end
 
+    @testset "Convert diag to dense with denseblocks" begin
+      D = diagITensor(v, i, j, k)
+      T = denseblocks(D)
+
+      @test storage(T) isa NDTensors.Dense{Float64}
+      for ii in 1:d, jj in 1:d, kk in 1:d
+        if ii == jj == kk
+          @test T[ii, ii, ii] == ii
+        else
+          @test T[i => ii, j => jj, k => kk] == 0.0
+        end
+      end
+    end
+
     @testset "Add (Diag + Diag)" begin
       v1 = randn(d)
       v2 = randn(d)


### PR DESCRIPTION
Add `denseblocks` definition for `Diag` storage. Previously it was only defined for `DiagBlockSparse` storage, this is helpful for making code generic between QN and non-QN ITensors.