### PR TITLE
[ITensors] [ENHANCMENT] Add more compact kwarg sweeps syntax for DMRG

### DIFF
--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -315,3 +315,20 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Number,MPS}
   end
   return (energy, psi)
 end
+
+function _dmrg_sweeps(; nsweeps, maxdim, mindim=1, cutoff=1e-8, noise=0.0, kwargs...)
+  sweeps = Sweeps(nsweeps)
+  setmaxdim!(sweeps, maxdim...)
+  setmindim!(sweeps, mindim...)
+  setcutoff!(sweeps, cutoff...)
+  setnoise!(sweeps, noise...)
+  return sweeps
+end
+
+function dmrg(x1, x2, psi0::MPS; kwargs...)
+  return dmrg(x1, x2, psi0, _dmrg_sweeps(; kwargs...); kwargs...)
+end
+
+function dmrg(x1, psi0::MPS; kwargs...)
+  return dmrg(x1, psi0, _dmrg_sweeps(; kwargs...); kwargs...)
+end

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -141,6 +141,29 @@ using ITensors, Test, Random
     @test abs((energy - energy_exact) / energy_exact) < 1e-4
   end
 
+  @testset "Compact Sweeps syntax" begin
+    N = 32
+    sites = siteinds("S=1/2", N)
+    Random.seed!(432)
+    psi0 = randomMPS(sites)
+
+    function ising(N; h=1.0)
+      os = OpSum()
+      for j in 1:N
+        j < N && (os -= ("Z", j, "Z", j + 1))
+        os -= h, "X", j
+      end
+      return os
+    end
+
+    h = 1.0
+    H = MPO(ising(N; h=h), sites)
+    energy, psi = dmrg(H, psi0; nsweeps=5, maxdim=[10, 20], cutoff=1e-12, noise=1e-10, outputlevel=0)
+
+    energy_exact = 1.0 - 1.0 / sin(π / (4 * N + 2))
+    @test abs((energy - energy_exact) / energy_exact) < 1e-4
+  end
+
   @testset "Transverse field Ising, conserve Sz parity" begin
     N = 32
     sites = siteinds("S=1/2", N; conserve_szparity=true)

--- a/test/dmrg.jl
+++ b/test/dmrg.jl
@@ -158,7 +158,9 @@ using ITensors, Test, Random
 
     h = 1.0
     H = MPO(ising(N; h=h), sites)
-    energy, psi = dmrg(H, psi0; nsweeps=5, maxdim=[10, 20], cutoff=1e-12, noise=1e-10, outputlevel=0)
+    energy, psi = dmrg(
+      H, psi0; nsweeps=5, maxdim=[10, 20], cutoff=1e-12, noise=1e-10, outputlevel=0
+    )
 
     energy_exact = 1.0 - 1.0 / sin(π / (4 * N + 2))
     @test abs((energy - energy_exact) / energy_exact) < 1e-4


### PR DESCRIPTION
Closes #827. See the new tests for the syntax, it includes all of the features of using the `Sweeps` object directly.