### PR TITLE
Fix ITensor rrule and generalize ITensor to Array conversion

### DIFF
--- a/src/ITensorChainRules/ITensorChainRules.jl
+++ b/src/ITensorChainRules/ITensorChainRules.jl
@@ -201,12 +201,12 @@ function ChainRulesCore.rrule(::typeof(itensor), x::Array, a...)
   return y, itensor_pullback
 end
 
-function ChainRulesCore.rrule(::typeof(ITensor), x::Array{<:Number}, a::Index...)
+function ChainRulesCore.rrule(::typeof(ITensor), x::Array{<:Number}, a...)
   y = ITensor(x, a...)
   function ITensor_pullback(ȳ)
     # TODO: define `Array(::ITensor)` directly
-    x̄ = Array(unthunk(ȳ), inds(unthunk(ȳ))...)
-    ā = broadcast(_ -> NoTangent(), a)
+    x̄ = Array(unthunk(ȳ), a...)
+    ā = broadcast_notangent(a)
     return (NoTangent(), x̄, ā...)
   end
   return y, ITensor_pullback

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1921,7 +1921,7 @@ end
 
 *(As::ITensor...; kwargs...)::ITensor = contract(As...; kwargs...)
 
-function contract!(C::ITensor, A::ITensor, B::ITensor, α::Number; β::Number=0)::ITensor
+function contract!(C::ITensor, A::ITensor, B::ITensor, α::Number, β::Number=0)::ITensor
   labelsCAB = compute_contraction_labels(inds(C), inds(A), inds(B))
   labelsC, labelsA, labelsB = labelsCAB
   CT = NDTensors.contract!!(

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -749,9 +749,9 @@ size(A::ITensor, d::Int) = size(tensor(A), d)
 copy(T::ITensor)::ITensor = itensor(copy(tensor(T)))
 
 """
-    Array{ElT, N}(T::ITensor, is:Index...)
-    Array{ElT}(T::ITensor, is:Index...)
-    Array(T::ITensor, is:Index...)
+    Array{ElT, N}(T::ITensor, i:Index...)
+    Array{ElT}(T::ITensor, i:Index...)
+    Array(T::ITensor, i:Index...)
 
     Matrix{ElT}(T::ITensor, row_i:Index, col_i::Index)
     Matrix(T::ITensor, row_i:Index, col_i::Index)

--- a/test/ITensorChainRules/test_chainrules.jl
+++ b/test/ITensorChainRules/test_chainrules.jl
@@ -38,10 +38,22 @@ using Zygote: ZygoteRuleConfig
   test_rrule(swapind, A, i', i; check_inferred=false)
   test_rrule(swapinds, A, (i',), (i,); check_inferred=false)
   test_rrule(itensor, randn(2, 2), i', i; check_inferred=false)
+  test_rrule(itensor, randn(2, 2), [i', i]; check_inferred=false)
   test_rrule(ITensor, randn(2, 2), i', i; check_inferred=false)
+  test_rrule(ITensor, randn(2, 2), [i', i]; check_inferred=false)
   test_rrule(ITensor, 2.3; check_inferred=false)
   test_rrule(dag, A; check_inferred=false)
   test_rrule(permute, A, reverse(inds(A)); check_inferred=false)
+
+  function f(A, B)
+    i = Index(2)
+    j = Index(2)
+    AT = ITensor(A, i, j)
+    BT = ITensor(B, j, i)
+    return (BT * AT)[1]
+  end
+  args = (rand(2, 2), rand(2, 2))
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
 
   f = function (x)
     j = Index(2, "j")


### PR DESCRIPTION
# Description

Fixes two issues in the ITensor rrule:
1. Index ordering could be lost during the pullback, resulting in permuted gradient.
2. The gradient of more generic ITensor constructions, such as ITensor(A, [i, j]), were not defined.

As part of the fix for the second issue, the ITensor to Array conversion was generalized to use more generic collections of indices (credit to @mtfishman) as suggested in the associated issue #815. I modified the documentation for Array slightly to mention the Array{ElT,N} constructor.

# How Has This Been Tested?
- [x] Additional tests have been added to the test_chainrules.jl testset addressing these cases
- [x] I've ran a few variations of Array construction from an ITensor with vectors and tuples of indices using @code_warntyped. Type inference actually seems slightly better for tuples than before. The output type of Array{ElT, N} with a vector of indices is known, however, the body seems to contain some type instability due to the NDTensor:
```julia
@code_warntype Array{Float64, 2}(AT, [i, j])
Variables
  #self#::Core.Const(Matrix{Float64})
  T::ITensor
  is::Vector{Index{Int64}}
  TT::NDTensors.Tensor

Body::Matrix{Float64}
1 ─       Core.NewvarNode(:(TT))
│   %2  = ITensors.ndims(T)::Int64
│   %3  = (%2 != $(Expr(:static_parameter, 2)))::Bool
└──       goto #3 if not %3
2 ─ %5  = ITensors.ndims(T)::Any
│   %6  = $(Expr(:static_parameter, 2))::Core.Const(2)
│   %7  = Base.string("cannot convert an ", %5, " dimensional ITensor to an ", %6, "-dimensional Array.")::Any
│   %8  = ITensors.DimensionMismatch(%7)::Any
│         ITensors.throw(%8)
└──       Core.Const(:(goto %11))
3 ┄ %11 = ITensors.permute(T, is)::Any
│         (TT = ITensors.tensor(%11))
│   %13 = Core.apply_type(ITensors.Array, $(Expr(:static_parameter, 1)), $(Expr(:static_parameter, 2)))::Core.Const(Matrix{Float64})
│   %14 = (%13)(TT)::Any
│   %15 = Core.apply_type(ITensors.Array, $(Expr(:static_parameter, 1)), $(Expr(:static_parameter, 2)))::Core.Const(Matrix{Float64})
│   %16 = Core.typeassert(%14, %15)::Matrix{Float64}
└──       return %16
``` 
There may be some way of fixing this with a function barrier, as using this function for vectors with the old version of the Array code
```julia
function Array{ElT,N}(x, a::Vector{<:Index}) where {ElT,N}
  return Array{ElT,N}(x, a...)
end
```
appeared to have a type stable body.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
