### PR TITLE
Fix bug in `permute`

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -604,7 +604,7 @@ function permute(is1::Indices, is2::Indices)
     ),
   )
   perm = getperm(is1, is2)
-  return is1[perm]
+  return is1[invperm(perm)]
 end
 
 #

--- a/test/indexset.jl
+++ b/test/indexset.jl
@@ -1,5 +1,6 @@
 using ITensors
 using Test
+using Combinatorics
 using Compat
 
 @testset "IndexSet" begin
@@ -321,6 +322,47 @@ using Compat
     #@inferred broadcast(=>, I, [1, 2])
     @test pairsI isa Vector{<:Pair}
     @test pairsI == [x => 1, y => 2]
+  end
+
+  @testset "ITensors.indpairs" begin
+    si = [QN(0) => 1, QN(1) => 2, QN(2) => 3]
+    sj = [QN(0) => 2, QN(1) => 3, QN(2) => 4]
+    sk = [QN(0) => 3, QN(1) => 4, QN(2) => 5]
+    sl = [QN(0) => 2]
+    i, j, k, l = Index.((si, sj, sk, sl), ("i", "j", "k", "l"))
+    T = randomITensor(dag(j), k', i', dag(k), j', dag(i))
+    ip = ITensors.indpairs(T)
+    i1 = first.(ip)
+    i2 = last.(ip)
+    @test i1' == i2
+    for x in i1
+      @test dir(x) == dir(T, x)
+    end
+    for x in i2
+      @test dir(x) == dir(T, x)
+    end
+  end
+
+  @testset "permute" begin
+    i, j, k = Index.(Ref([QN() => 2]), ("i", "j", "k"))
+    is1 = (dag(i), j, dag(k))
+    is2 = (i, dag(j), k)
+    for x1 in permutations(is1), x2 in permutations(is2)
+      # permute x1 into the ordering of x2
+      px1 = permute(x1, x2)
+      @test px1 == x2
+      for y in x1
+        @test dir(x1, y) == dir(px1, y)
+        @test -dir(x2, y) == dir(px1, y)
+      end
+      # permute x2 into the ordering of x1
+      px2 = permute(x2, x1)
+      @test px2 == x1
+      for y in x2
+        @test dir(x2, y) == dir(px2, y)
+        @test -dir(x1, y) == dir(px2, y)
+      end
+    end
   end
 end
 

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -163,6 +163,19 @@ end
       @test ndims(A) == 0
     end
 
+    @testset "trace (tr)" begin
+      i, j, k, l = Index.((2, 3, 4, 5), ("i", "j", "k", "l"))
+      T = randomITensor(j, k', i', k, j', i)
+      trT1 = tr(T)
+      trT2 = (T * δ(i, i') * δ(j, j') * δ(k, k'))[]
+      @test trT1 ≈ trT2
+
+      T = randomITensor(j, k', i', l, k, j', i)
+      trT1 = tr(T)
+      trT2 = T * δ(i, i') * δ(j, j') * δ(k, k')
+      @test trT1 ≈ trT2
+    end
+
     @testset "ITensor iteration" begin
       A = randomITensor(i, j)
       Is = eachindex(A)

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -14,27 +14,25 @@ end
 
 @testset "Dense ITensor basic functionality" begin
   @testset "ITensor constructors" begin
-    i = Index(2, "i")
-    j = Index(2, "j")
-    k = Index(2, "k")
-    l = Index(2, "l")
-
     @testset "Default" begin
       A = ITensor()
       @test storage(A) isa NDTensors.EmptyStorage{NDTensors.EmptyNumber}
     end
 
     @testset "Undef with index" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       A = ITensor(undef, i)
       @test storage(A) isa NDTensors.Dense{Float64}
     end
 
     @testset "Default with indices" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       A = ITensor(i, j)
       @test storage(A) isa NDTensors.EmptyStorage{NDTensors.EmptyNumber}
     end
 
     @testset "Index set operations" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       A = randomITensor(i, j)
       B = randomITensor(j, k)
       C = randomITensor(k, l)
@@ -82,6 +80,7 @@ end
       @test A[b => end - 2, a => 1] == A[a => 1, b => 1]
       @test A[b => end^2 - 7, a => 1] == A[a => 1, b => 2]
 
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       B = randomITensor(i)
       @test B[i => end] == B[i => dim(i)]
       @test B[i => end - 1] == B[i => dim(i) - 1]
@@ -89,6 +88,7 @@ end
       @test B[end - 1] == B[dim(i) - 1]
     end
     @testset "ITensor equality" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       Aij = randomITensor(i, j)
       Aji = permute(Aij, j, i)
       Bij′ = randomITensor(i, j')
@@ -120,6 +120,7 @@ end
     end
 
     @testset "Random" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       A = randomITensor(i, j)
 
       # Test hasind, hasinds
@@ -177,6 +178,7 @@ end
     end
 
     @testset "ITensor iteration" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       A = randomITensor(i, j)
       Is = eachindex(A)
       @test length(Is) == dim(A)
@@ -194,6 +196,7 @@ end
     end
 
     @testset "From matrix" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       M = [1 2; 3 4]
       A = itensor(M, i, j)
       @test storage(A) isa NDTensors.Dense{Float64}
@@ -219,6 +222,7 @@ end
     end
 
     @testset "To Matrix" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       TM = randomITensor(i, j)
 
       M1 = matrix(TM)
@@ -236,6 +240,7 @@ end
     end
 
     @testset "To Vector" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       TV = randomITensor(i)
 
       V = vector(TV)
@@ -260,16 +265,19 @@ end
     end
 
     @testset "Complex" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       A = ITensor(Complex, i, j)
       @test storage(A) isa NDTensors.EmptyStorage{Complex}
     end
 
     @testset "Random complex" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       A = randomITensor(ComplexF64, i, j)
       @test storage(A) isa NDTensors.Dense{ComplexF64}
     end
 
     @testset "From complex matrix" begin
+      i, j, k, l = Index.(2, ("i", "j", "k", "l"))
       M = [1+2im 2; 3 4]
       A = itensor(M, i, j)
       @test storage(A) isa NDTensors.Dense{ComplexF64}

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -120,6 +120,23 @@ Random.seed!(1234)
     @test_throws BoundsError flux(T, Block(3))
   end
 
+  @testset "trace (tr)" begin
+    si = [QN(0) => 1, QN(1) => 2, QN(2) => 3]
+    sj = [QN(0) => 2, QN(1) => 3, QN(2) => 4]
+    sk = [QN(0) => 3, QN(1) => 4, QN(2) => 5]
+    sl = [QN(0) => 2]
+    i, j, k, l = Index.((si, sj, sk, sl), ("i", "j", "k", "l"))
+    T = randomITensor(dag(j), k', i', dag(k), j', dag(i))
+    trT1 = tr(T)
+    trT2 = (T * δ(i, dag(i)') * δ(j, dag(j)') * δ(k, dag(k)'))[]
+    @test trT1 ≈ trT2
+
+    T = randomITensor(dag(j), k', i', l, dag(k), j', dag(i))
+    trT1 = tr(T)
+    trT2 = T * δ(i, dag(i)') * δ(j, dag(j)') * δ(k, dag(k)')
+    @test trT1 ≈ trT2
+  end
+
   @testset "QN ITensor Array constructor view behavior" begin
     d = 2
     i = Index([QN(0) => d ÷ 2, QN(1) => d ÷ 2])


### PR DESCRIPTION
Fix bug in `permute` which was causing problems for `indpairs` and `tr`.