### PR TITLE
[ITensors] [ENHANCMENT] Add docs for included site types

### DIFF
--- a/docs/settings.jl
+++ b/docs/settings.jl
@@ -32,6 +32,7 @@ settings = Dict(
       "MPS and MPO" => "MPSandMPO.md",
       "QN" => "QN.md",
       "SiteType and op, state, val functions" => "SiteType.md",
+      "SiteTypes Included with ITensor" => "IncludedSiteTypes.md",
       "DMRG" => [
         "DMRG.md",
         "Sweeps.md",

--- a/docs/src/IncludedSiteTypes.md
+++ b/docs/src/IncludedSiteTypes.md
@@ -1,0 +1,336 @@
+# SiteTypes Included with ITensor
+
+## "S=1/2" SiteType
+
+Site indices with the "S=1/2" site type represent ``S=1/2`` spins with the states
+``|\!\uparrow\rangle``, ``|\!\downarrow\rangle``.
+
+Making a single "S=1/2" site or collection of N "S=1/2" sites
+```
+s = siteind("S=1/2")
+sites = siteinds("S=1/2",N)
+```
+
+Available keyword arguments for enabling and customizing quantum numbers (QN) subspaces:
+- `conserve_qns` (default: false): conserve total ``S^z``
+- `conserve_sz` (default: conserve_qns): conserve total ``S^z``
+- `conserve_szparity` (default: false): conserve total ``S^z`` modulo two
+- `qnname_sz` (default: "Sz"): name of total ``S^z`` QN
+- `qnname_szparity` (default: "SzParity"): name of total ``S^z`` modulo two QN
+For example:
+```
+sites = siteinds("S=1/2",N; conserve_szparity=true, qnname_szparity="SzP")
+```
+
+Operators associated with "S=1/2" sites can be made using the `op` function,
+for example
+```
+Sz = op("Sz",s)
+Sz4 = op("Sz",sites[4])
+```
+
+Available operators are exactly the same as those for the "Qubit" site type. Please
+see the list of "Qubit" operators below.
+
+## "Qubit" SiteType
+
+Site indices with the "Qubit" site type represent qubits with the states
+``|0\rangle``, ``|1\rangle``.
+
+Making a single "Qubit" site or collection of N "Qubit" sites
+```
+s = siteind("Qubit")
+sites = siteinds("Qubit",N)
+```
+
+Available keyword arguments for enabling and customizing quantum numbers (QN) subspaces:
+- `conserve_qns` (default: false): conserve total qubit parity
+- `conserve_parity` (default: conserve_qns): conserve total qubit parity
+- `conserve_number` (default: false): conserve total qubit number
+- `qnname_parity` (default: "Parity"): name of total qubit parity QN
+- `qnname_number` (default: "Number"): name of total qubit number QN
+For example:
+```
+sites = siteinds("Qubit",N; conserve_parity=true)
+```
+
+Operators or gates associated with "Qubit" sites can be made using the `op` function,
+for example
+```
+H = op("H",s)
+H3 = op("H",sites[3])
+```
+
+Single-qubit operators:
+- `"X"` (aliases: `"σx"`, `"σ1"`) Pauli X operator
+- `"Y"` (aliases: `"σy"`, `"σ2"`) Pauli Y operator
+- `"iY"` (aliases: `"iσy"`, `"iσ2"`) Pauli Y operator times i
+- `"Z"` (aliases: `"σz"`, `"σ3"`) Pauli Z operator
+- `"√NOT"` (aliases: `"X"`)
+- `"H"` Hadamard gate
+- `"Phase"` (takes optional argument: ϕ=π/2) (aliases: `"P"`, `"S"`)
+- `"π/8"` (aliases: `"T"`)
+- `"Rx"` (takes argument: θ) Rotation around x axis
+- `"Ry"` (takes argument: θ) Rotation around y axis
+- `"Rz"` (takes argument: ϕ) Rotation around z axis
+- `"Rn"` (takes arguments: θ, ϕ, λ) (aliases: `"Rn̂"`) Rotation about axis n=(θ, ϕ, λ)
+
+Spin operators:
+- `"Sz"` (aliases: `"Sᶻ"`)
+- `"S+"` (alises: `"S⁺"`, `"Splus"`)
+- `"S-"` (aliases: `"S⁻"`, `"Sminus"`)
+- `"Sx"` (alises: `"Sˣ"`)
+- `"iSy"` (aliases: `"iSʸ"`)
+- `"Sy"` (aliases: `"Sʸ"`)
+- `"S2"` (aliases: "S²"`)
+- `"ProjUp"` (aliases: `"projUp"`)
+- `"ProjDn"` (aliases: `"projDn"`)
+
+Two-qubit gates:
+- `"CNOT"` (aliases: `"CX"`) Controlled NOT gate
+- `"CY"` Controlled Y gate
+- `"CZ"` Controlled Z gate
+- `"CPHASE"` (aliases: `"Cphase"`) Controlled Phase gate
+- `"CRx"` (aliases: `"CRX"`) (takes arguments: θ)
+- `"CRy"` (aliases: `"CRY"`) (takes arguments: θ)
+- `"CRz"` (aliases: `"CRZ"`) (takes arguments: ϕ)
+- `"CRn"` (aliases: `"CRn̂"`) (takes arguments: θ, ϕ, λ)
+- `"SWAP"` (aliases: `"Swap"`) 
+- `"√SWAP"` (aliases: `"√Swap"`) 
+- `"iSWAP"` (aliases: `"iSwap"`) 
+- `"√iSWAP"` (aliases: `"√iSwap"`) 
+- `"Rxx"` (aliases: `"RXX"`) (takes arguments: ϕ) Ising (XX) coupling gate
+- `"Ryy"` (aliases: `"RYY"`) (takes arguments: ϕ) Ising (YY) coupling gate
+- `"Rzz"` (aliases: `"RZZ"`) (takes arguments: ϕ) Ising (ZZ) coupling gate
+
+Three-qubit gates:
+- `"Toffoli"` (aliases `"CCNOT"`, `"CCX"`, `"TOFF"`)
+- `"Fredkin"` (aliases `"CSWAP"`, `"CSwap"`, `"CS"`)
+
+Four-qubit gates:
+- `"CCCNOT"`
+
+## "S=1" SiteType
+
+Site indices with the "S=1" site type represent ``S=1`` spins with the states
+``|\!\uparrow\rangle``, ``|0\rangle``, ``|\!\downarrow\rangle``.
+
+Making a single "S=1" site or collection of N "S=1" sites
+```
+s = siteind("S=1")
+sites = siteinds("S=1",N)
+```
+
+Available keyword arguments for enabling and customizing quantum numbers (QN) subspaces:
+- `conserve_qns` (default: false): conserve total ``S^z``
+- `conserve_sz` (default: conserve_qns): conserve total ``S^z``
+- `qnname_sz` (default: "Sz"): name of total ``S^z`` QN
+For example:
+```
+sites = siteinds("S=1",N; conserve_sz=true, qnname_sz="TotalSz")
+```
+
+Operators associated with "S=1" sites can be made using the `op` function,
+for example
+```
+Sz = op("Sz",s)
+Sz4 = op("Sz",sites[4])
+```
+
+Spin operators:
+- `"Sz"` (aliases: `"Sᶻ"`)
+- `"Sz2"` Square of `S^z` operator
+- `"S+"` (alises: `"S⁺"`, `"Splus"`)
+- `"S-"` (aliases: `"S⁻"`, `"Sminus"`)
+- `"Sx"` (alises: `"Sˣ"`)
+- `"Sx2"` Square of `S^x` operator
+- `"iSy"` (aliases: `"iSʸ"`)
+- `"Sy"` (aliases: `"Sʸ"`)
+- `"Sy2"` Square of `S^y` operator
+- `"S2"` (aliases: "S²"`)
+
+## "Boson" SiteType
+
+The "Boson" site type is an alias for the "Qudit" site type. Please
+see more information about "Qudit" below:
+
+## "Qudit" SiteType
+
+Making a single "Qudit" site or collection of N "Qudit" sites
+```
+s = siteind("Qudit")
+sites = siteinds("Qudit",N)
+```
+
+Available keyword arguments for enabling and customizing quantum numbers (QN) subspaces:
+- `dim` (default: 2): dimension of the index (number of qudit or boson values)
+- `conserve_qns` (default: false): conserve total qudit or boson number
+- `conserve_number` (default: conserve_qns): conserve total qudit or boson number
+- `qnname_number` (default: "Number"): name of total qudit or boson number QN
+For example:
+```
+sites = siteinds("Qudit",N; conserve_number=true)
+```
+
+Operators associated with "Qudit" sites can be made using the `op` function,
+for example
+```
+A = op("A",s)
+A4 = op("A",sites[4])
+```
+
+Single-qudit operators:
+- `"A"` (aliases: `"a"`)
+- `"Adag"` (aliases: `"adag"`, `"a†"`)
+- `"N"` (aliases: `"n"`)
+
+Two-qudit operators:
+- `"ab"`
+- `"a†b"`
+- `"ab†"`
+- `"a†b†"`
+
+## "Fermion" SiteType
+
+Site indices with the "Fermion" SiteType represent 
+spinless fermion sites with the states
+``|0\rangle``, ``|1\rangle``, corresponding to zero fermions or one fermion.
+
+Making a single "Fermion" site or collection of N "Fermion" sites
+```
+s = siteind("Fermion")
+sites = siteinds("Fermion",N)
+```
+
+Available keyword arguments for enabling and customizing quantum numbers (QN) subspaces:
+- `conserve_qns` (default: false): conserve total number of fermions
+- `conserve_nf` (default: conserve_qns): conserve total number of fermions
+- `conserve_nfparity` (default: conserve_qns): conserve total fermion number parity
+- `qnname_nf` (default: "Nf"): name of total fermion number QN
+- `qnname_nfparity` (default: "NfParity"): name of total fermion number parity QN
+For example:
+```
+sites = siteinds("Fermion",N; conserve_nfparity=true)
+```
+
+Operators associated with "Fermion" sites can be made using the `op` function,
+for example
+```
+C = op("C",s)
+C4 = op("C",sites[4])
+```
+
+Single-fermion operators:
+- `"N"` (aliases: `"n"`) Density operator
+- `"C"` (aliases: `"c"`) Fermion annihilation operator
+- `"Cdag"` (aliases: `"cdag"`, `"c†"`) Fermion creation operator
+- `"F"` Jordan-Wigner string operator
+
+## "Electron" SiteType
+
+The states of site indices with the "Electron" SiteType correspond to
+``|0\rangle``, ``|\!\uparrow\rangle``, ``|\!\downarrow\rangle``, ``|\!\uparrow\downarrow\rangle``.
+
+Making a single "Electron" site or collection of N "Electron" sites
+```
+s = siteind("Electron")
+sites = siteinds("Electron",N)
+```
+
+Available keyword arguments for enabling and customizing quantum numbers (QN) subspaces:
+- `conserve_qns` (default: false): conserve total number of electrons
+- `conserve_sz` (default: conserve_qns): conserve total ``S^z``
+- `conserve_nf` (default: conserve_qns): conserve total number of electrons
+- `conserve_nfparity` (default: conserve_qns): conserve total electron number parity
+- `qnname_sz` (default: "Sz"): name of total ``S^z`` QN
+- `qnname_nf` (default: "Nf"): name of total electron number QN
+- `qnname_nfparity` (default: "NfParity"): name of total electron number parity QN
+For example:
+```
+sites = siteinds("Electron",N; conserve_nfparity=true)
+```
+
+Operators associated with "Electron" sites can be made using the `op` function,
+for example
+```
+Cup = op("Cup",s)
+Cup4 = op("Cup",sites[4])
+```
+
+Single-fermion operators:
+- `"Ntot"` (aliases: `"ntot"`) Total density operator
+- `"Nup"` (aliases: `"n↑"`) Up density operator
+- `"Ndn"` (aliases: `"n↓"`) Down density operator
+- `"Cup"` (aliases: `"c↑"`) Up-spin annihilation operator
+- `"Cdn"` (aliases: `"c↓"`) Down-spin annihilation operator
+- `"Cdagup"` (aliases: `"c†↑"`) Up-spin creation operator
+- `"Cdagdn"` (aliases: `"c†↓"`) Down-spin creation operator
+- `"Sz"` (aliases: `"Sᶻ"`) 
+- `"Sx"` (aliases: `"Sˣ"`) 
+- `"S+"` (aliases: `"Sp"`, `"S⁺"`,`"Splus"`) 
+- `"S-"` (aliases: `"Sm"`, `"S⁻"`, `"Sminus"`) 
+- `"F"` Jordan-Wigner string operator
+- `"Fup"` (aliases: `"F↑"`) Up-spin Jordan-Wigner string operator
+- `"Fdn"` (aliases: `"F↓"`) Down-spin Jordan-Wigner string operator
+
+Non-fermionic single particle operators (these do not have Jordan-Wigner string attached,
+so will commute within systems such as OpSum or the `apply` function):
+- `"Aup"` (aliases: `"a↑"`) Up-spin annihilation operator
+- `"Adn"` (aliases: `"a↓"`) Down-spin annihilation operator
+- `"Adagup"` (aliases: `"a†↑"`) Up-spin creation operator
+- `"Adagdn"` (aliases: `"a†↓"`) Down-spin creation operator
+
+
+## "tJ" SiteType
+
+"tJ" sites are similar to electron sites, but cannot be doubly occupied
+The states of site indices with the "tJ" SiteType correspond to
+``|0\rangle``, ``|\!\uparrow\rangle``, ``|\!\downarrow\rangle``.
+
+Making a single "tJ" site or collection of N "tJ" sites
+```
+s = siteind("tJ")
+sites = siteinds("tJ",N)
+```
+
+Available keyword arguments for enabling and customizing quantum numbers (QN) subspaces:
+- `conserve_qns` (default: false): conserve total number of fermions
+- `conserve_nf` (default: conserve_qns): conserve total number of fermions
+- `conserve_nfparity` (default: conserve_qns): conserve total fermion number parity
+- `qnname_nf` (default: "Nf"): name of total fermion number QN
+- `qnname_nfparity` (default: "NfParity"): name of total fermion number parity QN
+For example:
+```
+sites = siteinds("tJ",N; conserve_nfparity=true)
+```
+
+Operators associated with "tJ" sites can be made using the `op` function,
+for example
+```
+Cup = op("Cup",s)
+Cup4 = op("Cup",sites[4])
+```
+
+Single-fermion operators:
+- `"Ntot"` (aliases: `"ntot"`) Total density operator
+- `"Nup"` (aliases: `"n↑"`) Up density operator
+- `"Ndn"` (aliases: `"n↓"`) Down density operator
+- `"Cup"` (aliases: `"c↑"`) Up-spin annihilation operator
+- `"Cdn"` (aliases: `"c↓"`) Down-spin annihilation operator
+- `"Cdagup"` (aliases: `"c†↑"`) Up-spin creation operator
+- `"Cdagdn"` (aliases: `"c†↓"`) Down-spin creation operator
+- `"Sz"` (aliases: `"Sᶻ"`) 
+- `"Sx"` (aliases: `"Sˣ"`) 
+- `"S+"` (aliases: `"Sp"`, `"S⁺"`,`"Splus"`) 
+- `"S-"` (aliases: `"Sm"`, `"S⁻"`, `"Sminus"`) 
+- `"F"` Jordan-Wigner string operator
+- `"Fup"` (aliases: `"F↑"`) Up-spin Jordan-Wigner string operator
+- `"Fdn"` (aliases: `"F↓"`) Down-spin Jordan-Wigner string operator
+
+Non-fermionic single particle operators (these do not have Jordan-Wigner string attached,
+so will commute within systems such as OpSum or the `apply` function):
+- `"Aup"` (aliases: `"a↑"`) Up-spin annihilation operator
+- `"Adn"` (aliases: `"a↓"`) Down-spin annihilation operator
+- `"Adagup"` (aliases: `"a†↑"`) Up-spin creation operator
+- `"Adagdn"` (aliases: `"a†↓"`) Down-spin creation operator
+

--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -28,15 +28,16 @@ the notation: `SiteType("MyTag")`
 There are currently a few built-in site types
 recognized by `ITensors.jl`. The system is easily extensible
 by users. To add new operators to an existing site type,
-you can follow the instructions [here](http://itensor.org/docs.cgi?vers=julia&page=formulas/sitetype_extending).
-To create new site types, you can follow the instructions
-[here](https://itensor.org/docs.cgi?vers=julia&page=formulas/sitetype_basic) and 
-[here](https://itensor.org/docs.cgi?vers=julia&page=formulas/sitetype_qns).
+or to create new site types, you can follow the instructions
+[here](https://itensor.github.io/ITensors.jl/stable/examples/Physics.html).
 
 The current built-in site types are:
 
 - `SiteType"S=1/2"` (or `SiteType"S=½"`)
 - `SiteType"S=1"`
+- `SiteType"Qubit"`
+- `SiteType"Qudit"`
+- `SiteType"Boson"`
 - `SiteType"Fermion"`
 - `SiteType"tJ"`
 - `SiteType"Electron"`
@@ -217,6 +218,9 @@ operators to MPS.
 s = Index(2, "Site,S=1/2")
 Sz = op("Sz", s)
 ```
+
+To see all of the operator names defined for the site types included with
+ITensor, please [view the source code for each site type](https://github.com/ITensor/ITensors.jl/tree/main/src/physics/site_types). Note that some site types such as "S=1/2" and "Qubit" are aliases for each other and share operator definitions.
 """
 function op(name::AbstractString, s::Index...; adjoint::Bool=false, kwargs...)
   name = strip(name)


### PR DESCRIPTION
Adds documentation for the site types included with ITensor directly into the Documenter docs.
