### PR TITLE
Add gmera constructions

### DIFF
--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -8,7 +8,8 @@ using LinearAlgebra
 import LinearAlgebra: Givens
 
 export slater_determinant_to_mps,
-  slater_determinant_to_gmps, hopping_hamiltonian, slater_determinant_matrix, slater_determinant_to_mera
+  slater_determinant_to_gmps, hopping_hamiltonian, slater_determinant_matrix, 
+  slater_determinant_to_gmera, slater_determinant_to_mera
 
 include("gmps.jl")
 include("gmera.jl")

--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 import LinearAlgebra: Givens
 
 export slater_determinant_to_mps,
-  slater_determinant_to_gmps, hopping_hamiltonian, slater_determinant_matrix
+  slater_determinant_to_gmps, hopping_hamiltonian, slater_determinant_matrix, slater_determinant_to_mera
 
 include("gmps.jl")
 include("gmera.jl")

--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -8,8 +8,11 @@ using LinearAlgebra
 import LinearAlgebra: Givens
 
 export slater_determinant_to_mps,
-  slater_determinant_to_gmps, hopping_hamiltonian, slater_determinant_matrix, 
-  slater_determinant_to_gmera, slater_determinant_to_mera
+  slater_determinant_to_gmps,
+  hopping_hamiltonian,
+  slater_determinant_matrix,
+  slater_determinant_to_gmera,
+  slater_determinant_to_mera
 
 include("gmps.jl")
 include("gmera.jl")

--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -11,5 +11,6 @@ export slater_determinant_to_mps,
   slater_determinant_to_gmps, hopping_hamiltonian, slater_determinant_matrix
 
 include("gmps.jl")
+include("gmera.jl")
 
 end

--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -11,8 +11,7 @@ export slater_determinant_to_mps,
   slater_determinant_to_gmps,
   hopping_hamiltonian,
   slater_determinant_matrix,
-  slater_determinant_to_gmera,
-  slater_determinant_to_mera
+  slater_determinant_to_gmera
 
 include("gmps.jl")
 include("gmera.jl")

