### PR TITLE
Remove ignore comments for JuliaFormatter

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1910,11 +1910,7 @@ end
 
 *(As::ITensor...; kwargs...)::ITensor = contract(As...; kwargs...)
 
-#! format: off
-# Turns off formatting since JuliaFormatter tries to change β to a keyword argument, i.e.
-# contract!(C::ITensor, A::ITensor, B::ITensor, α::Number; β::Number=0)::ITensor
 function contract!(C::ITensor, A::ITensor, B::ITensor, α::Number, β::Number=0)::ITensor
-#! format: on
   labelsCAB = compute_contraction_labels(inds(C), inds(A), inds(B))
   labelsC, labelsA, labelsB = labelsCAB
   CT = NDTensors.contract!!(

--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -28,12 +28,7 @@ function isingMPO(sites)::MPO
   return H
 end
 
-#! format: off
-# JuliaFormatter tries to change this line to:
-# heisenbergMPO(sites, h::Vector{Float64}; onsite::String="Sz")
-# so turn it off for this line.
 function heisenbergMPO(sites, h::Vector{Float64}, onsite::String="Sz")::MPO
-#! format: on
   H = MPO(sites)
   N = length(H)
   link = Vector{Index}(undef, N + 1)


### PR DESCRIPTION
Remove ignore comments for JuliaFormatter, which will not be necessary once the bug in JuliaFormatter https://github.com/domluna/JuliaFormatter.jl/issues/533 is fixed by https://github.com/domluna/JuliaFormatter.jl/pull/535.