### PR TITLE
Small improvements and remove Julia 1.3

### DIFF
--- a/.github/workflows/test_itensorgaussianmps.yml
+++ b/.github/workflows/test_itensorgaussianmps.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/test_itensors.yml
+++ b/.github/workflows/test_itensors.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
           - '1'
         os:
           - ubuntu-latest
@@ -27,9 +26,6 @@ jobs:
         exclude:
           # MacOS not available on x86
           - {os: 'macOS-latest', arch: 'x86'}
-          # Only test all os on the latest release
-          - {version: '1.3', os: 'windows-latest'}
-          - {version: '1.3', os: 'macOS-latest'}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/test_itensors_threaded.yml
+++ b/.github/workflows/test_itensors_threaded.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/test_itensorunicodeplots.yml
+++ b/.github/workflows/test_itensorunicodeplots.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/test_ndtensors.yml
+++ b/.github/workflows/test_ndtensors.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/examples/gate_evolution/quantum_simulator.jl
+++ b/examples/gate_evolution/quantum_simulator.jl
@@ -12,7 +12,7 @@ CX = ops(s, [("CX", n, m) for n in 1:N, m in 1:N])
 ψ0 = productMPS(s, "0")
 
 # Change to the state |1010...⟩
-gates = ITensor[X[n] for n in 1:2:N]
+gates = [X[n] for n in 1:2:N]
 ψ = apply(gates, ψ0; cutoff=1e-15)
 @assert inner(ψ, productMPS(s, n -> isodd(n) ? "1" : "0")) ≈ 1
 

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -316,7 +316,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Number,MPS}
   return (energy, psi)
 end
 
-function _dmrg_sweeps(; nsweeps, maxdim, mindim=1, cutoff=1e-8, noise=0.0, kwargs...)
+function _dmrg_sweeps(; nsweeps, maxdim=10_000, mindim=1, cutoff=1E-8, noise=0.0, kwargs...)
   sweeps = Sweeps(nsweeps)
   setmaxdim!(sweeps, maxdim...)
   setmindim!(sweeps, mindim...)


### PR DESCRIPTION
- Remove unneeded type before array
- Remove Julia 1.3 from testing
- Allow maxdim to be optional in DMRG sweeps keywords
