### PR TITLE
Apply docs

### DIFF
--- a/docs/src/ITensorType.md
+++ b/docs/src/ITensorType.md
@@ -11,8 +11,8 @@ ITensor
 ```@docs
 ITensor(::Type{<:Number}, ::ITensors.Indices)
 ITensor(::Type{<:Number}, ::UndefInitializer, ::ITensors.Indices)
-ITensor(::Type{ElT}, x::Number, inds::ITensors.Indices) where {ElT<:Number}
-ITensor(as::ITensors.AliasStyle, ::Type{ElT}, A::Array{<:Number}, inds::ITensors.Indices; kwargs...) where {ElT<:Number}
+ITensor(::Type{<:Number}, ::Number, ::ITensors.Indices)
+ITensor(::ITensors.AliasStyle, ::Type{<:Number}, ::Array{<:Number}, ::ITensors.Indices{Index{Int}}; kwargs...)
 randomITensor(::Type{<:Number}, ::ITensors.Indices)
 onehot
 ```
@@ -20,35 +20,24 @@ onehot
 ## Dense View Constructors
 
 ```@docs
-itensor(::Array{<:Number},::ITensors.Indices)
+itensor(::Array{<:Number}, ::ITensors.Indices)
 ```
 
 ## QN BlockSparse Constructors
 
 ```@docs
 ITensor(::Type{<:Number}, ::QN, ::ITensors.Indices)
-ITensor(::ITensors.AliasStyle, ::Type{ElT}, A::Array{<:Number}, inds::ITensors.QNIndices; tol=0) where {ElT<:Number}
+ITensor(::Type{<:Number}, ::ITensors.QNIndices)
+ITensor(::ITensors.AliasStyle, ::Type{<:Number}, A::Array{<:Number}, inds::ITensors.QNIndices; tol=0)
 ITensor(::Type{<:Number}, ::UndefInitializer, ::QN, ::ITensors.Indices)
-```
-
-## Empty Constructors
-
-```@docs
-emptyITensor(::Type{<:Number}, ::ITensors.Indices)
-```
-
-## QN Empty Constructors
-
-```@docs
-emptyITensor(::Type{<:Number}, ::ITensors.QNIndices)
 ```
 
 ## Diagonal constructors
 
 ```@docs
-diagITensor(::Type{ElT}, is::ITensors.Indices) where {ElT}
-diagITensor(as::ITensors.AliasStyle, ::Type{ElT}, v::Vector{<:Number}, is...) where {ElT<:Number}
-diagITensor(as::ITensors.AliasStyle, ::Type{ElT}, x::Number, is...) where {ElT<:Number}
+diagITensor(::Type{<:Number}, ::ITensors.Indices)
+diagITensor(::ITensors.AliasStyle, ::Type{<:Number}, ::Vector{<:Number}, ::ITensors.Indices)
+diagITensor(::ITensors.AliasStyle, ::Type{<:Number}, ::Number, ::ITensors.Indices)
 delta(::Type{<:Number}, ::ITensors.Indices)
 ```
 

--- a/docs/src/ITensorType.md
+++ b/docs/src/ITensorType.md
@@ -27,8 +27,7 @@ itensor(::Array{<:Number}, ::ITensors.Indices)
 
 ```@docs
 ITensor(::Type{<:Number}, ::QN, ::ITensors.Indices)
-ITensor(::Type{<:Number}, ::ITensors.QNIndices)
-ITensor(::ITensors.AliasStyle, ::Type{<:Number}, A::Array{<:Number}, inds::ITensors.QNIndices; tol=0)
+ITensor(::ITensors.AliasStyle, ::Type{<:Number}, ::Array{<:Number}, ::ITensors.QNIndices; tol=0)
 ITensor(::Type{<:Number}, ::UndefInitializer, ::QN, ::ITensors.Indices)
 ```
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -360,6 +360,7 @@ ITensor(x::RealOrComplex{Int}, is...) = ITensor(float(x), is...)
 # EmptyStorage ITensor constructors
 #
 
