### PR TITLE
Add show for Indices

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -856,7 +856,16 @@ ITensors.block(is, 1, 2) == (1,1)
 """
 block(inds::Indices, vals::Integer...) = blockindex(inds, vals...)[2]
 
-#show(io::IO, is::IndexSet) = show(io, MIME"text/plain"(), is)
+function show(io::IO, mime::MIME"text/plain", is::Indices)
+  for i in is
+    println(io, i)
+  end
+end
+
+function show(io::IO, is::Indices)
+  !isempty(is) && println(io)
+  return show(io, MIME"text/plain"(), is)
+end
 
 #
 # Read and write


### PR DESCRIPTION
Defines `show` for collections of Indices (the `Indices` Union type). Very helpful in commands such as `@show inds(T)` where T is an ITensor and when the indices have QNs.
