### PR TITLE
Fix `eltype` promotion dividing ITensor by scalar

### DIFF
--- a/NDTensors/src/dense.jl
+++ b/NDTensors/src/dense.jl
@@ -388,6 +388,10 @@ function (x::Number * T::Tensor)
 end
 (T::Tensor * x::Number) = x * T
 
+function (T::Tensor / x::Number)
+  return tensor(storage(T) / x, inds(T))
+end
+
 function permutedims!(
   R::DenseTensor{<:Number,N}, T::DenseTensor{<:Number,N}, perm, f::Function
 ) where {N}

--- a/NDTensors/src/tensorstorage.jl
+++ b/NDTensors/src/tensorstorage.jl
@@ -27,6 +27,7 @@ end
 
 (S::TensorStorage * x::Number) = setdata(S, x * data(S))
 (x::Number * S::TensorStorage) = S * x
+(S::TensorStorage / x::Number) = setdata(S, data(S) / x)
 
 -(S::TensorStorage) = setdata(S, -data(S))
 

--- a/NDTensors/test/blocksparse.jl
+++ b/NDTensors/test/blocksparse.jl
@@ -26,6 +26,20 @@ using Test
   # Test different ways of getting nnz
   @test nnz(blockoffsets(A), inds(A)) == nnz(A)
 
+  B = 2 * A
+  @test B[1, 1] == 2 * A[1, 1]
+  @test nnz(A) == 2 * 5 + 3 * 4
+  @test nnz(B) == 2 * 5 + 3 * 4
+  @test nnzblocks(A) == 2
+  @test nnzblocks(B) == 2
+
+  B = A / 2
+  @test B[1, 1] == A[1, 1] / 2
+  @test nnz(A) == 2 * 5 + 3 * 4
+  @test nnz(B) == 2 * 5 + 3 * 4
+  @test nnzblocks(A) == 2
+  @test nnzblocks(B) == 2
+
   A[1, 5] = 15
   A[2, 5] = 25
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1648,8 +1648,7 @@ end
 # TODO: what about noncommutative number types?
 (x::Number * T::ITensor) = T * x
 
-#TODO: make a proper element-wise division
-(A::ITensor / x::Number) = A * (1.0 / x)
+(A::ITensor / x::Number) = itensor(tensor(A) / x)
 
 -(A::ITensor) = itensor(-tensor(A))
 

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -284,6 +284,21 @@ end
     end
   end
 
+  @testset "eltype promotion with scalar * and /" begin
+    @test eltype(ITensor(1f0, Index(2)) * 2) === Float32
+    @test eltype(ITensor(1f0, Index(2)) .* 2) === Float32
+    @test eltype(ITensor(1f0, Index(2)) / 2) === Float32
+    @test eltype(ITensor(1f0, Index(2)) ./ 2) === Float32
+    @test eltype(ITensor(1f0, Index(2)) * 2f0) === Float32
+    @test eltype(ITensor(1f0, Index(2)) .* 2f0) === Float32
+    @test eltype(ITensor(1f0, Index(2)) / 2f0) === Float32
+    @test eltype(ITensor(1f0, Index(2)) ./ 2f0) === Float32
+    @test eltype(ITensor(1f0, Index(2)) * 2.0) === Float64
+    @test eltype(ITensor(1f0, Index(2)) .* 2.0) === Float64
+    @test eltype(ITensor(1f0, Index(2)) / 2.0) === Float64
+    @test eltype(ITensor(1f0, Index(2)) ./ 2.0) === Float64
+  end
+
   @testset "Convert to complex" begin
     i = Index(2, "i")
     j = Index(2, "j")

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -302,6 +302,37 @@ Random.seed!(1234)
 
     @test flux(B) == QN()
     @test nnzblocks(B) == 2
