### PR TITLE
Change excited state DMRG example to use randomMPS

### DIFF
--- a/docs/src/examples/DMRG.md
+++ b/docs/src/examples/DMRG.md
@@ -280,7 +280,7 @@ let
 
   h = 4.0
   
-  weight = 10*h # use a large weight
+  weight = 20*h # use a large weight
                 # since gap is expected to be large
 
 
@@ -291,14 +291,14 @@ let
   # Factors of 4 and 2 are to rescale
   # spin operators into Pauli matrices
   #
-  ampo = OpSum()
+  os = OpSum()
   for j=1:N-1
-    ampo += -4,"Sz",j,"Sz",j+1
+    os += -4,"Sz",j,"Sz",j+1
   end
   for j=1:N
-    ampo += -2*h,"Sx",j;
+    os += -2*h,"Sx",j;
   end
-  H = MPO(ampo,sites)
+  H = MPO(os,sites)
 
 
   #
@@ -313,17 +313,15 @@ let
   #
   # Compute the ground state psi0
   #
-  psi0_init = randomMPS(sites,2)
+  psi0_init = randomMPS(sites,linkdims=2)
   energy0,psi0 = dmrg(H,psi0_init,sweeps)
 
   println()
 
   #
   # Compute the first excited state psi1
-  # (Use ground state psi0 as initial state 
-  #  and as a 'penalty state')
   #
-  psi1_init = psi0
+  psi1_init = randomMPS(sites,linkdims=2)
   energy1,psi1 = dmrg(H,[psi0],psi1_init,sweeps; weight)
 
   # Check psi1 is orthogonal to psi0
@@ -334,7 +332,7 @@ let
   # The expected gap of the transverse field Ising
   # model is given by Eg = 2*|h-1|
   #
-  # (The DMRG gap will have finite-size corrections.)
+  # (The DMRG gap will have finite-size corrections)
   #
   println("DMRG energy gap = ",energy1-energy0);
   println("Theoretical gap = ",2*abs(h-1));
@@ -343,12 +341,11 @@ let
 
   #
   # Compute the second excited state psi2
-  # (Use ground state psi0 as initial state 
-  #  and [psi0,psi1] as 'penalty states')
   #
-  psi2_init = psi0
+  psi2_init = randomMPS(sites,linkdims=2)
   energy2,psi2 = dmrg(H,[psi0,psi1],psi2_init,sweeps;weight)
 
+  # Check psi2 is orthogonal to psi0 and psi1
   @show inner(psi2,psi0)
   @show inner(psi2,psi1)
 


### PR DESCRIPTION
Change excited state DMRG example to use randomMPS initial states. Issue #845 was motivation for the change.
