### PR TITLE
Define rmul! for AbstractMPS

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1555,6 +1555,8 @@ Currently, this works by scaling one of the sites within the orthogonality limit
 
 -(ψ::AbstractMPS) = -1 * ψ
 
+LinearAlgebra.rmul!(ψ::AbstractMPS, α::Number) = _apply_to_orthocenter!(*, ψ, α)
+
 """
     setindex!(::Union{MPS, MPO}, ::Union{MPS, MPO},
               r::UnitRange{Int64})


### PR DESCRIPTION
# Description

Defined `LinearAlgebra.rmul!(::MPS,::Number)` in terms of `_apply_to_orthocenter!`. The need for this function is that OptimKit requires it for the application of using AD to optimize the overlap of two MPS.

# How Has This Been Tested?

Just indirectly through some driver code that is doing AD on the overlap of two MPS. Maybe we should add an explicit test? But it is just a simple pass-through to `_apply_to_orthocenter!`.
