### PR TITLE
[ITensors] [ENHANCEMENT] Handle corner case of normalizing a zero MPS

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1264,12 +1264,24 @@ Change the MPS or MPO `A` in-place such that `norm(A) ≈ 1`. This modifies the 
 
 In practice, this evenly spreads `lognorm(A)` over the tensors within the range of the orthogonality center to avoid numerical overflow in the case of diverging norms.
 
+If the norm of the input MPS or MPO is 0, normalizing is ill-defined. In this case, we just return the original MPS or MPO. You can check for this case as follows:
+```julia
+s = siteinds("S=1/2", 4)
+ψ = 0 * randomMPS(s)
+lognorm_ψ = []
+normalize!(ψ; (lognorm!)=lognorm_ψ)
+lognorm_ψ[1] == -Inf # There was an infinite norm
+```
+
 See also [`normalize`](@ref), [`norm`](@ref), [`lognorm`](@ref).
 """
 function normalize!(M::AbstractMPS; (lognorm!)=[])
   c = ortho_lims(M)
   lognorm_M = lognorm(M)
   push!(lognorm!, lognorm_M)
+  if lognorm_M == -Inf
+    return M
+  end
   z = exp(lognorm_M / length(c))
   # XXX: this is not modifying `M` in-place.
   # M[c] ./= z

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -328,6 +328,18 @@ include("util.jl")
     @test norm(psi) ≈ 1
     @test inner(phi, psi) ≈ 1
 
+    # Zero norm
+    @test norm(0phi) == 0
+    @test lognorm(0phi) == -Inf
+
+    zero_phi = 0phi
+    lognorm = []
+    normalize!(zero_phi; (lognorm!)=lognorm)
+    @test lognorm![1] == -Inf
+    @test norm(zero_phi) == 0
+    @test norm(normalize(0phi)) == 0
+
+
     # Large number of sites
     psi = randomMPS(siteinds("S=1/2", 1_000); linkdims=10)
 


### PR DESCRIPTION
# Description

This PR checks if the norm of the MPS is nonzero before normalizing. The new behavior is that now if the norm is zero, it performs a no-op. Before, it returned an MPS filled with `NaN`.

<details><summary>Before this PR</summary><p>

```julia
julia> using ITensors

julia> s = siteinds("S=1/2", 4);

julia> ψ = randomMPS(s);

julia> ψ = 0 * randomMPS(s);

julia> norm(ψ)
0.0

julia> lognorm(ψ)
-Inf

julia> normalize!(ψ);

julia> norm(ψ)
NaN

julia> lognorm(ψ)
NaN
```
</p></details>

<details><summary>After this PR</summary><p>

```julia
julia> using ITensors

julia> s = siteinds("S=1/2", 4);

julia> ψ = randomMPS(s);

julia> ψ = 0 * randomMPS(s);

julia> norm(ψ)
0.0

julia> lognorm(ψ)
-Inf

julia> normalize!(ψ);

julia> norm(ψ)
0.0

julia> lognorm(ψ)
-Inf
```
</p></details>

Julia goes the route of returning an Array filled with `NaN`:
```julia
julia> using LinearAlgebra

julia> normalize!(zeros(2, 2))
2×2 Matrix{Float64}:
 NaN  NaN
 NaN  NaN
```

The motivation for the new behavior is that we had a user who is doing an application with monitored circuits, i.e. evolving circuits with projected measurements scattered throughout the gate evolution. Some of these projective measurements were leading to states with zero norm. The user had steps calling `normalize!` to normalize the states after the projective measurements, which was introducing `NaN`s into the MPS which was leading to some mysterious errors in different places (for example in a subsequent eigendecomposition inside of `apply`).

This change helped avoid errors like that and the code ran smoothly. A downside is that it may be less clear when a zero state is obtained, so is just putting off the issue for later. But that could get caught in other places in the code. For example, we could check for zero states in `apply`, `correlation_matrix`, etc. or the user will notice when they try to compute properties of the state.

@emstoudenmire I'm curious about your thoughts on this.

# How Has This Been Tested?

Tests added for normalizing zero MPS.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
