### PR TITLE
Fix expect for complex MPS

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,4 +2,9 @@ include("settings.jl")
 
 makedocs(; sitename=sitename, settings...)
 
-deploydocs(; repo="github.com/ITensor/ITensors.jl.git", devbranch="main", push_preview=true, deploy_config=Documenter.GitHubActions())
+deploydocs(;
+  repo="github.com/ITensor/ITensors.jl.git",
+  devbranch="main",
+  push_preview=true,
+  deploy_config=Documenter.GitHubActions(),
+)

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -782,7 +782,7 @@ function expect(psi::MPS, ops; kwargs...)
     orthogonalize!(psi, j)
     for (n, opname) in enumerate(ops)
       val = scalar(psi[j] * op(opname, s[j]) * dag(prime(psi[j], s[j]))) / norm2_psi
-      ex[n][entry] = convert(el_types[n], val)
+      ex[n][entry] = (el_types[n] <: Real) ? real(val) : val
     end
   end
 

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -721,15 +721,15 @@ end
 
   @testset "expect Function" begin
     N = 8
-    s = siteinds("S=1/2", N; conserve_qns=false)
-    psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn"; linkdims=4)
+    s = siteinds("S=1/2", N)
+    psi = randomMPS(ComplexF64, s; linkdims=2)
 
     eSz = zeros(N)
     eSx = zeros(N)
     for j in 1:N
       orthogonalize!(psi, j)
-      eSz[j] = scalar(dag(prime(psi[j], "Site")) * op("Sz", s[j]) * psi[j])
-      eSx[j] = scalar(dag(prime(psi[j], "Site")) * op("Sx", s[j]) * psi[j])
+      eSz[j] = real(scalar(dag(prime(psi[j], "Site")) * op("Sz", s[j]) * psi[j]))
+      eSx[j] = real(scalar(dag(prime(psi[j], "Site")) * op("Sx", s[j]) * psi[j]))
     end
 
     res = expect(psi, "Sz")
@@ -737,9 +737,6 @@ end
 
     res = expect(psi, "Sz"; sites=2:4)
     @test res ≈ eSz[2:4]
-
-    res = expect(psi, "Sz"; sites=1:2:N)
-    @test res ≈ eSz[1:2:N]
 
     res = expect(psi, "Sz"; sites=[2, 4, 8])
     @test res[1] ≈ eSz[2]
@@ -770,20 +767,6 @@ end
     @test res[2, 1] ≈ eSx[3:7]
     @test res[1, 2] ≈ eSx[3:7]
     @test res[2, 2] ≈ eSz[3:7]
-
-    #
-    # Test handling of non-Hermitian operators
-    # for complex-valued MPS
-    #
-    # Real-valued MPS
-    psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn"; linkdims=4)
-    res = expect(psi, ("S+", "Sx"))
-    @test res isa Tuple{Vector{Float64},Vector{Float64}}
-
-    # Complex-valued MPS
-    psi = randomMPS(ComplexF64, s, n -> isodd(n) ? "Up" : "Dn"; linkdims=4)
-    res = expect(psi, ("S+", "Sx"))
-    @test res isa Tuple{Vector{ComplexF64},Vector{Float64}}
   end
 
   @testset "Expected value and Correlations" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,14 +54,14 @@ if Threads.nthreads() == 1
       "examples.jl",
     ]
       println("Running $filename")
-      include(filename)
+      @time include(filename)
     end
   end
 elseif Threads.nthreads() > 1
   @testset "ITensors.jl threaded" begin
     @testset "$filename" for filename in ["threading.jl"]
       println("Running $filename")
-      include(filename)
+      @time include(filename)
     end
   end
 end


### PR DESCRIPTION
Fixes #866, bug in `expect` for complex-valued inputs and Hermitian operators. Check if the element type is expected to be real and take the real part if so.

- Add timers to runtests.jl
- Test and fix #866
- Formatting

