### PR TITLE
[ITensors] Fix string indexing when setting elements

### DIFF
--- a/src/ITensorChainRules/ITensorChainRules.jl
+++ b/src/ITensorChainRules/ITensorChainRules.jl
@@ -205,7 +205,7 @@ function ChainRulesCore.rrule(::typeof(itensor), x::Array, a...)
   return y, itensor_pullback
 end
 
-function ChainRulesCore.rrule(::typeof(ITensor), x::Array{<:Number}, a...)
+function ChainRulesCore.rrule(::Type{ITensor}, x::Array{<:Number}, a...)
   y = ITensor(x, a...)
   function ITensor_pullback(ȳ)
     # TODO: define `Array(::ITensor)` directly
@@ -216,7 +216,7 @@ function ChainRulesCore.rrule(::typeof(ITensor), x::Array{<:Number}, a...)
   return y, ITensor_pullback
 end
 
-function ChainRulesCore.rrule(::typeof(ITensor), x::Number)
+function ChainRulesCore.rrule(::Type{ITensor}, x::Number)
   y = ITensor(x)
   function ITensor_pullback(ȳ)
     x̄ = ȳ[]

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -889,7 +889,7 @@ A[i => 1, i' => 2] # 2.0, same as: A[i' => 2, i => 1]
   return tensor(T)[]
 end
 
-# Defining this with the type signature `I::Vararg{Integer, N}` instead of `I::Integere...` is much faster:
+# Defining this with the type signature `I::Vararg{Integer, N}` instead of `I::Integer...` is much faster:
 #
 # 58.720 ns (1 allocation: 368 bytes)
 #
@@ -977,6 +977,13 @@ end
   T::ITensor, x::Number, I::Vararg{<:Any,N}
 ) where {N}
   return settensor!(T, _setindex!!(tensor(T), x, I...))
+end
+
+@propagate_inbounds @inline function setindex!(
+  T::ITensor, x::Number, I::Pair{<:Index,String}...
+)
+  Iv = map(i -> i.first => val(i.first, i.second), I)
+  return setindex!(T, x, Iv...)
 end
 
 # XXX: what is this definition for?

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -980,9 +980,12 @@ end
 end
 
 @propagate_inbounds @inline function setindex!(
-  T::ITensor, x::Number, I::Pair{<:Index,String}...
+  T::ITensor,
+  x::Number,
+  I1::Pair{<:Index,String},
+  I::Pair{<:Index,String}...
 )
-  Iv = map(i -> i.first => val(i.first, i.second), I)
+  Iv = map(i -> i.first => val(i.first, i.second), (I1, I...))
   return setindex!(T, x, Iv...)
 end
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -980,10 +980,7 @@ end
 end
 
 @propagate_inbounds @inline function setindex!(
-  T::ITensor,
-  x::Number,
-  I1::Pair{<:Index,String},
-  I::Pair{<:Index,String}...
+  T::ITensor, x::Number, I1::Pair{<:Index,String}, I::Pair{<:Index,String}...
 )
   Iv = map(i -> i.first => val(i.first, i.second), (I1, I...))
   return setindex!(T, x, Iv...)

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -41,7 +41,22 @@ end
       @test !hascommoninds(A, C)
     end
 
-    @testset "Get element with end (lastindex, LastIndex)" begin
+    @testset "getindex with state string" begin
+      i₁ = Index(2, "S=1/2")
+      i₂ = Index(2, "S=1/2")
+      v = ITensor(i₁, i₂)
+      v[i₂ => "↑", i₁ => "↓"] = 1.0
+      @test v[1, 1] == 0.0
+      @test v[1, 2] == 0.0
+      @test v[2, 1] == 1.0
+      @test v[2, 2] == 0.0
+      @test v[i₁ => "↑", i₂ => "↑"] == 0.0
+      @test v[i₁ => "↑", i₂ => "↓"] == 0.0
+      @test v[i₁ => "↓", i₂ => "↑"] == 1.0
+      @test v[i₁ => "↓", i₂ => "↓"] == 0.0
+    end
+
+    @testset "getindex with end (lastindex, LastIndex)" begin
       a = Index(2)
       b = Index(3)
       A = randomITensor(a, b)


### PR DESCRIPTION
# Description

Fixes code like:
```julia
i₁ = Index(2, "S=1/2")
i₂ = Index(2, "S=1/2")
v = ITensor(i₁, i₂)
v[i₂ => "↑", i₁ => "↓"] = 1.0
```
which I think had worked a while ago but due to a rewrite of the `setindex!` functions stopped working.