### PR TITLE
Finite temperature example codes

### DIFF
--- a/examples/finite_temperature/metts.jl
+++ b/examples/finite_temperature/metts.jl
@@ -1,0 +1,103 @@
+using ITensors
+import ITensors: op
+using Printf
+
+function op(::OpName"expτSS", ::SiteType"S=1/2", s1::Index, s2::Index; τ)
+  h =
+    1 / 2 * op("S+", s1) * op("S-", s2) +
+    1 / 2 * op("S-", s1) * op("S+", s2) +
+    op("Sz", s1) * op("Sz", s2)
+  return exp(τ * h)
+end
+
+"""
+Given a Vector of numbers, returns
+the average and the standard error
+(= the width of distribution of the numbers)
+"""
+function avg_err(v::Vector)
+  N = length(v)
+  avg = v[1]/N
+  avg2 = v[1]^2/N
+  for j=2:N
+    avg  += v[j]/N
+    avg2 += v[j]^2/N
+  end
+  return avg,√((avg2-avg)/N)
+end
+
+function main(; N=10, cutoff=1E-8, δτ=0.1, beta=2.0, NMETTS=3000, Nwarm=10)
+
+  # Make an array of 'site' indices
+  s = siteinds("S=1/2", N)
+
+  # Make gates (1,2),(2,3),(3,4),...
+  gates = ops([("expτSS", (n, n + 1), (τ=-δτ/2,)) for n in 1:(N - 1)], s)
+  # Include gates in reverse order to complete Trotter formula
+  append!(gates, reverse(gates))
+
+  # Make y-rotation gates to use in METTS collapses
+  Ry_gates = ops([("Ry",n,(θ=π/2,)) for n=1:N],s)
+
+  # Arbitrary initial state
+  psi = randomMPS(s)
+
+  # Make H for measuring the energy
+  terms = OpSum()
+  for j=1:(N-1)
+    terms += 1/2,"S+",j,"S-",j+1
+    terms += 1/2,"S-",j,"S+",j+1
+    terms +=     "Sz",j,"Sz",j+1
+  end
+  H = MPO(terms,s)
+
+  # Make τ_range and check δτ is commensurate
+  τ_range = δτ:δτ:(beta/2)
+  if norm(length(τ_range)*δτ - beta/2) > 1E-10
+    error("Time step δτ=$δτ not commensurate with beta/2=$(beta/2)")
+  end
+
+  Ens = Float64[]
+
+  for step = 1:(Nwarm+NMETTS)
+    
+    if step <= Nwarm
+      println("Making warmup METTS number $step")
+    else
+      println("Making METTS number $(step-Nwarm)")
+    end
+
+    # Do the time evolution by applying the gates
+    for τ in τ_range
+      psi = apply(gates, psi; cutoff)
+      normalize!(psi)
+    end
+
+    # Measure properties after >= Nwarm 
+    # METTS have been made
+    if step > Nwarm
+
+      energy = inner(psi',H,psi)
+      push!(Ens,energy)
+      Nm = length(Ens)
+      @printf("  Energy of METTS %d = %.4f\n",Nm,energy)
+      a_En,err_En = avg_err(Ens)
+      @printf("  Estimated Energy = %.4f +- %.4f  [%.4f,%.4f]\n",a_En,err_En,a_En-err_En,a_En+err_En)
+
+    end
+
+    # Measure in X or Z basis on alternating steps
+    if step%2 == 1
+      psi = apply(Ry_gates,psi)
+      samp = sample!(psi)
+      new_state = [samp[j]==1 ? "X+" : "X-" for j=1:N]
+    else
+      samp = sample!(psi)
+      new_state = [samp[j]==1 ? "Z+" : "Z-" for j=1:N]
+    end
+    psi = productMPS(s,new_state)
+
+  end
+
+  return
+end

--- a/examples/finite_temperature/purification.jl
+++ b/examples/finite_temperature/purification.jl
@@ -10,8 +10,7 @@ function op(::OpName"expτSS", ::SiteType"S=1/2", s1::Index, s2::Index; τ)
 end
 
 function main(; N=10, cutoff=1E-8, δτ=0.05, beta_max=2.0)
-
-  L = 2*N
+  L = 2 * N
 
   # Make an array of 'site' indices
   s = siteinds("S=1/2", L; conserve_qns=true)
@@ -19,46 +18,46 @@ function main(; N=10, cutoff=1E-8, δτ=0.05, beta_max=2.0)
   # Make gates (1,3),(3,5),(5,7),...
   # Only on physical (odd numbered) sites
   # Even sites are "ancilla" sites and have no Hamiltonian terms
-  gates = ops([("expτSS", (n, n + 2), (τ=-δτ/2,)) for n in 1:2:(L - 2)], s)
+  gates = ops([("expτSS", (n, n + 2), (τ=-δτ / 2,)) for n in 1:2:(L - 2)], s)
   # Include gates in reverse order to complete Trotter formula
   append!(gates, reverse(gates))
 
   # Initialize psi to be a product of Bell pairs
   psi = MPS(L)
-  for j=1:2:(L - 1)
+  for j in 1:2:(L - 1)
     s1 = s[j]
-    s2 = s[j+1]
-    bell = ITensor([0 1/√2; 1/√2 0],s1,s2)
+    s2 = s[j + 1]
+    bell = ITensor([0 1/√2; 1/√2 0], s1, s2)
     # Restore MPS form
-    U,S,V = svd(bell,s1)
-    psi[j] = U*S
-    psi[j+1] = V
+    U, S, V = svd(bell, s1)
+    psi[j] = U * S
+    psi[j + 1] = V
   end
   # Put in remaining link indices
-  for j=2:2:(L - 1)
-    l = Index([QN()=>1],"n=$j")
-    psi[j] *= dag(onehot(l=>1))
-    psi[j+1] *= onehot(l=>1)
+  for j in 2:2:(L - 1)
+    l = Index([QN() => 1], "n=$j")
+    psi[j] *= dag(onehot(l => 1))
+    psi[j + 1] *= onehot(l => 1)
   end
 
   # Make H for measuring the energy
   terms = OpSum()
-  for j=1:2:(L-2)
-    terms += 1/2,"S+",j,"S-",j+2
-    terms += 1/2,"S-",j,"S+",j+2
-    terms +=     "Sz",j,"Sz",j+2
+  for j in 1:2:(L - 2)
+    terms += 1 / 2, "S+", j, "S-", j + 2
+    terms += 1 / 2, "S-", j, "S+", j + 2
+    terms += "Sz", j, "Sz", j + 2
   end
-  H = MPO(terms,s)
+  H = MPO(terms, s)
 
   # Do the time evolution by applying the gates
   # for Nsteps steps
-  for τ in 0:δτ:(beta_max/2)
-    En = inner(psi',H,psi)
+  for τ in 0:δτ:(beta_max / 2)
+    En = inner(psi', H, psi)
     β = 2τ
     println("β = $β energy = $En")
     psi = apply(gates, psi; cutoff)
     normalize!(psi)
   end
 
-  return
+  return nothing
 end

--- a/examples/finite_temperature/purification.jl
+++ b/examples/finite_temperature/purification.jl
@@ -1,0 +1,64 @@
+using ITensors
+import ITensors: op
+
+function op(::OpName"expτSS", ::SiteType"S=1/2", s1::Index, s2::Index; τ)
+  h =
+    1 / 2 * op("S+", s1) * op("S-", s2) +
+    1 / 2 * op("S-", s1) * op("S+", s2) +
+    op("Sz", s1) * op("Sz", s2)
+  return exp(τ * h)
+end
+
+function main(; N=10, cutoff=1E-8, δτ=0.05, beta_max=2.0)
+
+  L = 2*N
+
+  # Make an array of 'site' indices
+  s = siteinds("S=1/2", L; conserve_qns=true)
+
+  # Make gates (1,3),(3,5),(5,7),...
+  # Only on physical (odd numbered) sites
+  # Even sites are "ancilla" sites and have no Hamiltonian terms
+  gates = ops([("expτSS", (n, n + 2), (τ=-δτ/2,)) for n in 1:2:(L - 2)], s)
+  # Include gates in reverse order to complete Trotter formula
+  append!(gates, reverse(gates))
+
+  # Initialize psi to be a product of Bell pairs
+  psi = MPS(L)
+  for j=1:2:(L - 1)
+    s1 = s[j]
+    s2 = s[j+1]
+    bell = ITensor([0 1/√2; 1/√2 0],s1,s2)
+    # Restore MPS form
+    U,S,V = svd(bell,s1)
+    psi[j] = U*S
+    psi[j+1] = V
+  end
+  # Put in remaining link indices
+  for j=2:2:(L - 1)
+    l = Index([QN()=>1],"n=$j")
+    psi[j] *= dag(onehot(l=>1))
+    psi[j+1] *= onehot(l=>1)
+  end
+
+  # Make H for measuring the energy
+  terms = OpSum()
+  for j=1:2:(L-2)
+    terms += 1/2,"S+",j,"S-",j+2
+    terms += 1/2,"S-",j,"S+",j+2
+    terms +=     "Sz",j,"Sz",j+2
+  end
+  H = MPO(terms,s)
+
+  # Do the time evolution by applying the gates
+  # for Nsteps steps
+  for τ in 0:δτ:(beta_max/2)
+    En = inner(psi',H,psi)
+    β = 2τ
+    println("β = $β energy = $En")
+    psi = apply(gates, psi; cutoff)
+    normalize!(psi)
+  end
+
+  return
+end


### PR DESCRIPTION

This PR adds two new example codes for the METTS and purification methods for computing finite temperature properties. Both codes were tested against each other and using ED on a small system size. One improvement could be to add another observable besides the energy. Please let me know of any feedback about the way the codes are written or designed.

I did notice one possible issue with the `apply` function: while it behaves as expected for METTS (nearest-neighbor gates only), for purification which uses second-neighbor gates, `apply` seems extremely slow even for N=12. It might be scaling quadratically with N for this case or encountering some other performance issue.

- Add METTS and purification code examples
- Formatting
