### PR TITLE
Cleanup outer and add GEMM routing for CUDA

### DIFF
--- a/ITensorGPU/src/cuitensor.jl
+++ b/ITensorGPU/src/cuitensor.jl
@@ -25,8 +25,6 @@ function ITensor(
   inds::Indices{Index{Int}};
   kwargs...,
 )
-  @show size(A)
-  @show dim(inds)
   length(A) ≠ dim(inds) && throw(
     DimensionMismatch(
       "In ITensor(::CuArray, inds), length of AbstractArray ($(length(A))) must match total dimension of IndexSet ($(dim(inds)))",

--- a/ITensorGPU/src/cuitensor.jl
+++ b/ITensorGPU/src/cuitensor.jl
@@ -1,3 +1,7 @@
+import ITensors.NDTensors: NeverAlias, AliasStyle, AllowAlias 
+import ITensors: ITensor
+import CUDA: CuArray
+
 function cuITensor(::Type{T}, inds::IndexSet) where {T<:Number}
   return ITensor(Dense{float(T)}(CUDA.zeros(float(T), dim(inds))), inds)
 end
@@ -14,6 +18,41 @@ function cuITensor(x::S, inds::IndexSet{N}) where {S<:Number,N}
 end
 cuITensor(x::S, inds::Index...) where {S<:Number} = cuITensor(x, IndexSet(inds...))
 
+
+function ITensor(
+  as::AliasStyle,
+  eltype::Type{<:Number},
+  A::CuArray{<:Number},
+  inds::Indices{Index{Int}};
+  kwargs...,
+)
+  @show size(A)
+  @show dim(inds)
+  length(A) ≠ dim(inds) && throw(
+    DimensionMismatch(
+      "In ITensor(::CuArray, inds), length of AbstractArray ($(length(A))) must match total dimension of IndexSet ($(dim(inds)))",
+    ),
+  )
+  data = CuArray{eltype}(as, A)
+  return itensor(Dense(data), inds)
+end
+# Helper functions for different view behaviors
+CuArray{ElT,N}(::NeverAlias, A::AbstractArray) where {ElT,N} = CuArray{ElT,N}(A)
+function CuArray{ElT,N}(::AllowAlias, A::AbstractArray) where {ElT,N}
+  return convert(CuArray{ElT,N}, A)
+end
+function CuArray{ElT}(as::AliasStyle, A::AbstractArray{ElTA,N}) where {ElT,N,ElTA}
+  return CuArray{ElT,N}(as, A)
+end
+
+# TODO: Change to:
+# (Array{ElT, N} where {ElT})([...]) = [...]
+# once support for `VERSION < v"1.6"` is dropped.
+# Previous to Julia v1.6 `where` syntax couldn't be used in a function name
+function CuArray{<:Any,N}(as::AliasStyle, A::AbstractArray{ElTA,N}) where {N,ElTA}
+  return CuArray{ElTA,N}(as, A)
+end
+
 #TODO: check that the size of the Array matches the Index dimensions
 function cuITensor(A::Array{S}, inds) where {S<:Number}
   return ITensor(Dense(CuArray{S}(A)), inds)
@@ -23,6 +62,7 @@ function cuITensor(A::CuArray{S}, inds::IndexSet) where {S<:Number}
 end
 cuITensor(A::Array{S}, inds::Index...) where {S<:Number} = cuITensor(A, IndexSet(inds...))
 cuITensor(A::CuArray{S}, inds::Index...) where {S<:Number} = cuITensor(A, IndexSet(inds...))
+
 function cuITensor(A::ITensor)
   return if storage(tensor(A)) isa ITensors.EmptyStorage
     cuITensor(zero(eltype(storage(tensor(A)))), inds(A)...)

--- a/ITensorGPU/src/cuitensor.jl
+++ b/ITensorGPU/src/cuitensor.jl
@@ -1,4 +1,4 @@
-import ITensors.NDTensors: NeverAlias, AliasStyle, AllowAlias 
+import ITensors.NDTensors: NeverAlias, AliasStyle, AllowAlias
 import ITensors: ITensor
 import CUDA: CuArray
 
@@ -17,7 +17,6 @@ function cuITensor(x::S, inds::IndexSet{N}) where {S<:Number,N}
   return ITensor(Dense{S}(dat), inds)
 end
 cuITensor(x::S, inds::Index...) where {S<:Number} = cuITensor(x, IndexSet(inds...))
-
 
 function ITensor(
   as::AliasStyle,

--- a/ITensorGPU/src/tensor/cudense.jl
+++ b/ITensorGPU/src/tensor/cudense.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: BlasFloat
+
 const CuDense{ElT,VecT} = Dense{ElT,VecT} where {VecT<:CuVector}
 const CuDenseTensor{ElT,N,StoreT,IndsT} = Tensor{ElT,N,StoreT,IndsT} where {StoreT<:CuDense}
 
@@ -14,6 +16,7 @@ function Dense{T,S}(x::T, size::Integer) where {T,S<:CuArray{<:T}}
   return Dense{T,S}(arr)
 end
 cpu(x::CuDense{T}) where {T<:Number} = Dense(collect(x.data))
+cpu(x::CuDenseTensor{T}) where {T<:Number} = Tensor(inds(x), cpu(store(x)))
 function Base.complex(::Type{Dense{ElT,VT}}) where {ElT,VT<:CuArray}
   return Dense{complex(ElT),CuVector{complex(ElT)}}
 end
@@ -35,6 +38,13 @@ Base.getindex(D::CuDense{<:Number}) = collect(data(D))[]
 Base.getindex(D::CuDenseTensor{<:Number,0}) = store(D)[]
 LinearAlgebra.norm(T::CuDenseTensor) = norm(data(store(T)))
 
+function Base.copyto!(R::CuDenseTensor{<:Number,N}, T::CuDenseTensor{<:Number,N}) where {N}
+  RA = array(R)
+  TA = array(T)
+  RA .= TA
+  return R
+end
+
 # This is for type promotion for Scalar*Dense
 function Base.promote_rule(
   ::Type{<:Dense{ElT1,CuVector{ElT1}}}, ::Type{ElT2}
@@ -42,19 +52,6 @@ function Base.promote_rule(
   ElR = promote_type(ElT1, ElT2)
   VecR = CuVector{ElR}
   return Dense{ElR,VecR}
-end
-
-function Base.permutedims(T::CuDenseTensor{<:Number,N}, perm::NTuple{N,Int}) where {N}
-  Tp = NDTensors.similar(T, ITensors.NDTensors.permute(inds(T), perm))
-  #Tp = permute(T,perm; always_copy=true)
-  permute!(Tp, T)
-  return Tp
-end
-
-function Base.permutedims!(
-  R::CuDenseTensor{<:Number,N}, T::CuDenseTensor{<:Number,N}, perm::NTuple{N,Int}
-) where {N}
-  return permutedims!!(R, T, perm)
 end
 
 function permutedims!!(
@@ -79,11 +76,61 @@ function Base.similar(::Type{<:CuDenseTensor{ElT}}, inds) where {ElT}
   return Tensor(Dense(storage_arr), inds)
 end
 
-function outer!(R::CuDenseTensor, T1::CuDenseTensor, T2::CuDenseTensor)
-  R_dat = vec(array(T1)) * transpose(vec(array(T2)))
-  copyto!(data(store(R)), vec(R_dat))
-  inds_outer = unioninds(inds(T1), inds(T2))
-  return R
+import ITensors.NDTensors: GemmBackend, auto_select_backend, _gemm!
+function backend_cutensor()
+    return gemm_backend[] = :CUTENSOR
+end
+function backend_cublas()
+    return gemm_backend[] = :CUBLAS
+end
+
+@inline function auto_select_backend(
+  ::Type{<:CuArray{<:BlasFloat}},
+  ::Type{<:CuArray{<:BlasFloat}},
+  ::Type{<:CuArray{<:BlasFloat}},
+)
+  return GemmBackend(:CUBLAS)
+end
+
+@inline function auto_select_backend(
+  ::Type{<:CuArray{<:BlasFloat}},
+  ::Type{<:CuArray{<:BlasFloat}},
+  ::Type{<:AbstractVecOrMat},
+)
+  return GemmBackend(:GenericCUDA)
+end
+
+# CUBLAS matmul
+function _gemm!(
+  ::GemmBackend{:CUBLAS},
+  tA,
+  tB,
+  alpha,
+  A::AbstractVecOrMat,
+  B::AbstractVecOrMat,
+  beta,
+  C::AbstractVecOrMat,
+)
+  return CUBLAS.gemm!(tA, tB, alpha, A, B, beta, C)
+end
+
+# CUDA generic matmul
+function _gemm!(
+  ::GemmBackend{:GenericCUDA},
+  tA,
+  tB,
+  alpha,
+  A::AbstractVecOrMat,
+  B::AbstractVecOrMat,
+  beta,
+  C::CuDenseTensor,
+)
+  C_dat = reshape(data(store(C)), size(C))
+  A_ = tA == 'T' ? transpose(A) : A
+  B_ = tB == 'T' ? transpose(B) : B
+  C_dat = mul!(C_dat, A_, B_, alpha, beta)
+  copyto!(data(store(C)), C_dat)
+  return C 
 end
 
 function _contract_scalar!(
@@ -485,7 +532,7 @@ function Base.permute!(B::CuDenseTensor, A::CuDenseTensor)
   Bdata = data(store(B))
   reshapeBdata = reshape(Bdata, dims(Bis)...)
   reshapeAdata = reshape(Adata, dims(Ais)...)
-  if ndims(A) < 12 # use CUTENSOR
+  if ndims(A) < 40 # use CUTENSOR
     ctainds = zeros(Int, length(Ais))
     ctbinds = zeros(Int, length(Bis))
     for (ii, ia) in enumerate(Ais)
@@ -510,7 +557,7 @@ function Base.permute!(B::CuDenseTensor, A::CuDenseTensor)
     @assert isperm(perm)
     permutedims!(reshapeBdata, reshapeAdata, invperm(perm))
   end
-  return vec(reshapeBdata)
+  return Tensor(inds(B), Dense(vec(reshapeBdata)))
 end
 
 function Base.permute!(B::CuDense, Bis::IndexSet, A::CuDense, Ais::IndexSet)
@@ -538,7 +585,7 @@ function Base.permute!(B::CuDense, Bis::IndexSet, A::CuDense, Ais::IndexSet)
     reshapeBdata,
     Vector{Char}(ctbinds),
   )
-  return vec(reshapeBdata)
+  return Tensor(Bis, Dense(vec(reshapeBdata)))
 end
 
 Base.:/(A::CuDenseTensor, x::Number) = A * inv(x)

--- a/ITensorGPU/src/tensor/cudense.jl
+++ b/ITensorGPU/src/tensor/cudense.jl
@@ -78,10 +78,10 @@ end
 
 import ITensors.NDTensors: GemmBackend, auto_select_backend, _gemm!
 function backend_cutensor()
-    return gemm_backend[] = :CUTENSOR
+  return gemm_backend[] = :CUTENSOR
 end
 function backend_cublas()
-    return gemm_backend[] = :CUBLAS
+  return gemm_backend[] = :CUBLAS
 end
 
 @inline function auto_select_backend(
@@ -93,9 +93,7 @@ end
 end
 
 @inline function auto_select_backend(
-  ::Type{<:CuArray{<:BlasFloat}},
-  ::Type{<:CuArray{<:BlasFloat}},
-  ::Type{<:AbstractVecOrMat},
+  ::Type{<:CuArray{<:BlasFloat}}, ::Type{<:CuArray{<:BlasFloat}}, ::Type{<:AbstractVecOrMat}
 )
   return GemmBackend(:GenericCUDA)
 end
@@ -130,7 +128,7 @@ function _gemm!(
   B_ = tB == 'T' ? transpose(B) : B
   C_dat = mul!(C_dat, A_, B_, alpha, beta)
   copyto!(data(store(C)), C_dat)
-  return C 
+  return C
 end
 
 function _contract_scalar!(

--- a/ITensorGPU/test/test_cudense.jl
+++ b/ITensorGPU/test/test_cudense.jl
@@ -37,8 +37,8 @@ using ITensors,
     B = [SType(0.0) for ii in 1:dim(j), jj in 1:dim(j)]
     dB = ITensorGPU.CuDense{SType,CuVector{SType}}(SType(0.0), dim(i) * dim(j))
     dC = permute!(dB, IndexSet(j, i), dA, IndexSet(i, j))
-    hC = collect(dC)
-    @test vec(transpose(A)) == hC
+    hC = cpu(dC)
+    @test transpose(A) == hC
   end
   @testset "Test move CuDense on/off GPU" begin
     A = [SType(1.0) for ii in 1:dim(i), jj in 1:dim(j)]
@@ -58,7 +58,7 @@ using ITensors,
       dC = complex(dA)
       @test typeof(dC) !== typeof(dA)
       cdC = CuArray(dC)
-      hC = collect(cdC)
+      hC  = collect(cdC)
       ccA = complex.(A)
       @test hC == collect(ccA)
     end

--- a/ITensorGPU/test/test_cudense.jl
+++ b/ITensorGPU/test/test_cudense.jl
@@ -58,7 +58,7 @@ using ITensors,
       dC = complex(dA)
       @test typeof(dC) !== typeof(dA)
       cdC = CuArray(dC)
-      hC  = collect(cdC)
+      hC = collect(cdC)
       ccA = complex.(A)
       @test hC == collect(ccA)
     end

--- a/NDTensors/src/dense.jl
+++ b/NDTensors/src/dense.jl
@@ -344,7 +344,9 @@ function copyto!(
 end
 
 # If they are something more complicated like views, use Strided copyto!
-function copyto!(R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}) where {N, StoreT<:StridedArray}
+function copyto!(
+  R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}
+) where {N,StoreT<:StridedArray}
   RA = array(R)
   TA = array(T)
   @strided RA .= TA
@@ -354,7 +356,7 @@ end
 # TODO: call permutedims!(R,T,perm,(r,t)->t)?
 function permutedims!(
   R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}, perm::NTuple{N,Int}
-) where {N, StoreT<:StridedArray}
+) where {N,StoreT<:StridedArray}
   RA = array(R)
   TA = array(T)
   @strided RA .= permutedims(TA, perm)
@@ -378,7 +380,11 @@ function permutedims!(
   return R
 end
 
-function apply!(R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}, f::Function=(r, t) -> t) where {N,StoreT<:StridedArray}
+function apply!(
+  R::DenseTensor{<:Number,N,StoreT},
+  T::DenseTensor{<:Number,N,StoreT},
+  f::Function=(r, t) -> t,
+) where {N,StoreT<:StridedArray}
   RA = array(R)
   TA = array(T)
   @strided RA .= f.(RA, TA)
@@ -394,7 +400,12 @@ end
 
 # Version that may overwrite the result or promote
 # and return the result
-function permutedims!!(R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}, perm::Tuple, f::Function=(r, t) -> t) where {N, StoreT<:StridedArray}
+function permutedims!!(
+  R::DenseTensor{<:Number,N,StoreT},
+  T::DenseTensor{<:Number,N,StoreT},
+  perm::Tuple,
+  f::Function=(r, t) -> t,
+) where {N,StoreT<:StridedArray}
   RR = convert(promote_type(typeof(R), typeof(T)), R)
   RA = ReshapedArray(data(RR), dims(RR), ())
   TA = ReshapedArray(data(T), dims(T), ())

--- a/NDTensors/src/dense.jl
+++ b/NDTensors/src/dense.jl
@@ -344,10 +344,27 @@ function copyto!(
 end
 
 # If they are something more complicated like views, use Strided copyto!
-function copyto!(R::DenseTensor{<:Number,N}, T::DenseTensor{<:Number,N}) where {N}
+function copyto!(R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}) where {N, StoreT<:StridedArray}
   RA = array(R)
   TA = array(T)
   @strided RA .= TA
+  return R
+end
+
+# TODO: call permutedims!(R,T,perm,(r,t)->t)?
+function permutedims!(
+  R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}, perm::NTuple{N,Int}
+) where {N, StoreT<:StridedArray}
+  RA = array(R)
+  TA = array(T)
+  @strided RA .= permutedims(TA, perm)
+  return R
+end
+
+function copyto!(R::DenseTensor{<:Number,N}, T::DenseTensor{<:Number,N}) where {N}
+  RA = array(R)
+  TA = array(T)
+  RA .= TA
   return R
 end
 
@@ -357,27 +374,46 @@ function permutedims!(
 ) where {N}
   RA = array(R)
   TA = array(T)
-  @strided RA .= permutedims(TA, perm)
+  RA .= permutedims(TA, perm)
   return R
 end
 
-function apply!(R::DenseTensor, T::DenseTensor, f::Function=(r, t) -> t)
+function apply!(R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}, f::Function=(r, t) -> t) where {N,StoreT<:StridedArray}
   RA = array(R)
   TA = array(T)
   @strided RA .= f.(RA, TA)
   return R
 end
 
+function apply!(R::DenseTensor, T::DenseTensor, f::Function=(r, t) -> t)
+  RA = array(R)
+  TA = array(T)
+  RA .= f.(RA, TA)
+  return R
+end
+
 # Version that may overwrite the result or promote
 # and return the result
-function permutedims!!(R::DenseTensor, T::DenseTensor, perm::Tuple, f::Function=(r, t) -> t)
+function permutedims!!(R::DenseTensor{<:Number,N,StoreT}, T::DenseTensor{<:Number,N,StoreT}, perm::Tuple, f::Function=(r, t) -> t) where {N, StoreT<:StridedArray}
   RR = convert(promote_type(typeof(R), typeof(T)), R)
-  #RA = array(R)
-  #TA = array(T)
   RA = ReshapedArray(data(RR), dims(RR), ())
   TA = ReshapedArray(data(T), dims(T), ())
   if !is_trivial_permutation(perm)
     @strided RA .= f.(RA, permutedims(TA, perm))
+  else
+    # TODO: specialize for specific functions
+    RA .= f.(RA, TA)
+  end
+  return RR
+end
+
+function permutedims!!(R::DenseTensor, T::DenseTensor, perm::Tuple, f::Function=(r, t) -> t)
+  RR = convert(promote_type(typeof(R), typeof(T)), R)
+  RA = ReshapedArray(data(RR), dims(RR), ())
+  TA = ReshapedArray(data(T), dims(T), ())
+  if !is_trivial_permutation(perm)
+    TB = permutedims(TA, perm)
+    RA .= f.(RA, TB)
   else
     # TODO: specialize for specific functions
     RA .= f.(RA, TA)


### PR DESCRIPTION
# Description
This actually turned into a code addition. Added some functions as fall backs for array types that `@strided` doesn't work on, and fixed up some `ITensorGPU` code to be more consistent with `ITensors`.

Fixes # (issue)

# How Has This Been Tested?

`julia test/runtests.jl` passed for `ITensorGPU`, `NDTensors`, and `ITensor`.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
