### PR TITLE
Add support for multisite operators in OpSum

### DIFF
--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -12,7 +12,8 @@ struct SiteOp{N}
   site::NTuple{N,Int}
   params::NamedTuple
 end
-SiteOp(name::String, site::Tuple) = SiteOp(name, site, (;))
+# Change NamedTuple() to (;) when we drop older Julia versions
+SiteOp(name::String, site::Tuple) = SiteOp(name, site, NamedTuple())
 SiteOp(name::String, site::Int...) = SiteOp(name, site)
 function SiteOp(name::String, site_params::Union{Int,NamedTuple}...)
   return SiteOp(name, Base.front(site_params), last(site_params))
@@ -126,32 +127,9 @@ function MPOTerm(c::Number, op1::String, ops_rest...)
   return MPOTerm(c, vop)
 end
 
-#function MPOTerm(c::Number, op1::String, i1)
-#  return MPOTerm(convert(ComplexF64, c), [SiteOp(op1, i1)])
-#end
-#
-#function MPOTerm(c::Number, op1::String, i1, op2::String, i2)
-#  return MPOTerm(convert(ComplexF64, c), [SiteOp(op1, i1), SiteOp(op2, i2)])
-#end
-#
-#function MPOTerm(c::Number, op1::String, i1, op2::String, i2, ops...)
-#  vop = OpTerm(undef, 2 + div(length(ops), 2))
-#  vop[1] = SiteOp(op1, i1)
-#  vop[2] = SiteOp(op2, i2)
-#  for n in 1:div(length(ops), 2)
-#    vop[2 + n] = SiteOp(ops[2 * n - 1], ops[2 * n])
-#  end
-#  return MPOTerm(convert(ComplexF64, c), vop)
-#end
-
 function MPOTerm(op1::String, ops...)
   return MPOTerm(one(Float64), op1, ops...)
 end
-
-#function MPOTerm(c::Number,
-#                 ops::OpTerm)
-#  return MPOTerm(convert(ComplexF64,c),ops)
-#end
 
 function Base.show(io::IO, op::MPOTerm)
   c = coef(op)

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -131,6 +131,10 @@ function MPOTerm(op1::String, ops...)
   return MPOTerm(one(Float64), op1, ops...)
 end
 
+function MPOTerm(ops::Vector{Pair{String,Int}})
+  return MPOTerm(Iterators.flatten(ops)...)
+end
+
 function Base.show(io::IO, op::MPOTerm)
   c = coef(op)
   if iszero(imag(c))

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -14,7 +14,9 @@ struct SiteOp{N}
 end
 SiteOp(name::String, site::Tuple) = SiteOp(name, site, (;))
 SiteOp(name::String, site::Int...) = SiteOp(name, site)
-SiteOp(name::String, site_params::Union{Int,NamedTuple}...) = SiteOp(name, Base.front(site_params), last(site_params))
+function SiteOp(name::String, site_params::Union{Int,NamedTuple}...)
+  return SiteOp(name, Base.front(site_params), last(site_params))
+end
 SiteOp(name::String, params::NamedTuple, site::Tuple) = SiteOp(name, site, params)
 SiteOp(name::String, params::NamedTuple, site::Int...) = SiteOp(name, site, params)
 

--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -182,59 +182,59 @@ end
     @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
     @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
 
-    os = OpSum() + ("CX", 1, 2, (ϕ=π/3,))
+    os = OpSum() + ("CX", 1, 2, (ϕ=π / 3,))
     @test length(os) == 1
     @test ITensors.coef(os[1]) == 1
     @test length(ITensors.ops(os[1])) == 1
     @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
     @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
-    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π / 3,)
 
-    os = OpSum() + ("CX", 1, 2, (ϕ=π/3,), "CZ", 3, 4, (θ=π/2,))
+    os = OpSum() + ("CX", 1, 2, (ϕ=π / 3,), "CZ", 3, 4, (θ=π / 2,))
     @test length(os) == 1
     @test ITensors.coef(os[1]) == 1
     @test length(ITensors.ops(os[1])) == 2
     @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
     @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
-    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π / 3,)
     @test ITensors.name(ITensors.ops(os[1])[2]) == "CZ"
     @test ITensors.sites(ITensors.ops(os[1])[2]) == (3, 4)
-    @test ITensors.params(ITensors.ops(os[1])[2]) == (θ=π/2,)
+    @test ITensors.params(ITensors.ops(os[1])[2]) == (θ=π / 2,)
 
-    os = OpSum() + ("CX", (ϕ=π/3,), 1, 2, "CZ", (θ=π/2,), 3, 4)
+    os = OpSum() + ("CX", (ϕ=π / 3,), 1, 2, "CZ", (θ=π / 2,), 3, 4)
     @test length(os) == 1
     @test ITensors.coef(os[1]) == 1
     @test length(ITensors.ops(os[1])) == 2
     @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
     @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
-    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π / 3,)
     @test ITensors.name(ITensors.ops(os[1])[2]) == "CZ"
     @test ITensors.sites(ITensors.ops(os[1])[2]) == (3, 4)
-    @test ITensors.params(ITensors.ops(os[1])[2]) == (θ=π/2,)
+    @test ITensors.params(ITensors.ops(os[1])[2]) == (θ=π / 2,)
 
-    os = OpSum() + ("CX", (1, 2), (ϕ=π/3,))
+    os = OpSum() + ("CX", (1, 2), (ϕ=π / 3,))
     @test length(os) == 1
     @test ITensors.coef(os[1]) == 1
     @test length(ITensors.ops(os[1])) == 1
     @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
     @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
-    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π / 3,)
 
