### PR TITLE
correlation_matrix sites keyword

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -627,16 +627,23 @@ function correlation_matrix(psi::MPS, _Op1::AbstractString, _Op2::AbstractString
     end
   end
 
-  site_range::UnitRange{Int} = get(kwargs, :site_range, 1:N)
-  start_site = first(site_range)
-  end_site = last(site_range)
+  if haskey(kwargs, :site_range)
+    @warn "The `site_range` keyword arg. to `correlation_matrix` is deprecated: use the keyword `sites` instead"
+    sites_ = kwargs[:site_range]
+  else
+    sites_ = get(kwargs, :sites, 1:N)
+  end
+  sites = (sites_ isa AbstractRange) ? sites_ : collect(sites_)
+
+  start_site = first(sites)
+  end_site = last(sites)
 
   psi = copy(psi)
   orthogonalize!(psi, start_site)
   norm2_psi = norm(psi[start_site])^2
 
   # Nb = size of block of correlation matrix
-  Nb = end_site - start_site + 1
+  Nb = length(sites)
 
   C = zeros(ElT, Nb, Nb)
 
@@ -646,38 +653,59 @@ function correlation_matrix(psi::MPS, _Op1::AbstractString, _Op2::AbstractString
     lind = commonind(psi[start_site], psi[start_site - 1])
     L = delta(dag(lind), lind')
   end
+  pL = start_site-1
 
-  for i in start_site:(end_site - 1)
-    ci = i - start_site + 1
+  for (ni,i) in enumerate(sites[1:end-1])
+
+    while pL < i-1
+      pL += 1
+      L = (L * psi[pL]) * dag(prime(psi[pL], "Link"))
+    end
 
     Li = L * psi[i]
 
     # Get j == i diagonal correlations
     rind = commonind(psi[i], psi[i + 1])
-    C[ci, ci] =
+    C[ni, ni] =
       scalar((Li * op(onsiteOp, s, i)) * prime(dag(psi[i]), not(rind))) / norm2_psi
 
     # Get j > i correlations
     if !using_auto_fermion() && fermionic2
       Op1 = "$Op1 * F"
     end
+
     Li12 = (Li * op(Op1, s, i)) * dag(prime(psi[i]))
-    for j in (i + 1):end_site
-      cj = j - start_site + 1
+    pL12 = i
+
+    for (n,j) in enumerate(sites[ni+1:end])
+      nj = ni+n
+
+      while pL12 < j-1
+        pL12 += 1
+        if !using_auto_fermion() && fermionic2
+          Li12 *= op("F", s[pL12]) * dag(prime(psi[pL12]))
+        else
+          Li12 *= dag(prime(psi[pL12], "Link"))
+        end
+        Li12 *= psi[pL12]
+      end
+
       lind = commonind(psi[j], Li12)
       Li12 *= psi[j]
 
       val = (Li12 * op(Op2, s, j)) * dag(prime(prime(psi[j], "Site"), lind))
-      C[ci, cj] = scalar(val) / norm2_psi
+      C[ni, nj] = scalar(val) / norm2_psi
       if is_cm_hermitian
-        C[cj, ci] = conj(C[ci, cj])
+        C[nj, ni] = conj(C[ni, nj])
       end
 
+      pL12 += 1
       if !using_auto_fermion() && fermionic2
-        Li12 *= op("F", s, j) * dag(prime(psi[j]))
+        Li12 *= op("F", s[pL12]) * dag(prime(psi[pL12]))
       else
-        Li12 *= dag(prime(psi[j], "Link"))
+        Li12 *= dag(prime(psi[pL12], "Link"))
       end
+      @assert pL12 == j
     end #for j
     Op1 = _Op1 #"Restore Op1 with no Fs"
 
@@ -688,31 +716,51 @@ function correlation_matrix(psi::MPS, _Op1::AbstractString, _Op2::AbstractString
         Op2 = "$Op2 * F"
       end
       Li21 = (Li * op(Op2, s, i)) * dag(prime(psi[i]))
+      pL21 = i
       if !using_auto_fermion() && fermionic1
         Li21 = -Li21 #Required because we swapped fermionic ops, instead of sweeping right to left.
       end
-      for j in (i + 1):end_site
-        cj = j - start_site + 1
+
+      for (n,j) in enumerate(sites[ni+1:end])
+        nj = ni+n
+
+        while pL21 < j-1
+          pL21 += 1
+          if !using_auto_fermion() && fermionic1
+            Li21 *= op("F", s[pL21]) * dag(prime(psi[pL21]))
+          else
+            Li21 *= dag(prime(psi[pL21], "Link"))
+          end
+          Li21 *= psi[pL21]
+        end
+
         lind = commonind(psi[j], Li21)
         Li21 *= psi[j]
 
         val = (Li21 * op(Op1, s, j)) * dag(prime(prime(psi[j], "Site"), lind))
-        C[cj, ci] = scalar(val) / norm2_psi
+        C[nj, ni] = scalar(val) / norm2_psi
 
+        pL21 += 1
         if !using_auto_fermion() && fermionic1
-          Li21 *= op("F", s, j) * dag(prime(psi[j]))
+          Li21 *= op("F", s[pL21]) * dag(prime(psi[pL21]))
         else
-          Li21 *= dag(prime(psi[j], "Link"))
+          Li21 *= dag(prime(psi[pL21], "Link"))
         end
+        @assert pL21 == j
       end #for j
       Op2 = _Op2 #"Restore Op2 with no Fs"
     end #if is_cm_hermitian
 
-    L = (L * psi[i]) * dag(prime(psi[i], "Link"))
+    pL += 1
+    L = Li * dag(prime(psi[i], "Link"))
   end #for i
 
   # Get last diagonal element of C
   i = end_site
+  while pL < i-1
+    pL += 1
+    L = (L * psi[pL]) * dag(prime(psi[pL], "Link"))
+  end
   lind = commonind(psi[i], psi[i - 1])
   C[Nb, Nb] =
     scalar(L * psi[i] * op(onsiteOp, s, i) * prime(prime(dag(psi[i]), "Site"), lind)) /

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -653,11 +653,10 @@ function correlation_matrix(psi::MPS, _Op1::AbstractString, _Op2::AbstractString
     lind = commonind(psi[start_site], psi[start_site - 1])
     L = delta(dag(lind), lind')
   end
-  pL = start_site-1
+  pL = start_site - 1
 
-  for (ni,i) in enumerate(sites[1:end-1])
-
-    while pL < i-1
+  for (ni, i) in enumerate(sites[1:(end - 1)])
+    while pL < i - 1
       pL += 1
       L = (L * psi[pL]) * dag(prime(psi[pL], "Link"))
     end
@@ -677,10 +676,10 @@ function correlation_matrix(psi::MPS, _Op1::AbstractString, _Op2::AbstractString
     Li12 = (Li * op(Op1, s, i)) * dag(prime(psi[i]))
     pL12 = i
 
-    for (n,j) in enumerate(sites[ni+1:end])
-      nj = ni+n
+    for (n, j) in enumerate(sites[(ni + 1):end])
+      nj = ni + n
 
-      while pL12 < j-1
+      while pL12 < j - 1
         pL12 += 1
         if !using_auto_fermion() && fermionic2
           Li12 *= op("F", s[pL12]) * dag(prime(psi[pL12]))
@@ -721,10 +720,10 @@ function correlation_matrix(psi::MPS, _Op1::AbstractString, _Op2::AbstractString
         Li21 = -Li21 #Required because we swapped fermionic ops, instead of sweeping right to left.
       end
 
-      for (n,j) in enumerate(sites[ni+1:end])
-        nj = ni+n
+      for (n, j) in enumerate(sites[(ni + 1):end])
+        nj = ni + n
 
-        while pL21 < j-1
+        while pL21 < j - 1
           pL21 += 1
           if !using_auto_fermion() && fermionic1
             Li21 *= op("F", s[pL21]) * dag(prime(psi[pL21]))
@@ -757,7 +756,7 @@ function correlation_matrix(psi::MPS, _Op1::AbstractString, _Op2::AbstractString
 
   # Get last diagonal element of C
   i = end_site
-  while pL < i-1
+  while pL < i - 1
     pL += 1
     L = (L * psi[pL]) * dag(prime(psi[pL], "Link"))
   end

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -267,7 +267,7 @@ function op(name::AbstractString, s::Index...; adjoint::Bool=false, kwargs...)
       op1 = name[1:prevind(name, oploc.start)]
       op2 = name[nextind(name, oploc.start):end]
       if !(op1[end] == ' ' && op2[1] == ' ')
-        @warn "composite op definition `A*B` deprecated: please use `A * B` instead (with spaces)"
+        @warn "($op1*$op2) composite op definition `A*B` deprecated: please use `A * B` instead (with spaces)"
       end
     end
     return product(op(op1, s...; kwargs...), op(op2, s...; kwargs...))

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -579,7 +579,7 @@ function test_correlation_matrix(psi::MPS, ops::Vector{Tuple{String,String}}; kw
       a += op[1], i, op[2], j
       Copsum[i, j] = inner(psi, MPO(a, s), psi)
     end
-    @test Cpm ≈ Copsum
+    @test Cpm ≈ Copsum rtol = 1E-11
     PM = expect(psi, op[1] * " * " * op[2])
     @test norm(PM - diag(Cpm)) < 1E-8
   end

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -580,6 +580,7 @@ function test_correlation_matrix(psi::MPS, ops::Vector{Tuple{String,String}}; kw
       Copsum[i, j] = inner(psi, MPO(a, s), psi)
     end
     @test Cpm ≈ Copsum rtol = 1E-11
+
     PM = expect(psi, op[1] * " * " * op[2])
     @test norm(PM - diag(Cpm)) < 1E-8
   end

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -573,11 +573,11 @@ function test_correlation_matrix(psi::MPS, ops::Vector{Tuple{String,String}}; kw
   for op in ops
     Cpm = correlation_matrix(psi, op[1], op[2]; kwargs...)
     # Check using OpSum:
-    Copsum = 0.0*Cpm
+    Copsum = 0.0 * Cpm
     for i in 1:N, j in 1:N
       a = OpSum()
       a += op[1], i, op[2], j
-      Copsum[i,j] = inner(psi, MPO(a, s), psi)
+      Copsum[i, j] = inner(psi, MPO(a, s), psi)
     end
     @test Cpm ≈ Copsum atol = 5E-15
     PM = expect(psi, op[1] * "*" * op[2])
@@ -879,17 +879,16 @@ end
     #
     # Test non-contiguous sites input
     #
-    C = correlation_matrix(psi,"N","N")
+    C = correlation_matrix(psi, "N", "N")
     display(C)
-    non_contiguous = [1,3,8]
-    Cs = correlation_matrix(psi,"N","N";sites=non_contiguous)
-    for (ni,i) in enumerate(non_contiguous), (nj,j) in enumerate(non_contiguous)
-      @test Cs[ni,nj] ≈ C[i,j]
+    non_contiguous = [1, 3, 8]
+    Cs = correlation_matrix(psi, "N", "N"; sites=non_contiguous)
+    for (ni, i) in enumerate(non_contiguous), (nj, j) in enumerate(non_contiguous)
+      @test Cs[ni, nj] ≈ C[i, j]
     end
 
-    C2 = correlation_matrix(psi,"N","N";sites=2)
-    @test C2[1,1] ≈ C[2,2]
-
+    C2 = correlation_matrix(psi, "N", "N"; sites=2)
+    @test C2[1, 1] ≈ C[2, 2]
   end #testset
 
   @testset "expect regression test for in-place modification of input MPS" begin

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -580,7 +580,7 @@ function test_correlation_matrix(psi::MPS, ops::Vector{Tuple{String,String}}; kw
       Copsum[i, j] = inner(psi, MPO(a, s), psi)
     end
     @test Cpm ≈ Copsum atol = 5E-15
-    PM = expect(psi, op[1] * "*" * op[2])
+    PM = expect(psi, op[1] * " * " * op[2])
     @test norm(PM - diag(Cpm)) < 1E-8
   end
 end
@@ -880,7 +880,6 @@ end
     # Test non-contiguous sites input
     #
     C = correlation_matrix(psi, "N", "N")
-    display(C)
     non_contiguous = [1, 3, 8]
     Cs = correlation_matrix(psi, "N", "N"; sites=non_contiguous)
     for (ni, i) in enumerate(non_contiguous), (nj, j) in enumerate(non_contiguous)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -581,7 +581,7 @@ function test_correlation_matrix(psi::MPS, ops::Vector{Tuple{String,String}}; kw
     end
     @test Cpm ≈ Copsum
     PM = expect(psi, op[1] * " * " * op[2])
-    @test PM ≈ diag(Cpm)
+    @test norm(PM - diag(Cpm)) < 1E-8
   end
 end
 

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -579,9 +579,9 @@ function test_correlation_matrix(psi::MPS, ops::Vector{Tuple{String,String}}; kw
       a += op[1], i, op[2], j
       Copsum[i, j] = inner(psi, MPO(a, s), psi)
     end
-    @test Cpm ≈ Copsum atol = 5E-15
+    @test Cpm ≈ Copsum
     PM = expect(psi, op[1] * " * " * op[2])
-    @test norm(PM - diag(Cpm)) < 1E-8
+    @test PM ≈ diag(Cpm)
   end
 end
 
@@ -887,6 +887,7 @@ end
     end
 
     C2 = correlation_matrix(psi, "N", "N"; sites=2)
+    @test C2 isa Matrix
     @test C2[1, 1] ≈ C[2, 2]
   end #testset
 

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -35,7 +35,7 @@ using ITensors, Test
     @test x ≈ array(op("a - a†", q))
     x = Amat * Adagmat - Adagmat
     @test x ≈ array(op("a * a† - a†", q))
-    @test x ≈ array(op("a*a† - a†", q))
+    @test x ≈ array(op("a * a† - a†", q))
     x = Adagmat * Adagmat * Amat * Amat
     @test x ≈ array(op("a† * a† * a * a", q))
 
@@ -53,10 +53,10 @@ using ITensors, Test
     @test x ≈ array(op("S+ - S- - S+", q))
     x = Sp * Sm + Sm * Sp
     @test x ≈ array(op("S+ * S- + S- * S+", q))
-    @test x ≈ array(op("S+*S- + S-*S+", q))
+    @test x ≈ array(op("S+ * S- + S-*S+", q))
     x = Sp * Sm - Sm * Sp
     @test x ≈ array(op("S+ * S- - S- * S+", q))
-    @test x ≈ array(op("S+* S- - S- * S+", q))
+    @test x ≈ array(op("S+ * S- - S- * S+", q))
     x = Sp * Sm + Sm * Sp + Sz * Sx * Sy
     @test x ≈ array(op("S+ * S- + S- * S+ + Sz * Sx * Sy", q))
     x = Sp * Sm - Sm * Sp + Sz * Sx * Sy


### PR DESCRIPTION
Fixes #850 by implementing a new `sites` keyword argument that also allows non-contiguous ranges (as well as a single number if desired). The older keyword name `site_range` still works as an alias but produces a warning. Added two tests of the new feature.

- Implement non-contiguous sites for correlation_matrix
- Formatting