+
+    # Scalar algebra
+    C = 2 * B
+    @test C[1, 1] == 2 * B[1, 1]
+    @test flux(B) == QN()
+    @test flux(C) == QN()
+    @test nnzblocks(B) == 2
+    @test nnzblocks(C) == 2
+
+    C = B / 2
+    @test C[1, 1] == B[1, 1] / 2
+    @test flux(B) == QN()
+    @test flux(C) == QN()
+    @test nnzblocks(B) == 2
+    @test nnzblocks(C) == 2
+  end
+
+  @testset "eltype promotion with scalar * and /" begin
+    i = Index([QN(0) => 2, QN(1) => 3])
+    @test eltype(ITensor(1f0, i', dag(i)) * 2) === Float32
+    @test eltype(ITensor(1f0, i', dag(i)) .* 2) === Float32
+    @test eltype(ITensor(1f0, i', dag(i)) / 2) === Float32
+    @test eltype(ITensor(1f0, i', dag(i)) ./ 2) === Float32
+    @test eltype(ITensor(1f0, i', dag(i)) * 2f0) === Float32
+    @test eltype(ITensor(1f0, i', dag(i)) .* 2f0) === Float32
+    @test eltype(ITensor(1f0, i', dag(i)) / 2f0) === Float32
+    @test eltype(ITensor(1f0, i', dag(i)) ./ 2f0) === Float32
+    @test eltype(ITensor(1f0, i', dag(i)) * 2.0) === Float64
+    @test eltype(ITensor(1f0, i', dag(i)) .* 2.0) === Float64
+    @test eltype(ITensor(1f0, i', dag(i)) / 2.0) === Float64
+    @test eltype(ITensor(1f0, i', dag(i)) ./ 2.0) === Float64
   end
 
   @testset "Complex Number Operations" begin

--- a/test/qnitensor.jl
+++ b/test/qnitensor.jl
@@ -321,18 +321,18 @@ Random.seed!(1234)
 
   @testset "eltype promotion with scalar * and /" begin
     i = Index([QN(0) => 2, QN(1) => 3])
-    @test eltype(ITensor(1f0, i', dag(i)) * 2) === Float32
-    @test eltype(ITensor(1f0, i', dag(i)) .* 2) === Float32
-    @test eltype(ITensor(1f0, i', dag(i)) / 2) === Float32
-    @test eltype(ITensor(1f0, i', dag(i)) ./ 2) === Float32
-    @test eltype(ITensor(1f0, i', dag(i)) * 2f0) === Float32
-    @test eltype(ITensor(1f0, i', dag(i)) .* 2f0) === Float32
-    @test eltype(ITensor(1f0, i', dag(i)) / 2f0) === Float32
-    @test eltype(ITensor(1f0, i', dag(i)) ./ 2f0) === Float32
-    @test eltype(ITensor(1f0, i', dag(i)) * 2.0) === Float64
-    @test eltype(ITensor(1f0, i', dag(i)) .* 2.0) === Float64
-    @test eltype(ITensor(1f0, i', dag(i)) / 2.0) === Float64
-    @test eltype(ITensor(1f0, i', dag(i)) ./ 2.0) === Float64
+    @test eltype(ITensor(1.0f0, i', dag(i)) * 2) === Float32
+    @test eltype(ITensor(1.0f0, i', dag(i)) .* 2) === Float32
+    @test eltype(ITensor(1.0f0, i', dag(i)) / 2) === Float32
+    @test eltype(ITensor(1.0f0, i', dag(i)) ./ 2) === Float32
+    @test eltype(ITensor(1.0f0, i', dag(i)) * 2.0f0) === Float32
+    @test eltype(ITensor(1.0f0, i', dag(i)) .* 2.0f0) === Float32
+    @test eltype(ITensor(1.0f0, i', dag(i)) / 2.0f0) === Float32
+    @test eltype(ITensor(1.0f0, i', dag(i)) ./ 2.0f0) === Float32
+    @test eltype(ITensor(1.0f0, i', dag(i)) * 2.0) === Float64
+    @test eltype(ITensor(1.0f0, i', dag(i)) .* 2.0) === Float64
+    @test eltype(ITensor(1.0f0, i', dag(i)) / 2.0) === Float64
+    @test eltype(ITensor(1.0f0, i', dag(i)) ./ 2.0) === Float64
   end
 
   @testset "Complex Number Operations" begin


### PR DESCRIPTION
Fix `eltype` promotion when dividing an ITensor by scalar by directly using Tensor division instead of multiplying by the inverse of the scalar.

Before:
```julia
julia> a = ITensor(1f0, Index(2))
ITensor ord=1 (dim=2|id=848)
NDTensors.Dense{Float32, Vector{Float32}}

julia> a / 2
ITensor ord=1 (dim=2|id=848)
NDTensors.Dense{Float64, Vector{Float64}}
```
and now:
```julia
julia> a = ITensor(1f0, Index(2))
ITensor ord=1 (dim=2|id=754)
Dense{Float32, Vector{Float32}}

julia> a / 2
ITensor ord=1 (dim=2|id=754)
Dense{Float32, Vector{Float32}}
```