-    os = OpSum() + ("CRz", (ϕ=π/3,), 1, 2)
+    os = OpSum() + (1 + 2im, "CRz", (ϕ=π / 3,), 1, 2)
+    @test length(os) == 1
+    @test ITensors.coef(os[1]) == 1 + 2im
+    @test length(ITensors.ops(os[1])) == 1
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CRz"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π / 3,)
+
+    os = OpSum() + ("CRz", (ϕ=π / 3,), (1, 2))
     @test length(os) == 1
     @test ITensors.coef(os[1]) == 1
     @test length(ITensors.ops(os[1])) == 1
     @test ITensors.name(ITensors.ops(os[1])[1]) == "CRz"
     @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
-    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
-
-    os = OpSum() + ("CRz", (ϕ=π/3,), (1, 2))
-    @test length(os) == 1
-    @test ITensors.coef(os[1]) == 1
-    @test length(ITensors.ops(os[1])) == 1
-    @test ITensors.name(ITensors.ops(os[1])[1]) == "CRz"
-    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
-    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π / 3,)
   end
 
   @testset "Show OpSum" begin

--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -154,6 +154,28 @@ end
     @test length(sprint(show, ITensors.data(ampo)[1])) > 1
   end
 
+  @testset "Multisite operator" begin
+    os = OpSum()
+    os += ("CX", (1, 2))
+    os += (2.3, "R", (3, 4), "S", 2)
+    os += ("X", 3)
+    @test length(os) == 3
+    @test ITensors.coef(os[1]) == 1
+    @test length(ITensors.ops(os[1])) == 1
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+    @test ITensors.coef(os[2]) == 2.3
+    @test length(ITensors.ops(os[2])) == 2
+    @test ITensors.name(ITensors.ops(os[2])[1]) == "R"
+    @test ITensors.sites(ITensors.ops(os[2])[1]) == (3, 4)
+    @test ITensors.name(ITensors.ops(os[2])[2]) == "S"
+    @test ITensors.sites(ITensors.ops(os[2])[2]) == (2,)
+    @test ITensors.coef(os[3]) == 1
+    @test length(ITensors.ops(os[3])) == 1
+    @test ITensors.name(ITensors.ops(os[3])[1]) == "X"
+    @test ITensors.sites(ITensors.ops(os[3])[1]) == (3,)
+  end
+
   @testset "Show OpSum" begin
     ampo = OpSum()
     add!(ampo, "Sz", 1, "Sz", 2)

--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -174,6 +174,67 @@ end
     @test length(ITensors.ops(os[3])) == 1
     @test ITensors.name(ITensors.ops(os[3])[1]) == "X"
     @test ITensors.sites(ITensors.ops(os[3])[1]) == (3,)
+
+    os = OpSum() + ("CX", 1, 2)
+    @test length(os) == 1
+    @test ITensors.coef(os[1]) == 1
+    @test length(ITensors.ops(os[1])) == 1
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+
+    os = OpSum() + ("CX", 1, 2, (ϕ=π/3,))
+    @test length(os) == 1
+    @test ITensors.coef(os[1]) == 1
+    @test length(ITensors.ops(os[1])) == 1
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+
+    os = OpSum() + ("CX", 1, 2, (ϕ=π/3,), "CZ", 3, 4, (θ=π/2,))
+    @test length(os) == 1
+    @test ITensors.coef(os[1]) == 1
+    @test length(ITensors.ops(os[1])) == 2
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+    @test ITensors.name(ITensors.ops(os[1])[2]) == "CZ"
+    @test ITensors.sites(ITensors.ops(os[1])[2]) == (3, 4)
+    @test ITensors.params(ITensors.ops(os[1])[2]) == (θ=π/2,)
+
+    os = OpSum() + ("CX", (ϕ=π/3,), 1, 2, "CZ", (θ=π/2,), 3, 4)
+    @test length(os) == 1
+    @test ITensors.coef(os[1]) == 1
+    @test length(ITensors.ops(os[1])) == 2
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+    @test ITensors.name(ITensors.ops(os[1])[2]) == "CZ"
+    @test ITensors.sites(ITensors.ops(os[1])[2]) == (3, 4)
+    @test ITensors.params(ITensors.ops(os[1])[2]) == (θ=π/2,)
+
+    os = OpSum() + ("CX", (1, 2), (ϕ=π/3,))
+    @test length(os) == 1
+    @test ITensors.coef(os[1]) == 1
+    @test length(ITensors.ops(os[1])) == 1
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CX"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+
+    os = OpSum() + ("CRz", (ϕ=π/3,), 1, 2)
+    @test length(os) == 1
+    @test ITensors.coef(os[1]) == 1
+    @test length(ITensors.ops(os[1])) == 1
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CRz"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
+
+    os = OpSum() + ("CRz", (ϕ=π/3,), (1, 2))
+    @test length(os) == 1
+    @test ITensors.coef(os[1]) == 1
+    @test length(ITensors.ops(os[1])) == 1
+    @test ITensors.name(ITensors.ops(os[1])[1]) == "CRz"
+    @test ITensors.sites(ITensors.ops(os[1])[1]) == (1, 2)
+    @test ITensors.params(ITensors.ops(os[1])[1]) == (ϕ=π/3,)
   end
 
   @testset "Show OpSum" begin


### PR DESCRIPTION
Add support for multisite operators in OpSum (no MPO construction support yet).

For example:
```julia
julia> os = OpSum()
OpSum:


julia> os += "CX", 1, 2
OpSum:
  1.0 "CX"(1, 2) 


julia> os += "Z", 3
OpSum:
  1.0 "CX"(1, 2) 
  1.0 "Z"(3) 
```
The current application is for creating a trotter decomposition from a Hamiltonian as discussed in #741.

@GTorlai is this sufficient for what you had in mind? Do we also need support for parameters?