### PR TITLE
Fix ITensor rrule with array reshaping

### DIFF
--- a/src/ITensorChainRules/ITensorChainRules.jl
+++ b/src/ITensorChainRules/ITensorChainRules.jl
@@ -209,7 +209,8 @@ function ChainRulesCore.rrule(::typeof(ITensor), x::Array{<:Number}, a...)
   y = ITensor(x, a...)
   function ITensor_pullback(ȳ)
     # TODO: define `Array(::ITensor)` directly
-    x̄ = Array(unthunk(ȳ), a...)
+    uȳ = Array(unthunk(ȳ), a...)
+    x̄ = reshape(uȳ, size(x))
     ā = broadcast_notangent(a)
     return (NoTangent(), x̄, ā...)
   end

--- a/test/ITensorChainRules/test_chainrules.jl
+++ b/test/ITensorChainRules/test_chainrules.jl
@@ -39,8 +39,10 @@ using Zygote: ZygoteRuleConfig
   test_rrule(swapinds, A, (i',), (i,); check_inferred=false)
   test_rrule(itensor, randn(2, 2), i', i; check_inferred=false)
   test_rrule(itensor, randn(2, 2), [i', i]; check_inferred=false)
+  test_rrule(itensor, randn(4), i', i; check_inferred=false)
   test_rrule(ITensor, randn(2, 2), i', i; check_inferred=false)
   test_rrule(ITensor, randn(2, 2), [i', i]; check_inferred=false)
+  test_rrule(ITensor, randn(4), i', i; check_inferred=false)
   test_rrule(ITensor, 2.3; check_inferred=false)
   test_rrule(dag, A; check_inferred=false)
   test_rrule(permute, A, reverse(inds(A)); check_inferred=false)
@@ -53,6 +55,10 @@ using Zygote: ZygoteRuleConfig
     return (BT * AT)[1]
   end
   args = (rand(2, 2), rand(2, 2))
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
+  args = (rand(4), rand(4))
+  test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
+  args = (rand(4), rand(2, 2))
   test_rrule(ZygoteRuleConfig(), f, args...; rrule_f=rrule_via_ad, check_inferred=false)
 
   f = function (x)


### PR DESCRIPTION
# Description

Adds an array reshaping line to the ITensor rrule to account for cases where the ITensor has been constructed using an array with different dimensions to those defined by the index arguments.

# How Has This Been Tested?

Additional tests have been added to check for correct derivatives when ITensors are constructed from arrays with different dimensions to its own. The package was tested to ensure no errors were introduced.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
