### PR TITLE
Allow `AbstractArray` inputs when constructing `ITensor`

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -34,7 +34,9 @@ tuple_vcat(a, args...) = (tuple_vcat(a)..., tuple_vcat(args...)...)
 tuple_to_vector(t::Tuple) = collect(t)
 tuple_to_vector(t) = t
 
-_narrow_eltype(v::Vector{T}) where {T} = convert(Vector{mapreduce(typeof, promote_type, v)}, v)
+function _narrow_eltype(v::Vector{T}) where {T}
+  return convert(Vector{mapreduce(typeof, promote_type, v)}, v)
+end
 narrow_eltype(v::Vector{T}) where {T} = isconcretetype(T) ? v : _narrow_eltype(v)
 
 push_or_append!(v, x::Union{Vector,Tuple}) = append!(v, x)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -388,7 +388,7 @@ end
 
 # Helper functions for different view behaviors
 Array{ElT,N}(::NeverAlias, A::AbstractArray) where {ElT,N} = Array{ElT,N}(A)
-Array{ElT,N}(::AllowAlias, A::AbstractArray) where {ElT,N} = convert(Array{ElT,N}, A)
+Array{ElT,N}(::AllowAlias, A::AbstractArray) where {ElT,N} = convert(AbstractArray{ElT,N}, A)
 function Array{ElT}(as::AliasStyle, A::AbstractArray{ElTA,N}) where {ElT,N,ElTA}
   return Array{ElT,N}(as, A)
 end
