### PR TITLE
[ITensors] [BUG] Fix for performance issues when applying gates to every other site

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -2087,11 +2087,15 @@ expτH = ops(os, s)
 ```
 """
 function product(
-  As::Vector{<:ITensor}, ψ::AbstractMPS; move_sites_back::Bool=true, kwargs...
+  As::Vector{<:ITensor},
+  ψ::AbstractMPS;
+  move_sites_back_between_gates::Bool=false,
+  move_sites_back::Bool=true,
+  kwargs...
 )
   Aψ = ψ
   for A in As
-    Aψ = product(A, Aψ; move_sites_back=false, kwargs...)
+    Aψ = product(A, Aψ; move_sites_back=move_sites_back_between_gates, kwargs...)
   end
   if move_sites_back
     s = siteinds(Aψ)

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -2089,15 +2089,15 @@ expτH = ops(os, s)
 function product(
   As::Vector{<:ITensor},
   ψ::AbstractMPS;
-  move_sites_back_between_gates::Bool=false,
+  move_sites_back_between_gates::Bool=true,
   move_sites_back::Bool=true,
-  kwargs...
+  kwargs...,
 )
   Aψ = ψ
   for A in As
     Aψ = product(A, Aψ; move_sites_back=move_sites_back_between_gates, kwargs...)
   end
-  if move_sites_back
+  if !move_sites_back_between_gates && move_sites_back
     s = siteinds(Aψ)
     ns = 1:length(ψ)
     ñs = [findsite(ψ, i) for i in s]


### PR DESCRIPTION
This fixes #892 by defaulting to moving the sites back to the original positions after each gate application.

There is a new keyword argument `move_sites_back_between_gates=false` which disables this feature, which can be faster in some cases. The goal of the previous behavior (`move_sites_back_between_gates=false`) was to try to minimize the number of swap gates that were necessary by only moving the sites around as needed, but #892 is a bad corner case that causes problems for the current swapping strategy we are using.

An issue is that now, with the new behavior `move_sites_back_between_gates=true`, there will be unnecessary swaps that happen in certain cases. Even with `move_sites_back_between_gates=true` we can have some automated swap cancellations by looking ahead to the next gate and seeing which swaps will happen. I'll leave that for future work, since #892 is pretty bad and we should fix it even at the expense of making some calculations slower with the default settings.

Here is a quick demonstration of the fix:
```julia
using ITensors

function main(; n)
  s = siteinds("S=1/2", n)
  ψ = randomMPS(s; linkdims=10)
  ψ2 = MPS([ψ[j] * ψ[j + 1] for j in 1:2:(n - 1)])
  
  @show maxlinkdim(ψ)

  u = [("CX", j, j + 2) for j in 1:2:(n - 2)]
  U = ops(u, s)

  for kwarg1 in [false, true], kwarg2 in [false, true]
    kwargs = (; move_sites_back_between_gates=kwarg1, move_sites_back=kwarg2)
    @show kwargs
    Uψ = @time apply(U, ψ; cutoff=1e-15, kwargs...)
    @show maxlinkdim(Uψ)
    println()

    Uψ2 = @time apply(U, ψ2; cutoff=1e-15, kwargs...)
    @show maxlinkdim(Uψ2)
    println()
  end
end
```
gives:
```julia
julia> main(; n=10)
maxlinkdim(ψ) = 10
kwargs = (move_sites_back_between_gates = false, move_sites_back = false)
  0.026793 seconds (39.06 k allocations: 4.846 MiB, 81.70% compilation time)
maxlinkdim(Uψ) = 32

  0.001541 seconds (4.17 k allocations: 1.034 MiB)
maxlinkdim(Uψ2) = 16

kwargs = (move_sites_back_between_gates = false, move_sites_back = true)
  0.101610 seconds (102.40 k allocations: 10.704 MiB, 87.27% compilation time)
maxlinkdim(Uψ) = 20

  0.001355 seconds (4.33 k allocations: 1.066 MiB)
maxlinkdim(Uψ2) = 16

kwargs = (move_sites_back_between_gates = true, move_sites_back = false)
  0.002995 seconds (11.20 k allocations: 2.332 MiB)
maxlinkdim(Uψ) = 20

  0.001233 seconds (4.21 k allocations: 1.037 MiB)
maxlinkdim(Uψ2) = 16

kwargs = (move_sites_back_between_gates = true, move_sites_back = true)
  0.002953 seconds (11.20 k allocations: 2.332 MiB)
maxlinkdim(Uψ) = 20

  0.001216 seconds (4.21 k allocations: 1.037 MiB)
maxlinkdim(Uψ2) = 16
```
and for a larger system:
```julia
julia> main(; n=20)
maxlinkdim(ψ) = 10
kwargs = (move_sites_back_between_gates = false, move_sites_back = false)
  1.789906 seconds (58.84 k allocations: 1.143 GiB, 2.05% gc time)
maxlinkdim(Uψ) = 1024

  0.003904 seconds (9.77 k allocations: 3.771 MiB)
maxlinkdim(Uψ2) = 20

kwargs = (move_sites_back_between_gates = false, move_sites_back = true)
  3.405958 seconds (114.95 k allocations: 2.285 GiB, 0.98% gc time)
maxlinkdim(Uψ) = 20

  0.003580 seconds (10.21 k allocations: 3.853 MiB)
maxlinkdim(Uψ2) = 20

kwargs = (move_sites_back_between_gates = true, move_sites_back = false)
  0.008753 seconds (25.87 k allocations: 6.732 MiB)
maxlinkdim(Uψ) = 20

  0.009027 seconds (9.86 k allocations: 3.777 MiB)
maxlinkdim(Uψ2) = 20

kwargs = (move_sites_back_between_gates = true, move_sites_back = true)
  0.015417 seconds (25.87 k allocations: 6.732 MiB)
maxlinkdim(Uψ) = 20

  0.004134 seconds (9.86 k allocations: 3.777 MiB)
maxlinkdim(Uψ2) = 20
```
As I guessed in #892, the issue is that the previous swapping strategy (`move_sites_back_between_gates=false`) leads to a reordering of the sites from:
```julia
s1 s2 s3 s4 ...
```
to:
```julia
s1 s3 s5 ... s2 s4 s6 ...
```
so for a generic MPS with a nontrivial bond dimension the bond dimension in the middle of the system grows exponentially with system size. The change made in this PR swaps sites back to the original ordering:
```julia
s1 s2 s3 s4 ...
```
after each gate application so avoids this problem.

An interesting thing to note is that I also tried the strategy of grouping neighboring MPS tensors so that the sites are like this:
```julia
(s1 s2) (s3 s4) ...
```
That avoids the original problem in all cases since the sites don't need to be swapped. It looks like it is a bit faster and less memory intensive than the swapping strategy for this case, so that is a good thing to keep in mind. Also emphasizing that the code automatically handles MPS with grouped site indices which is pretty nontrivial! It is similar to the grouping strategy used in: https://arxiv.org/abs/2002.07730 so that paper should be easy to reproduce with the current functionality. I think the only part that is missing is the QR preprocessing step in Fig. 10 of that paper, which would be good to add to the `apply` function.