### PR TITLE
[ITensors] [ENHANCEMENT]  More flexible `state` syntax (overloading and calling)

### DIFF
--- a/src/physics/site_types/qudit.jl
+++ b/src/physics/site_types/qudit.jl
@@ -31,7 +31,7 @@ function ITensors.state(::StateName{N}, ::SiteType"Qudit", s::Index) where {N}
   n = parse(Int, String(N))
   st = zeros(dim(s))
   st[n + 1] = 1.0
-  return st
+  return itensor(st, s)
 end
 
 function _op(::OpName"Id", ::SiteType"Qudit"; dim=2)

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -468,7 +468,14 @@ function state(s::Index, name::AbstractString; kwargs...)::ITensor
   # Try calling state(::StateName"Name",::SiteType"Tag",s::Index)
   for st in stypes
     v = state(sname, st, s; kwargs...)
-    !isnothing(v) && return v
+    if !isnothing(v)
+      if v isa ITensor
+        return v
+      else
+        # TODO: deprecate, only for backwards compatibility.
+        return itensor(v, s)
+      end
+    end
   end
 
   # Try calling state!(::ITensor,::StateName"Name",::SiteType"Tag",s::Index)

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -429,6 +429,9 @@ state(::StateName, ::SiteType) = nothing
 state(::StateName, ::SiteType, ::Index) = nothing
 state!(::ITensor, ::StateName, ::SiteType, ::Index) = nothing
 
+# Syntax `state("Up", Index(2, "S=1/2"))`
+state(sn::String, i::Index) = state(i, sn)
+
 """
     state(s::Index, name::String; kwargs...)
 
@@ -465,7 +468,7 @@ function state(s::Index, name::AbstractString; kwargs...)::ITensor
   # Try calling state(::StateName"Name",::SiteType"Tag",s::Index)
   for st in stypes
     v = state(sname, st, s; kwargs...)
-    !isnothing(v) && return itensor(v, s)
+    !isnothing(v) && return v
   end
 
   # Try calling state!(::ITensor,::StateName"Name",::SiteType"Tag",s::Index)

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -337,10 +337,45 @@ using ITensors, Test
       n = parse(Int, String(N))
       st = zeros(dim(s))
       st[n + 1] = 1.0
-      return return itensor(st, s)
+      return itensor(st, s)
     end
 
     s = siteind("MyQudit"; dim=3)
+    v0 = state(s, "0")
+    v1 = state(s, "1")
+    v2 = state(s, "2")
+    @test v0 == state("0", s)
+    @test v1 == state("1", s)
+    @test v2 == state("2", s)
+    @test dim(v0) == 3
+    @test dim(v1) == 3
+    @test dim(v2) == 3
+    @test v0[s => 1] == 1
+    @test v0[s => 2] == 0
+    @test v0[s => 3] == 0
+    @test v1[s => 1] == 0
+    @test v1[s => 2] == 1
+    @test v1[s => 3] == 0
+    @test v2[s => 1] == 0
+    @test v2[s => 2] == 0
+    @test v2[s => 3] == 1
+    @test_throws BoundsError state(s, "3")
+  end
+
+  @testset "state with variable dimension (deprecated)" begin
+    ITensors.space(::SiteType"MyQudit2"; dim=2) = dim
+
+    # XXX: This syntax is deprecated, only testing for
+    # backwards compatibility. Should return the
+    # ITensor `itensor(st, s)`.
+    function ITensors.state(::StateName{N}, ::SiteType"MyQudit2", s::Index) where {N}
+      n = parse(Int, String(N))
+      st = zeros(dim(s))
+      st[n + 1] = 1.0
+      return st
+    end
+
+    s = siteind("MyQudit2"; dim=3)
     v0 = state(s, "0")
     v1 = state(s, "1")
     v2 = state(s, "2")

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -337,13 +337,16 @@ using ITensors, Test
       n = parse(Int, String(N))
       st = zeros(dim(s))
       st[n + 1] = 1.0
-      return st
+      return return itensor(st, s)
     end
 
     s = siteind("MyQudit"; dim=3)
     v0 = state(s, "0")
     v1 = state(s, "1")
     v2 = state(s, "2")
+    @test v0 == state("0", s)
+    @test v1 == state("1", s)
+    @test v2 == state("2", s)
     @test dim(v0) == 3
     @test dim(v1) == 3
     @test dim(v2) == 3


### PR DESCRIPTION
- `state` defined with `Index` now should return an `ITensor`, for consistency with how `op` definitions work (this PR supports backwards compatibility for the now-deprecated syntax which returns a `Vector` that gets automatically converted to an `ITensor`).
- Allow syntax like `state("Up", Index(2, "S=1/2"))` (previously only `state(Index(2, "S=1/2"), "Up")` worked).