### PR TITLE
Implement changes in #800 for expect interface

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -177,6 +177,7 @@ export
   swapprime!,
   settags!,
   swaptags!,
+  transpose,
   uniqueinds,
   uniqueind,
   unioninds,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -142,6 +142,7 @@ export
   ind,
   inds,
   insertblock!,
+  ishermitian,
   itensor,
   mul!,
   matrix,

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -89,6 +89,7 @@ import LinearAlgebra:
   eigen,
   exp,
   factorize,
+  ishermitian,
   lmul!,
   mul!,
   norm,

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -98,7 +98,8 @@ import LinearAlgebra:
   qr,
   rmul!,
   svd,
-  tr
+  tr,
+  transpose
 
 using ITensors.NDTensors:
   EmptyNumber,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1997,15 +1997,26 @@ function indpairs(T::ITensor; plev::Pair{Int,Int}=0 => 1, tags::Pair=ts"" => ts"
 end
 
 """
-    ishermitian(T::ITensor; eps = 1E-10)
+    transpose(T::ITensor)
+
+Treating an ITensor as a map from a set of indices
+of prime level 0 to a matching set of indices but
+of prime level 1 
+[for example: (i,j,k,...) -> (j',i',k',...)]
+return the ITensor which is the transpose of this map.
+"""
+transpose(T::ITensor) = swapprime(T, 0 => 1)
+
+"""
+    ishermitian(T::ITensor; kwargs...)
 
 Test whether an ITensor is a Hermitian operator,
-up to a numerical tolerance. To be considered an
-operator, an ITensor must have matching pairs
-of indices with prime level 0 and 1.
+that is whether taking `dag` of the ITensor and
+transposing its indices returns numerically 
+the same ITensor.
 """
 function ishermitian(T::ITensor; kwargs...)
-  return isapprox(T, dag(swapprime(T, 0, 1)); kwargs...)
+  return isapprox(T, dag(transpose(T)); kwargs...)
 end
 
 # Trace an ITensor over pairs of indices determined by

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -2003,12 +2003,9 @@ Test whether an ITensor is a Hermitian operator,
 up to a numerical tolerance. To be considered an
 operator, an ITensor must have matching pairs
 of indices with prime level 0 and 1.
-
-# Optional Keyword Arguments
-- `eps = 1E-10`: the numerical tolerance to use 
 """
-function ishermitian(T::ITensor; eps=1E-10)
-  return norm(T - dag(swapprime(T, 0, 1))) < eps
+function ishermitian(T::ITensor; kwargs...)
+  return isapprox(T, dag(swapprime(T, 0, 1)); kwargs...)
 end
 
 # Trace an ITensor over pairs of indices determined by

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -1996,6 +1996,21 @@ function indpairs(T::ITensor; plev::Pair{Int,Int}=0 => 1, tags::Pair=ts"" => ts"
   return is_first .=> is_last
 end
 
+"""
+    ishermitian(T::ITensor; eps = 1E-10)
+
+Test whether an ITensor is a Hermitian operator,
+up to a numerical tolerance. To be considered an
+operator, an ITensor must have matching pairs
+of indices with prime level 0 and 1.
+
+# Optional Keyword Arguments
+- `eps = 1E-10`: the numerical tolerance to use 
+"""
+function ishermitian(T::ITensor; eps=1E-10)
+  return norm(T - dag(swapprime(T, 0, 1))) < eps
+end
+
 # Trace an ITensor over pairs of indices determined by
 # the prime levels and tags. Indices that are not in pairs
 # are not traced over, corresponding to a "batched" trace.

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1350,6 +1350,11 @@ Either modify in-place with `orthogonalize!` or
 out-of-place with `orthogonalize`.
 """
 function orthogonalize!(M::AbstractMPS, j::Int; kwargs...)
+  @debug_check begin
+    if !(1 <= j <= length(M))
+      error("Input j=$j to `orthogonalize!` out of range (valid range = 1:$(length(M)))")
+    end
+  end
   while leftlim(M) < (j - 1)
     (leftlim(M) < 0) && setleftlim!(M, 0)
     b = leftlim(M) + 1

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -772,7 +772,7 @@ function expect(psi::MPS, ops; kwargs...)
   Ns = length(site_range)
   start_site = first(site_range)
 
-  el_types = map(o -> ishermitian(op(o, s[start_site])) ? Float64 : ElT, ops)
+  el_types = map(o -> ishermitian(op(o, s[start_site])) ? real(ElT) : ElT, ops)
 
   orthogonalize!(psi, start_site)
   norm2_psi = norm(psi)^2

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -722,7 +722,7 @@ function correlation_matrix(psi::MPS, _Op1::AbstractString, _Op2::AbstractString
 end
 
 """
-    expect(psi::MPS,ops::AbstractString...; kwargs...)
+    expect(psi::MPS,op::AbstractString...; kwargs...)
     expect(psi::MPS,ops; kwargs...)
 
 Given an MPS `psi` and a single operator name, returns
@@ -737,8 +737,7 @@ same type of container with names replaced by vectors
 of expectation values.
 
 # Optional Keyword Arguments
-- `site_range = 1:length(psi)`: compute expected values only for sites in the given range
-- `site`: compute the expected value on a given site
+- `sites = 1:length(psi)`: compute expected values only for sites in the given range
 
 # Examples
 
@@ -747,12 +746,13 @@ N = 10
 
 s = siteinds("S=1/2",N)
 psi = randomMPS(s; linkdims=8)
-Z = expect(psi,"Sz";site_range=2:6)
+Z = expect(psi,"Sz";sites=2:4) # compute for sites 2,3,4
+Z3 = expect(psi,"Sz";sites=3)  # compute for site 3 only (output will be a scalar)
 
 s = siteinds("Electron",N)
 psi = randomMPS(s; linkdims=8)
 dens = expect(psi,"Ntot")
-updens,dndens = expect(psi,"Nup","Ndn")
+updens,dndens = expect(psi,"Nup","Ndn") # pass more than one operator
 ```
 """
 function expect(psi::MPS, ops; kwargs...)

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -5,6 +5,7 @@ using Test
 using Combinatorics: permutations
 
 import Random: seed!
+import ITensors.NDTensors: DenseTensor
 
 # Enable debug checking for these tests
 ITensors.enable_debug_checks()
@@ -1597,6 +1598,14 @@ end
         end
       end
     end
+  end
+
+  @testset "ishermitian" begin
+    s = Index(2, "s")
+    Sz = ITensor([0.5 0.0; 0.0 -0.5], s', s)
+    Sp = ITensor([0.0 1.0; 0.0 0.0], s', s)
+    @test ishermitian(Sz)
+    @test !ishermitian(Sp)
   end
 end # End Dense ITensor basic functionality
 

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -808,7 +808,7 @@ end
     PM = expect(psi, "S+*S-")
     Cpm = correlation_matrix(psi, "S+", "S-")
     range = 3:7
-    Cpm37 = correlation_matrix(psi, "S+", "S-"; sites=range)
+    Cpm37 = correlation_matrix(psi, "S+", "S-"; site_range=range)
     @test norm(Cpm37 - Cpm[range, range]) < 1E-8
 
     @test norm(PM[range] - expect(psi, "S+*S-"; sites=range)) < 1E-8

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -767,6 +767,20 @@ end
     @test res[2, 1] ≈ eSx[3:7]
     @test res[1, 2] ≈ eSx[3:7]
     @test res[2, 2] ≈ eSz[3:7]
+
+    #
+    # Test handling of non-Hermitian operators
+    # for complex-valued MPS
+    #
+    # Real-valued MPS
+    psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn"; linkdims=4)
+    res = expect(psi, ("S+", "Sx"))
+    @test res isa Tuple{Vector{Float64},Vector{Float64}}
+
+    # Complex-valued MPS
+    psi = randomMPS(ComplexF64, s, n -> isodd(n) ? "Up" : "Dn"; linkdims=4)
+    res = expect(psi, ("S+", "Sx"))
+    @test res isa Tuple{Vector{ComplexF64},Vector{Float64}}
   end
 
   @testset "Expected value and Correlations" begin

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -738,7 +738,7 @@ end
     res = expect(psi, "Sz"; sites=2:4)
     @test res ≈ eSz[2:4]
 
-    res = expect(psi, "Sz"; sites=[2,4,8])
+    res = expect(psi, "Sz"; sites=[2, 4, 8])
     @test res[1] ≈ eSz[2]
     @test res[2] ≈ eSz[4]
     @test res[3] ≈ eSz[8]
@@ -761,12 +761,12 @@ end
     @test res[1] ≈ eSz
     @test res[2] ≈ eSx
 
-    res = expect(psi, ["Sz"  "Sx"; "Sx" "Sz"]; sites=3:7)
+    res = expect(psi, ["Sz" "Sx"; "Sx" "Sz"]; sites=3:7)
     @test res isa Matrix{Vector{Float64}}
-    @test res[1,1] ≈ eSz[3:7]
-    @test res[2,1] ≈ eSx[3:7]
-    @test res[1,2] ≈ eSx[3:7]
-    @test res[2,2] ≈ eSz[3:7]
+    @test res[1, 1] ≈ eSz[3:7]
+    @test res[2, 1] ≈ eSx[3:7]
+    @test res[1, 2] ≈ eSx[3:7]
+    @test res[2, 2] ≈ eSz[3:7]
   end
 
   @testset "Expected value and Correlations" begin
@@ -808,10 +808,10 @@ end
     PM = expect(psi, "S+*S-")
     Cpm = correlation_matrix(psi, "S+", "S-")
     range = 3:7
-    Cpm37 = correlation_matrix(psi, "S+", "S-"; site_range=range)
+    Cpm37 = correlation_matrix(psi, "S+", "S-"; sites=range)
     @test norm(Cpm37 - Cpm[range, range]) < 1E-8
 
-    @test norm(PM[range] - expect(psi, "S+*S-"; site_range=range)) < 1E-8
+    @test norm(PM[range] - expect(psi, "S+*S-"; sites=range)) < 1E-8
 
     # With start_site, end_site arguments:
     s = siteinds("S=1/2", 8)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -735,31 +735,38 @@ end
     res = expect(psi, "Sz")
     @test res ≈ eSz
 
-    res = expect(psi, "Sz"; site_range=2:4)
+    res = expect(psi, "Sz"; sites=2:4)
     @test res ≈ eSz[2:4]
+
+    res = expect(psi, "Sz"; sites=[2,4,8])
+    @test res[1] ≈ eSz[2]
+    @test res[2] ≈ eSz[4]
+    @test res[3] ≈ eSz[8]
 
     res = expect(psi, "Sz", "Sx")
     @test res[1] ≈ eSz
     @test res[2] ≈ eSx
 
-    res = expect(psi, "Sz"; site=3)
-    @test typeof(res) == Vector{Float64}
-    @test res ≈ [eSz[3]]
+    res = expect(psi, "Sz"; sites=3)
+    @test res isa Float64
+    @test res ≈ eSz[3]
 
-    res = expect(psi, "Sz", "Sx"; site=3)
-    @test typeof(res) == Tuple{Vector{Float64},Vector{Float64}}
-    @test res[1] ≈ [eSz[3]]
-    @test res[2] ≈ [eSx[3]]
+    res = expect(psi, "Sz", "Sx"; sites=3)
+    @test res isa Tuple{Float64,Float64}
+    @test res[1] ≈ eSz[3]
+    @test res[2] ≈ eSx[3]
 
     res = expect(psi, ("Sz", "Sx"))
-    @test typeof(res) == Tuple{Vector{Float64},Vector{Float64}}
+    @test res isa Tuple{Vector{Float64},Vector{Float64}}
     @test res[1] ≈ eSz
     @test res[2] ≈ eSx
 
-    res = expect(psi, ["Sz", "Sx"])
-    @test typeof(res) == Vector{Vector{Float64}}
-    @test res[1] ≈ eSz
-    @test res[2] ≈ eSx
+    res = expect(psi, ["Sz"  "Sx"; "Sx" "Sz"]; sites=3:7)
+    @test res isa Matrix{Vector{Float64}}
+    @test res[1,1] ≈ eSz[3:7]
+    @test res[2,1] ≈ eSx[3:7]
+    @test res[1,2] ≈ eSx[3:7]
+    @test res[2,2] ≈ eSz[3:7]
   end
 
   @testset "Expected value and Correlations" begin


### PR DESCRIPTION
Implements changes discussed in issue JuliaLang/julia#800 for the `expect` function.
Also implements a new keyword arg `site=s` which is equivalent to passing
`site_range=s:s`. It is an error if both keywords are passed.

Internally, `expect` now uses the `map` function to convert the container
of op names (`ops`) into an equivalent container of vectors of zeros,
then fills these up with the expectation values computed.

There are now two helper functions which convert variable numbers of 
string arguments into tuples to pass into the version of `expect` 
taking a container.

Added a unit test.
