### PR TITLE
[ITensors] [ENHANCEMENT] Add support for defining MPOs from operators represented as matrices

### DIFF
--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -102,7 +102,8 @@ end
 MPO(sites::Vector{<:Index}, op::String) = MPO(Float64, sites, op)
 
 function MPO(::Type{ElT}, sites::Vector{<:Index}, op::Matrix{<:Number}) where {ElT<:Number}
-  return MPO(ElT, sites, fill(op, length(sites)))
+  # return MPO(ElT, sites, fill(op, length(sites)))
+  return error("Not defined on purpose because of potential ambiguity with `MPO(A::Array, sites::Vector)`. Pass the on-site matrices as functions like `MPO(sites, n -> [1 0; 0 1])` instead.")
 end
 
 MPO(sites::Vector{<:Index}, op::Matrix{ElT}) where {ElT<:Number} = MPO(ElT, sites, op)

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -66,7 +66,7 @@ MPO(N::Int) = MPO(Vector{ITensor}(undef, N))
 Make an MPO with pairs of sites `s[i]` and `s[i]'`
 and operators `ops` on each site.
 """
-function MPO(::Type{ElT}, sites::Vector{<:Index}, ops::Vector{String}) where {ElT<:Number}
+function MPO(::Type{ElT}, sites::Vector{<:Index}, ops::Vector) where {ElT<:Number}
   N = length(sites)
   ampo = OpSum() + [ops[n] => n for n in 1:N]
   M = MPO(ampo, sites)
@@ -100,6 +100,12 @@ function MPO(::Type{ElT}, sites::Vector{<:Index}, op::String) where {ElT<:Number
 end
 
 MPO(sites::Vector{<:Index}, op::String) = MPO(Float64, sites, op)
+
+function MPO(::Type{ElT}, sites::Vector{<:Index}, op::Matrix{<:Number}) where {ElT<:Number}
+  return MPO(ElT, sites, fill(op, length(sites)))
+end
+
+MPO(sites::Vector{<:Index}, op::Matrix{ElT}) where {ElT<:Number} = MPO(ElT, sites, op)
 
 function randomMPO(sites::Vector{<:Index}, m::Int=1)
   M = MPO(sites, "Id")

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -103,7 +103,9 @@ MPO(sites::Vector{<:Index}, op::String) = MPO(Float64, sites, op)
 
 function MPO(::Type{ElT}, sites::Vector{<:Index}, op::Matrix{<:Number}) where {ElT<:Number}
   # return MPO(ElT, sites, fill(op, length(sites)))
-  return error("Not defined on purpose because of potential ambiguity with `MPO(A::Array, sites::Vector)`. Pass the on-site matrices as functions like `MPO(sites, n -> [1 0; 0 1])` instead.")
+  return error(
+    "Not defined on purpose because of potential ambiguity with `MPO(A::Array, sites::Vector)`. Pass the on-site matrices as functions like `MPO(sites, n -> [1 0; 0 1])` instead.",
+  )
 end
 
 MPO(sites::Vector{<:Index}, op::Matrix{ElT}) where {ElT<:Number} = MPO(ElT, sites, op)

--- a/src/physics/autompo.jl
+++ b/src/physics/autompo.jl
@@ -137,7 +137,7 @@ function MPOTerm(op1::Union{String,AbstractArray}, ops...)
   return MPOTerm(one(Float64), op1, ops...)
 end
 
-function MPOTerm(ops::Vector{Pair{String,Int}})
+function MPOTerm(ops::Vector{<:Pair})
   return MPOTerm(Iterators.flatten(ops)...)
 end
 
@@ -301,7 +301,7 @@ function (ampo::OpSum + term::MPOTerm)
 end
 
 (ampo::OpSum + term::Tuple) = ampo + MPOTerm(term...)
-(ampo::OpSum + term::Vector{Pair{String,Int64}}) = ampo + MPOTerm(term)
+(ampo::OpSum + term::Vector{<:Pair}) = ampo + MPOTerm(term)
 
 function (ampo::OpSum - term::Tuple)
   ampo_plus_term = copy(ampo)

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -399,7 +399,7 @@ end
     l = [Index(3, "left_$n") for n in 1:2]
     r = [Index(3, "right_$n") for n in 1:2]
 
-    sis = IndexSet.(prime.(s), s)
+    sis = [[sₙ', sₙ] for sₙ in s]
 
     A = randomITensor(s..., prime.(s)...)
     ψ = MPO(A, sis; orthocenter=4)
@@ -428,6 +428,10 @@ end
     @test prod(ψ) ≈ A
     @test ITensors.orthocenter(ψ) == 3
     @test maxlinkdim(ψ) == 1
+
+    # Use matrix
+    @test MPO(s, [1/2 0; 0 1/2]) ≈ MPO(s, "Id") ./ 2
+    @test MPO(s, _ -> [1/2 0; 0 1/2]) ≈ MPO(s, "Id") ./ 2
 
     ψ0 = MPO(s, "Id")
     A = prod(ψ0)

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -430,7 +430,7 @@ end
     @test maxlinkdim(ψ) == 1
 
     # Use matrix
-    @test MPO(s, [1/2 0; 0 1/2]) ≈ MPO(s, "Id") ./ 2
+    @test_throws ErrorException MPO(s, [1/2 0; 0 1/2])
     @test MPO(s, _ -> [1/2 0; 0 1/2]) ≈ MPO(s, "Id") ./ 2
 
     ψ0 = MPO(s, "Id")


### PR DESCRIPTION
# Description

Motivated by: https://itensor.discourse.group/t/generate-maximally-mixed-state/67

Over all it would be good to be able to use matrices interchangeably with the string representation, like #899 and #902, so this helps us move towards that goal.

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
using ITensors
s = siteinds("S=1/2", 4)
H = MPO(s, [1 0; 0 1])
H ≈ MPO(s, "Id")

# Function version
H = MPO(s, n -> [1 0; 0 1])
H ≈ MPO(s, "Id")
```
</p></details>

# How Has This Been Tested?

Tests were added for the behavior above.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
