### PR TITLE
[ITensors] [ENHANCEMENT] Clean up QN `svd` code in `ITensors` by handling QN blocks better in `NDTensors`

### DIFF
--- a/NDTensors/src/blocksparse/blockdims.jl
+++ b/NDTensors/src/blocksparse/blockdims.jl
@@ -202,6 +202,12 @@ blockindex(T) = (), Block{0}()
 # This is to help with ITensor compatibility
 #
 
+block(i::BlockDim,n::Integer) = i[n]
+
+resize(n::Int,newdim::Int) = newdim
+
+addblock!(i::BlockDim,b::Int) = push!(i,b)
+
 setblockdim!(dim1::BlockDim, newdim::Int, n::Int) = setindex!(dim1, newdim, n)
 
 sim(dim::BlockDim) = copy(dim)

--- a/NDTensors/src/blocksparse/blockdims.jl
+++ b/NDTensors/src/blocksparse/blockdims.jl
@@ -206,7 +206,7 @@ block(i::BlockDim, n::Integer) = i[n]
 
 resize(n::Int, newdim::Int) = newdim
 
-addblock!(i::BlockDim, b::Int) = push!(i, b)
+pushblock!(i::BlockDim, b::Int) = push!(i, b)
 
 setblockdim!(dim1::BlockDim, newdim::Int, n::Int) = setindex!(dim1, newdim, n)
 

--- a/NDTensors/src/blocksparse/blockdims.jl
+++ b/NDTensors/src/blocksparse/blockdims.jl
@@ -202,11 +202,11 @@ blockindex(T) = (), Block{0}()
 # This is to help with ITensor compatibility
 #
 
-block(i::BlockDim,n::Integer) = i[n]
+block(i::BlockDim, n::Integer) = i[n]
 
-resize(n::Int,newdim::Int) = newdim
+resize(n::Int, newdim::Int) = newdim
 
-addblock!(i::BlockDim,b::Int) = push!(i,b)
+addblock!(i::BlockDim, b::Int) = push!(i, b)
 
 setblockdim!(dim1::BlockDim, newdim::Int, n::Int) = setindex!(dim1, newdim, n)
 

--- a/NDTensors/src/blocksparse/blockdims.jl
+++ b/NDTensors/src/blocksparse/blockdims.jl
@@ -206,9 +206,9 @@ block(i::BlockDim, n::Integer) = i[n]
 
 resize(n::Int, newdim::Int) = newdim
 
-pushblock!(i::BlockDim, b::Int) = push!(i, b)
-
 setblockdim!(dim1::BlockDim, newdim::Int, n::Int) = setindex!(dim1, newdim, n)
+
+setblock!(i::BlockDim, b::Int, n::Integer) = (i[n] = b)
 
 sim(dim::BlockDim) = copy(dim)
 

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -74,7 +74,7 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
   dropblocks = Int[]
   if truncate
     truncerr, docut = truncate!(d; kwargs...)
-    for (n,blockT) in enumerate(nzblocksT)
+    for (n, blockT) in enumerate(nzblocksT)
       blockdim = _truncated_blockdim(Ss[n], docut; singular_values=true, truncate=truncate)
       if blockdim == 0
         push!(dropblocks, n)
@@ -95,19 +95,19 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
   # Make indices of U and V 
   # that connect to S
   #
-  i1 = ind(T,1)
-  i2 = ind(T,2)
+  i1 = ind(T, 1)
+  i2 = ind(T, 2)
   uind = dag(sim(i1))
   vind = dag(sim(i2))
-  resize!(uind,0)
-  resize!(vind,0)
-  for (n,blockT) in enumerate(nzblocksT)
-    Udim = size(Us[n],2)
-    b1 = block(i1,blockT[1])
-    addblock!(uind,resize(b1,Udim))
-    Vdim = size(Vs[n],2)
-    b2 = block(i2,blockT[2])
-    addblock!(vind,resize(b2,Vdim))
+  resize!(uind, 0)
+  resize!(vind, 0)
+  for (n, blockT) in enumerate(nzblocksT)
+    Udim = size(Us[n], 2)
+    b1 = block(i1, blockT[1])
+    addblock!(uind, resize(b1, Udim))
+    Vdim = size(Vs[n], 2)
+    b2 = block(i2, blockT[2])
+    addblock!(vind, resize(b2, Vdim))
   end
 
   #