+# TODO: Deprecated!
 """
     emptyITensor([::Type{ElT} = NDTensors.EmptyNumber, ]inds)
     emptyITensor([::Type{ElT} = NDTensors.EmptyNumber, ]inds::Index...)

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1553,13 +1553,14 @@ _number_inds(s::IndexSet) = length(s)
 _number_inds(sites) = sum(_number_inds(s) for s in sites)
 
 """
-    MPS(A::ITensor, sites; <keyword arguments>)
-    MPO(A::ITensor, sites; <keyword arguments>)
+    MPS(A::ITensor, sites; kwargs...)
+    MPO(A::ITensor, sites; kwargs...)
 
 Construct an MPS/MPO from an ITensor `A` by decomposing it site
 by site according to the site indices `sites`.
 
-# Arguments
+# Keywords
+
 - `leftinds = nothing`: optional left dangling indices. Indices that are not in `sites` and `leftinds` will be dangling off of the right side of the MPS/MPO.
 - `orthocenter::Integer = length(sites)`: the desired final orthogonality center of the output MPS/MPO.
 - `cutoff`: the desired truncation error at each link.
@@ -1716,8 +1717,8 @@ function movesites(ψ::AbstractMPS, ns, ns′; kwargs...)
 end
 
 """
-    product(o::ITensor, ψ::Union{MPS, MPO}, [ns::Vector{Int}]; <keyword argument>)
-    apply([...])
+    apply(o::ITensor, ψ::Union{MPS, MPO}, [ns::Vector{Int}]; kwargs...)
+    product([...])
 
 Get the product of the operator `o` with the MPS/MPO `ψ`,
 where the operator is applied to the sites `ns`. If `ns`
@@ -1730,8 +1731,12 @@ back to their original locations. You can leave them where
 they are by setting the keyword argument `move_sites_back`
 to false.
 
-# Arguments
-- `move_sites_back::Bool = true`: after the ITensor is applied to the MPS or MPO, move the sites of the MPS or MPO back to their original locations.
+# Keywords
+
+- `cutoff::Real`: singular value truncation cutoff.
+- `maxdim::Int`: maximum MPS/MPO dimension.
+- `apply_dag::Bool = false`: apply the gate and the dagger of the gate (only relevant for MPO evolution).
+- `move_sites_back::Bool = true`: after the ITensors are applied to the MPS or MPO, move the sites of the MPS or MPO back to their original locations.
 """
 function product(
   o::ITensor,
@@ -1769,10 +1774,17 @@ function product(
 end
 
 """
-    product(As::Vector{<:ITensor}, M::Union{MPS, MPO}; <keyword arguments>)
-    apply([...])
+    apply(As::Vector{<:ITensor}, M::Union{MPS, MPO}; kwargs...)
+    product([...])
 
 Apply the ITensors `As` to the MPS or MPO `M`, treating them as gates or matrices from pairs of prime or unprimed indices.
+
+# Keywords
+
+- `cutoff::Real`: singular value truncation cutoff.
+- `maxdim::Int`: maximum MPS/MPO dimension.
+- `apply_dag::Bool = false`: apply the gate and the dagger of the gate (only relevant for MPO evolution).
+- `move_sites_back::Bool = true`: after the ITensor is applied to the MPS or MPO, move the sites of the MPS or MPO back to their original locations.
 
 # Examples
 

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -19,23 +19,120 @@ Construct an ITensor with BlockSparse storage filled with `zero(ElT)` where the 
 
 If `ElT` is not specified it defaults to `Float64`.
 
+If `flux` is not specified, the ITensor will be empty (it will contain no blocks, and
+have an undefined flux). The flux will be set by the first element that is set.
+
 # Examples
 
 ```julia
-i = Index([QN(0)=>1, QN(1)=>2], "i")
+julia> i
+(dim=3|id=212|"i") <Out>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
 
-# QN ITensors with flux of QN(0):
+julia> @show ITensor(QN(0), i', dag(i));
+ITensor(QN(0), i', dag(i)) = ITensor ord=2
+Dim 1: (dim=3|id=212|"i")' <Out>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+Dim 2: (dim=3|id=212|"i") <In>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+NDTensors.BlockSparse{Float64, Vector{Float64}, 2}
+ 3×3
+Block(1, 1)
+ [1:1, 1:1]
+ 0.0
 
-A = ITensor(i',dag(i))
-B = ITensor(QN(0),i',dag(i))
+Block(2, 2)
+ [2:3, 2:3]
+ 0.0  0.0
+ 0.0  0.0
 
-# QN ITensor with flux of QN(1):
+julia> @show ITensor(QN(1), i', dag(i));
+ITensor(QN(1), i', dag(i)) = ITensor ord=2
+Dim 1: (dim=3|id=212|"i")' <Out>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+Dim 2: (dim=3|id=212|"i") <In>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+NDTensors.BlockSparse{Float64, Vector{Float64}, 2}
+ 3×3
+Block(2, 1)
+ [2:3, 1:1]
+ 0.0
+ 0.0
 
-C = ITensor(QN(1),i',dag(i))
+julia> @show ITensor(ComplexF64, QN(1), i', dag(i));
+ITensor(ComplexF64, QN(1), i', dag(i)) = ITensor ord=2
+Dim 1: (dim=3|id=212|"i")' <Out>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+Dim 2: (dim=3|id=212|"i") <In>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+NDTensors.BlockSparse{ComplexF64, Vector{ComplexF64}, 2}
+ 3×3
+Block(2, 1)
+ [2:3, 1:1]
+ 0.0 + 0.0im
+ 0.0 + 0.0im
 
-# Complex QN ITensor with flux of QN(1):
+julia> @show ITensor(undef, QN(1), i', dag(i));
+ITensor(undef, QN(1), i', dag(i)) = ITensor ord=2
+Dim 1: (dim=3|id=212|"i")' <Out>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+Dim 2: (dim=3|id=212|"i") <In>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+NDTensors.BlockSparse{Float64, Vector{Float64}, 2}
+ 3×3
+Block(2, 1)
+ [2:3, 1:1]
+ 0.0
+ 1.63e-322
+```
+Construction with undefined flux:
+```julia
+julia> A = ITensor(i', dag(i));
 
-C = ITensor(ComplexF64,QN(1),i',dag(i))
+julia> @show A;
+A = ITensor ord=2
+Dim 1: (dim=3|id=212|"i")' <Out>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+Dim 2: (dim=3|id=212|"i") <In>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+NDTensors.EmptyStorage{NDTensors.EmptyNumber, NDTensors.BlockSparse{NDTensors.EmptyNumber, Vector{NDTensors.EmptyNumber}, 2}}
+ 3×3
+
+
+
+julia> isnothing(flux(A))
+true
+
+julia> A[i' => 1, i => 2] = 2
+2
+
+julia> @show A;
+A = ITensor ord=2
+Dim 1: (dim=3|id=212|"i")' <Out>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+Dim 2: (dim=3|id=212|"i") <In>
+ 1: QN(0) => 1
+ 2: QN(1) => 2
+NDTensors.BlockSparse{Int64, Vector{Int64}, 2}
+ 3×3
+Block(1, 2)
+ [1:1, 2:3]
+ 2  0
+
+julia> flux(A)
+QN(-1)
 ```
 """
 function ITensor(::Type{ElT}, flux::QN, inds::Indices) where {ElT<:Number}
@@ -201,6 +298,7 @@ function ITensor(
   return T
 end
 
+# TODO: Deprecated.
 """
     emptyITensor([::Type{ElT} = EmptyNumber, ]inds)
     emptyITensor([::Type{ElT} = EmptyNumber, ]inds::QNIndex...)


### PR DESCRIPTION
# Description

This adds information about using keyword arguments like `maxdim`, `cutoff`, and `apply_dag` to the `apply` function docstring.

It also fixes some outdated `ITensor` constructor docstrings.