### PR TITLE
Compact MPS printing

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1995,35 +1995,8 @@ function Base.show(io::IO, ::MIME"text/plain", M::AbstractMPS)
   end
 end
 
-const compact_show_cutoff = Ref(10)
-
 function Base.show(io::IO, M::AbstractMPS)
-  print(io, "$(typeof(M))")
-  if length(M) > compact_show_cutoff[]
-    indsl = @view eachindex(M)[1:compact_show_cutoff[]÷2]
-    indsr = @view eachindex(M)[(end - compact_show_cutoff[]÷2):end]
-  else
-    indsl = eachindex(M)
-    indsr = 1:0
-  end
-  is = [indsl; indsr]
-
-  (length(M) > 0) && print(io, " ")
-  itr = Iterators.map(is) do i
-    if i == compact_show_cutoff[] ÷2
-      "... "
-      elseif !isassigned(M, i)
-        "#undef"
-      else
-        A = M[i]
-        if order(A) != 0
-          "[$i] $(inds(A))"
-        else
-          "[$i] ITensor()"
-        end
-      end
-  end
-  join(io, itr, ", ")
+  print(io, typeof(M), "(", length(M), ")")
 end
 #
 # Old code for adding MPS/MPO

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1978,7 +1978,7 @@ end
 # Printing functions
 #
 
-function Base.show(io::IO, M::AbstractMPS)
+function Base.show(io::IO, ::MIME"text/plain", M::AbstractMPS)
   print(io, "$(typeof(M))")
   (length(M) > 0) && print(io, "\n")
   for i in eachindex(M)
@@ -1995,6 +1995,36 @@ function Base.show(io::IO, M::AbstractMPS)
   end
 end
 
+const compact_show_cutoff = Ref(10)
+
+function Base.show(io::IO, M::AbstractMPS)
+  print(io, "$(typeof(M))")
+  if length(M) > compact_show_cutoff[]
+    indsl = @view eachindex(M)[1:compact_show_cutoff[]÷2]
+    indsr = @view eachindex(M)[(end - compact_show_cutoff[]÷2 - 1):end]
+  else
+    indsl = eachindex(M)
+    indsr = 1:0
+  end
+  is = [indsl; indsr]
+
+  (length(M) > 0) && print(io, " ")
+  itr = Iterators.map(is) do i
+    if i == compact_show_cutoff[] ÷2 + 1
+      "... "
+      elseif !isassigned(M, i)
+        "#undef"
+      else
+        A = M[i]
+        if order(A) != 0
+          " $(inds(A))"
+        else
+          " ITensor()"
+        end
+      end
+  end
+  join(io, itr, ", ")
+end
 #
 # Old code for adding MPS/MPO
 #

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1994,21 +1994,21 @@ function Base.show(io::IO, ::MIME"text/plain", M::AbstractMPS)
     end
   end
 end
-                                                                                                                                        
+
+function Base.show(io::IO, M::AbstractMPS)
+  print(io, typeof(M), "(", length(M), ")")
+end
+
 macro show_verbose(exs...)
   blk = Expr(:block)
   for ex in exs
