### PR TITLE
Fix subtraction of term from OpSum. Add more unicode operator name aliases

### DIFF
--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -285,14 +285,14 @@ is specified by a name (String) and a
 site number (Int). The second version
 accepts a real or complex coefficient.
 """
-function subtract!(ampo::OpSum, op1::String, i1::Int, op2::String, i2::Int, ops...)
-  return add!(ampo, -1.0, op1, i1, op2, i2, ops...)
+function subtract!(ampo::OpSum, op1::String, i1::Int, ops...)
+  return add!(ampo, -1.0, op1, i1, ops...)
 end
 
 function subtract!(
-  ampo::OpSum, coef::Number, op1::String, i1::Int, op2::String, i2::Int, ops...
+  ampo::OpSum, coef::Number, op1::String, i1::Int, ops...
 )
-  push!(ampo, -MPOTerm(coef, op1, i1, op2, i2, ops...))
+  push!(ampo, -MPOTerm(coef, op1, i1, ops...))
   return ampo
 end
 

--- a/src/physics/site_types/electron.jl
+++ b/src/physics/site_types/electron.jl
@@ -76,64 +76,97 @@ ITensors.state(::StateName"↑", st::SiteType"Electron") = state(StateName("Up")
 ITensors.state(::StateName"↓", st::SiteType"Electron") = state(StateName("Dn"), st)
 ITensors.state(::StateName"↑↓", st::SiteType"Electron") = state(StateName("UpDn"), st)
 
+alias(::OpName"c↑") = OpName("Cup")
+alias(::OpName"c↓") = OpName("Cdn")
+alias(::OpName"c†↑") = OpName("Cdagup")
+alias(::OpName"c†↓") = OpName("Cdagdn")
+alias(::OpName"n↑") = OpName("Nup")
+alias(::OpName"n↓") = OpName("Ndn")
+alias(::OpName"n↑↓") = OpName("Nupdn")
+alias(::OpName"ntot") = OpName("Ntot")
+alias(::OpName"F↑") = OpName("Fup")
+alias(::OpName"F↓") = OpName("Fdn")
+
 function ITensors.op!(Op::ITensor, ::OpName"Nup", ::SiteType"Electron", s::Index)
   Op[s' => 2, s => 2] = 1.0
   return Op[s' => 4, s => 4] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"n↑", st::SiteType"Electron", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Ndn", ::SiteType"Electron", s::Index)
   Op[s' => 3, s => 3] = 1.0
   return Op[s' => 4, s => 4] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"n↓", st::SiteType"Electron", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Nupdn", ::SiteType"Electron", s::Index)
   return Op[s' => 4, s => 4] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"n↑↓", st::SiteType"Electron", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Ntot", ::SiteType"Electron", s::Index)
   Op[s' => 2, s => 2] = 1.0
   Op[s' => 3, s => 3] = 1.0
   return Op[s' => 4, s => 4] = 2.0
 end
+ITensors.op!(Op::ITensor, on::OpName"ntot", st::SiteType"Electron", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cup", ::SiteType"Electron", s::Index)
   Op[s' => 1, s => 2] = 1.0
   return Op[s' => 3, s => 4] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c↑", st::SiteType"Electron", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cdagup", ::SiteType"Electron", s::Index)
   Op[s' => 2, s => 1] = 1.0
   return Op[s' => 4, s => 3] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c†↑", st::SiteType"Electron", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cdn", ::SiteType"Electron", s::Index)
   Op[s' => 1, s => 3] = 1.0
   return Op[s' => 2, s => 4] = -1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c↓", st::SiteType"Electron", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cdagdn", ::SiteType"Electron", s::Index)
   Op[s' => 3, s => 1] = 1.0
   return Op[s' => 4, s => 2] = -1.0
+end
+function ITensors.op!(Op::ITensor, ::OpName"c†↓", st::SiteType"Electron", s::Index)
+  return op!(Op, OpName("Cdagdn"), st, s)
 end
 
 function ITensors.op!(Op::ITensor, ::OpName"Aup", ::SiteType"Electron", s::Index)
   Op[s' => 1, s => 2] = 1.0
   return Op[s' => 3, s => 4] = 1.0
 end
+function ITensors.op!(Op::ITensor, ::OpName"a↑", st::SiteType"Electron", s::Index)
+  return op!(Op, OpName("Aup"), st, s)
+end
 
 function ITensors.op!(Op::ITensor, ::OpName"Adagup", ::SiteType"Electron", s::Index)
   Op[s' => 2, s => 1] = 1.0
   return Op[s' => 4, s => 3] = 1.0
+end
+function ITensors.op!(Op::ITensor, ::OpName"a†↑", st::SiteType"Electron", s::Index)
+  return op!(Op, OpName("Adagup"), st, s)
 end
 
 function ITensors.op!(Op::ITensor, ::OpName"Adn", ::SiteType"Electron", s::Index)
   Op[s' => 1, s => 3] = 1.0
   return Op[s' => 2, s => 4] = 1.0
 end
+function ITensors.op!(Op::ITensor, ::OpName"a↓", st::SiteType"Electron", s::Index)
+  return op!(Op, OpName("Adn"), st, s)
+end
 
 function ITensors.op!(Op::ITensor, ::OpName"Adagdn", ::SiteType"Electron", s::Index)
   Op[s' => 3, s => 1] = 1.0
   return Op[s' => 4, s => 2] = 1.0
+end
+function ITensors.op!(Op::ITensor, ::OpName"a†↓", st::SiteType"Electron", s::Index)
+  return op!(Op, OpName("Adagdn"), st, s)
 end
 
 function ITensors.op!(Op::ITensor, ::OpName"F", ::SiteType"Electron", s::Index)
@@ -149,12 +182,18 @@ function ITensors.op!(Op::ITensor, ::OpName"Fup", ::SiteType"Electron", s::Index
   Op[s' => 3, s => 3] = +1.0
   return Op[s' => 4, s => 4] = -1.0
 end
+function ITensors.op!(Op::ITensor, ::OpName"F↑", st::SiteType"Electron", s::Index)
+  return op!(Op, OpName("Fup"), st, s)
+end
 
 function ITensors.op!(Op::ITensor, ::OpName"Fdn", ::SiteType"Electron", s::Index)
   Op[s' => 1, s => 1] = +1.0
   Op[s' => 2, s => 2] = +1.0
   Op[s' => 3, s => 3] = -1.0
   return Op[s' => 4, s => 4] = -1.0
+end
+function ITensors.op!(Op::ITensor, ::OpName"F↓", st::SiteType"Electron", s::Index)
+  return op!(Op, OpName("Fdn"), st, s)
 end
 
 function ITensors.op!(Op::ITensor, ::OpName"Sz", ::SiteType"Electron", s::Index)
@@ -204,6 +243,10 @@ function ITensors.op!(Op::ITensor, ::OpName"Sminus", st::SiteType"Electron", s::
 end
 
 ITensors.has_fermion_string(::OpName"Cup", ::SiteType"Electron") = true
+ITensors.has_fermion_string(on::OpName"c↑", st::SiteType"Electron") = has_fermion_string(alias(on), st)
 ITensors.has_fermion_string(::OpName"Cdagup", ::SiteType"Electron") = true
+ITensors.has_fermion_string(on::OpName"c†↑", st::SiteType"Electron") = has_fermion_string(alias(on), st)
 ITensors.has_fermion_string(::OpName"Cdn", ::SiteType"Electron") = true
+ITensors.has_fermion_string(on::OpName"c↓", st::SiteType"Electron") = has_fermion_string(alias(on), st)
 ITensors.has_fermion_string(::OpName"Cdagdn", ::SiteType"Electron") = true
+ITensors.has_fermion_string(on::OpName"c†↓", st::SiteType"Electron") = has_fermion_string(alias(on), st)

--- a/src/physics/site_types/fermion.jl
+++ b/src/physics/site_types/fermion.jl
@@ -69,17 +69,24 @@ ITensors.state(::StateName"Occ", ::SiteType"Fermion") = [0.0 1.0]
 ITensors.state(::StateName"0", st::SiteType"Fermion") = state(StateName("Emp"), st)
 ITensors.state(::StateName"1", st::SiteType"Fermion") = state(StateName("Occ"), st)
 
+alias(::OpName"c") = OpName("C")
+alias(::OpName"c†") = OpName("Cdag")
+alias(::OpName"n") = OpName("N")
+
 function ITensors.op!(Op::ITensor, ::OpName"N", ::SiteType"Fermion", s::Index)
   return Op[s' => 2, s => 2] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"n", st::SiteType"Fermion", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"C", ::SiteType"Fermion", s::Index)
   return Op[s' => 1, s => 2] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c", st::SiteType"Fermion", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cdag", ::SiteType"Fermion", s::Index)
   return Op[s' => 2, s => 1] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c†", st::SiteType"Fermion", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"F", ::SiteType"Fermion", s::Index)
   Op[s' => 1, s => 1] = +1.0
@@ -87,4 +94,7 @@ function ITensors.op!(Op::ITensor, ::OpName"F", ::SiteType"Fermion", s::Index)
 end
 
 ITensors.has_fermion_string(::OpName"C", ::SiteType"Fermion") = true
+ITensors.has_fermion_string(on::OpName"c", st::SiteType"Fermion") = has_fermion_string(alias(on), st)
 ITensors.has_fermion_string(::OpName"Cdag", ::SiteType"Fermion") = true
+ITensors.has_fermion_string(on::OpName"c†", st::SiteType"Fermion") = has_fermion_string(alias(on), st)
+

--- a/src/physics/site_types/tj.jl
+++ b/src/physics/site_types/tj.jl
@@ -71,47 +71,58 @@ ITensors.state(::StateName"↓", st::SiteType"tJ") = state(StateName("Dn"), st)
 function ITensors.op!(Op::ITensor, ::OpName"Nup", ::SiteType"tJ", s::Index)
   return Op[s' => 2, s => 2] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"n↑", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Ndn", ::SiteType"tJ", s::Index)
   return Op[s' => 3, s => 3] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"n↓", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Ntot", ::SiteType"tJ", s::Index)
   Op[s' => 2, s => 2] = 1.0
   return Op[s' => 3, s => 3] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"ntot", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cup", ::SiteType"tJ", s::Index)
   return Op[s' => 1, s => 2] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c↑", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cdagup", ::SiteType"tJ", s::Index)
   return Op[s' => 2, s => 1] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c†↑", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cdn", ::SiteType"tJ", s::Index)
   return Op[s' => 1, s => 3] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c↓", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Cdagdn", ::SiteType"tJ", s::Index)
   return Op[s' => 3, s => 1] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"c†↓", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Aup", ::SiteType"tJ", s::Index)
   return Op[s' => 1, s => 2] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"a↑", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Adagup", ::SiteType"tJ", s::Index)
   return Op[s' => 2, s => 1] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"a†↑", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Adn", ::SiteType"tJ", s::Index)
   return Op[s' => 1, s => 3] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"a↓", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Adagdn", ::SiteType"tJ", s::Index)
   return Op[s' => 3, s => 1] = 1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"a†↓", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"F", ::SiteType"tJ", s::Index)
   Op[s' => 1, s => 1] = +1.0
@@ -124,12 +135,14 @@ function ITensors.op!(Op::ITensor, ::OpName"Fup", ::SiteType"tJ", s::Index)
   Op[s' => 2, s => 2] = -1.0
   return Op[s' => 3, s => 3] = +1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"F↑", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Fdn", ::SiteType"tJ", s::Index)
   Op[s' => 1, s => 1] = +1.0
   Op[s' => 2, s => 2] = +1.0
   return Op[s' => 3, s => 3] = -1.0
 end
+ITensors.op!(Op::ITensor, on::OpName"F↓", st::SiteType"tJ", s::Index) = op!(Op, alias(on), st, s)
 
 function ITensors.op!(Op::ITensor, ::OpName"Sz", ::SiteType"tJ", s::Index)
   Op[s' => 2, s => 2] = +0.5
@@ -178,6 +191,10 @@ function ITensors.op!(Op::ITensor, ::OpName"Sminus", st::SiteType"tJ", s::Index)
 end
 
 ITensors.has_fermion_string(::OpName"Cup", ::SiteType"tJ") = true
+ITensors.has_fermion_string(on::OpName"c↑", st::SiteType"tJ") = has_fermion_string(alias(on), st)
 ITensors.has_fermion_string(::OpName"Cdagup", ::SiteType"tJ") = true
+ITensors.has_fermion_string(on::OpName"c†↑", st::SiteType"tJ") = has_fermion_string(alias(on), st)
 ITensors.has_fermion_string(::OpName"Cdn", ::SiteType"tJ") = true
+ITensors.has_fermion_string(on::OpName"c↓", st::SiteType"tJ") = has_fermion_string(alias(on), st)
 ITensors.has_fermion_string(::OpName"Cdagdn", ::SiteType"tJ") = true
+ITensors.has_fermion_string(on::OpName"c†↓", st::SiteType"tJ") = has_fermion_string(alias(on), st)

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -653,10 +653,10 @@ function has_fermion_string(opname::AbstractString, s::Index; kwargs...)::Bool
 
   # Interpret operator names joined by *
   # as acting sequentially on the same site
-  starpos = findfirst("*", opname)
+  starpos = findfirst(isequal('*'), opname)
   if !isnothing(starpos)
-    op1 = opname[1:(starpos.start - 1)]
-    op2 = opname[(starpos.start + 1):end]
+    op1 = opname[1:prevind(opname, starpos)]
+    op2 = opname[nextind(opname, starpos):end]
     return xor(has_fermion_string(op1, s; kwargs...), has_fermion_string(op2, s; kwargs...))
   end
 

--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -186,6 +186,20 @@ end
     @test Oa ≈ Oe
   end
 
+  @testset "Ising" begin
+    ampo = OpSum()
+    for j in 1:(N - 1)
+      ampo -= "Sz", j, "Sz", j + 1
+    end
+    sites = siteinds("S=1/2", N)
+    Ha = MPO(ampo, sites)
+    He = -isingMPO(sites)
+    psi = makeRandomMPS(sites)
+    Oa = inner(psi, Ha, psi)
+    Oe = inner(psi, He, psi)
+    @test Oa ≈ Oe
+  end
+
   @testset "Ising-Different Order" begin
     ampo = OpSum()
     for j in 1:(N - 1)

--- a/test/phys_site_types.jl
+++ b/test/phys_site_types.jl
@@ -78,7 +78,9 @@ using ITensors, Test
 
     s = siteinds("S=1/2", N)
     @test val(s[1], "Up") == 1
+    @test val(s[1], "↑") == 1
     @test val(s[1], "Dn") == 2
+    @test val(s[1], "↓") == 2
     @test_throws ArgumentError val(s[1], "Fake")
 
     Sz5 = op("Sz", s, 5)
@@ -113,8 +115,10 @@ using ITensors, Test
     s = siteinds("S=1", N)
 
     @test val(s[1], "Up") == 1
+    @test val(s[1], "↑") == 1
     @test val(s[1], "0") == 2
     @test val(s[1], "Dn") == 3
+    @test val(s[1], "↓") == 3
     @test_throws ArgumentError val(s[1], "Fake")
 
     Sz5 = op("Sz", s, 5)
@@ -153,19 +157,31 @@ using ITensors, Test
     @test_throws ArgumentError op(s, "Fake")
     N = Array(op(s, "N"), s', s)
     @test N ≈ [0.0 0; 0 1]
+    N = Array(op(s, "n"), s', s)
+    @test N ≈ [0.0 0; 0 1]
     C = Array(op(s, "C"), s', s)
     @test C ≈ [0.0 1; 0 0]
+    C = Array(op(s, "c"), s', s)
+    @test C ≈ [0.0 1; 0 0]
     Cdag = Array(op(s, "Cdag"), s', s)
+    @test Cdag ≈ [0.0 0; 1 0]
+    Cdag = Array(op(s, "c†"), s', s)
     @test Cdag ≈ [0.0 0; 1 0]
     F = Array(op(s, "F"), s', s)
     @test F ≈ [1.0 0; 0 -1]
 
     @test has_fermion_string("C", s)
+    @test has_fermion_string("c", s)
     @test has_fermion_string("Cdag", s)
+    @test has_fermion_string("c†", s)
     @test has_fermion_string("C*F", s)
+    @test has_fermion_string("c*F", s)
     @test has_fermion_string("F*Cdag*F", s)
+    @test has_fermion_string("F*c†*F", s)
     @test !has_fermion_string("N", s)
+    @test !has_fermion_string("n", s)
     @test !has_fermion_string("N*F", s)
+    @test !has_fermion_string("n*F", s)
 
     s = siteind("Fermion"; conserve_nf=true)
     @test qn(s, 1) == QN("Nf", 0, -1)
@@ -199,10 +215,14 @@ using ITensors, Test
   @testset "Electron sites" begin
     s = siteind("Electron")
 
+    @test val(s, "Emp") == 1
     @test val(s, "0") == 1
     @test val(s, "Up") == 2
+    @test val(s, "↑") == 2
     @test val(s, "Dn") == 3
+    @test val(s, "↓") == 3
     @test val(s, "UpDn") == 4
+    @test val(s, "↑↓") == 4
     @test_throws ArgumentError val(s, "Fake")
 
     Nup = op(s, "Nup")
@@ -211,42 +231,77 @@ using ITensors, Test
     @test_throws ArgumentError op(s, "Fake")
     Nup = Array(op(s, "Nup"), s', s)
     @test Nup ≈ [0.0 0 0 0; 0 1 0 0; 0 0 0 0; 0 0 0 1]
+    Nup = Array(op(s, "n↑"), s', s)
+    @test Nup ≈ [0.0 0 0 0; 0 1 0 0; 0 0 0 0; 0 0 0 1]
     Ndn = Array(op(s, "Ndn"), s', s)
+    @test Ndn ≈ [0.0 0 0 0; 0 0 0 0; 0 0 1 0; 0 0 0 1]
+    Ndn = Array(op(s, "n↓"), s', s)
     @test Ndn ≈ [0.0 0 0 0; 0 0 0 0; 0 0 1 0; 0 0 0 1]
     Ntot = Array(op(s, "Ntot"), s', s)
     @test Ntot ≈ [0.0 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 2]
+    Ntot = Array(op(s, "ntot"), s', s)
+    @test Ntot ≈ [0.0 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 2]
     Cup = Array(op(s, "Cup"), s', s)
+    @test Cup ≈ [0.0 1 0 0; 0 0 0 0; 0 0 0 1; 0 0 0 0]
+    Cup = Array(op(s, "c↑"), s', s)
     @test Cup ≈ [0.0 1 0 0; 0 0 0 0; 0 0 0 1; 0 0 0 0]
     Cdagup = Array(op(s, "Cdagup"), s', s)
     @test Cdagup ≈ [0.0 0 0 0; 1 0 0 0; 0 0 0 0; 0 0 1 0]
+    Cdagup = Array(op(s, "c†↑"), s', s)
+    @test Cdagup ≈ [0.0 0 0 0; 1 0 0 0; 0 0 0 0; 0 0 1 0]
     Cdn = Array(op(s, "Cdn"), s', s)
     @test Cdn ≈ [0.0 0 1 0; 0 0 0 -1; 0 0 0 0; 0 0 0 0]
+    Cdn = Array(op(s, "c↓"), s', s)
+    @test Cdn ≈ [0.0 0 1 0; 0 0 0 -1; 0 0 0 0; 0 0 0 0]
     Cdagdn = Array(op(s, "Cdagdn"), s', s)
+    @test Cdagdn ≈ [0.0 0 0 0; 0 0 0 0; 1 0 0 0; 0 -1 0 0]
+    Cdagdn = Array(op(s, "c†↓"), s', s)
     @test Cdagdn ≈ [0.0 0 0 0; 0 0 0 0; 1 0 0 0; 0 -1 0 0]
     F = Array(op(s, "F"), s', s)
     @test F ≈ [1.0 0 0 0; 0 -1 0 0; 0 0 -1 0; 0 0 0 1]
     Fup = Array(op(s, "Fup"), s', s)
     @test Fup ≈ [1.0 0 0 0; 0 -1 0 0; 0 0 1 0; 0 0 0 -1]
+    Fup = Array(op(s, "F↑"), s', s)
+    @test Fup ≈ [1.0 0 0 0; 0 -1 0 0; 0 0 1 0; 0 0 0 -1]
     Fdn3 = Array(op(s, "Fdn"), s', s)
+    @test Fdn3 ≈ [1.0 0 0 0; 0 1 0 0; 0 0 -1 0; 0 0 0 -1]
+    Fdn3 = Array(op(s, "F↓"), s', s)
     @test Fdn3 ≈ [1.0 0 0 0; 0 1 0 0; 0 0 -1 0; 0 0 0 -1]
     Sz3 = Array(op(s, "Sz"), s', s)
     @test Sz3 ≈ [0.0 0 0 0; 0 0.5 0 0; 0 0 -0.5 0; 0 0 0 0]
+    Sz3 = Array(op(s, "Sᶻ"), s', s)
+    @test Sz3 ≈ [0.0 0 0 0; 0 0.5 0 0; 0 0 -0.5 0; 0 0 0 0]
     Sx3 = Array(op(s, "Sx"), s', s)
+    @test Sx3 ≈ [0.0 0 0 0; 0 0 0.5 0; 0 0.5 0 0; 0 0 0 0]
+    Sx3 = Array(op(s, "Sˣ"), s', s)
     @test Sx3 ≈ [0.0 0 0 0; 0 0 0.5 0; 0 0.5 0 0; 0 0 0 0]
     Sp3 = Array(op(s, "S+"), s', s)
     @test Sp3 ≈ [0.0 0 0 0; 0 0 1 0; 0 0 0 0; 0 0 0 0]
+    Sp3 = Array(op(s, "S⁺"), s', s)
+    @test Sp3 ≈ [0.0 0 0 0; 0 0 1 0; 0 0 0 0; 0 0 0 0]
     Sm3 = Array(op(s, "S-"), s', s)
+    @test Sm3 ≈ [0.0 0 0 0; 0 0 0 0; 0 1 0 0; 0 0 0 0]
+    Sm3 = Array(op(s, "S⁻"), s', s)
     @test Sm3 ≈ [0.0 0 0 0; 0 0 0 0; 0 1 0 0; 0 0 0 0]
 
     @test has_fermion_string("Cup", s)
+    @test has_fermion_string("c↑", s)
     @test has_fermion_string("Cup*F", s)
+    @test has_fermion_string("c↑*F", s)
     @test has_fermion_string("Cdagup", s)
+    @test has_fermion_string("c†↑", s)
     @test has_fermion_string("F*Cdagup", s)
+    @test has_fermion_string("F*c†↑", s)
     @test has_fermion_string("Cdn", s)
+    @test has_fermion_string("c↓", s)
     @test has_fermion_string("Cdn*F", s)
+    @test has_fermion_string("c↓*F", s)
     @test has_fermion_string("Cdagdn", s)
+    @test has_fermion_string("c†↓", s)
     @test !has_fermion_string("N", s)
+    @test !has_fermion_string("n", s)
     @test !has_fermion_string("F*N", s)
+    @test !has_fermion_string("F*n", s)
 
     s = siteind("Electron"; conserve_nf=true)
     @test qn(s, 1) == QN("Nf", 0, -1)
@@ -268,49 +323,84 @@ using ITensors, Test
   @testset "tJ sites" begin
     s = siteind("tJ")
 
+    @test val(s, "Emp") == 1
     @test val(s, "0") == 1
     @test val(s, "Up") == 2
+    @test val(s, "↑") == 2
     @test val(s, "Dn") == 3
+    @test val(s, "↓") == 3
     @test_throws ArgumentError val(s, "Fake")
 
     @test_throws ArgumentError op(s, "Fake")
     Nup = op(s, "Nup")
     @test Nup[2, 2] ≈ 1.0
+    Nup = op(s, "n↑")
+    @test Nup[2, 2] ≈ 1.0
     Ndn = op(s, "Ndn")
     @test Ndn[3, 3] ≈ 1.0
+    Ndn = op(s, "n↓")
+    @test Ndn[3, 3] ≈ 1.0
     Ntot = op(s, "Ntot")
+    @test Ntot[2, 2] ≈ 1.0
+    @test Ntot[3, 3] ≈ 1.0
+    Ntot = op(s, "ntot")
     @test Ntot[2, 2] ≈ 1.0
     @test Ntot[3, 3] ≈ 1.0
     Id = Array(op(s, "Id"), s', s)
     @test Id ≈ [1.0 0 0; 0 1 0; 0 0 1]
     Cup = Array(op(s, "Cup"), s', s)
     @test Cup ≈ [0.0 1 0; 0 0 0; 0 0 0]
+    Cup = Array(op(s, "c↑"), s', s)
+    @test Cup ≈ [0.0 1 0; 0 0 0; 0 0 0]
     Cdup = Array(op(s, "Cdagup"), s', s)
+    @test Cdup ≈ [0 0 0; 1.0 0 0; 0 0 0]
+    Cdup = Array(op(s, "c†↑"), s', s)
     @test Cdup ≈ [0 0 0; 1.0 0 0; 0 0 0]
     Cdn = Array(op(s, "Cdn"), s', s)
     @test Cdn ≈ [0.0 0.0 1; 0 0 0; 0 0 0]
+    Cdn = Array(op(s, "c↓"), s', s)
+    @test Cdn ≈ [0.0 0.0 1; 0 0 0; 0 0 0]
     Cddn = Array(op(s, "Cdagdn"), s', s)
+    @test Cddn ≈ [0 0 0; 0.0 0 0; 1 0 0]
+    Cddn = Array(op(s, "c†↓"), s', s)
     @test Cddn ≈ [0 0 0; 0.0 0 0; 1 0 0]
     FP = Array(op(s, "F"), s', s)
     @test FP ≈ [1.0 0.0 0; 0 -1.0 0; 0 0 -1.0]
     Fup = Array(op(s, "Fup"), s', s)
     @test Fup ≈ [1.0 0.0 0; 0 -1.0 0; 0 0 1.0]
+    Fup = Array(op(s, "F↑"), s', s)
+    @test Fup ≈ [1.0 0.0 0; 0 -1.0 0; 0 0 1.0]
     Fdn = Array(op(s, "Fdn"), s', s)
+    @test Fdn ≈ [1.0 0.0 0; 0 1.0 0; 0 0 -1.0]
+    Fdn = Array(op(s, "F↓"), s', s)
     @test Fdn ≈ [1.0 0.0 0; 0 1.0 0; 0 0 -1.0]
     Sz = Array(op(s, "Sz"), s', s)
     @test Sz ≈ [0.0 0.0 0; 0 0.5 0; 0 0 -0.5]
+    Sz = Array(op(s, "Sᶻ"), s', s)
+    @test Sz ≈ [0.0 0.0 0; 0 0.5 0; 0 0 -0.5]
     Sx = Array(op(s, "Sx"), s', s)
+    @test Sx ≈ [0.0 0.0 0; 0 0 0.5; 0 0.5 0]
+    Sx = Array(op(s, "Sˣ"), s', s)
     @test Sx ≈ [0.0 0.0 0; 0 0 0.5; 0 0.5 0]
     Sp = Array(op(s, "Splus"), s', s)
     @test Sp ≈ [0.0 0.0 0; 0 0 1.0; 0 0 0]
+    Sp = Array(op(s, "S⁺"), s', s)
+    @test Sp ≈ [0.0 0.0 0; 0 0 1.0; 0 0 0]
     Sm = Array(op(s, "Sminus"), s', s)
+    @test Sm ≈ [0.0 0.0 0; 0 0 0; 0 1.0 0]
+    Sm = Array(op(s, "S⁻"), s', s)
     @test Sm ≈ [0.0 0.0 0; 0 0 0; 0 1.0 0]
 
     @test has_fermion_string("Cup", s)
+    @test has_fermion_string("c↑", s)
     @test has_fermion_string("Cdagup", s)
+    @test has_fermion_string("c†↑", s)
     @test has_fermion_string("Cdn", s)
+    @test has_fermion_string("c↓", s)
     @test has_fermion_string("Cdagdn", s)
+    @test has_fermion_string("c†↓", s)
     @test !has_fermion_string("N", s)
+    @test !has_fermion_string("n", s)
   end
 
   @testset "$st" for st in ["Qudit", "Boson"]


### PR DESCRIPTION
Adds support for: `OpSum() - ("Sx", 1)`.

Also adds more unicode aliases for operator names. Closese #747.