@@ -129,7 +129,7 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
   nzblocksS = Vector{Block{2}}(undef, nnzblocksT)
   nzblocksV = Vector{Block{2}}(undef, nnzblocksT)
 
-  for (n,blockT) in enumerate(nzblocksT)
+  for (n, blockT) in enumerate(nzblocksT)
     blockU = (blockT[1], UInt(n))
     nzblocksU[n] = blockU
 

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -70,11 +70,10 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
   # that are not dropped
   nzblocksT = nzblocks(T)
 
-  truncerr, docut = 0.0, 0.0
   dropblocks = Int[]
   if truncate
     truncerr, docut = truncate!(d; kwargs...)
-    for (n, blockT) in enumerate(nzblocksT)
+    for n in 1:nnzblocks(T)
       blockdim = _truncated_blockdim(Ss[n], docut; singular_values=true, truncate=truncate)
       if blockdim == 0
         push!(dropblocks, n)
@@ -89,6 +88,8 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
     deleteat!(Ss, dropblocks)
     deleteat!(Vs, dropblocks)
     deleteat!(nzblocksT, dropblocks)
+  else
+    truncerr, docut = 0.0, 0.0
   end
 
   #

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -108,10 +108,10 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
   for (n, blockT) in enumerate(nzblocksT)
     Udim = size(Us[n], 2)
     b1 = block(i1, blockT[1])
-    setblock!(uind, resize(b1, Udim),n)
+    setblock!(uind, resize(b1, Udim), n)
     Vdim = size(Vs[n], 2)
     b2 = block(i2, blockT[2])
-    setblock!(vind, resize(b2, Vdim),n)
+    setblock!(vind, resize(b2, Vdim), n)
   end
 
   #

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -105,10 +105,10 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
   for (n, blockT) in enumerate(nzblocksT)
     Udim = size(Us[n], 2)
     b1 = block(i1, blockT[1])
-    addblock!(uind, resize(b1, Udim))
+    pushblock!(uind, resize(b1, Udim))
     Vdim = size(Vs[n], 2)
     b2 = block(i2, blockT[2])
-    addblock!(vind, resize(b2, Vdim))
+    pushblock!(vind, resize(b2, Vdim))
   end
 
   #

--- a/src/decomp.jl
+++ b/src/decomp.jl
@@ -116,27 +116,6 @@ function svd(A::ITensor, Linds...; kwargs...)
   u = commonind(S, UC)
   v = commonind(S, VC)
 
-  if hasqns(A)
-    # Fix the flux of UC,S,VC
-    # such that flux(UC) == flux(VC) == QN()
-    # and flux(S) == flux(A)
-    for b in nzblocks(UC)
-      i1 = inds(UC)[1]
-      i2 = inds(UC)[2]
-      newqn = -dir(i2) * flux(i1 => Block(b[1]))
-      setblockqn!(i2, newqn, b[2])
-      setblockqn!(u, newqn, b[2])
-    end
-
-    for b in nzblocks(VC)
-      i1 = inds(VC)[1]
-      i2 = inds(VC)[2]
-      newqn = -dir(i2) * flux(i1 => Block(b[1]))
-      setblockqn!(i2, newqn, b[2])
-      setblockqn!(v, newqn, b[2])
-    end
-  end
-
   U = UC * dag(CL)
   V = VC * dag(CR)
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -124,6 +124,7 @@ import ITensors.NDTensors:
   AllowAlias,
   NeverAlias,
   # Methods
+  addblock!,
   array,
   blockdim,
   blockoffsets,

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -123,8 +123,6 @@ import ITensors.NDTensors:
   AliasStyle,
   AllowAlias,
   NeverAlias,
-  # Methods
-  addblock!,
   array,
   blockdim,
   blockoffsets,
@@ -154,6 +152,7 @@ import ITensors.NDTensors:
   permuteblocks,
   polar,
   scale!,
+  setblock!,
   setblockdim!,
   setinds,
   setstorage,

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -8,6 +8,8 @@ qn(qnblock::QNBlock) = qnblock.first
 # Get the dimension of the specified block
 blockdim(qnblock::QNBlock) = qnblock.second
 