-    push!(blk.args, :(println($(sprint(show_unquoted,ex)*" = "),
+    push!(blk.args, :(println($(sprint(Base.show_unquoted,ex)*" = "),
                               repr("text/plain", begin local value = $(esc(ex)) end))))
   end
   isempty(exs) || push!(blk.args, :value)
   return blk
 end
 
-function Base.show(io::IO, M::AbstractMPS)
-  print(io, typeof(M), "(", length(M), ")")
-end
-#
 # Old code for adding MPS/MPO
 #
 

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -2017,9 +2017,9 @@ function Base.show(io::IO, M::AbstractMPS)
       else
         A = M[i]
         if order(A) != 0
-          " $(inds(A))"
+          "[$i] $(inds(A))"
         else
-          " ITensor()"
+          "[$i] ITensor()"
         end
       end
   end

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -2001,7 +2001,7 @@ function Base.show(io::IO, M::AbstractMPS)
   print(io, "$(typeof(M))")
   if length(M) > compact_show_cutoff[]
     indsl = @view eachindex(M)[1:compact_show_cutoff[]÷2]
-    indsr = @view eachindex(M)[(end - compact_show_cutoff[]÷2 - 1):end]
+    indsr = @view eachindex(M)[(end - compact_show_cutoff[]÷2):end]
   else
     indsl = eachindex(M)
     indsr = 1:0
@@ -2010,7 +2010,7 @@ function Base.show(io::IO, M::AbstractMPS)
 
   (length(M) > 0) && print(io, " ")
   itr = Iterators.map(is) do i
-    if i == compact_show_cutoff[] ÷2 + 1
+    if i == compact_show_cutoff[] ÷2
       "... "
       elseif !isassigned(M, i)
         "#undef"

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1994,6 +1994,16 @@ function Base.show(io::IO, ::MIME"text/plain", M::AbstractMPS)
     end
   end
 end
+                                                                                                                                        
+macro show_verbose(exs...)
+  blk = Expr(:block)
+  for ex in exs
+    push!(blk.args, :(println($(sprint(show_unquoted,ex)*" = "),
+                              repr("text/plain", begin local value = $(esc(ex)) end))))
+  end
+  isempty(exs) || push!(blk.args, :value)
+  return blk
+end
 
 function Base.show(io::IO, M::AbstractMPS)
   print(io, typeof(M), "(", length(M), ")")


### PR DESCRIPTION
Fixes #771

Okay, so there's a few ways to go about this, and I'm trying one way here but I'm open to changing direction. This makes it so when a `MPS` is `print`ed or shown from some sort of compact enviornment, it defaults to a more compact representation of the MPS.

Generally speaking, in something like the inside of an array, types avoid putting newlines into their `show` methods because it can cause some weird printing stuff. 

Therefore, I made this basically just like the the current non-compact printing of an `MPS` except I omit the newlines and only show the first and last 5 elements of the MPS:
```julia
julia> [randomMPS(siteinds("S=1/2", 50)) for _ ∈ 1:1]
1-element Vector{MPS}:
 MPS [1] ((dim=2|id=394|"S=1/2,Site,n=1"), (dim=1|id=885|"Link,l=1")), [2] ((dim=1|id=885|"Link,l=1"), (dim=2|id=156|"S=1/2,Site,n=2"), (dim=1|id=6|"Link,l=2")), [3] ((dim=1|id=6|"Link,l=2"), (dim=2|id=734|"S=1/2,Site,n=3"), (dim=1|id=193|"Link,l=3")), [4] ((dim=1|id=193|"Link,l=3"), (dim=2|id=788|"S=1/2,Site,n=4"), (dim=1|id=934|"Link,l=4")), ... , [45] ((dim=1|id=906|"Link,l=44"), (dim=2|id=342|"S=1/2,Site,n=45"), (dim=1|id=635|"Link,l=45")), [46] ((dim=1|id=635|"Link,l=45"), (dim=2|id=955|"S=1/2,Site,n=46"), (dim=1|id=626|"Link,l=46")), [47] ((dim=1|id=626|"Link,l=46"), (dim=2|id=252|"S=1/2,Site,n=47"), (dim=1|id=262|"Link,l=47")), [48] ((dim=1|id=262|"Link,l=47"), (dim=2|id=59|"S=1/2,Site,n=48"), (dim=1|id=203|"Link,l=48")), [49] ((dim=1|id=203|"Link,l=48"), (dim=2|id=771|"S=1/2,Site,n=49"), (dim=1|id=31|"Link,l=49")), [50] ((dim=1|id=31|"Link,l=49"), (dim=2|id=635|"S=1/2,Site,n=50"))
```
This is adjustable through a `const Ref`:
```julia
julia> ITensors.compact_show_cutoff[]
10

julia> ITensors.compact_show_cutoff[] = 4
4

julia> [randomMPS(siteinds("S=1/2", 50)) for _ ∈ 1:1]
1-element Vector{MPS}:
 MPS [1] ((dim=2|id=24|"S=1/2,Site,n=1"), (dim=1|id=360|"Link,l=1")), ... , [48] ((dim=1|id=828|"Link,l=47"), (dim=2|id=79|"S=1/2,Site,n=48"), (dim=1|id=404|"Link,l=48")), [49] ((dim=1|id=404|"Link,l=48"), (dim=2|id=407|"S=1/2,Site,n=49"), (dim=1|id=112|"Link,l=49")), [50] ((dim=1|id=112|"Link,l=49"), (dim=2|id=731|"S=1/2,Site,n=50"))
```
Regular toplevel printing is not effected:
```julia
julia> randomMPS(siteinds("S=1/2", 20))
MPS
[1] ((dim=2|id=710|"S=1/2,Site,n=1"), (dim=1|id=864|"Link,l=1"))
[2] ((dim=1|id=864|"Link,l=1"), (dim=2|id=750|"S=1/2,Site,n=2"), (dim=1|id=189|"Link,l=2"))
[3] ((dim=1|id=189|"Link,l=2"), (dim=2|id=353|"S=1/2,Site,n=3"), (dim=1|id=910|"Link,l=3"))
[4] ((dim=1|id=910|"Link,l=3"), (dim=2|id=552|"S=1/2,Site,n=4"), (dim=1|id=318|"Link,l=4"))
[5] ((dim=1|id=318|"Link,l=4"), (dim=2|id=826|"S=1/2,Site,n=5"), (dim=1|id=717|"Link,l=5"))
[6] ((dim=1|id=717|"Link,l=5"), (dim=2|id=149|"S=1/2,Site,n=6"), (dim=1|id=360|"Link,l=6"))
[7] ((dim=1|id=360|"Link,l=6"), (dim=2|id=91|"S=1/2,Site,n=7"), (dim=1|id=216|"Link,l=7"))
[8] ((dim=1|id=216|"Link,l=7"), (dim=2|id=293|"S=1/2,Site,n=8"), (dim=1|id=182|"Link,l=8"))
[9] ((dim=1|id=182|"Link,l=8"), (dim=2|id=741|"S=1/2,Site,n=9"), (dim=1|id=245|"Link,l=9"))
[10] ((dim=1|id=245|"Link,l=9"), (dim=2|id=367|"S=1/2,Site,n=10"), (dim=1|id=295|"Link,l=10"))
[11] ((dim=1|id=295|"Link,l=10"), (dim=2|id=901|"S=1/2,Site,n=11"), (dim=1|id=823|"Link,l=11"))
[12] ((dim=1|id=823|"Link,l=11"), (dim=2|id=604|"S=1/2,Site,n=12"), (dim=1|id=69|"Link,l=12"))
[13] ((dim=1|id=69|"Link,l=12"), (dim=2|id=73|"S=1/2,Site,n=13"), (dim=1|id=569|"Link,l=13"))
[14] ((dim=1|id=569|"Link,l=13"), (dim=2|id=27|"S=1/2,Site,n=14"), (dim=1|id=470|"Link,l=14"))
[15] ((dim=1|id=470|"Link,l=14"), (dim=2|id=946|"S=1/2,Site,n=15"), (dim=1|id=697|"Link,l=15"))
[16] ((dim=1|id=697|"Link,l=15"), (dim=2|id=124|"S=1/2,Site,n=16"), (dim=1|id=776|"Link,l=16"))
[17] ((dim=1|id=776|"Link,l=16"), (dim=2|id=484|"S=1/2,Site,n=17"), (dim=1|id=86|"Link,l=17"))
[18] ((dim=1|id=86|"Link,l=17"), (dim=2|id=306|"S=1/2,Site,n=18"), (dim=1|id=108|"Link,l=18"))
[19] ((dim=1|id=108|"Link,l=18"), (dim=2|id=914|"S=1/2,Site,n=19"), (dim=1|id=405|"Link,l=19"))
[20] ((dim=1|id=405|"Link,l=19"), (dim=2|id=333|"S=1/2,Site,n=20"))
```

What do you think about this implementation? I find the way I've done it here a bit noisy and not very helpful honestly, and it makes me thing we should show even less information. Perhaps something more like just showing that it's an MPS and showing what sort of sites it's on? E.g. something like
```julia
MPS on sites S=1/2,Site,n=1", "S=1/2,Site,n=2", "S=1/2,Site,n=3",  ... "S=1/2,Site,n=48", "S=1/2,Site,n=49", "S=1/2,Site,n=50"]
```

Suggestions welcome!