### PR TITLE
Limit maxdim in default contract

### DIFF
--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -449,7 +449,8 @@ function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
 
   ψ_out = similar(ψ)
   cutoff::Float64 = get(kwargs, :cutoff, 1e-13)
-  maxdim::Int = get(kwargs, :maxdim, maxlinkdim(A) * maxlinkdim(ψ))
+  maxdim_defined = haskey(kwargs,:maxdim)
+  max_maxdim::Int = get(kwargs, :maxdim, maxlinkdim(A) * maxlinkdim(ψ))
   mindim::Int = max(get(kwargs, :mindim, 1), 1)
   normalize::Bool = get(kwargs, :normalize, false)
 
@@ -491,6 +492,16 @@ function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
   R = R * dag(Ut) * ψ[n - 1] * A[n - 1]
   simR_c = simR_c * U * ψ_c[n - 1] * simA_c[n - 1]
   for j in reverse(2:(n - 1))
+    if maxdim_defined
+      maxdim = max_maxdim
+    else
+      maxdim = 1
+      cip = commonind(ψ[j],E[j-1])
+      ciA = commonind(A[j],E[j-1])
+      (cip != nothing) && (maxdim *= dim(cip))
+      (ciA != nothing) && (maxdim *= dim(ciA))
+      (cip == nothing && ciA == nothing) && (maxdim = max_maxdim)
+    end
     s = siteinds(uniqueinds, A, ψ, j)
     s̃ = siteinds(uniqueinds, simA_c, ψ_c, j)
     ρ = E[j - 1] * R * simR_c
@@ -498,7 +509,7 @@ function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
     ts = isnothing(l) ? "" : tags(l)
     Lis = IndexSet(s..., l_renorm)
     Ris = IndexSet(s̃..., r_renorm)
-    F = eigen(ρ, Lis, Ris; ishermitian=true, tags=ts, kwargs...)
+    F = eigen(ρ, Lis, Ris; ishermitian=true, maxdim=maxdim, tags=ts, kwargs...)
     D, U, Ut = F.D, F.V, F.Vt
     l_renorm, r_renorm = F.l, F.r
     ψ_out[j] = Ut

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -495,8 +495,8 @@ function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
     # Determine smallest maxdim to use
     cip = commoninds(ψ[j], E[j - 1])
     ciA = commoninds(A[j], E[j - 1])
-    prod_dims = dim(cip)*dim(ciA)
-    maxdim = min(prod_dims,requested_maxdim)
+    prod_dims = dim(cip) * dim(ciA)
+    maxdim = min(prod_dims, requested_maxdim)
 
     s = siteinds(uniqueinds, A, ψ, j)
     s̃ = siteinds(uniqueinds, simA_c, ψ_c, j)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -449,7 +449,6 @@ function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
 
   ψ_out = similar(ψ)
   cutoff::Float64 = get(kwargs, :cutoff, 1e-13)
-  maxdim_defined = haskey(kwargs, :maxdim)
   requested_maxdim::Int = get(kwargs, :maxdim, maxlinkdim(A) * maxlinkdim(ψ))
   mindim::Int = max(get(kwargs, :mindim, 1), 1)
   normalize::Bool = get(kwargs, :normalize, false)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -449,7 +449,7 @@ function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
 
   ψ_out = similar(ψ)
   cutoff::Float64 = get(kwargs, :cutoff, 1e-13)
-  maxdim_defined = haskey(kwargs,:maxdim)
+  maxdim_defined = haskey(kwargs, :maxdim)
   max_maxdim::Int = get(kwargs, :maxdim, maxlinkdim(A) * maxlinkdim(ψ))
   mindim::Int = max(get(kwargs, :mindim, 1), 1)
   normalize::Bool = get(kwargs, :normalize, false)
@@ -496,8 +496,8 @@ function _contract_densitymatrix(A::MPO, ψ::MPS; kwargs...)::MPS
       maxdim = max_maxdim
     else
       maxdim = 1
-      cip = commonind(ψ[j],E[j-1])
-      ciA = commonind(A[j],E[j-1])
+      cip = commonind(ψ[j], E[j - 1])
+      ciA = commonind(A[j], E[j - 1])
       (cip != nothing) && (maxdim *= dim(cip))
       (ciA != nothing) && (maxdim *= dim(ciA))
       (cip == nothing && ciA == nothing) && (maxdim = max_maxdim)

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -657,31 +657,31 @@ end
     N = 8
     chi1 = 6
     chi2 = 2
-    s = siteinds(2,N)
+    s = siteinds(2, N)
 
     A = begin
-      l = [Index(chi1,"n=$n,Link") for n=1:N]
+      l = [Index(chi1, "n=$n,Link") for n in 1:N]
       M = MPO(N)
-      M[1] = randomITensor(dag(s[1]),l[1],s'[1])
-      for n=2:N-1
-        M[n] = randomITensor(dag(s[n]),dag(l[n-1]),l[n],s'[n])
+      M[1] = randomITensor(dag(s[1]), l[1], s'[1])
+      for n in 2:(N - 1)
+        M[n] = randomITensor(dag(s[n]), dag(l[n - 1]), l[n], s'[n])
       end
-      M[N] = randomITensor(dag(s[N]),dag(l[N-1]),s'[N])
-      nrm = inner(M,M)
-      for n=1:N
-        M[n] ./= (nrm)^(1/(2N))
+      M[N] = randomITensor(dag(s[N]), dag(l[N - 1]), s'[N])
+      nrm = inner(M, M)
+      for n in 1:N
+        M[n] ./= (nrm)^(1 / (2N))
       end
-      truncate!(M;cutoff=1E-10)
+      truncate!(M; cutoff=1E-10)
       M
     end
 
-    psi = randomMPS(s,chi2)
+    psi = randomMPS(s, chi2)
 
-    Apsi = contract(A,psi)
+    Apsi = contract(A, psi)
 
     dims = linkdims(Apsi)
     for d in dims
-      @test d <= chi1*chi2
+      @test d <= chi1 * chi2
     end
   end
 end

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -652,6 +652,38 @@ end
     H2H2 = prime(H2; tags=!ts"X") * dag(H2)
     @test @disable_warn_order prod(HH) ≈ prod(H2H2)
   end
+
+  @testset "Bond dimensions of MPO*MPS in default contract" begin
+    N = 8
+    chi1 = 6
+    chi2 = 2
+    s = siteinds(2,N)
+
+    A = begin
+      l = [Index(chi1,"n=$n,Link") for n=1:N]
+      M = MPO(N)
+      M[1] = randomITensor(dag(s[1]),l[1],s'[1])
+      for n=2:N-1
+        M[n] = randomITensor(dag(s[n]),dag(l[n-1]),l[n],s'[n])
+      end
+      M[N] = randomITensor(dag(s[N]),dag(l[N-1]),s'[N])
+      nrm = inner(M,M)
+      for n=1:N
+        M[n] ./= (nrm)^(1/(2N))
+      end
+      truncate!(M;cutoff=1E-10)
+      M
+    end
+
+    psi = randomMPS(s,chi2)
+
+    Apsi = contract(A,psi)
+
+    dims = linkdims(Apsi)
+    for d in dims
+      @test d <= chi1*chi2
+    end
+  end
 end
 
 nothing


### PR DESCRIPTION
Fixes #422. Use bound of MPS times MPO bond dimensions to limit bond dimension in default, non-truncating contract(::MPO,::MPS).

- Implement rigorous default maxdims for _contract_densitymatrix
- Test for contract(MPO,MPS) without truncation
