### PR TITLE
[ITensors] [ENHANCMENT] Haar random unitary gate

### DIFF
--- a/ITensorGaussianMPS/test/electron.jl
+++ b/ITensorGaussianMPS/test/electron.jl
@@ -86,7 +86,7 @@ end
   end
 
   H_noninteracting = MPO(os_noninteracting, s)
-  @test tr(Φ_up' * h_up * Φ_up) + tr(Φ_dn' * h_dn * Φ_dn) ≈ inner(ψ0, H_noninteracting, ψ0) rtol =
+  @test tr(Φ_up' * h_up * Φ_up) + tr(Φ_dn' * h_dn * Φ_dn) ≈ inner(ψ0', H_noninteracting, ψ0) rtol =
     1e-3
 
   # The total interacting Hamiltonian
@@ -108,7 +108,7 @@ end
   @test flux(ψr) == QN(("Nf", Nf, -1), ("Sz", 0))
   @test flux(ψ0) == QN(("Nf", Nf, -1), ("Sz", 0))
 
-  @test inner(ψ0, H, ψ0) < inner(ψr, H, ψr)
+  @test inner(ψ0', H, ψ0) < inner(ψr', H, ψr)
 
   sweeps = Sweeps(3)
   setmaxdim!(sweeps, 10, 20, _maxlinkdim)
@@ -122,7 +122,7 @@ end
   setnoise!(sweeps, 1e-5, 1e-6, 1e-7, 0.0)
   e0, _ = dmrg(H, ψ0, sweeps; outputlevel=0)
 
-  @test e0 > inner(ψ0, H_noninteracting, ψ0)
+  @test e0 > inner(ψ0', H_noninteracting, ψ0)
   @test e0 < er
 end
 
@@ -147,7 +147,7 @@ end
   Φ_up = slater_determinant_matrix(h_up, Nf_up)
   Φ_dn = slater_determinant_matrix(h_dn, Nf_dn)
   ψ = slater_determinant_to_mps(s, Φ_up, Φ_dn; eigval_cutoff=0.0, cutoff=0.0)
-  @test inner(ψ, H, ψ) ≈ tr(Φ_up'h_up * Φ_up) + tr(Φ_dn'h_dn * Φ_dn)
+  @test inner(ψ', H, ψ) ≈ tr(Φ_up'h_up * Φ_up) + tr(Φ_dn'h_dn * Φ_dn)
   @test maxlinkdim(ψ) == 2
   @test flux(ψ) == QN(("Nf", 1, -1), ("Sz", 1))
   ns_up = expect_compat(ψ, "Nup")

--- a/ITensorGaussianMPS/test/gmera.jl
+++ b/ITensorGaussianMPS/test/gmera.jl
@@ -52,7 +52,7 @@ end
   end
   H = MPO(os, s)
 
-  @test inner(ψ, H, ψ) ≈ E rtol = 1e-5
+  @test inner(ψ', H, ψ) ≈ E rtol = 1e-5
 
   # Compare to DMRG
   sweeps = Sweeps(10)
@@ -62,7 +62,7 @@ end
 
   # Create an mps
   @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
-  @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
+  @test inner(ψ̃', H, ψ̃) ≈ inner(ψ', H, ψ) rtol = 1e-5
   @test E ≈ energy
 end
 
@@ -109,8 +109,8 @@ end
   end
   H = MPO(os, s)
 
-  @test inner(ψ, H, ψ) ≈ E rtol = 1e-5
-  @test inner(ψ, H, ψ) / norm(ψ) ≈ E rtol = 1e-5
+  @test inner(ψ', H, ψ) ≈ E rtol = 1e-5
+  @test inner(ψ', H, ψ) / norm(ψ) ≈ E rtol = 1e-5
 
   # Compare to DMRG
   sweeps = Sweeps(10)
@@ -120,7 +120,7 @@ end
 
   # Create an mps
   @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
-  @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
+  @test inner(ψ̃', H, ψ̃) ≈ inner(ψ', H, ψ) rtol = 1e-5
   @test E ≈ energy
 end
 

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -52,7 +52,7 @@ end
   end
   H = MPO(os, s)
 
-  @test inner(ψ, H, ψ) ≈ E rtol = 1e-5
+  @test inner(ψ', H, ψ) ≈ E rtol = 1e-5
 
   # Compare to DMRG
   sweeps = Sweeps(10)
@@ -62,7 +62,7 @@ end
 
   # Create an mps
   @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
-  @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
+  @test inner(ψ̃', H, ψ̃) ≈ inner(ψ', H, ψ) rtol = 1e-5
   @test E ≈ energy
 end
 
@@ -109,8 +109,8 @@ end
   end
   H = MPO(os, s)
 
-  @test inner(ψ, H, ψ) ≈ E rtol = 1e-5
-  @test inner(ψ, H, ψ) / norm(ψ) ≈ E rtol = 1e-5
+  @test inner(ψ', H, ψ) ≈ E rtol = 1e-5
+  @test inner(ψ', H, ψ) / norm(ψ) ≈ E rtol = 1e-5
 
   # Compare to DMRG
   sweeps = Sweeps(10)
@@ -120,6 +120,6 @@ end
 
   # Create an mps
   @test abs(inner(ψ, ψ̃)) ≈ 1 rtol = 1e-5
-  @test inner(ψ̃, H, ψ̃) ≈ inner(ψ, H, ψ) rtol = 1e-5
+  @test inner(ψ̃', H, ψ̃) ≈ inner(ψ', H, ψ) rtol = 1e-5
   @test E ≈ energy
 end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -363,6 +363,8 @@ export
   ops,
   OpName,
   @OpName_str,
+  ValName,
+  @ValName_str,
   state,
   TagType,
   @TagType_str,

--- a/src/physics/site_types/generic_sites.jl
+++ b/src/physics/site_types/generic_sites.jl
@@ -4,7 +4,9 @@ function op(::OpName"Id", ::SiteType"Generic", s1::Index, sn::Index...; eltype=F
   return itensor(Matrix(one(eltype) * I, n, n), prime.(s)..., dag.(s)...)
 end
 
-op(::OpName"I", st::SiteType"Generic", s::Index...; kwargs...) = op(OpName("Id"), st, s...; kwargs...)
+function op(::OpName"I", st::SiteType"Generic", s::Index...; kwargs...)
+  return op(OpName("Id"), st, s...; kwargs...)
+end
 
 function op(::OpName"F", st::SiteType"Generic", s::Index; kwargs...)
   return op(OpName("Id"), st, s; kwargs...)

--- a/src/physics/site_types/generic_sites.jl
+++ b/src/physics/site_types/generic_sites.jl
@@ -1,11 +1,38 @@
-function op!(Op::ITensor, ::OpName"Id", ::SiteType"Generic", s::Index)
-  for n in 1:dim(s)
-    Op[n, n] = 1.0
-  end
+function op(::OpName"Id", ::SiteType"Generic", s1::Index, sn::Index...; eltype=Float64)
+  s = (s1, sn...)
+  n = prod(dim.(s))
+  return itensor(Matrix(one(eltype) * I, n, n), prime.(s)..., dag.(s)...)
 end
 
-op(::OpName"I", t::SiteType"Generic", s::Index) = op("Id", s)
+op(::OpName"I", st::SiteType"Generic", s::Index...; kwargs...) = op(OpName("Id"), st, s...; kwargs...)
 
-function op!(Op::ITensor, ::OpName"F", st::SiteType"Generic", s::Index)
-  return op!(Op, OpName("Id"), st, s)
+function op(::OpName"F", st::SiteType"Generic", s::Index; kwargs...)
+  return op(OpName("Id"), st, s; kwargs...)
+end
+
+function default_random_matrix(eltype::Type, s::Index...)
+  n = prod(dim.(s))
+  return randn(eltype, n, n)
+end
+
+# Haar-random unitary
+#
+# Reference:
+# Section 4.6
+# http://math.mit.edu/~edelman/publications/random_matrix_theory.pdf
+function op(
+  ::OpName"RandomUnitary",
+  ::SiteType"Generic",
+  s1::Index,
+  sn::Index...;
+  eltype=ComplexF64,
+  random_matrix=default_random_matrix(eltype, s1, sn...),
+)
+  s = (s1, sn...)
+  Q, _ = NDTensors.qr_positive(random_matrix)
+  return itensor(Q, prime.(s)..., dag.(s)...)
+end
+
+function op(::OpName"randU", st::SiteType"Generic", s::Index...; kwargs...)
+  return op(OpName("RandomUnitary"), st, s...; kwargs...)
 end

--- a/src/physics/site_types/generic_sites.jl
+++ b/src/physics/site_types/generic_sites.jl
@@ -1,4 +1,4 @@
-function op!(o::ITensors, ::OpName"Id", ::SiteType"Generic", s1::Index, sn::Index...; eltype=Float64)
+function op!(o::ITensor, ::OpName"Id", ::SiteType"Generic", s1::Index, sn::Index...; eltype=Float64)
   s = (s1, sn...)
   n = prod(dim.(s))
   t = itensor(Matrix(one(eltype) * I, n, n), prime.(s)..., dag.(s)...)

--- a/src/physics/site_types/generic_sites.jl
+++ b/src/physics/site_types/generic_sites.jl
@@ -1,4 +1,6 @@
-function op!(o::ITensor, ::OpName"Id", ::SiteType"Generic", s1::Index, sn::Index...; eltype=Float64)
+function op!(
+  o::ITensor, ::OpName"Id", ::SiteType"Generic", s1::Index, sn::Index...; eltype=Float64
+)
   s = (s1, sn...)
   n = prod(dim.(s))
   t = itensor(Matrix(one(eltype) * I, n, n), prime.(s)..., dag.(s)...)

--- a/src/physics/site_types/generic_sites.jl
+++ b/src/physics/site_types/generic_sites.jl
@@ -1,15 +1,16 @@
-function op(::OpName"Id", ::SiteType"Generic", s1::Index, sn::Index...; eltype=Float64)
+function op!(o::ITensors, ::OpName"Id", ::SiteType"Generic", s1::Index, sn::Index...; eltype=Float64)
   s = (s1, sn...)
   n = prod(dim.(s))
-  return itensor(Matrix(one(eltype) * I, n, n), prime.(s)..., dag.(s)...)
+  t = itensor(Matrix(one(eltype) * I, n, n), prime.(s)..., dag.(s)...)
+  return settensor!(o, tensor(t))
 end
 
-function op(::OpName"I", st::SiteType"Generic", s::Index...; kwargs...)
-  return op(OpName("Id"), st, s...; kwargs...)
+function op!(o::ITensor, ::OpName"I", st::SiteType"Generic", s::Index...; kwargs...)
+  return op!(o, OpName("Id"), st, s...; kwargs...)
 end
 
-function op(::OpName"F", st::SiteType"Generic", s::Index; kwargs...)
-  return op(OpName("Id"), st, s; kwargs...)
+function op!(o::ITensor, ::OpName"F", st::SiteType"Generic", s::Index; kwargs...)
+  return op!(o, OpName("Id"), st, s; kwargs...)
 end
 
 function default_random_matrix(eltype::Type, s::Index...)
@@ -22,7 +23,8 @@ end
 # Reference:
 # Section 4.6
 # http://math.mit.edu/~edelman/publications/random_matrix_theory.pdf
-function op(
+function op!(
+  o::ITensor,
   ::OpName"RandomUnitary",
   ::SiteType"Generic",
   s1::Index,
@@ -32,9 +34,10 @@ function op(
 )
   s = (s1, sn...)
   Q, _ = NDTensors.qr_positive(random_matrix)
-  return itensor(Q, prime.(s)..., dag.(s)...)
+  t = itensor(Q, prime.(s)..., dag.(s)...)
+  return settensor!(o, tensor(t))
 end
 
-function op(::OpName"randU", st::SiteType"Generic", s::Index...; kwargs...)
-  return op(OpName("RandomUnitary"), st, s...; kwargs...)
+function op!(o::ITensor, ::OpName"randU", st::SiteType"Generic", s::Index...; kwargs...)
+  return op!(o, OpName("RandomUnitary"), st, s...; kwargs...)
 end

--- a/test/qnmpo.jl
+++ b/test/qnmpo.jl
@@ -61,10 +61,10 @@ using ITensors, Test
   @testset "orthogonalize!" begin
     orthogonalize!(phi, 1)
     orthogonalize!(K, 1)
-    orig_inner = ⋅(phi, K, phi)
+    orig_inner = ⋅(phi', K, phi)
     orthogonalize!(phi, div(N, 2))
     orthogonalize!(K, div(N, 2))
-    @test ⋅(phi, K, phi) ≈ orig_inner
+    @test ⋅(phi', K, phi) ≈ orig_inner
   end
 
   @testset "inner <y|A|x>" begin


### PR DESCRIPTION
# Description

Introduce a `"RandomUnitary"` operator type for generic sites with arbitrary number of site indices (though obviously exponential in the number of sites). Uses a positive QR, and currently only works for no-QN types but this will be extended to QN types once we have a block-sparse QR decomposition code.

Also extends the generic `"Id"`/`"I"` to arbitrary numbers of sites.

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
julia> U = op("RandomUnitary", Index(2));

julia> @show U;
U = ITensor ord=2
Dim 1: (dim=2|id=555)'
Dim 2: (dim=2|id=555)
NDTensors.Dense{ComplexF64, Vector{ComplexF64}}
 2×2
 -0.44499690218411403 - 0.40285137604815163im  -0.5260346128947571 - 0.6024749886089176im
    -0.70042276570126 - 0.38613012722403606im   0.4881449473231141 + 0.3493221787122336im

julia> @show product(transpose(dag(U)), U);
product(transpose(dag(U)), U) = ITensor ord=2
Dim 1: (dim=2|id=555)'
Dim 2: (dim=2|id=555)
NDTensors.Dense{ComplexF64, Vector{ComplexF64}}
 2×2
      0.9999999999999998 + 0.0im                     -2.7755575615628914e-16 + 2.7755575615628914e-17im
 -2.7755575615628914e-16 - 2.7755575615628914e-17im       0.9999999999999998 + 0.0im

julia> U = op("RandomUnitary", Index(2); eltype=Float64);

julia> @show product(transpose(dag(U)), U);
product(transpose(dag(U)), U) = ITensor ord=2
Dim 1: (dim=2|id=559)'
Dim 2: (dim=2|id=559)
NDTensors.Dense{Float64, Vector{Float64}}
 2×2
  0.9999999999999994      -3.2809879224885144e-18
 -3.2809879224885144e-18   0.9999999999999999
```
</p></details>

# How Has This Been Tested?

Added tests for making `"RandomUnitary"` with variable numbers of indices, including checking they are unitary.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
