### PR TITLE
Allow cutruncate to work for Float32s

### DIFF
--- a/ITensorGPU/src/tensor/cutruncate.jl
+++ b/ITensorGPU/src/tensor/cutruncate.jl
@@ -1,57 +1,57 @@
-function truncate!(
-  P::CuVector{Float64}; kwargs...
-)::Tuple{Float64,Float64,CuVector{Float64}}
+import LinearAlgebra: BlasReal
+
+function truncate!(P::CuVector{T}; kwargs...)::Tuple{T,T,CuVector{T}} where {T<:BlasReal}
   maxdim::Int = min(get(kwargs, :maxdim, length(P)), length(P))
   mindim::Int = min(get(kwargs, :mindim, 1), maxdim)
   cutoff::Float64 = get(kwargs, :cutoff, 0.0)
   absoluteCutoff::Bool = get(kwargs, :absoluteCutoff, false)
   doRelCutoff::Bool = get(kwargs, :doRelCutoff, true)
   origm = length(P)
-  docut = 0.0
+  docut = zero(T)
   # handle the case where nothing is to be cut off
   minP = minimum(P)
   if minP > cutoff
-    return 0.0, 0.0, P
+    return zero(T), zero(T), P
   end
   maxP = maximum(P)
-  if maxP == 0.0
-    P = CUDA.zeros(Float64, 1)
-    return 0.0, 0.0, P
+  if maxP == zero(T)
+    P = CUDA.zeros(T, 1)
+    return zero(T), zero(T), P
   end
   if origm == 1
     docut = maxP / 2
-    return 0.0, docut, P[1:1]
+    return zero(T), docut, P[1:1]
   end
   @timeit "setup rP" begin
     #Zero out any negative weight
     #neg_z_f = (!signbit(x) ? x : 0.0)
-    rP = map(x -> !signbit(x) ? x : 0.0, P)
+    rP = map(x -> !signbit(x) ? Float64(x) : 0.0, P)
     n = origm
   end
   @timeit "handle cutoff" begin
     if absoluteCutoff
       #Test if individual prob. weights fall below cutoff
       #rather than using *sum* of discarded weights
-      sub_arr = rP .- cutoff
+      sub_arr = rP .- Float64(cutoff)
       err_rP = sub_arr ./ abs.(sub_arr)
       flags = reinterpret(Float64, (signbit.(err_rP) .<< 1 .& 2) .<< 61)
       cut_ind = CUDA.CUBLAS.iamax(length(err_rP), err_rP .* flags) - 1
       n = min(maxdim, cut_ind)
       n = max(n, mindim)
-      truncerr = sum(rP[(n + 1):end])
+      truncerr = T(sum(rP[(n + 1):end]))
     else
-      truncerr = 0.0
-      scale = 1.0
+      truncerr = zero(T)
+      scale = one(T)
       @timeit "find scale" begin
         if doRelCutoff
           scale = sum(P)
-          scale = scale > 0.0 ? scale : 1.0
+          scale = scale > zero(T) ? scale : one(T)
         end
       end
       #Truncating until *sum* of discarded probability 
       #weight reaches cutoff reached (or m==mindim)
-      csum_rp = CUDA.reverse(CUDA.cumsum(CUDA.reverse(rP)))
-      sub_arr = csum_rp .- cutoff * scale
+      csum_rp = Float64.(CUDA.reverse(CUDA.cumsum(CUDA.reverse(rP))))
+      sub_arr = csum_rp .- Float64(cutoff * scale)
       err_rP = sub_arr ./ abs.(sub_arr)
       flags = reinterpret(Float64, (signbit.(err_rP) .<< 1 .& 2) .<< 61)
       cut_ind = (CUDA.CUBLAS.iamax(length(err_rP), err_rP .* flags) - 1)