+NDTensors.resize(qnblock::QNBlock,newdim::Int64) = QNBlock(qnblock.first,newdim)
+
 # Get the dimension of the specified block
 blockdim(qnblocks::QNBlocks, b::Integer) = blockdim(qnblocks[b])
 blockdim(qnblocks::QNBlocks, b::Block{1}) = blockdim(qnblocks[only(b)])
@@ -356,6 +358,10 @@ end
 
 # Make a new Index with the specified qn blocks
 replaceqns(i::QNIndex, qns::QNBlocks) = setspace(i, qns)
+
+NDTensors.block(i::QNIndex,n::Integer) = space(i)[n]
+
+NDTensors.addblock!(i::QNIndex,b::QNBlock) = push!(i.space,b)
 
 function setblockdim!(i::QNIndex, newdim::Integer, n::Integer)
   qns = space(i)

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -8,7 +8,7 @@ qn(qnblock::QNBlock) = qnblock.first
 # Get the dimension of the specified block
 blockdim(qnblock::QNBlock) = qnblock.second
 
-NDTensors.resize(qnblock::QNBlock,newdim::Int64) = QNBlock(qnblock.first,newdim)
+NDTensors.resize(qnblock::QNBlock, newdim::Int64) = QNBlock(qnblock.first, newdim)
 
 # Get the dimension of the specified block
 blockdim(qnblocks::QNBlocks, b::Integer) = blockdim(qnblocks[b])
@@ -359,9 +359,9 @@ end
 # Make a new Index with the specified qn blocks
 replaceqns(i::QNIndex, qns::QNBlocks) = setspace(i, qns)
 
-NDTensors.block(i::QNIndex,n::Integer) = space(i)[n]
+NDTensors.block(i::QNIndex, n::Integer) = space(i)[n]
 
-NDTensors.addblock!(i::QNIndex,b::QNBlock) = push!(i.space,b)
+NDTensors.addblock!(i::QNIndex, b::QNBlock) = push!(i.space, b)
 
 function setblockdim!(i::QNIndex, newdim::Integer, n::Integer)
   qns = space(i)

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -361,7 +361,7 @@ replaceqns(i::QNIndex, qns::QNBlocks) = setspace(i, qns)
 
 NDTensors.block(i::QNIndex, n::Integer) = space(i)[n]
 
-NDTensors.addblock!(i::QNIndex, b::QNBlock) = push!(i.space, b)
+NDTensors.pushblock!(i::QNIndex, b::QNBlock) = push!(i.space, b)
 
 function setblockdim!(i::QNIndex, newdim::Integer, n::Integer)
   qns = space(i)

--- a/src/qn/qnindex.jl
+++ b/src/qn/qnindex.jl
@@ -361,8 +361,6 @@ replaceqns(i::QNIndex, qns::QNBlocks) = setspace(i, qns)
 
 NDTensors.block(i::QNIndex, n::Integer) = space(i)[n]
 
-NDTensors.pushblock!(i::QNIndex, b::QNBlock) = push!(i.space, b)
-
 function setblockdim!(i::QNIndex, newdim::Integer, n::Integer)
   qns = space(i)
   qns[n] = qn(qns[n]) => newdim
@@ -372,6 +370,12 @@ end
 function setblockqn!(i::QNIndex, newqn::QN, n::Integer)
   qns = space(i)
   qns[n] = newqn => blockdim(qns[n])
+  return i
+end
+
+function setblock!(i::QNIndex, b::QNBlock, n::Integer)
+  qns = space(i)
+  qns[n] = b
   return i
 end
 


### PR DESCRIPTION
## Description

Removes the QN fixing logic in `ITensors.svd` in favor of building the new indices of U and V inside of `NDTensors.svd`. This change will be **essential to fixing the SVD for the auto fermion system**. 

Handling the QNs in a generic way takes a bit of care inside NDTensors, so I added a few helper methods that use the concept of "blocks" of indices such as QNIndex or BlockDim, where the blocks for a QNIndex are QNBlocks. The function `addblock!` pushes new blocks onto the end of the space of a block-sparse index.

However, the resulting code is I think simpler than before, since it basically just builds up the new indices by looping over the non-zero blocks of U and V and then reading off the sizes of their column indices. The rest of the new code is just making sure that other information in the spaces such as the QN information gets passed through when making the new indices.

## How Has This Been Tested?

Ran the qnitensor.jl unit tests (plus will run the CI below) and some tests of my own.