--- a/ITensorGaussianMPS/src/gmera.jl
+++ b/ITensorGaussianMPS/src/gmera.jl
@@ -1,0 +1,183 @@
+include("gmps.jl")
+
+# brick wall scanning for a single MERA layer with treatment to the tail
+function correlation_matrix_to_gmps_brickwall_tailed(
+    Λ0::AbstractMatrix{ElT}, inds::Vector{Int}; eigval_cutoff::Float64=1e-8, maxblocksize::Int=size(Λ0, 1)
+) where {ElT<:Number}
+    Λ = Hermitian(Λ0)
+    N = size(Λ, 1)
+    V = Circuit{ElT}([])
+    #ns = Vector{real(ElT)}(undef, 2*N)
+    err_tot = 0.0
+    indsnext = Int[]
+    relinds = Int[]
+    for i in 1:N
+        if i % 2 == 0
+            append!(indsnext,inds[i])
+            append!(relinds,i)
+            continue
+        end
+        blocksize = 0
+        n = 0.0
+        err = 0.0
+        p = Int[]
+        uB = 0.0
+        # find the block whose lowest eigenvalue is within torelence
+        for blocksize in 1:maxblocksize
+            j = min(i + blocksize, N)
+            ΛB = deepcopy(Λ[i:j, i:j]) #@view Λ[i:j, i:j] # \LambdaB is still part of Lambda
+            nB, uB = eigen(Hermitian(ΛB))
+            # sort by -(n * log(n) + (1 - n) * log(1 - n)) in ascending order
+            p = sortperm(nB; by=entropy)
+            n = nB[p[1]]
+            err = min(n, 1 - n)
+            err ≤ eigval_cutoff && break
+        end
+        # keep the node if the err cannot be reduced
+        if i + maxblocksize >= N && err > eigval_cutoff
+            append!(indsnext,inds[i])
+            append!(relinds,i)
+            continue
+        end
+        err_tot += err
+        #ns[i] = n # eigenvalue
+        v = deepcopy(uB[:, p[1]]) #@view uB[:, p[1]] # eigenvector of the correlation matrix
+        g, _ = givens_rotations(v) # convert eigenvector into givens rotation
+        shift!(g, i - 1) # shift rotation location
+        # In-place version of:
+        # V = g * V
+        lmul!(g, V)
+        #@show g
+        Λ = Hermitian(g * Λ * g') #isolate current site i
+    end
+    return Λ, V, indsnext, relinds
+end
+
+# shift givens rotation indexes according to the inds 
+function shiftByInds!(G::Circuit, inds::Vector{Int})
+    for (n, g) in enumerate(G.rotations)
+        G.rotations[n] = Givens(inds[g.i1], inds[g.i2], g.c, g.s)
+    end
+  return G
+end
+
+# Combine gates for each MERA layer
+function correlation_matrix_to_gmera_tailed(
+    Λ0::AbstractMatrix{ElT}; eigval_cutoff::Float64=1e-8,maxblocksize::Int=size(Λ0, 1)
+) where {ElT<:Number}
+    Λ = Hermitian(Λ0)
+    N = size(Λ, 1)
+    Nnew = N-1
+    inds = collect(1:N)
+    V = Circuit{ElT}([])
+    Λtemp = deepcopy(Λ)
+    layer = 0                                 # layer label of MERA
+    while N > Nnew # conditioned on the reduction of nodes
+        N = Nnew
+        # indsnext: next layer indexes with original matrix labels
+        # relinds: next layer indexes with labels from the last layer
+        Λr, C, indsnext, relinds = correlation_matrix_to_gmps_brickwall_tailed(
+            Λtemp, inds; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
+        )
+        shiftByInds!(C, inds)    # shift the index back to the original matrix
+        inds = indsnext
+        Λtemp = deepcopy(Λr[relinds,relinds]) # project to even site for next layer based on keeping indexes relinds
+        Nnew = size(Λtemp,1)
+        lmul!(C, V)                           # add vector of givens rotation C into the larger vector V
+        #V = C * V
+        layer += 1
+        #Λ = ITensors.Hermitian(C * Λ * C')
+    end
+    # gmps for the final layer
+    Λr, C = correlation_matrix_to_gmps(
+        Λtemp; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
+    )
+    shiftByInds!(C, inds)
+    lmul!(C, V)
+    Λ = V * Λ0 * V'
+    return Λ, V
+end
+
+
+
+
+
+# output the MPS based on the MERA gates
+function correlation_matrix_to_mera(
+    s::Vector{<:Index},
+    Λ::AbstractMatrix;
+    eigval_cutoff::Float64=1e-8,
+    maxblocksize::Int=size(Λ, 1),
+    kwargs...,
+)
+    @assert size(Λ, 1) == size(Λ, 2)
+    Λdiag, C = correlation_matrix_to_gmera_tailed(
+        Λ; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
+    )
+    #@show C
+    ns = diag(Λdiag)
+    if all(hastags("Fermion"), s)
+        U = [ITensor(s, g) for g in reverse(C.rotations)]
+        ψ = MPS(s, n -> round(Int, ns[n]) + 1, U; kwargs...)
+    elseif all(hastags("Electron"), s)
+        isodd(length(s)) && error(
+          "For Electron type, must have even number of sites of alternating up and down spins.",
+        )
+        N = length(s)
+        if isspinful(s)
+            error(
+            "correlation_matrix_to_mps(Λ::AbstractMatrix) currently only supports spinless Fermions or Electrons that do not conserve Sz. Use correlation_matrix_to_mps(Λ_up::AbstractMatrix, Λ_dn::AbstractMatrix) to use spinful Fermions/Electrons.",
+            )
+        else
+            sf = siteinds("Fermion", 2 * N; conserve_qns=true)
+        end
+        U = [ITensor(sf, g) for g in reverse(C.rotations)]
+        ψf = MPS(sf, n -> round(Int, ns[n]) + 1, U; kwargs...)
+        ψ = MPS(N)
+        for n in 1:N
+            i, j = 2 * n - 1, 2 * n
+            C = combiner(sf[i], sf[j])
+            c = combinedind(C)
+            ψ[n] = ψf[i] * ψf[j] * C
+            ψ[n] *= δ(dag(c), s[n])
+        end
+    else
+        error("All sites must be Fermion or Electron type.")
+    end
+    return ψ
+end
+
+
+function slater_determinant_to_mera(s::Vector{<:Index}, Φ::AbstractMatrix; kwargs...)
+    return correlation_matrix_to_mera(s, conj(Φ) * transpose(Φ); kwargs...)
+end
+
+
+
+
+# G the circuit from the gates, N is the total number of sites
+function UmatFromGates(G::Circuit, N::Int)
+    U = Matrix{Float64}(I, N, N)
+    n = size(G.rotations,1)
+    for k in 1:n
+        rot = G.rotations[k]
+        U = rot * U
+    end
+    return U
+end
+
+# compute the energy of the state based on the gates
+function EfromGates(H::Matrix{<:Number},U::Matrix{<:Number})
+    Htemp = U * H * U'
+    Etot = 0
+    N = size(U, 1)
+    for i in 1:N
+        if Htemp[i,i] < 0.0
+            Etot += Htemp[i,i]
+        end
+    end
+    return Etot
+end
+
+
+

--- a/ITensorGaussianMPS/src/gmera.jl
+++ b/ITensorGaussianMPS/src/gmera.jl
@@ -64,7 +64,7 @@ function shiftByInds!(G::Circuit, inds::Vector{Int})
 end
 
 # Combine gates for each MERA layer
-function correlation_matrix_to_gmera_tailed(
+function correlation_matrix_to_gmera(
   Λ0::AbstractMatrix{ElT}; eigval_cutoff::Float64=1e-8, maxblocksize::Int=size(Λ0, 1)
 ) where {ElT<:Number}
   Λ = Hermitian(Λ0)
@@ -109,7 +109,7 @@ function correlation_matrix_to_mera(
   kwargs...,
 )
   @assert size(Λ, 1) == size(Λ, 2)
-  Λdiag, C = correlation_matrix_to_gmera_tailed(
+  Λdiag, C = correlation_matrix_to_gmera(
     Λ; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
   )
   #@show C

--- a/ITensorGaussianMPS/src/gmera.jl
+++ b/ITensorGaussianMPS/src/gmera.jl
@@ -2,182 +2,174 @@ include("gmps.jl")
 
 # brick wall scanning for a single MERA layer with treatment to the tail
 function correlation_matrix_to_gmps_brickwall_tailed(
-    Λ0::AbstractMatrix{ElT}, inds::Vector{Int}; eigval_cutoff::Float64=1e-8, maxblocksize::Int=size(Λ0, 1)
+  Λ0::AbstractMatrix{ElT},
+  inds::Vector{Int};
+  eigval_cutoff::Float64=1e-8,
+  maxblocksize::Int=size(Λ0, 1),
 ) where {ElT<:Number}
-    Λ = Hermitian(Λ0)
-    N = size(Λ, 1)
-    V = Circuit{ElT}([])
-    #ns = Vector{real(ElT)}(undef, 2*N)
-    err_tot = 0.0
-    indsnext = Int[]
-    relinds = Int[]
-    for i in 1:N
-        if i % 2 == 0
-            append!(indsnext,inds[i])
-            append!(relinds,i)
-            continue
-        end
-        blocksize = 0
-        n = 0.0
-        err = 0.0
-        p = Int[]
-        uB = 0.0
-        # find the block whose lowest eigenvalue is within torelence
-        for blocksize in 1:maxblocksize
-            j = min(i + blocksize, N)
-            ΛB = deepcopy(Λ[i:j, i:j]) #@view Λ[i:j, i:j] # \LambdaB is still part of Lambda
-            nB, uB = eigen(Hermitian(ΛB))
-            # sort by -(n * log(n) + (1 - n) * log(1 - n)) in ascending order
-            p = sortperm(nB; by=entropy)
-            n = nB[p[1]]
-            err = min(n, 1 - n)
-            err ≤ eigval_cutoff && break
-        end
-        # keep the node if the err cannot be reduced
-        if i + maxblocksize >= N && err > eigval_cutoff
-            append!(indsnext,inds[i])
-            append!(relinds,i)
-            continue
-        end
-        err_tot += err
-        #ns[i] = n # eigenvalue
-        v = deepcopy(uB[:, p[1]]) #@view uB[:, p[1]] # eigenvector of the correlation matrix
-        g, _ = givens_rotations(v) # convert eigenvector into givens rotation
-        shift!(g, i - 1) # shift rotation location
-        # In-place version of:
-        # V = g * V
-        lmul!(g, V)
-        #@show g
-        Λ = Hermitian(g * Λ * g') #isolate current site i
+  Λ = Hermitian(Λ0)
+  N = size(Λ, 1)
+  V = Circuit{ElT}([])
+  #ns = Vector{real(ElT)}(undef, 2*N)
+  err_tot = 0.0
+  indsnext = Int[]
+  relinds = Int[]
+  for i in 1:N
+    if i % 2 == 0
+      append!(indsnext, inds[i])
+      append!(relinds, i)
+      continue
     end
-    return Λ, V, indsnext, relinds
+    blocksize = 0
+    n = 0.0
+    err = 0.0
+    p = Int[]
+    uB = 0.0
+    # find the block whose lowest eigenvalue is within torelence
+    for blocksize in 1:maxblocksize
+      j = min(i + blocksize, N)
+      ΛB = deepcopy(Λ[i:j, i:j]) #@view Λ[i:j, i:j] # \LambdaB is still part of Lambda
+      nB, uB = eigen(Hermitian(ΛB))
+      # sort by -(n * log(n) + (1 - n) * log(1 - n)) in ascending order
+      p = sortperm(nB; by=entropy)
+      n = nB[p[1]]
+      err = min(n, 1 - n)
+      err ≤ eigval_cutoff && break
+    end
+    # keep the node if the err cannot be reduced
+    if i + maxblocksize >= N && err > eigval_cutoff
+      append!(indsnext, inds[i])
+      append!(relinds, i)
+      continue
+    end
+    err_tot += err
+    #ns[i] = n # eigenvalue
+    v = deepcopy(uB[:, p[1]]) #@view uB[:, p[1]] # eigenvector of the correlation matrix
+    g, _ = givens_rotations(v) # convert eigenvector into givens rotation
+    shift!(g, i - 1) # shift rotation location
+    # In-place version of:
+    # V = g * V
+    lmul!(g, V)
+    #@show g
+    Λ = Hermitian(g * Λ * g') #isolate current site i
+  end
+  return Λ, V, indsnext, relinds
 end
 
 # shift givens rotation indexes according to the inds 
 function shiftByInds!(G::Circuit, inds::Vector{Int})
-    for (n, g) in enumerate(G.rotations)
-        G.rotations[n] = Givens(inds[g.i1], inds[g.i2], g.c, g.s)
-    end
+  for (n, g) in enumerate(G.rotations)
+    G.rotations[n] = Givens(inds[g.i1], inds[g.i2], g.c, g.s)
+  end
   return G
 end
 
 # Combine gates for each MERA layer
 function correlation_matrix_to_gmera_tailed(
-    Λ0::AbstractMatrix{ElT}; eigval_cutoff::Float64=1e-8,maxblocksize::Int=size(Λ0, 1)
+  Λ0::AbstractMatrix{ElT}; eigval_cutoff::Float64=1e-8, maxblocksize::Int=size(Λ0, 1)
 ) where {ElT<:Number}
-    Λ = Hermitian(Λ0)
-    N = size(Λ, 1)
-    Nnew = N-1
-    inds = collect(1:N)
-    V = Circuit{ElT}([])
-    Λtemp = deepcopy(Λ)
-    layer = 0                                 # layer label of MERA
-    while N > Nnew # conditioned on the reduction of nodes
-        N = Nnew
-        # indsnext: next layer indexes with original matrix labels
-        # relinds: next layer indexes with labels from the last layer
-        Λr, C, indsnext, relinds = correlation_matrix_to_gmps_brickwall_tailed(
-            Λtemp, inds; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
-        )
-        shiftByInds!(C, inds)    # shift the index back to the original matrix
-        inds = indsnext
-        Λtemp = deepcopy(Λr[relinds,relinds]) # project to even site for next layer based on keeping indexes relinds
-        Nnew = size(Λtemp,1)
-        lmul!(C, V)                           # add vector of givens rotation C into the larger vector V
-        #V = C * V
-        layer += 1
-        #Λ = ITensors.Hermitian(C * Λ * C')
-    end
-    # gmps for the final layer
-    Λr, C = correlation_matrix_to_gmps(
-        Λtemp; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
+  Λ = Hermitian(Λ0)
+  N = size(Λ, 1)
+  Nnew = N - 1
+  inds = collect(1:N)
+  V = Circuit{ElT}([])
+  Λtemp = deepcopy(Λ)
+  layer = 0                                 # layer label of MERA
+  while N > Nnew # conditioned on the reduction of nodes
+    N = Nnew
+    # indsnext: next layer indexes with original matrix labels
+    # relinds: next layer indexes with labels from the last layer
+    Λr, C, indsnext, relinds = correlation_matrix_to_gmps_brickwall_tailed(
+      Λtemp, inds; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
     )
-    shiftByInds!(C, inds)
-    lmul!(C, V)
-    Λ = V * Λ0 * V'
-    return Λ, V
+    shiftByInds!(C, inds)    # shift the index back to the original matrix
+    inds = indsnext
+    Λtemp = deepcopy(Λr[relinds, relinds]) # project to even site for next layer based on keeping indexes relinds
+    Nnew = size(Λtemp, 1)
+    lmul!(C, V)                           # add vector of givens rotation C into the larger vector V
+    #V = C * V
+    layer += 1
+    #Λ = ITensors.Hermitian(C * Λ * C')
+  end
+  # gmps for the final layer
+  Λr, C = correlation_matrix_to_gmps(
+    Λtemp; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
+  )
+  shiftByInds!(C, inds)
+  lmul!(C, V)
+  Λ = V * Λ0 * V'
+  return Λ, V
 end
-
-
-
-
 
 # output the MPS based on the MERA gates
 function correlation_matrix_to_mera(
-    s::Vector{<:Index},
-    Λ::AbstractMatrix;
-    eigval_cutoff::Float64=1e-8,
-    maxblocksize::Int=size(Λ, 1),
-    kwargs...,
+  s::Vector{<:Index},
+  Λ::AbstractMatrix;
+  eigval_cutoff::Float64=1e-8,
+  maxblocksize::Int=size(Λ, 1),
+  kwargs...,
 )
-    @assert size(Λ, 1) == size(Λ, 2)
-    Λdiag, C = correlation_matrix_to_gmera_tailed(
-        Λ; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
+  @assert size(Λ, 1) == size(Λ, 2)
+  Λdiag, C = correlation_matrix_to_gmera_tailed(
+    Λ; eigval_cutoff=eigval_cutoff, maxblocksize=maxblocksize
+  )
+  #@show C
+  ns = diag(Λdiag)
+  if all(hastags("Fermion"), s)
+    U = [ITensor(s, g) for g in reverse(C.rotations)]
+    ψ = MPS(s, n -> round(Int, ns[n]) + 1, U; kwargs...)
+  elseif all(hastags("Electron"), s)
+    isodd(length(s)) && error(
+      "For Electron type, must have even number of sites of alternating up and down spins.",
     )
-    #@show C
-    ns = diag(Λdiag)
-    if all(hastags("Fermion"), s)
-        U = [ITensor(s, g) for g in reverse(C.rotations)]
-        ψ = MPS(s, n -> round(Int, ns[n]) + 1, U; kwargs...)
-    elseif all(hastags("Electron"), s)
-        isodd(length(s)) && error(
-          "For Electron type, must have even number of sites of alternating up and down spins.",
-        )
-        N = length(s)
-        if isspinful(s)
-            error(
-            "correlation_matrix_to_mps(Λ::AbstractMatrix) currently only supports spinless Fermions or Electrons that do not conserve Sz. Use correlation_matrix_to_mps(Λ_up::AbstractMatrix, Λ_dn::AbstractMatrix) to use spinful Fermions/Electrons.",
-            )
-        else
-            sf = siteinds("Fermion", 2 * N; conserve_qns=true)
-        end
-        U = [ITensor(sf, g) for g in reverse(C.rotations)]
-        ψf = MPS(sf, n -> round(Int, ns[n]) + 1, U; kwargs...)
-        ψ = MPS(N)
-        for n in 1:N
-            i, j = 2 * n - 1, 2 * n
-            C = combiner(sf[i], sf[j])
-            c = combinedind(C)
-            ψ[n] = ψf[i] * ψf[j] * C
-            ψ[n] *= δ(dag(c), s[n])
-        end
+    N = length(s)
+    if isspinful(s)
+      error(
+        "correlation_matrix_to_mps(Λ::AbstractMatrix) currently only supports spinless Fermions or Electrons that do not conserve Sz. Use correlation_matrix_to_mps(Λ_up::AbstractMatrix, Λ_dn::AbstractMatrix) to use spinful Fermions/Electrons.",
+      )
     else
-        error("All sites must be Fermion or Electron type.")
+      sf = siteinds("Fermion", 2 * N; conserve_qns=true)
     end
-    return ψ
+    U = [ITensor(sf, g) for g in reverse(C.rotations)]
+    ψf = MPS(sf, n -> round(Int, ns[n]) + 1, U; kwargs...)
+    ψ = MPS(N)
+    for n in 1:N
+      i, j = 2 * n - 1, 2 * n
+      C = combiner(sf[i], sf[j])
+      c = combinedind(C)
+      ψ[n] = ψf[i] * ψf[j] * C
+      ψ[n] *= δ(dag(c), s[n])
+    end
+  else
+    error("All sites must be Fermion or Electron type.")
+  end
+  return ψ
 end
-
 
 function slater_determinant_to_mera(s::Vector{<:Index}, Φ::AbstractMatrix; kwargs...)
-    return correlation_matrix_to_mera(s, conj(Φ) * transpose(Φ); kwargs...)
+  return correlation_matrix_to_mera(s, conj(Φ) * transpose(Φ); kwargs...)
 end
-
-
-
 
 # G the circuit from the gates, N is the total number of sites
 function UmatFromGates(G::Circuit, N::Int)
-    U = Matrix{Float64}(I, N, N)
-    n = size(G.rotations,1)
-    for k in 1:n
-        rot = G.rotations[k]
-        U = rot * U
-    end
-    return U
+  U = Matrix{Float64}(I, N, N)
+  n = size(G.rotations, 1)
+  for k in 1:n
+    rot = G.rotations[k]
+    U = rot * U
+  end
+  return U
 end
 
 # compute the energy of the state based on the gates
-function EfromGates(H::Matrix{<:Number},U::Matrix{<:Number})
-    Htemp = U * H * U'
-    Etot = 0
-    N = size(U, 1)
-    for i in 1:N
-        if Htemp[i,i] < 0.0
-            Etot += Htemp[i,i]
-        end
+function EfromGates(H::Matrix{<:Number}, U::Matrix{<:Number})
+  Htemp = U * H * U'
+  Etot = 0
+  N = size(U, 1)
+  for i in 1:N
+    if Htemp[i, i] < 0.0
+      Etot += Htemp[i, i]
     end
-    return Etot
+  end
+  return Etot
 end
-
-
-

--- a/ITensorGaussianMPS/src/gmera.jl
+++ b/ITensorGaussianMPS/src/gmera.jl
@@ -105,11 +105,13 @@ function correlation_matrix_to_gmera(
   return ns, V
 end
 
-# output the MPS based on the MERA gates
+# output the MERA gates and eigenvalues of correlation matrix from WF
 function slater_determinant_to_gmera(Φ::AbstractMatrix; kwargs...)
   return correlation_matrix_to_gmera(conj(Φ) * transpose(Φ); kwargs...)
 end
 
+#=
+# ouput the MPS based on the MERA gates
 function correlation_matrix_to_mera(
   s::Vector{<:Index},
   Λ::AbstractMatrix;
@@ -151,10 +153,10 @@ function correlation_matrix_to_mera(
   end
   return ψ
 end
-
 function slater_determinant_to_mera(s::Vector{<:Index}, Φ::AbstractMatrix; kwargs...)
   return correlation_matrix_to_mera(s, conj(Φ) * transpose(Φ); kwargs...)
 end
+=#
 
 # G the circuit from the gates, N is the total number of sites
 function UmatFromGates(G::Circuit, N::Int)

--- a/ITensorGaussianMPS/src/gmera.jl
+++ b/ITensorGaussianMPS/src/gmera.jl
@@ -110,7 +110,6 @@ function slater_determinant_to_gmera(Φ::AbstractMatrix; kwargs...)
   return correlation_matrix_to_gmera(conj(Φ) * transpose(Φ); kwargs...)
 end
 
-#=
 # ouput the MPS based on the MERA gates
 function correlation_matrix_to_mera(
   s::Vector{<:Index},
@@ -153,10 +152,10 @@ function correlation_matrix_to_mera(
   end
   return ψ
 end
+
 function slater_determinant_to_mera(s::Vector{<:Index}, Φ::AbstractMatrix; kwargs...)
   return correlation_matrix_to_mera(s, conj(Φ) * transpose(Φ); kwargs...)
 end
-=#
 
 # G the circuit from the gates, N is the total number of sites
 function UmatFromGates(G::Circuit, N::Int)

--- a/ITensorGaussianMPS/src/gmera.jl
+++ b/ITensorGaussianMPS/src/gmera.jl
@@ -1,4 +1,3 @@
-include("gmps.jl")
 
 # brick wall scanning for a single MERA layer with treatment to the tail
 function correlation_matrix_to_gmps_brickwall_tailed(

--- a/ITensorGaussianMPS/src/gmera.jl
+++ b/ITensorGaussianMPS/src/gmera.jl
@@ -62,7 +62,6 @@ function shiftByInds!(G::Circuit, inds::Vector{Int})
   return G
 end
 
-
 """
     correlation_matrix_to_gmera(Λ::AbstractMatrix{ElT}; eigval_cutoff::Float64 = 1e-8, maxblocksize::Int = size(Λ0, 1))
 Diagonalize a correlation matrix through MERA layers,
@@ -110,7 +109,6 @@ end
 function slater_determinant_to_gmera(Φ::AbstractMatrix; kwargs...)
   return correlation_matrix_to_gmera(conj(Φ) * transpose(Φ); kwargs...)
 end
-
 
 function correlation_matrix_to_mera(
   s::Vector{<:Index},

--- a/ITensorGaussianMPS/test/gmera.jl
+++ b/ITensorGaussianMPS/test/gmera.jl
@@ -1,0 +1,182 @@
+using ITensorGaussianMPS
+using ITensors
+using LinearAlgebra
+using Test
+
+@testset "Basic" begin
+  # Test Givens rotations
+  v = randn(6)
+  g, r = ITensorGaussianMPS.givens_rotations(v)
+  @test g * v ≈ r * [n == 1 ? 1 : 0 for n in 1:length(v)]
+end
+
+@testset "Fermion" begin
+  N = 10
+  Nf = N ÷ 2
+
+  # Hopping
+  t = 1.0
+
+  # Hopping Hamiltonian
+  h = Hermitian(diagm(1 => fill(-t, N - 1), -1 => fill(-t, N - 1)))
+  e, u = eigen(h)
+
+  @test h * u ≈ u * Diagonal(e)
+
+  E = sum(e[1:Nf])
+
+  # Get the Slater determinant
+  Φ = u[:, 1:Nf]
+  @test h * Φ ≈ Φ * Diagonal(e[1:Nf])
+
+  # Diagonalize the correlation matrix as a
+  # Gaussian MPS (GMPS)
+  n, gmps = slater_determinant_to_gmera(Φ; maxblocksize=10)
+
+  ns = round.(Int, n)
+  @test sum(ns) == Nf
+  
+  Λ = conj(Φ) * transpose(Φ)
+  @test gmps * Λ * gmps' ≈ Diagonal(ns) rtol = 1e-2
+  @test gmps' * Diagonal(ns) * gmps ≈ Λ rtol = 1e-2
+
+  # Form the MPS
+  s = siteinds("Fermion", N; conserve_qns=true)
+  ψ = slater_determinant_to_mps(s, Φ; blocksize=4)
+
+  os = OpSum()
+  for i in 1:N, j in 1:N
+    if h[i, j] ≠ 0
+      os .+= h[i, j], "Cdag", i, "C", j
+    end
+  end
+  H = MPO(os, s)
+
+  @test inner(ψ, H, ψ) ≈ E rtol = 1e-5
+
+  # Compare to DMRG
+  sweeps = Sweeps(10)
+  setmaxdim!(sweeps, 10, 20, 40, 60)
+  setcutoff!(sweeps, 1E-12)
+  energy, ψ̃ = dmrg(H, productMPS(s, n -> n ≤ Nf ? "1" : "0"), sweeps; outputlevel=0)
+
+  # Create an mps
+  @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
+  @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
+  @test E ≈ energy
+end
+
+@testset "Fermion (complex)" begin
+  N = 10
+  Nf = N ÷ 2
+
+  # Hopping
+  θ = π / 8
+  t = exp(im * θ)
+
+  # Hopping Hamiltonian
+  h = Hermitian(diagm(1 => fill(-t, N - 1), -1 => fill(-conj(t), N - 1)))
+  e, u = eigen(h)
+
+  @test h * u ≈ u * Diagonal(e)
+
+  E = sum(e[1:Nf])
+
+  # Get the Slater determinant
+  Φ = u[:, 1:Nf]
+  @test h * Φ ≈ Φ * Diagonal(e[1:Nf])
+
+  # Diagonalize the correlation matrix as a
+  # Gaussian MPS (GMPS)
+  n, gmps = slater_determinant_to_gmera(Φ; maxblocksize=4)
+
+  ns = round.(Int, n)
+  @test sum(ns) == Nf
+
+  Λ = conj(Φ) * transpose(Φ)
+  @test gmps * Λ * gmps' ≈ Diagonal(ns) rtol = 1e-2
+  @test gmps' * Diagonal(ns) * gmps ≈ Λ rtol = 1e-2
+
+  # Form the MPS
+  s = siteinds("Fermion", N; conserve_qns=true)
+  ψ = slater_determinant_to_mera(s, Φ; blocksize=4)
+
+  os = OpSum()
+  for i in 1:N, j in 1:N
+    if h[i, j] ≠ 0
+      os .+= h[i, j], "Cdag", i, "C", j
+    end
+  end
+  H = MPO(os, s)
+
+  @test inner(ψ, H, ψ) ≈ E rtol = 1e-5
+  @test inner(ψ, H, ψ) / norm(ψ) ≈ E rtol = 1e-5
+
+  # Compare to DMRG
+  sweeps = Sweeps(10)
+  setmaxdim!(sweeps, 10, 20, 40, 60)
+  setcutoff!(sweeps, 1E-12)
+  energy, ψ̃ = dmrg(H, productMPS(s, n -> n ≤ Nf ? "1" : "0"), sweeps; outputlevel=0)
+
+  # Create an mps
+  @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
+  @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
+  @test E ≈ energy
+end
+
+
+# Build 1-d SSH model
+function SSH1dModel(N::Int, t::Float64, vardelta::Float64)
+  # N should be even
+  s = siteinds("Fermion", N; conserve_qns=true)
+  limit = div(N-1,2)
+  t1 = -t * (1+vardelta/2)
+  t2 = -t * (1-vardelta/2)
+  os = OpSum()
+  for n in 1:limit
+      os .+= t1, "Cdag", 2*n-1, "C", 2*n
+      os .+= t1, "Cdag", 2*n, "C", 2*n-1
+      os .+= t2, "Cdag", 2*n, "C", 2*n+1
+      os .+= t2, "Cdag", 2*n+1, "C", 2*n
+  end
+  if N % 2 == 0
+      os .+= t1, "Cdag", N-1, "C", N
+      os .+= t1, "Cdag", N, "C", N-1
+  end
+  h = hopping_hamiltonian(os)
+  H = MPO(os, s)
+  #display(t1)
+  return (h, H, s)
+end
+
+
+@testset "Energy" begin
+  N = 2^4
+  Nf = div(N,2)
+  t = 1.0
+  gapsize = 0
+  vardelta = gapsize / 2
+  h, H, s = SSH1dModel(N, t, vardelta) 
+
+  Φ = slater_determinant_matrix(h, Nf)
+  E,V = eigen(h)
+  sort(E)
+  Eana = sum(E[1:Nf])
+
+  Λ0 = Φ * Φ'
+  @test Eana ≈ tr(h * Λ0) rtol = 1e-5
+  # Diagonalize the correlation matrix as a
+  # Gaussian MPS (GMPS) and GMERA
+  ngmps, V1 = ITensorGaussianMPS.correlation_matrix_to_gmps(Λ0; eigval_cutoff=1e-8)
+  nmera, V1 = ITensorGaussianMPS.correlation_matrix_to_gmera(Λ0; eigval_cutoff=1e-8)#,maxblocksize=6)
+  @test sum(round.(Int, nmera)) == sum(round.(Int, ngmps))
+
+  U = ITensorGaussianMPS.UmatFromGates(V1, N)
+  Etest = ITensorGaussianMPS.EfromGates(h,U)
+
+  @test Eana ≈ Etest rtol = 1e-5
+
+  
+  
+end
+

--- a/ITensorGaussianMPS/test/gmera.jl
+++ b/ITensorGaussianMPS/test/gmera.jl
@@ -40,10 +40,9 @@ end
   @test gmps * Λ * gmps' ≈ Diagonal(ns) rtol = 1e-2
   @test gmps' * Diagonal(ns) * gmps ≈ Λ rtol = 1e-2
 
-  #=
   # Form the MPS
   s = siteinds("Fermion", N; conserve_qns=true)
-  ψ = slater_determinant_to_mps(s, Φ; blocksize=4)
+  ψ = ITensorGaussianMPS.slater_determinant_to_mera(s, Φ; blocksize=4)
 
   os = OpSum()
   for i in 1:N, j in 1:N
@@ -65,7 +64,6 @@ end
   @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
   @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
   @test E ≈ energy
-  =#
 end
 
 @testset "Fermion (complex)" begin
@@ -99,10 +97,9 @@ end
   @test gmps * Λ * gmps' ≈ Diagonal(ns) rtol = 1e-2
   @test gmps' * Diagonal(ns) * gmps ≈ Λ rtol = 1e-2
 
-  #=
   # Form the MPS
   s = siteinds("Fermion", N; conserve_qns=true)
-  ψ = slater_determinant_to_mera(s, Φ; blocksize=4)
+  ψ = ITensorGaussianMPS.slater_determinant_to_mera(s, Φ; blocksize=4)
 
   os = OpSum()
   for i in 1:N, j in 1:N
@@ -125,7 +122,6 @@ end
   @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
   @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
   @test E ≈ energy
-  =#
 end
 
 # Build 1-d SSH model

--- a/ITensorGaussianMPS/test/gmera.jl
+++ b/ITensorGaussianMPS/test/gmera.jl
@@ -35,7 +35,7 @@ end
 
   ns = round.(Int, n)
   @test sum(ns) == Nf
-  
+
   Λ = conj(Φ) * transpose(Φ)
   @test gmps * Λ * gmps' ≈ Diagonal(ns) rtol = 1e-2
   @test gmps' * Diagonal(ns) * gmps ≈ Λ rtol = 1e-2
@@ -124,24 +124,23 @@ end
   @test E ≈ energy
 end
 
-
 # Build 1-d SSH model
 function SSH1dModel(N::Int, t::Float64, vardelta::Float64)
   # N should be even
   s = siteinds("Fermion", N; conserve_qns=true)
-  limit = div(N-1,2)
-  t1 = -t * (1+vardelta/2)
-  t2 = -t * (1-vardelta/2)
+  limit = div(N - 1, 2)
+  t1 = -t * (1 + vardelta / 2)
+  t2 = -t * (1 - vardelta / 2)
   os = OpSum()
   for n in 1:limit
-      os .+= t1, "Cdag", 2*n-1, "C", 2*n
-      os .+= t1, "Cdag", 2*n, "C", 2*n-1
-      os .+= t2, "Cdag", 2*n, "C", 2*n+1
-      os .+= t2, "Cdag", 2*n+1, "C", 2*n
+    os .+= t1, "Cdag", 2 * n - 1, "C", 2 * n
+    os .+= t1, "Cdag", 2 * n, "C", 2 * n - 1
+    os .+= t2, "Cdag", 2 * n, "C", 2 * n + 1
+    os .+= t2, "Cdag", 2 * n + 1, "C", 2 * n
   end
   if N % 2 == 0
-      os .+= t1, "Cdag", N-1, "C", N
-      os .+= t1, "Cdag", N, "C", N-1
+    os .+= t1, "Cdag", N - 1, "C", N
+    os .+= t1, "Cdag", N, "C", N - 1
   end
   h = hopping_hamiltonian(os)
   H = MPO(os, s)
@@ -149,17 +148,16 @@ function SSH1dModel(N::Int, t::Float64, vardelta::Float64)
   return (h, H, s)
 end
 
-
 @testset "Energy" begin
   N = 2^4
-  Nf = div(N,2)
+  Nf = div(N, 2)
   t = 1.0
   gapsize = 0
   vardelta = gapsize / 2
-  h, H, s = SSH1dModel(N, t, vardelta) 
+  h, H, s = SSH1dModel(N, t, vardelta)
 
   Φ = slater_determinant_matrix(h, Nf)
-  E,V = eigen(h)
+  E, V = eigen(h)
   sort(E)
   Eana = sum(E[1:Nf])
 
@@ -172,11 +170,7 @@ end
   @test sum(round.(Int, nmera)) == sum(round.(Int, ngmps))
 
   U = ITensorGaussianMPS.UmatFromGates(V1, N)
-  Etest = ITensorGaussianMPS.EfromGates(h,U)
+  Etest = ITensorGaussianMPS.EfromGates(h, U)
 
   @test Eana ≈ Etest rtol = 1e-5
-
-  
-  
 end
-

--- a/ITensorGaussianMPS/test/gmera.jl
+++ b/ITensorGaussianMPS/test/gmera.jl
@@ -30,7 +30,7 @@ end
   @test h * Φ ≈ Φ * Diagonal(e[1:Nf])
 
   # Diagonalize the correlation matrix as a
-  # Gaussian MPS (GMPS)
+  # Gaussian MPS (GMPS) gates
   n, gmps = slater_determinant_to_gmera(Φ; maxblocksize=10)
 
   ns = round.(Int, n)
@@ -40,6 +40,7 @@ end
   @test gmps * Λ * gmps' ≈ Diagonal(ns) rtol = 1e-2
   @test gmps' * Diagonal(ns) * gmps ≈ Λ rtol = 1e-2
 
+  #=
   # Form the MPS
   s = siteinds("Fermion", N; conserve_qns=true)
   ψ = slater_determinant_to_mps(s, Φ; blocksize=4)
@@ -64,6 +65,7 @@ end
   @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
   @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
   @test E ≈ energy
+  =#
 end
 
 @testset "Fermion (complex)" begin
@@ -97,6 +99,7 @@ end
   @test gmps * Λ * gmps' ≈ Diagonal(ns) rtol = 1e-2
   @test gmps' * Diagonal(ns) * gmps ≈ Λ rtol = 1e-2
 
+  #=
   # Form the MPS
   s = siteinds("Fermion", N; conserve_qns=true)
   ψ = slater_determinant_to_mera(s, Φ; blocksize=4)
@@ -122,6 +125,7 @@ end
   @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
   @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
   @test E ≈ energy
+  =#
 end
 
 # Build 1-d SSH model


### PR DESCRIPTION
# Description

Add the MERA construction to the Fermionic Gaussian MPS.

# How Has This Been Tested?

Test with a simple 1-D hopping Hamiltonian and compare with the gmps
Codes:
```julia
N = 2^4
Nf = N ÷ 2
t = 1
os = OpSum()
for n in 1:(N-1)
	os .+= -t, "Cdag", n, "C", n+1
	os .+= -t, "Cdag", n+1, "C", n
end

h = hopping_hamiltonian(os)
Φ = slater_determinant_matrix(h, Nf)
Λ0 = Φ * Φ'

Λ1, V1 = correlation_matrix_to_gmera_tailed(Λ0; eigval_cutoff=1e-8)#,maxblocksize=6)
Λmasked, V1 = correlation_matrix_to_gmps(Λ0; eigval_cutoff=1e-8)

display(Λ1)
display(Λmasked)
```

# Checklist:

- [Yes] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [Yes] I have performed a self-review of my own code.
- [Yes] I have commented my code, particularly in hard-to-understand areas.
- [No] I have made corresponding changes to the documentation.
- [Yes ] My changes generate no new warnings.
- [Yes] Any dependent changes have been merged and published in downstream modules.
