### PR TITLE
Change `randomMPS` bond dim error to warning

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -123,7 +123,7 @@ function randomizeMPS!(M::MPS, sites::Vector{<:Index}, linkdim=1)
   setleftlim!(M, 0)
   setrightlim!(M, 2)
   if dim(commonind(M[c], M[c + 1])) < linkdim
-    error("MPS center bond dim less than requested")
+    @warn "MPS center bond dimension is less than requested (you requested $linkdim, but in practice it is $(dim(commonind(M[c], M[c + 1]))). This is likely due to technicalities of truncating quantum number sectors."
   end
 end
 


### PR DESCRIPTION
Currently, `randomMPS` errors when the bond dimension doesn't reach the desired one. This appears to happen fairly often with quantum numbers, probably because of technicalities of quantum number conservation (for example, to reach the desired bond dimension it might be trying to add a block inconsistent with the flux). This changes it into a more informative warning.