### PR TITLE
[ITensors] [ENHANCMENT] Introduce `Algorithm` type for selecting algorithm backends

### DIFF
--- a/ITensorGPU/test/test_cumpo.jl
+++ b/ITensorGPU/test/test_cumpo.jl
@@ -101,7 +101,7 @@ using ITensors, ITensorGPU, Test
     psi = randomCuMPS(sites)
     psi_out = contract(K, psi; maxdim=1)
     @test inner(phi', psi_out) ≈ inner(phi', K, psi)
-    @test_throws ArgumentError contract(K', psi, method="fakemethod")
+    @test_throws MethodError contract(K', psi, method="fakemethod")
 
     badsites = [Index(2, "Site") for n in 1:(N + 1)]
     badpsi = randomCuMPS(badsites)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,17 @@ Note that as of Julia v1.5, in order to see deprecation warnings you will need t
 
 After we release v1 of the package, we will start following [semantic versioning](https://semver.org).
 
+ITensors v0.3.1 Release Notes
+=============================
+
+Bugs:
+
+Enhancements:
+
+- Introduce `Algorithm` type for selecting algorithm backends (#886)
+
 ITensors v0.3.0 Release Notes
-==============================
+=============================
 
 Bugs:
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -71,13 +71,6 @@ using Zeros
 include("utils.jl")
 
 #####################################
-# Algorithm type for selecting
-# different algorithm backends
-# (for internal or advanced usage)
-#
-include("algorithm.jl")
-
-#####################################
 # ContractionSequenceOptimization
 #
 include("ContractionSequenceOptimization/ContractionSequenceOptimization.jl")
@@ -109,6 +102,13 @@ include("imports.jl")
 # Global Variables
 #
 include("global_variables.jl")
+
+#####################################
+# Algorithm type for selecting
+# different algorithm backends
+# (for internal or advanced usage)
+#
+include("algorithm.jl")
 
 #####################################
 # Index and IndexSet

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -71,6 +71,13 @@ using Zeros
 include("utils.jl")
 
 #####################################
+# Algorithm type for selecting
+# different algorithm backends
+# (for internal or advanced usage)
+#
+include("algorithm.jl")
+
+#####################################
 # ContractionSequenceOptimization
 #
 include("ContractionSequenceOptimization/ContractionSequenceOptimization.jl")

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -25,5 +25,5 @@ adding methods to a function in ITensor that supports multiple algorithm
 backends (like contracting an MPO with an MPS).
 """
 macro Algorithm_str(s)
-  :(Algorithm{$(Expr(:quote, Symbol(s)))})
+  return :(Algorithm{$(Expr(:quote, Symbol(s)))})
 end

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -1,0 +1,29 @@
+"""
+    Algorithm
+
+A type representing an algorithm backend for a function.
+
+For example, ITensor provides multiple backend algorithms for contracting
+an MPO with an MPS, which internally are selected with an `Algorithm` type.
+
+This allows users to extend functions in ITensor with new algorithms, but
+use the same interface.
+"""
+struct Algorithm{Alg} end
+
+Algorithm(s) = Algorithm{Symbol(s)}()
+algorithm(::Algorithm{Alg}) where {Alg} = string(Alg)
+
+show(io::IO, alg::Algorithm) = print(io, "Algorithm type ", algorithm(alg))
+print(io::IO, ::Algorithm{Alg}) where {Alg} = print(io, Alg)
+
+"""
+    @Algorithm_str
+
+A convenience macro for writing [`Algorithm`](@ref) types, typically used when
+adding methods to a function in ITensor that supports multiple algorithm
+backends (like contracting an MPO with an MPS).
+"""
+macro Algorithm_str(s)
+  :(Algorithm{$(Expr(:quote, Symbol(s)))})
+end

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -48,6 +48,7 @@ import Base:
   map!,
   ndims,
   permutedims,
+  print,
   promote_rule,
   push!,
   resize!,

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1500,7 +1500,11 @@ Perform a truncation of all bonds of an MPS/MPO,
 using the truncation parameters (cutoff,maxdim, etc.)
 provided as keyword arguments.
 """
-function truncate!(M::AbstractMPS; kwargs...)
+function truncate!(M::AbstractMPS; alg="frobenius", kwargs...)
+  return truncate!(Algorithm(alg), M; kwargs...)
+end
+
+function truncate!(::Algorithm"frobenius", M::AbstractMPS; kwargs...)
   N = length(M)
 
   # Left-orthogonalize all tensors to make

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -479,18 +479,23 @@ end
 
 (A::MPO)(ψ::MPS; kwargs...) = apply(A, ψ; kwargs...)
 
-function contract(A::MPO, ψ::MPS; method="densitymatrix", kwargs...)
-  # Keyword argument deprecations
-  if method == "DensityMatrix"
-    @warn "In contract, method DensityMatrix is deprecated in favor of densitymatrix"
-    method = "densitymatrix"
-  end
-  if method == "Naive"
-    @warn "In contract, method Naive is deprecated in favor of naive"
-    method = "naive"
+function contract(A::MPO, ψ::MPS; alg="densitymatrix", kwargs...)
+  if haskey(kwargs, :method)
+    # Backwards compatibility, use `method`.
+    alg = get(kwargs, :method, "densitymatrix")
   end
 
-  return contract(Algorithm(method), A, ψ; kwargs...)
+  # Keyword argument deprecations
+  if alg == "DensityMatrix"
+    @warn "In contract, method DensityMatrix is deprecated in favor of densitymatrix"
+    alg = "densitymatrix"
+  end
+  if alg == "Naive"
+    @warn "In contract, `alg=\"Naive\"` is deprecated in favor of `alg=\"naive\"`"
+    alg = "naive"
+  end
+
+  return contract(Algorithm(alg), A, ψ; kwargs...)
 end
 
 contract_mpo_mps_doc = """

--- a/test/algorithm.jl
+++ b/test/algorithm.jl
@@ -1,0 +1,31 @@
+using ITensors
+using Test
+
+@testset "Algorithm" begin
+  alg = ITensors.Algorithm("X")
+
+  @test alg isa ITensors.Algorithm"X"
+  @test alg == ITensors.Algorithm"X"()
+
+  s = siteinds("S=1/2", 4)
+  A = MPO(s, "Id")
+  ψ = randomMPS(s)
+
+  @test_throws MethodError contract(alg, A, ψ)
+  @test_throws MethodError contract(A, ψ; method="X")
+  @test_throws MethodError contract(A, ψ; alg="X")
+  @test contract(ITensors.Algorithm("densitymatrix"), A, ψ) ≈ A * ψ
+  @test contract(ITensors.Algorithm("naive"), A, ψ) ≈ A * ψ
+  @test contract(A, ψ; alg="densitymatrix") ≈ A * ψ
+  @test contract(A, ψ; method="densitymatrix") ≈ A * ψ
+  @test contract(A, ψ; alg="naive") ≈ A * ψ
+  @test contract(A, ψ; method="naive") ≈ A * ψ
+
+  B = copy(A)
+  truncate!(ITensors.Algorithm("frobenius"), B)
+  @test A ≈ B
+
+  B = copy(A)
+  truncate!(B; alg="frobenius")
+  @test A ≈ B
+end

--- a/test/algorithm.jl
+++ b/test/algorithm.jl
@@ -28,4 +28,12 @@ using Test
   B = copy(A)
   truncate!(B; alg="frobenius")
   @test A ≈ B
+
+  # Custom algorithm
+  function ITensors.truncate!(::ITensors.Algorithm"my_new_algorithm", A::MPO; cutoff=1e-15)
+    return "my_new_algorithm was called with cutoff $cutoff"
+  end
+  cutoff = 1e-5
+  res = truncate!(A; alg="my_new_algorithm", cutoff=cutoff)
+  @test res == "my_new_algorithm was called with cutoff $cutoff"
 end

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -203,7 +203,7 @@ end
     psi = randomMPS(sites)
     psi_out = contract(K, psi; maxdim=1)
     @test inner(phi', psi_out) ≈ inner(phi', K, psi)
-    @test_throws ArgumentError contract(K, psi; method="fakemethod")
+    @test_throws MethodError contract(K, psi; method="fakemethod")
 
     badsites = [Index(2, "Site") for n in 1:(N + 1)]
     badpsi = randomMPS(badsites)

--- a/test/qnmpo.jl
+++ b/test/qnmpo.jl
@@ -112,7 +112,7 @@ using ITensors, Test
     @test maxlinkdim(K) == 1
     psi_out = contract(K, psi; maxdim=1)
     @test inner(phi', psi_out) ≈ inner(phi', K, psi)
-    @test_throws ArgumentError contract(K, psi; method="fakemethod")
+    @test_throws MethodError contract(K, psi; method="fakemethod")
   end
 
   # TODO: implement add for QN MPOs and add this test back

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ if Threads.nthreads() == 1
       "lattices.jl",
       "mps.jl",
       "mpo.jl",
+      "algorithm.jl",
       "sweeps.jl",
       "sweepnext.jl",
       "autompo.jl",


### PR DESCRIPTION
# Description

Introduce a new `Algorithm` type for selecting algorithm backends and allowing functions to have customizable/extendable algorithm backends. It is now used in `contract(::MPO, ::MPS)` and `truncate!(::MPO/MPS)`. For example, you can now extend `truncate!` as follows:
```julia
s = siteinds("S=1/2", 4)
A = MPO(s, "Id")

# Standard algorithm using "Frobenius norm", i.e. treat it as an MPS
truncate!(A)
truncate!(A; alg="frobenius")

# Low-level internal interface, which can be used for overloading `truncate!`
# with a new algorithm
truncate!(ITensors.Algorithm("frobenius"), A)
```
Then to define a new `truncate!` algorithm for MPOs, you can do:
```julia
import ITensors: truncate!

function truncate!(::ITensors.Algorithm"my_new_algorithm", A::MPO; cutoff=1e-15)
  # Implement a new truncation algorithm for MPOs
end
```
which then can be called as:
```julia
truncate!(A; alg="my_new_algorithm", cutoff=1e-8)
```

Also introduce `alg` as an alternative keyword argument for `method` in `contract(::MPO, ::MPS; kwargs...)`.

@JanReimers @emstoudenmire