### PR TITLE
[ITensorVisualizationBase] [ENHANCEMENT] Generalize `visualize`

### DIFF
--- a/ITensorVisualizationBase/src/defaults.jl
+++ b/ITensorVisualizationBase/src/defaults.jl
@@ -92,7 +92,7 @@ function edge_labels(b::Backend, params::NamedTuple, g::AbstractGraph)
   return IndexLabels(b; params...)(g)
 end
 
-function edge_label(l::IndexLabels, g, e)
+function edge_label(l::IndexLabels, g::AbstractGraph, e)
   indsₑ = get_prop(g, e, :inds)
   return label_string(
     indsₑ;
@@ -105,6 +105,13 @@ function edge_label(l::IndexLabels, g, e)
     newlines=l.newlines,
   )
 end
+
+function _edge_label(l, g::Graph, e)
+  return string(e)
+end
+
+edge_label(l::IndexLabels, g::Graph, e) = _edge_label(l, g, e)
+edge_label(l, g::Graph, e) = _edge_label(l, g, e)
 
 #function default_edge_labels(b::Backend, g; kwargs...)
 #  return [edge_label(g, e; kwargs...) for e in edges(g)]
@@ -189,6 +196,10 @@ function default_edge_widths(b::Backend, g::AbstractGraph)
   return Float64[width(get_prop(g, e, :inds)) for e in edges(g)]
 end
 
+function default_edge_widths(b::Backend, g::Graph)
+  return [1.0 for e in edges(g)]
+end
+
 #############################################################################
 # arrow
 #
@@ -196,6 +207,7 @@ end
 default_arrow_size(b::Backend, g) = 30
 
 _hasqns(tn::Vector{ITensor}) = any(hasqns, tn)
+
 function _hasqns(g::AbstractGraph)
   if iszero(ne(g))
     if has_prop(g, first(vertices(g)), :inds)
@@ -206,6 +218,8 @@ function _hasqns(g::AbstractGraph)
   end
   return hasqns(get_prop(g, first(edges(g)), :inds))
 end
+
+_hasqns(g::Graph) = false
 
 default_arrow_show(b::Backend, g) = _hasqns(g)
 

--- a/ITensorVisualizationBase/src/visualize.jl
+++ b/ITensorVisualizationBase/src/visualize.jl
@@ -130,9 +130,10 @@ function visualize!(
   return visualize!(fig, tn, sequence; kwargs...)
 end
 
-function visualize(f::Union{Function,Type}, As...; kwargs...)
+# Macro outputs a 1-tuple of the function arguments
+function visualize(f::Union{Function,Type}, tn::Tuple{T}, sequence; kwargs...) where {T}
   # TODO: specialize on the function type. Also accept a general collection.
-  return visualize(As...; kwargs...)
+  return visualize(only(tn), sequence; kwargs...)
 end
 
 function visualize!(fig, f::Union{Function,Type}, As...; kwargs...)

--- a/ITensorVisualizationBase/src/visualize.jl
+++ b/ITensorVisualizationBase/src/visualize.jl
@@ -136,6 +136,12 @@ function visualize(f::Union{Function,Type}, tn::Tuple{T}, sequence; kwargs...) w
   return visualize(only(tn), sequence; kwargs...)
 end
 
+# Macro outputs a tuple of ITensors to visualize
+function visualize(f::Union{Function,Type}, tn::Tuple{Vararg{ITensor}}, sequence; kwargs...)
+  # TODO: specialize on the function type. Also accept a general collection.
+  return visualize(tn, sequence; kwargs...)
+end
+
 function visualize!(fig, f::Union{Function,Type}, As...; kwargs...)
   # TODO: specialize of the function type. Also accept a general collection.
   return visualize!(fig, As...; kwargs...)


### PR DESCRIPTION
- Generalize `ITensorVisualizationBase.visualize` to make it easier to overload for new types.
- Add generic fallbacks in visualization code so that `visualize` works with `Graphs.Graph`.