### PR TITLE
[ITensors] [ENHANCEMENT] Allow `Matrix` representations for operators in `expect` and `correlation_matrix`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,22 @@ Please include a summary of the change and which issue is fixed (if applicable).
 
 Fixes #(issue)
 
+If practical and applicable, please include a minimal demonstration of the previous behavior and new behavior below.
+
+<details><summary>Minimal demonstration of previous behavior</summary><p>
+
+```julia
+[YOUR MINIMAL DEMONSTRATION OF PREVIOUS BEHAVIOR]
+```
+</p></details>
+
+<details><summary>Minimal demonstration of new behavior</summary><p>
+
+```julia
+[YOUR MINIMAL DEMONSTRATION OF NEW BEHAVIOR]
+```
+</p></details>
+
 # How Has This Been Tested?
 
 Please add tests that verify your changes to a file in the `test` directory.

--- a/test/fermions.jl
+++ b/test/fermions.jl
@@ -554,8 +554,8 @@ using ITensors, Test
         psiA = productMPS(sites, stateA)
         psiB = productMPS(sites, stateB)
 
-        @test inner(psiA, H, psiB) ≈ -t1
-        @test inner(psiB, H, psiA) ≈ -t1
+        @test inner(psiA', H, psiB) ≈ -t1
+        @test inner(psiB', H, psiA) ≈ -t1
       end
 
       for j in 1:(N - 1)
@@ -563,7 +563,7 @@ using ITensors, Test
         state[j] = 2
         state[j + 1] = 2
         psi = productMPS(sites, state)
-        @test inner(psi, H, psi) ≈ V1
+        @test inner(psi', H, psi) ≈ V1
       end
     end
 
@@ -598,13 +598,13 @@ using ITensors, Test
       state3[4] = 2
       psi3 = productMPS(s, state3)
 
-      @test inner(psi1, H, psi2) ≈ -t1
-      @test inner(psi2, H, psi1) ≈ -t1
-      @test inner(psi2, H, psi3) ≈ -t1
-      @test inner(psi3, H, psi2) ≈ -t1
+      @test inner(psi1', H, psi2) ≈ -t1
+      @test inner(psi2', H, psi1) ≈ -t1
+      @test inner(psi2', H, psi3) ≈ -t1
+      @test inner(psi3', H, psi2) ≈ -t1
 
-      @test inner(psi1, H, psi3) ≈ -t2
-      @test inner(psi3, H, psi1) ≈ -t2
+      @test inner(psi1', H, psi3) ≈ -t2
+      @test inner(psi3', H, psi1) ≈ -t2
 
       # Add stationary particle to site 2,
       # hopping over should change sign:
@@ -612,8 +612,8 @@ using ITensors, Test
       psi1 = productMPS(s, state1)
       state3[2] = 2
       psi3 = productMPS(s, state3)
-      @test inner(psi1, H, psi3) ≈ +t2
-      @test inner(psi3, H, psi1) ≈ +t2
+      @test inner(psi1', H, psi3) ≈ +t2
+      @test inner(psi3', H, psi1) ≈ +t2
     end
   end
 
@@ -796,7 +796,7 @@ using ITensors, Test
 
       energy, psi = dmrg(Ht, psi0, sweeps; outputlevel=0)
 
-      energy_inner = inner(psi, Ht, psi)
+      energy_inner = inner(psi', Ht, psi)
 
       C = correlation_matrix(psi, "Cdag", "C")
       C_energy =

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -785,8 +785,8 @@ end
     @test correlation_matrix(psi, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2]) ≈
       correlation_matrix(psi, "Sz", "Sz")
     @test expect(psi, [1/2 0; 0 -1/2]) ≈ expect(psi, "Sz")
-    @test expect(psi, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2]) ≈ expect(psi, "Sz", "Sz")
-    @test all(expect(psi, [[1/2 0; 0 -1/2], [1/2 0; 0 -1/2]]) .≈ expect(psi, ["Sz", "Sz"]))
+    @test all(expect(psi, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2]) .≈ expect(psi, "Sz", "Sz"))
+    @test expect(psi, [[1/2 0; 0 -1/2], [1/2 0; 0 -1/2]]) ≈ expect(psi, ["Sz", "Sz"])
 
     s = siteinds("S=1/2", length(s); conserve_qns=false)
     psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn"; linkdims=m)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -782,6 +782,11 @@ end
     psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn"; linkdims=m)
     test_correlation_matrix(psi, [("S-", "S+"), ("S+", "S-")])
 
+    @test correlation_matrix(psi, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2]) ≈ correlation_matrix(psi, "Sz", "Sz")
+    @test expect(psi, [1/2 0; 0 -1/2]) ≈ expect(psi, "Sz")
+    @test expect(psi, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2]) ≈ expect(psi, "Sz", "Sz")
+    @test all(expect(psi, [[1/2 0; 0 -1/2], [1/2 0; 0 -1/2]]) .≈ expect(psi, ["Sz", "Sz"]))
+
     s = siteinds("S=1/2", length(s); conserve_qns=false)
     psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn"; linkdims=m)
     test_correlation_matrix(

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -782,7 +782,8 @@ end
     psi = randomMPS(s, n -> isodd(n) ? "Up" : "Dn"; linkdims=m)
     test_correlation_matrix(psi, [("S-", "S+"), ("S+", "S-")])
 
-    @test correlation_matrix(psi, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2]) ≈ correlation_matrix(psi, "Sz", "Sz")
+    @test correlation_matrix(psi, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2]) ≈
+      correlation_matrix(psi, "Sz", "Sz")
     @test expect(psi, [1/2 0; 0 -1/2]) ≈ expect(psi, "Sz")
     @test expect(psi, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2]) ≈ expect(psi, "Sz", "Sz")
     @test all(expect(psi, [[1/2 0; 0 -1/2], [1/2 0; 0 -1/2]]) .≈ expect(psi, ["Sz", "Sz"]))


### PR DESCRIPTION
# Description

Allow `Matrix` representations for operators in `expect` and `correlation_matrix`. This can make it a bit easier to measure an operator that is not defined already without having to define the operator by overloading `op`.

For inspiration see the discussion here: https://itensor.discourse.group/t/measuring-correlations/51/6

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
julia> using ITensors

julia> s = siteinds("S=1/2", 4);

julia> ψ = randomMPS(s);

julia> expect(ψ, [1/2 0; 0 -1/2])
4-element Vector{Float64}:
  0.1968928836524881
 -0.4253469177197064
  0.4028392528567332
 -0.4026126134149185

julia> expect(ψ, "Sz")
4-element Vector{Float64}:
  0.1968928836524881
 -0.4253469177197064
  0.4028392528567332
 -0.4026126134149185

julia> correlation_matrix(ψ, [1/2 0; 0 -1/2], [1/2 0; 0 -1/2])
4×4 Matrix{Float64}:
  0.25       -0.0837478   0.0793162  -0.0792716
 -0.0837478   0.25       -0.171346    0.17125
  0.0793162  -0.171346    0.25       -0.162188
 -0.0792716   0.17125    -0.162188    0.25

julia> correlation_matrix(ψ, "Sz", "Sz")
4×4 Matrix{Float64}:
  0.25       -0.0837478   0.0793162  -0.0792716
 -0.0837478   0.25       -0.171346    0.17125
  0.0793162  -0.171346    0.25       -0.162188
 -0.0792716   0.17125    -0.162188    0.25
```
</p></details>

# How Has This Been Tested?

Added tests of the behavior shown above.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
