### PR TITLE
Fix itensor rrule

### DIFF
--- a/src/ITensorChainRules/ITensorChainRules.jl
+++ b/src/ITensorChainRules/ITensorChainRules.jl
@@ -194,7 +194,8 @@ end
 function ChainRulesCore.rrule(::typeof(itensor), x::Array, a...)
   y = itensor(x, a...)
   function itensor_pullback(ȳ)
-    x̄ = reshape(array(unthunk(ȳ)), size(x))
+    uȳ = permute(unthunk(ȳ), a...)
+    x̄ = reshape(array(uȳ), size(x))
     ā = broadcast_notangent(a)
     return (NoTangent(), x̄, ā...)
   end

--- a/test/ITensorChainRules/test_chainrules.jl
+++ b/test/ITensorChainRules/test_chainrules.jl
@@ -42,11 +42,10 @@ using Zygote: ZygoteRuleConfig
   test_rrule(ITensor, 2.3; check_inferred=false)
   test_rrule(dag, A; check_inferred=false)
   test_rrule(permute, A, reverse(inds(A)); check_inferred=false)
-  
 
   f = function (x)
     j = Index(2, "j")
-    b = itensor([0,0,0,1],i,j) 
+    b = itensor([0,0,1,1],i,j) 
     k = itensor([0,1,0,0],i,j) 
     T = itensor([0 x x^2 1;0 0 sin(x) 0; 0 cos(x) 0 exp(x); x 0 0 0], i',j',i,j) 
     return x * real((b' * T * k)[])
@@ -56,7 +55,7 @@ using Zygote: ZygoteRuleConfig
   
   f = function (x)
     j = Index(2, "j")
-    b = itensor([0,0,0,1],i,j) 
+    b = itensor([0,0,1,1],i,j) 
     k = itensor([0,1,0,0],i,j) 
     T = itensor([0 x x^2 1;0 0 sin(x) 0; 0 cos(x) 0 exp(x); x 0 0 0], i,j,i',j') 
     return x * real((b' * T * k)[])

--- a/test/ITensorChainRules/test_chainrules.jl
+++ b/test/ITensorChainRules/test_chainrules.jl
@@ -45,24 +45,23 @@ using Zygote: ZygoteRuleConfig
 
   f = function (x)
     j = Index(2, "j")
-    b = itensor([0,0,1,1],i,j) 
-    k = itensor([0,1,0,0],i,j) 
-    T = itensor([0 x x^2 1;0 0 sin(x) 0; 0 cos(x) 0 exp(x); x 0 0 0], i',j',i,j) 
+    b = itensor([0, 0, 1, 1], i, j)
+    k = itensor([0, 1, 0, 0], i, j)
+    T = itensor([0 x x^2 1; 0 0 sin(x) 0; 0 cos(x) 0 exp(x); x 0 0 0], i', j', i, j)
     return x * real((b' * T * k)[])
   end
   args = (0.3,)
-  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false) 
-  
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
+
   f = function (x)
     j = Index(2, "j")
-    b = itensor([0,0,1,1],i,j) 
-    k = itensor([0,1,0,0],i,j) 
-    T = itensor([0 x x^2 1;0 0 sin(x) 0; 0 cos(x) 0 exp(x); x 0 0 0], i,j,i',j') 
+    b = itensor([0, 0, 1, 1], i, j)
+    k = itensor([0, 1, 0, 0], i, j)
+    T = itensor([0 x x^2 1; 0 0 sin(x) 0; 0 cos(x) 0 exp(x); x 0 0 0], i, j, i', j')
     return x * real((b' * T * k)[])
   end
   args = (0.3,)
-  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false) 
-
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
 
   f = x -> sin(scalar(x)^3)
   args = (C,)
@@ -193,6 +192,4 @@ using Zygote: ZygoteRuleConfig
   f = x -> prime(x; plev=1)[1, 1]
   args = (A,)
   @test_throws ErrorException f'(args...)
-  
 end
-

--- a/test/ITensorChainRules/test_chainrules.jl
+++ b/test/ITensorChainRules/test_chainrules.jl
@@ -42,6 +42,28 @@ using Zygote: ZygoteRuleConfig
   test_rrule(ITensor, 2.3; check_inferred=false)
   test_rrule(dag, A; check_inferred=false)
   test_rrule(permute, A, reverse(inds(A)); check_inferred=false)
+  
+
+  f = function (x)
+    j = Index(2, "j")
+    b = itensor([0,0,0,1],i,j) 
+    k = itensor([0,1,0,0],i,j) 
+    T = itensor([0 x x^2 1;0 0 sin(x) 0; 0 cos(x) 0 exp(x); x 0 0 0], i',j',i,j) 
+    return x * real((b' * T * k)[])
+  end
+  args = (0.3,)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false) 
+  
+  f = function (x)
+    j = Index(2, "j")
+    b = itensor([0,0,0,1],i,j) 
+    k = itensor([0,1,0,0],i,j) 
+    T = itensor([0 x x^2 1;0 0 sin(x) 0; 0 cos(x) 0 exp(x); x 0 0 0], i,j,i',j') 
+    return x * real((b' * T * k)[])
+  end
+  args = (0.3,)
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false) 
+
 
   f = x -> sin(scalar(x)^3)
   args = (C,)
@@ -172,4 +194,6 @@ using Zygote: ZygoteRuleConfig
   f = x -> prime(x; plev=1)[1, 1]
   args = (A,)
   @test_throws ErrorException f'(args...)
+  
 end
+


### PR DESCRIPTION
This PR fixes a bug in the `rrule` for the `itensor` function, which now takes into account different index ordering. Before this fix, the gradients of these two functions were identical:

```julia
i = Index(2, "i")
j = Index(2, "j")
M = rand(2,2,2,2)

function f1(x)
  T = itensor(M, i',j',i,j)
  ...
end
  
function f2(x)
  T = itensor(M, i,j,i',j')
  ...
end
```