### PR TITLE
[NDTensors] [ENHANCEMENT] Add fallbacks for when LAPACK SVD fails

### DIFF
--- a/NDTensors/src/linearalgebra.jl
+++ b/NDTensors/src/linearalgebra.jl
@@ -127,8 +127,23 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT}; kwargs...) where {ElT,In
   #@timeit_debug timer "dense svd" begin
   if alg == "divide_and_conquer"
     MUSV = svd_catch_error(matrix(T); alg=LinearAlgebra.DivideAndConquer())
+    if isnothing(MUSV)
+      # If "divide_and_conquer" fails, try "qr_iteration"
+      alg = "qr_iteration"
+      MUSV = svd_catch_error(matrix(T); alg=LinearAlgebra.QRIteration())
+      if isnothing(MUSV)
+        # If "qr_iteration" fails, try "recursive"
+        alg = "recursive"
+        MUSV = svd_recursive(matrix(T))
+      end
+    end
   elseif alg == "qr_iteration"
     MUSV = svd_catch_error(matrix(T); alg=LinearAlgebra.QRIteration())
+    if isnothing(MUSV)
+      # If "qr_iteration" fails, try "recursive"
+      alg = "recursive"
+      MUSV = svd_recursive(matrix(T))
+    end
   elseif alg == "recursive"
     MUSV = svd_recursive(matrix(T))
   else

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -73,23 +73,23 @@ include("util.jl")
   end
 
   # TODO: remove this test, it takes a long time
-  @testset "Ill-conditioned matrix" begin
-    d = 5000
-    i = Index(d, "i")
-    T = itensor(make_illconditioned_matrix(dim(i)), i', i)
+  ## @testset "Ill-conditioned matrix" begin
+  ##   d = 5000
+  ##   i = Index(d, "i")
+  ##   T = itensor(make_illconditioned_matrix(dim(i)), i', i)
 
-    @suppress begin
-      F = svd(T, i'; alg="divide_and_conquer")
-    end
-    # Depending on the LAPACK implementation,
-    # this sometimes works so don't test it
-    #@test isnothing(F)
+  ##   @suppress begin
+  ##     F = svd(T, i'; alg="divide_and_conquer")
+  ##   end
+  ##   # Depending on the LAPACK implementation,
+  ##   # this sometimes works so don't test it
+  ##   #@test isnothing(F)
 
-    # XXX: This fails on Windows, removing for now.
-    # F = svd(T, i'; alg="qr_iteration")
-    # @test !isnothing(F)
-    # @test F.U * F.S * F.V ≈ T
-  end
+  ##   # XXX: This fails on Windows, removing for now.
+  ##   # F = svd(T, i'; alg="qr_iteration")
+  ##   # @test !isnothing(F)
+  ##   # @test F.U * F.S * F.V ≈ T
+  ## end
 end
 
 nothing


### PR DESCRIPTION
# Description

Add fallbacks for when LAPACK SVD fails. For example, if the `"divide_and_conquer"` (LAPACK's gesdd) algorithm fails, it falls back to `"qr_iteration"` (LAPACK's gesvd), and if that fails it falls back to `"recursive"` (ITensor's custom SVD that recursively performs eigendcompositions to get U and QRs to get V).
