### PR TITLE
[ITensors] [ENHANCMENT] Non-Hermitian `dmrg`

### DIFF
--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -229,7 +229,6 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
             maxiter=eigsolve_maxiter,
           )
         end
-        #energy::Complex = vals[1]
         energy::Complex = vals[1]
         
         phi::ITensor = vecs[1]

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -37,7 +37,7 @@ Optional keyword arguments:
 * `observer` - object implementing the [Observer](@ref observer) interface which can perform measurements and stop DMRG early
 * `write_when_maxdim_exceeds::Int` - when the allowed maxdim exceeds this value, begin saving tensors to disk to free memory in large calculations
 """
-function dmrg(H::MPO, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
+function dmrg(H::MPO, psi0::MPS, sweeps::Sweeps; kwargs...)
   check_hascommoninds(siteinds, H, psi0)
   check_hascommoninds(siteinds, H, psi0')
   # Permute the indices to have a better memory layout
@@ -68,7 +68,7 @@ Returns:
 * `energy::Complex` - eigenvalue of the optimized MPS
 * `psi::MPS` - optimized MPS
 """
-function dmrg(Hs::Vector{MPO}, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
+function dmrg(Hs::Vector{MPO}, psi0::MPS, sweeps::Sweeps; kwargs...)
   for H in Hs
     check_hascommoninds(siteinds, H, psi0)
     check_hascommoninds(siteinds, H, psi0')
@@ -99,8 +99,7 @@ Returns:
 * `psi::MPS` - optimized MPS
 """
 function dmrg(
-  H::MPO, Ms::Vector{MPS}, psi0::MPS, sweeps::Sweeps; kwargs...
-)::Tuple{Complex,MPS}
+  H::MPO, Ms::Vector{MPS}, psi0::MPS, sweeps::Sweeps; kwargs...)
   check_hascommoninds(siteinds, H, psi0)
   check_hascommoninds(siteinds, H, psi0')
   for M in Ms
@@ -113,7 +112,7 @@ function dmrg(
   return dmrg(PMM, psi0, sweeps; kwargs...)
 end
 
-function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
+function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
   if length(psi0) == 1
     error(
       "`dmrg` currently does not support system sizes of 1. You can diagonalize the MPO tensor directly with tools like `LinearAlgebra.eigen`, `KrylovKit.eigsolve`, etc.",
@@ -182,7 +181,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
   @assert isortho(psi) && orthocenter(psi) == 1
 
   position!(PH, psi, 1)
-  energy = 0.0 + 0.0im
+  energy = 0.0 
 
   for sw in 1:nsweep(sweeps)
     sw_time = @elapsed begin
@@ -229,8 +228,8 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
             maxiter=eigsolve_maxiter,
           )
         end
-        energy::Complex = vals[1]
         
+        energy = vals[1]
         phi::ITensor = vecs[1]
 
         ortho = ha == 1 ? "left" : "right"
@@ -271,7 +270,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
 
         if outputlevel >= 2
           @printf(
-            "Sweep %d, half %d, bond (%d,%d) energy=%.12f\n", sw, ha, b, b + 1, energy
+            "Sweep %d, half %d, bond (%d,%d) energy=%s\n", sw, ha, b, b + 1, energy
           )
           @printf(
             "  Truncated using cutoff=%.1E maxdim=%d mindim=%d\n",
@@ -299,13 +298,11 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
         )
       end
     end
-####problema aca!
     if outputlevel >= 1
       @printf(
-         "After sweep %d Real_energy=%.12f Im_energy=%.12f  maxlinkdim=%d maxerr=%.2E time=%.3f\n",
+        "After sweep %d energy=%s  maxlinkdim=%d maxerr=%.2E time=%.3f\n",
         sw,
-        real(energy),
-        imag(energy),
+        energy,
         maxlinkdim(psi),
         maxtruncerr,
         sw_time
@@ -317,7 +314,6 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)::Tuple{Complex,MPS}
   end
   return (energy, psi)
 end
-
 
 function _dmrg_sweeps(;
   nsweeps, maxdim=typemax(Int), mindim=1, cutoff=1E-8, noise=0.0, kwargs...

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -40,7 +40,7 @@ end
 """
     DMRGObserver(;energy_tol=0.0,
                   minsweeps=2,
-                  complex_energies=false)
+                  energy_type=Float64)
 
 Construct a DMRGObserver by providing the energy
 tolerance used for early stopping, and minimum number
@@ -51,15 +51,17 @@ Optional keyword arguments:
     next no longer changes by more than this amount,
     stop after the current sweep
   - minsweeps: do at least this many sweeps
-  - complex_energies: allow stored energies to be 
-    complex for non-Hermitian DMRG
+  - energy_type: type to use when storing energies at each step
 """
-function DMRGObserver(; energy_tol=0.0, minsweeps=2, complex_energies=false)
-  if complex_energies
-    return DMRGObserver([], Index[], Dict{String,DMRGMeasurement}(), ComplexF64[], Float64[], energy_tol, minsweeps)
-  end
+function DMRGObserver(; energy_tol=0.0, minsweeps=2, energy_type=Float64)
   return DMRGObserver(
-    [], Index[], Dict{String,DMRGMeasurement}(), Float64[], Float64[], energy_tol, minsweeps
+    [],
+    Index[],
+    Dict{String,DMRGMeasurement}(),
+    energy_type[],
+    Float64[],
+    energy_tol,
+    minsweeps,
   )
 end
 
@@ -68,7 +70,7 @@ end
                  sites::Vector{<:Index};
                  energy_tol=0.0,
                  minsweeps=2,
-                 complex_energies=false)
+                 energy_type=Float64)
 
 Construct a DMRGObserver, provide an array
 of `ops` of operator names which are strings 
@@ -89,18 +91,17 @@ Optional keyword arguments:
     next no longer changes by more than this amount,
     stop after the current sweep
   - minsweeps: do at least this many sweeps
-  - complex_energies: allow stored energies to be 
-    complex for non-Hermitian DMRG
+  - energy_type: type to use when storing energies at each step
 """
 function DMRGObserver(
-  ops::Vector{String}, sites::Vector{<:Index}; 
-  energy_tol=0.0, minsweeps=2, complex_energies=false
+  ops::Vector{String},
+  sites::Vector{<:Index};
+  energy_tol=0.0,
+  minsweeps=2,
+  energy_type=Float64,
 )
   measurements = Dict(o => DMRGMeasurement() for o in ops)
-  if complex_energies
-    return DMRGObserver(ops, sites, measurements, ComplexF64[], Float64[], energy_tol, minsweeps)
-  end
-  return DMRGObserver(ops, sites, measurements, Float64[], Float64[], energy_tol, minsweeps)
+  return DMRGObserver(ops, sites, measurements, energy_type[], Float64[], energy_tol, minsweeps)
 end
 
 """

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -159,7 +159,6 @@ function checkdone!(o::DMRGObserver; kwargs...)
   outputlevel = get(kwargs, :outputlevel, false)
   if (
     length(real(energies(o))) > o.minsweeps &&
-    #abs(energies(o)[end] - energies(o)[end - 1]) < o.etol
     abs(real(energies(o))[end] - real(energies(o))[end - 1]) < o.etol
   )
     outputlevel > 0 && println("Energy difference less than $(o.etol), stopping DMRG")

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -31,7 +31,8 @@ struct DMRGObserver <: AbstractObserver
   ops::Vector{String}
   sites::Vector{<:Index}
   measurements::Dict{String,DMRGMeasurement}
-  energies::Vector{Float64}
+  #energies::Vector{Float64}
+  energies::Vector{Complex}
   truncerrs::Vector{Float64}
   etol::Float64
   minsweeps::Int64
@@ -157,8 +158,9 @@ end
 function checkdone!(o::DMRGObserver; kwargs...)
   outputlevel = get(kwargs, :outputlevel, false)
   if (
-    length(energies(o)) > o.minsweeps &&
-    abs(energies(o)[end] - energies(o)[end - 1]) < o.etol
+    length(real(energies(o))) > o.minsweeps &&
+    #abs(energies(o)[end] - energies(o)[end - 1]) < o.etol
+    abs(real(energies(o))[end] - real(energies(o))[end - 1]) < o.etol
   )
     outputlevel > 0 && println("Energy difference less than $(o.etol), stopping DMRG")
     return true

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -55,7 +55,7 @@ Optional keyword arguments:
 """
 function DMRGObserver(; energy_tol=0.0, minsweeps=2, energy_type=Float64)
   return DMRGObserver(
-    [],
+    String[],
     Index[],
     Dict{String,DMRGMeasurement}(),
     energy_type[],
@@ -101,7 +101,9 @@ function DMRGObserver(
   energy_type=Float64,
 )
   measurements = Dict(o => DMRGMeasurement() for o in ops)
-  return DMRGObserver(ops, sites, measurements, energy_type[], Float64[], energy_tol, minsweeps)
+  return DMRGObserver{energy_type}(
+    ops, sites, measurements, energy_type[], Float64[], energy_tol, minsweeps
+  )
 end
 
 """

--- a/src/mps/observer.jl
+++ b/src/mps/observer.jl
@@ -31,7 +31,6 @@ struct DMRGObserver <: AbstractObserver
   ops::Vector{String}
   sites::Vector{<:Index}
   measurements::Dict{String,DMRGMeasurement}
-  #energies::Vector{Float64}
   energies::Vector{Complex}
   truncerrs::Vector{Float64}
   etol::Float64

--- a/test/XXZ_complex.jl
+++ b/test/XXZ_complex.jl
@@ -1,0 +1,94 @@
+#########
+## XXZ model with imaginary part
+#########
+
+using Revise
+using ITensors
+using Printf
+using ITensors.HDF5
+using MKL
+using KrylovKit
+using LinearAlgebra
+
+
+BLAS.set_num_threads(8)
+
+
+
+function Hamiltonian(sites, Δ::Float64, J::Float64, γ::Float64, h::Float64)
+
+    N = length(sites)
+    ampo = AutoMPO()
+
+    for j in 1:(N - 1)
+        ampo += Δ,"Sz",j,"Sz",j+1
+        ampo += -(J+im*γ*(-1.0)^j),"Sx",j,"Sx",j+1
+        ampo += -(J+im*γ*(-1.0)^j),"Sy",j,"Sy",j+1
+    end
+    for j in 1:N
+        ampo +=  h*(-1.0)^j, "Sz",j
+    end
+#  Convert these terms to an MPO tensor network
+  return MPO(ampo, sites)
+end
+
+
+
+
+let
+  #-----------------------------------------------------------------------
+
+  #models parameters
+  N = 4
+  Δ = -0.70
+  J = 1.0
+  γ = 0.1
+  h = 0.1
+
+
+  alg = "qr_iteration"
+
+  #dmrg parameters
+  sweeps = Sweeps(1000)
+  minsweeps = 5
+  maxdim!(sweeps, 50,100,200)
+  #cutoff!(sweeps, 1E-12)
+  etol=1E-12  
+
+  #-----------------------------------------------------------------------
+
+
+ sites = siteinds("S=1/2",N;conserve_qns=false)
+#-----------------------------------------------------------------------
+
+
+#initial state
+state = ["Emp" for n in 1:N]
+p = N
+for i in N:-1:1
+  if p > i
+    #println("Doubly occupying site $i")
+    state[i] = "UpDn"
+    p -= 2
+elseif p > 0
+    #println("Singly occupying site $i")
+    state[i] = (isodd(i) ? "Up" : "Dn")
+    p -= 1
+  end
+end
+psi0 = randomMPS(sites, state)
+@show flux(psi0)
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+
+H = Hamiltonian(sites, Δ, J, γ, h)
+ #-----------------------------------------------------------------------
+
+obs = DMRGObserver(["Sz"], sites; energy_tol=etol,minsweeps=minsweeps)
+
+energy, psi = dmrg(H, psi0, sweeps;svd_alg=alg,observer=obs, outputlevel=1, ishermitian=false)
+println("Final energy = $energy")
+
+
+end

--- a/test/trans_ising_complex.jl
+++ b/test/trans_ising_complex.jl
@@ -1,0 +1,90 @@
+using Revise
+using ITensors
+using Printf
+using ITensors.HDF5
+using MKL
+using KrylovKit
+using LinearAlgebra
+
+
+BLAS.set_num_threads(8)
+
+
+
+#define el hamiltoniano
+
+function Hamiltonian(sites, λ::Float64, k::Float64)
+
+    N = length(sites)
+    ampo = AutoMPO()
+
+    for j in 1:(N - 1)
+        ampo += -0.5*2*λ,"Sz",j,"Sz",j+1
+    end
+    for j in 1:N
+        ampo +=  -0.5*2*im*k, "Sz",j
+        ampo += -0.5, "S+",j
+        ampo += -0.5, "S-",j
+    end
+#  Convert these terms to an MPO tensor network
+  return MPO(ampo, sites)
+end
+
+
+
+
+let
+  #-----------------------------------------------------------------------
+
+  #models parameters
+  N = 4
+  λ = 0.1
+  k = 0.5
+
+
+  
+  alg = "qr_iteration"
+
+  #dmrg parameters
+  sweeps = Sweeps(1000)
+  minsweeps = 5
+  maxdim!(sweeps, 50,100,200)
+  #cutoff!(sweeps, 1E-12)
+  etol=1E-12  
+
+  #-----------------------------------------------------------------------
+
+
+ sites = siteinds("S=1/2",N;conserve_qns=false)
+#-----------------------------------------------------------------------
+
+ #inicial state
+ state = ["Emp" for n in 1:N]
+ p = N
+ for i in N:-1:1
+   if p > i
+     state[i] = "UpDn"
+     p -= 2
+   elseif p > 0
+     state[i] = (isodd(i) ? "Up" : "Dn")
+     p -= 1
+   end
+ end
+ psi0 = randomMPS(sites, state)
+ @show flux(psi0)
+#-----------------------------------------------------------------------
+
+#-----------------------------------------------------------------------
+
+ H = Hamiltonian(sites, λ, k)
+ #-----------------------------------------------------------------------
+
+ #obs = DMRGObserver(["Sz"], sites; energy_tol=etol,minsweeps=minsweeps)
+ obs = DMRGObserver(; energy_tol=etol, minsweeps=2)
+
+ energy, psi = dmrg(H, psi0, sweeps;svd_alg=alg,observer=obs, outputlevel=1, ishermitian=false)
+ println("Final energy = $energy")
+
+
+
+end


### PR DESCRIPTION
# Description

Make simple changes to the DMRG implementation so that the function accepts non-Hermitian Hamiltonians and computes the ground state energy using the Arnoldi algorithm from the KrilovKit library. 
To ensure convergence to the ground state, the ```observer.jl``` file was changed to compare the real part of the energy of step N with that of step N-1



```julia
Final energy = -0.8484877923059384 + 0.04647927681301231im 
```
</p></details>

# How Has This Been Tested?
To test the correct operation, tests were carried out on two non-Hermitian Hamiltonians (XXZ and Ising with imaginary field) for a wide range of parameters and compared with exact diagonalization results, finding a correct agreement.


- [x] XXZ_complex.jl
- [x] trans_ising_complex.jl

