### PR TITLE
Remove duplicate definition of + for OpSum (AutoMPO)

### DIFF
--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -141,10 +141,6 @@ function slater_determinant_matrix(h::AbstractMatrix, Nf::Int)
   return u[:, 1:Nf]
 end
 
-function Base.:+(a1::AutoMPO, a2::AutoMPO)
-  return AutoMPO(vcat(a1.data, a2.data))
-end
-
 #
 # Correlation matrix diagonalization
 #


### PR DESCRIPTION
# Description

Removed definition of `+(::AutoMPO, ::AutoMPO)` in gmps.jl that now conflicts with definition of same function in ITensors.jl.

# How Has This Been Tested?

Ran the tests in ITensorGaussianMPS.