@@ -60,8 +60,8 @@ function truncate!(
         n = max(n, mindim)
         truncerr = sum(rP[(n + 1):end])
       end
-      if scale == 0.0
-        truncerr = 0.0
+      if scale == zero(T)
+        truncerr = zero(T)
       else
         truncerr /= scale
       end
@@ -74,7 +74,7 @@ function truncate!(
     hP = collect(P)
     docut = (hP[n] + hP[n + 1]) / 2
     if abs(hP[n] - hP[n + 1]) < 1E-3 * hP[n]
-      docut += 1E-3 * hP[n]
+      docut += T(1E-3) * hP[n]
     end
   end
   @timeit "setup return" begin

--- a/ITensorGPU/test/test_cutruncate.jl
+++ b/ITensorGPU/test/test_cutruncate.jl
@@ -6,23 +6,27 @@ using ITensors,
 
 # gpu tests!
 @testset "cutrunctate" begin
-  @test ITensorGPU.truncate!(CUDA.zeros(Float64, 10)) == (0.0, 0.0, CUDA.zeros(Float64, 1))
-  trunc = ITensorGPU.truncate!(
-    CuArray([1.0, 0.5, 0.4, 0.1, 0.05]); absoluteCutoff=true, cutoff=0.2
-  )
-  @test trunc[1] ≈ 0.15
-  @test trunc[2] ≈ 0.25
-  @test Array(trunc[3]) == [1.0, 0.5, 0.4]
-  trunc = ITensorGPU.truncate!(
-    CuArray([0.4, 0.26, 0.19, 0.1, 0.05]); relativeCutoff=true, cutoff=0.2
-  )
-  @test trunc[1] ≈ 0.15
-  @test trunc[2] ≈ 0.145
-  @test Array(trunc[3]) == [0.4, 0.26, 0.19]
-  trunc = ITensorGPU.truncate!(
-    CuArray([0.4, 0.26, 0.19, 0.1, 0.05] / 2); relativeCutoff=true, cutoff=0.2
-  )
-  @test trunc[1] ≈ 0.15
-  @test trunc[2] ≈ 0.145 / 2
-  @test Array(trunc[3]) == [0.4, 0.26, 0.19] / 2
+  @testset for T in (Float32, Float64)
+    @test ITensorGPU.truncate!(CUDA.zeros(T, 10)) == (zero(T), zero(T), CUDA.zeros(T, 1))
+    trunc = ITensorGPU.truncate!(
+      CuArray(T[1.0, 0.5, 0.4, 0.1, 0.05]); absoluteCutoff=true, cutoff=T(0.2)
+    )
+    @test trunc[1] ≈ T(0.15)
+    @test trunc[2] ≈ T(0.25)
+    @test Array(trunc[3]) == T[1.0, 0.5, 0.4]
+    trunc = ITensorGPU.truncate!(
+      CuArray(T[0.4, 0.26, 0.19, 0.1, 0.05]); relativeCutoff=true, cutoff=T(0.2)
+    )
+    @test trunc[1] ≈ T(0.15)
+    @test trunc[2] ≈ T(0.145)
+    @test Array(trunc[3]) == T[0.4, 0.26, 0.19]
+    trunc = ITensorGPU.truncate!(
+      CuArray(convert(Vector{T}, [0.4, 0.26, 0.19, 0.1, 0.05] / 2));
+      relativeCutoff=true,
+      cutoff=T(0.2),
+    )
+    @test trunc[1] ≈ T(0.15)
+    @test trunc[2] ≈ T(0.145 / 2)
+    @test Array(trunc[3]) == convert(Vector{T}, [0.4, 0.26, 0.19] / 2)
+  end
 end # End truncate test


### PR DESCRIPTION
# Description

Widen allowed types for `cutruncate` to allow people to truncate vectors of Float32s. 

Fixes [#890 ](https://github.com/ITensor/ITensors.jl/issues/890)

# How Has This Been Tested?

`test/test_cutruncate.jl` passed.

# Checklist:

- [ x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