@@ -443,30 +443,37 @@ T[i => 1, j => 1] == 3.3
     In future versions this may not automatically convert `Int`/`Complex{Int}` inputs to floating point versions with `float` (once tensor operations using `Int`/`Complex{Int}` are natively as fast as floating point operations), and in that case the particular element type should not be relied on. To avoid extra conversions (and therefore allocations) it is best practice to directly construct with `itensor([0. 1; 1 0], i', dag(i))` if you want a floating point element type. The conversion is done as a performance optimization since often tensors are passed to BLAS/LAPACK and need to be converted to floating point types compatible with those libraries, but future projects in Julia may allow for efficient operations with more general element types (for example see https://github.com/JuliaLinearAlgebra/Octavian.jl).
 """
 function ITensor(
-  as::AliasStyle, ::Type{ElT}, A::Array{<:Number}, inds::Indices; kwargs...
-) where {ElT<:Number}
+  as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}, inds::Indices{Index{Int}}; kwargs...
+)
   length(A) ≠ dim(inds) && throw(
     DimensionMismatch(
-      "In ITensor(::Array, inds), length of Array ($(length(A))) must match total dimension of IndexSet ($(dim(inds)))",
+      "In ITensor(::AbstractArray, inds), length of AbstractArray ($(length(A))) must match total dimension of IndexSet ($(dim(inds)))",
     ),
   )
-  data = Array{ElT}(as, A)
+  data = Array{eltype}(as, A)
   return itensor(Dense(vec(data)), inds)
 end
 
+## function ITensor(
+##   as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}, inds::Vector; kwargs...
+## )
+##   # identity.(inds) narrows the Index type to a concrete type
+##   return ITensor(as, eltype, A, indices(inds); kwargs...)
+## end
+
 function ITensor(
-  as::AliasStyle, eltype::Type{<:Number}, A::Array{<:Number}, is...; kwargs...
+  as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}, is...; kwargs...
 )
   return ITensor(as, eltype, A, indices(is...); kwargs...)
 end
 
-function ITensor(eltype::Type{<:Number}, A::Array{<:Number}, is...; kwargs...)
+function ITensor(eltype::Type{<:Number}, A::AbstractArray{<:Number}, is...; kwargs...)
   return ITensor(NeverAlias(), eltype, A, is...; kwargs...)
 end
 
 # For now, it's not well defined to construct an ITensor without indices
 # from a non-zero dimensional Array
-function ITensor(as::AliasStyle, eltype::Type{<:Number}, A::Array{<:Number}; kwargs...)
+function ITensor(as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}; kwargs...)
   if length(A) > 1
     error(
       "Trying to create an ITensor without any indices from Array $A of dimensions $(size(A)). Cannot construct an ITensor from an Array with more than one element without any indices.",
@@ -475,22 +482,22 @@ function ITensor(as::AliasStyle, eltype::Type{<:Number}, A::Array{<:Number}; kwa
   return ITensor(eltype, A[]; kwargs...)
 end
 
-function ITensor(eltype::Type{<:Number}, A::Array{<:Number}; kwargs...)
+function ITensor(eltype::Type{<:Number}, A::AbstractArray{<:Number}; kwargs...)
   return ITensor(NeverAlias(), eltype, A; kwargs...)
 end
-ITensor(A::Array{<:Number}; kwargs...) = ITensor(NeverAlias(), eltype(A), A; kwargs...)
+ITensor(A::AbstractArray{<:Number}; kwargs...) = ITensor(NeverAlias(), eltype(A), A; kwargs...)
 
-function ITensor(as::AliasStyle, A::Array{ElT}, is...; kwargs...) where {ElT<:Number}
+function ITensor(as::AliasStyle, A::AbstractArray{ElT}, is...; kwargs...) where {ElT<:Number}
   return ITensor(as, ElT, A, indices(is...); kwargs...)
 end
 
 function ITensor(
-  as::AliasStyle, A::Array{ElT}, is...; kwargs...
+  as::AliasStyle, A::AbstractArray{ElT}, is...; kwargs...
 ) where {ElT<:RealOrComplex{Int}}
   return ITensor(as, float(ElT), A, is...; kwargs...)
 end
 
-function ITensor(A::Array{<:Number}, is...; kwargs...)
+function ITensor(A::AbstractArray{<:Number}, is...; kwargs...)
   return ITensor(NeverAlias(), A, is...; kwargs...)
 end
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -388,7 +388,9 @@ end
 
 # Helper functions for different view behaviors
 Array{ElT,N}(::NeverAlias, A::AbstractArray) where {ElT,N} = Array{ElT,N}(A)
-Array{ElT,N}(::AllowAlias, A::AbstractArray) where {ElT,N} = convert(AbstractArray{ElT,N}, A)
+function Array{ElT,N}(::AllowAlias, A::AbstractArray) where {ElT,N}
+  return convert(AbstractArray{ElT,N}, A)
+end
 function Array{ElT}(as::AliasStyle, A::AbstractArray{ElTA,N}) where {ElT,N,ElTA}
   return Array{ElT,N}(as, A)
 end
@@ -443,7 +445,11 @@ T[i => 1, j => 1] == 3.3
     In future versions this may not automatically convert `Int`/`Complex{Int}` inputs to floating point versions with `float` (once tensor operations using `Int`/`Complex{Int}` are natively as fast as floating point operations), and in that case the particular element type should not be relied on. To avoid extra conversions (and therefore allocations) it is best practice to directly construct with `itensor([0. 1; 1 0], i', dag(i))` if you want a floating point element type. The conversion is done as a performance optimization since often tensors are passed to BLAS/LAPACK and need to be converted to floating point types compatible with those libraries, but future projects in Julia may allow for efficient operations with more general element types (for example see https://github.com/JuliaLinearAlgebra/Octavian.jl).
 """
 function ITensor(
-  as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}, inds::Indices{Index{Int}}; kwargs...
+  as::AliasStyle,
+  eltype::Type{<:Number},
+  A::AbstractArray{<:Number},
+  inds::Indices{Index{Int}};
+  kwargs...,
 )
   length(A) ≠ dim(inds) && throw(
     DimensionMismatch(
@@ -466,7 +472,9 @@ end
 
 # For now, it's not well defined to construct an ITensor without indices
 # from a non-zero dimensional Array
-function ITensor(as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}; kwargs...)
+function ITensor(
+  as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}; kwargs...
+)
   if length(A) > 1
     error(
       "Trying to create an ITensor without any indices from Array $A of dimensions $(size(A)). Cannot construct an ITensor from an Array with more than one element without any indices.",
@@ -478,9 +486,13 @@ end
 function ITensor(eltype::Type{<:Number}, A::AbstractArray{<:Number}; kwargs...)
   return ITensor(NeverAlias(), eltype, A; kwargs...)
 end
-ITensor(A::AbstractArray{<:Number}; kwargs...) = ITensor(NeverAlias(), eltype(A), A; kwargs...)
+function ITensor(A::AbstractArray{<:Number}; kwargs...)
+  return ITensor(NeverAlias(), eltype(A), A; kwargs...)
+end
 
-function ITensor(as::AliasStyle, A::AbstractArray{ElT}, is...; kwargs...) where {ElT<:Number}
+function ITensor(
+  as::AliasStyle, A::AbstractArray{ElT}, is...; kwargs...
+) where {ElT<:Number}
   return ITensor(as, ElT, A, indices(is...); kwargs...)
 end
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -454,13 +454,6 @@ function ITensor(
   return itensor(Dense(vec(data)), inds)
 end
 
-## function ITensor(
-##   as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}, inds::Vector; kwargs...
-## )
-##   # identity.(inds) narrows the Index type to a concrete type
-##   return ITensor(as, eltype, A, indices(inds); kwargs...)
-## end
-
 function ITensor(
   as::AliasStyle, eltype::Type{<:Number}, A::AbstractArray{<:Number}, is...; kwargs...
 )

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -147,7 +147,7 @@ ITensor(eltype::Type{<:Number}, x::Number, is::QNIndices) = ITensor(eltype, x, Q
 #ITensor(x::RealOrComplex{Int}, flux::QN, is...) = ITensor(float(x), is...)
 
 """
-    ITensor([ElT::Type, ]::Array, inds; tol = 0)
+    ITensor([ElT::Type, ]::AbstractArray, inds; tol = 0)
 
 Create a block sparse ITensor from the input Array, and collection 
 of QN indices. Zeros are dropped and nonzero blocks are determined
@@ -182,12 +182,12 @@ Block: (2, 2)
 ```
 """
 function ITensor(
-  ::AliasStyle, ::Type{ElT}, A::Array{<:Number}, inds::QNIndices; tol=0
+  ::AliasStyle, ::Type{ElT}, A::AbstractArray{<:Number}, inds::QNIndices; tol=0
 ) where {ElT<:Number}
   is = Tuple(inds)
   length(A) ≠ dim(inds) && throw(
     DimensionMismatch(
-      "In ITensor(::Array, inds), length of Array ($(length(A))) must match total dimension of the indices ($(dim(is)))",
+      "In ITensor(::AbstractArray, inds), length of AbstractArray ($(length(A))) must match total dimension of the indices ($(dim(is)))",
     ),
   )
   T = emptyITensor(ElT, is)

--- a/test/indices.jl
+++ b/test/indices.jl
@@ -1,5 +1,6 @@
 using Test
 using ITensors
+using ITensors.NDTensors
 
 @testset "Allow general mixtures of collections of indices" begin
   d = 2
@@ -210,3 +211,33 @@ end
   @test_throws ErrorException hassameinds(emptyITensor(Float64, QN(), is2), is)
   @test_throws ErrorException hassameinds(emptyITensor(Float64, QN(), is1...), is)
 end
+
+@testset "Test Index collection as Vector of abstract type" begin
+  d = 2
+  i = Index(d)
+  A = randn(d, d)
+  T = itensor(A, Index[i', dag(i)])
+  @test storage(T) isa NDTensors.Dense{Float64}
+  T = itensor(A, Any[i', dag(i)])
+  @test storage(T) isa NDTensors.Dense{Float64}
+
+  i = Index([QN() => d])
+  A = randn(d, d)
+  T = itensor(A, Index[i', dag(i)])
+  @test storage(T) isa NDTensors.BlockSparse{Float64}
+  T = itensor(A, Any[i', dag(i)])
+  @test storage(T) isa NDTensors.BlockSparse{Float64}
+end
+
+@testset "Test output types of ITensors.indices" begin
+  i = Index(2)
+  @test ITensors.indices([i'', i', i]) == Index{Int}[i'', i', i]
+  @test ITensors.indices((i'', i', i)) == (i'', i', i)
+  @test ITensors.indices([(i'',), (i',), (i,)]) == Index{Int}[i'', i', i]
+  @test ITensors.indices(Any[(i'',), (i',), (i,)]) == Index{Int}[i'', i', i]
+  @test ITensors.indices([(i'',), (i',), [i]]) == Index{Int}[i'', i', i]
+  @test ITensors.indices([(i'',), i', [i]]) == Index{Int}[i'', i', i]
+  @test ITensors.indices(Any[(i'',), i', [i]]) == Index{Int}[i'', i', i]
+  @test ITensors.indices(((i'',), i', [i])) == Index{Int}[i'', i', i]
+end
+

--- a/test/indices.jl
+++ b/test/indices.jl
@@ -234,7 +234,7 @@ end
   @test ITensors.indices([i'', i', i]) == Index{Int}[i'', i', i]
   @test ITensors.indices((i'', i', i)) == (i'', i', i)
   @test ITensors.indices(((i'',), (i',), i)) == (i'', i', i)
-  @test ITensors.indices(((i'', i',), (i,))) == (i'', i', i)
+  @test ITensors.indices(((i'', i'), (i,))) == (i'', i', i)
   @test ITensors.indices([(i'',), (i',), (i,)]) == Index{Int}[i'', i', i]
   @test ITensors.indices(Any[(i'',), (i',), (i,)]) == Index{Int}[i'', i', i]
   @test ITensors.indices([(i'',), (i',), [i]]) == Index{Int}[i'', i', i]
@@ -242,4 +242,3 @@ end
   @test ITensors.indices(Any[(i'',), i', [i]]) == Index{Int}[i'', i', i]
   @test ITensors.indices(((i'',), i', [i])) == Index{Int}[i'', i', i]
 end
-

--- a/test/indices.jl
+++ b/test/indices.jl
@@ -233,6 +233,8 @@ end
   i = Index(2)
   @test ITensors.indices([i'', i', i]) == Index{Int}[i'', i', i]
   @test ITensors.indices((i'', i', i)) == (i'', i', i)
+  @test ITensors.indices(((i'',), (i',), i)) == (i'', i', i)
+  @test ITensors.indices(((i'', i',), (i,))) == (i'', i', i)
   @test ITensors.indices([(i'',), (i',), (i,)]) == Index{Int}[i'', i', i]
   @test ITensors.indices(Any[(i'',), (i',), (i,)]) == Index{Int}[i'', i', i]
   @test ITensors.indices([(i'',), (i',), [i]]) == Index{Int}[i'', i', i]

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -700,6 +700,23 @@ end
     @test T[i => 1, j => 1] == 3.3
   end
 
+  @testset "Construct from AbstractArray" begin
+    i = Index(2, "index_i")
+    j = Index(2, "index_j")
+
+    X = [
+      1.0 2 0
+      3 4 0
+      0 0 0
+    ]
+    M = @view X[1:2, 1:2]
+    T = itensor(M, i, j)
+    T[i => 1, j => 1] = 3.3
+    @test M[1, 1] == 3.3
+    @test T[i => 1, j => 1] == 3.3
+    @test storage(T) isa NDTensors.Dense{Float64}
+  end
+
   @testset "ITensor Array constructor view behavior" begin
     d = 2
     i = Index(d)

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -537,7 +537,7 @@ end
     ρ = projector(ψ; normalize=false)
     @test prod(ρ) ≈ M
     # Deprecated syntax
-    ρ = MPO(ψ)
+    ρ = @test_deprecated MPO(ψ)
     @test prod(ρ) ≈ M
   end
 


### PR DESCRIPTION
This generalizes `ITensor` constructor calls to allow more general `AbstractArray`s, such as views:
```julia
julia> i = Index(2)
(dim=2|id=80)

julia> A = randn(3, 3)
3×3 Matrix{Float64}:
  1.09161     -2.57016   -0.179175
  0.00337991   0.645025   0.620601
 -0.360845    -1.05635    0.280979

julia> T = itensor(@view(A[1:2, 1:2]), i', i)
ITensor ord=2 (dim=2|id=80)' (dim=2|id=80)
Dense{Float64, Base.ReshapedArray{Float64, 1, SubArray{Float64, 2, Matrix{Float64}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}, Tuple{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64}}}}

julia> @show T;
T = ITensor ord=2
Dim 1: (dim=2|id=80)'
Dim 2: (dim=2|id=80)
Dense{Float64, Base.ReshapedArray{Float64, 1, SubArray{Float64, 2, Matrix{Float64}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}, Tuple{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64}}}}
 2×2
 1.09161033355609      -2.5701619590506115
 0.003379905603743644   0.6450248941156372

julia> T[1, 1] = 11
11

julia> @show T;
T = ITensor ord=2
Dim 1: (dim=2|id=80)'
Dim 2: (dim=2|id=80)
Dense{Float64, Base.ReshapedArray{Float64, 1, SubArray{Float64, 2, Matrix{Float64}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}, Tuple{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64}}}}
 2×2
 11.0                   -2.5701619590506115
  0.003379905603743644   0.6450248941156372

julia> @show A;
A = [11.0 -2.5701619590506115 -0.17917503341437718; 0.003379905603743644 0.6450248941156372 0.6206013238978528; -0.36084534734340146 -1.056352020463183 0.2809788842059119]
```

It also fixes a subtle dispatch bug where if an Index collection was input into an ITensor constructor with an abstract element type like:
```julia
ITensor(randn(2), Index[Index([QN() => 2])])
```
or
```julia
ITensor(randn(2), Any[Index([QN() => 2])])
```
it was creating a `Dense` tensor instead of a `BlockSparse` tensor. Now it does the correct thing:
```julia
julia> ITensor(randn(2), Index[Index([QN() => 2])])
ITensor ord=1
(dim=2|id=254) <Out>
 1: QN() => 2
BlockSparse{Float64, Vector{Float64}, 1}
```