### PR TITLE
[ITensors] [NDTensors] [ENHANCMENT] Add more backends for MPS/MPO addition and contraction

### DIFF
--- a/NDTensors/src/linearalgebra.jl
+++ b/NDTensors/src/linearalgebra.jl
@@ -214,7 +214,7 @@ function LinearAlgebra.eigen(
   truncate = haskey(kwargs, :maxdim) || haskey(kwargs, :cutoff)
   maxdim::Int = get(kwargs, :maxdim, minimum(dims(T)))
   mindim::Int = get(kwargs, :mindim, 1)
-  cutoff::Float64 = get(kwargs, :cutoff, 0.0)
+  cutoff::Union{Nothing,Float64} = get(kwargs, :cutoff, 0.0)
   use_absolute_cutoff::Bool = get(kwargs, :use_absolute_cutoff, use_absolute_cutoff)
   use_relative_cutoff::Bool = get(kwargs, :use_relative_cutoff, use_relative_cutoff)
 
@@ -228,6 +228,7 @@ function LinearAlgebra.eigen(
   if truncate
     truncerr, _ = truncate!(
       DM;
+      mindim=mindim,
       maxdim=maxdim,
       cutoff=cutoff,
       use_absolute_cutoff=use_absolute_cutoff,

--- a/NDTensors/src/truncate.jl
+++ b/NDTensors/src/truncate.jl
@@ -3,7 +3,7 @@ export truncate!
 function truncate!(P::Vector{Float64}; kwargs...)::Tuple{Float64,Float64}
   cutoff = get(kwargs, :cutoff, 0.0)
   if isnothing(cutoff)
-    return 0.0, 0.0
+    cutoff = -Inf
   end
 
   # Keyword argument deprecations
@@ -20,7 +20,7 @@ function truncate!(P::Vector{Float64}; kwargs...)::Tuple{Float64,Float64}
 
   maxdim::Int = min(get(kwargs, :maxdim, length(P)), length(P))
   mindim::Int = max(get(kwargs, :mindim, 1), 1)
-  cutoff = max(cutoff, 0.0)
+
   use_absolute_cutoff::Bool = get(kwargs, :use_absolute_cutoff, use_absolute_cutoff)
   use_relative_cutoff::Bool = get(kwargs, :use_relative_cutoff, use_relative_cutoff)
 

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -2227,7 +2227,7 @@ function directsum(
   tags=["sum$i" for i in 1:length(last(A_and_I))],
 )
   return directsum(
-    Pair(directsum(A_and_I, B_and_J; kwargs...)...), C_and_K, itensor_and_inds...; tags=tags
+    Pair(directsum(A_and_I, B_and_J; tags)...), C_and_K, itensor_and_inds...; tags
   )
 end
 

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -2128,7 +2128,7 @@ expτH = ops(os, s)
 ```
 """
 function product(
-  As::Vector{ITensor},
+  As::Vector{<:ITensor},
   ψ::AbstractMPS;
   move_sites_back_between_gates::Bool=true,
   move_sites_back::Bool=true,
@@ -2145,27 +2145,6 @@ function product(
     Aψ = movesites(Aψ, ns .=> ñs; kwargs...)
   end
   return Aψ
-end
-
-# Apply in the reverse order for proper order of operations
-# For example:
-#
-# s = siteinds("Qubit", 1)
-# ψ = randomMPS(s)
-#
-# # U = Z₁X₁
-# U = Prod{Op}()
-# U = ("X", 1) * U
-# U = ("Z", 1) * U
-#
-# # U|ψ⟩ = Z₁X₁|ψ⟩
-# apply(U, 
-function product(o::Prod{ITensor}, ψ::AbstractMPS; kwargs...)
-  return product(reverse(terms(o)), ψ; kwargs...)
-end
-
-function (o::Prod{ITensor})(ψ::AbstractMPS; kwargs...)
-  return apply(o, ψ; kwargs...)
 end
 
 #

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1376,9 +1376,7 @@ println()
       inner(ψ₃, ψ₁) + 2 * inner(ψ₃, ψ₂) + inner(ψ₃, ψ₃)
 ```
 """
-function +(ψ⃗::MPST...; cutoff=1e-15, kwargs...) where {MPST<:AbstractMPS}
-  # TODO: Check that the inputs have the same site indices
-
+function +(::Algorithm"densitymatrix", ψ⃗::MPST...; cutoff=1e-15, kwargs...) where {MPST<:AbstractMPS}
   if !all(ψ -> hassameinds(siteinds, first(ψ⃗), ψ), ψ⃗)
     error(
       "In `+(::MPS/MPO...)`, the input `MPS` or `MPO` do not have the same site indices. For example, the site indices of the first site are $(siteinds.(ψ⃗, 1))",
@@ -1445,6 +1443,37 @@ function +(ψ⃗::MPST...; cutoff=1e-15, kwargs...) where {MPST<:AbstractMPS}
 
   return convert(MPST, ψ)
 end
+
+function +(::Algorithm"directsum", ψ⃗::MPST...) where {MPST<:AbstractMPS}
+  n = length(first(ψ⃗))
+  @assert all(ψᵢ -> length(first(ψ⃗)) == length(ψᵢ), ψ⃗)
+
+  # Output tensor
+  ϕ = MPS(n)
+
+  # Direct sum first tensor
+  j = 1
+  l⃗j = map(ψᵢ -> linkind(ψᵢ, j), ψ⃗)
+  ϕj, (lj,) = directsum((ψ⃗[i][j] => (l⃗j[i],) for i in 1:length(ψ⃗))...; tags=[tags(first(l⃗j))])
+  ljm_prev = lj
+  ϕ[j] = ϕj
+  for j in 2:(n - 1)
+    l⃗jm = map(ψᵢ -> linkind(ψᵢ, j - 1), ψ⃗)
+    l⃗j = map(ψᵢ -> linkind(ψᵢ, j), ψ⃗)
+    ϕj, (ljm, lj) = directsum((ψ⃗[i][j] => (l⃗jm[i], l⃗j[i]) for i in 1:length(ψ⃗))...; tags=[tags(first(l⃗jm)), tags(first(l⃗j))])
+    ϕj = replaceind(ϕj, ljm => dag(ljm_prev))
+    ljm_prev = lj
+    ϕ[j] = ϕj
+  end
+  j = n
+  l⃗jm = map(ψᵢ -> linkind(ψᵢ, j - 1), ψ⃗)
+  ϕj, (ljm,) = directsum((ψ⃗[i][j] => (l⃗jm[i],) for i in 1:length(ψ⃗))...; tags=[tags(first(l⃗jm))])
+  ϕj = replaceind(ϕj, ljm => dag(ljm_prev))
+  ϕ[j] = ϕj
+  return ϕ
+end
+
++(ψ⃗::AbstractMPS...; alg=Algorithm"densitymatrix"(), kwargs...) = +(Algorithm(alg), ψ⃗...; kwargs...)
 
 +(ψ::AbstractMPS) = ψ
 
@@ -2099,7 +2128,7 @@ expτH = ops(os, s)
 ```
 """
 function product(
-  As::Vector{<:ITensor},
+  As::Vector{ITensor},
   ψ::AbstractMPS;
   move_sites_back_between_gates::Bool=true,
   move_sites_back::Bool=true,
@@ -2116,6 +2145,27 @@ function product(
     Aψ = movesites(Aψ, ns .=> ñs; kwargs...)
   end
   return Aψ
+end
+
+# Apply in the reverse order for proper order of operations
+# For example:
+#
+# s = siteinds("Qubit", 1)
+# ψ = randomMPS(s)
+#
+# # U = Z₁X₁
+# U = Prod{Op}()
+# U = ("X", 1) * U
+# U = ("Z", 1) * U
+#
+# # U|ψ⟩ = Z₁X₁|ψ⟩
+# apply(U, 
+function product(o::Prod{ITensor}, ψ::AbstractMPS; kwargs...)
+  return product(reverse(terms(o)), ψ; kwargs...)
+end
+
+function (o::Prod{ITensor})(ψ::AbstractMPS; kwargs...)
+  return apply(o, ψ; kwargs...)
 end
 
 #

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1376,7 +1376,9 @@ println()
       inner(ψ₃, ψ₁) + 2 * inner(ψ₃, ψ₂) + inner(ψ₃, ψ₃)
 ```
 """
-function +(::Algorithm"densitymatrix", ψ⃗::MPST...; cutoff=1e-15, kwargs...) where {MPST<:AbstractMPS}
+function +(
+  ::Algorithm"densitymatrix", ψ⃗::MPST...; cutoff=1e-15, kwargs...
+) where {MPST<:AbstractMPS}
   if !all(ψ -> hassameinds(siteinds, first(ψ⃗), ψ), ψ⃗)
     error(
       "In `+(::MPS/MPO...)`, the input `MPS` or `MPO` do not have the same site indices. For example, the site indices of the first site are $(siteinds.(ψ⃗, 1))",
@@ -1454,26 +1456,35 @@ function +(::Algorithm"directsum", ψ⃗::MPST...) where {MPST<:AbstractMPS}
   # Direct sum first tensor
   j = 1
   l⃗j = map(ψᵢ -> linkind(ψᵢ, j), ψ⃗)
-  ϕj, (lj,) = directsum((ψ⃗[i][j] => (l⃗j[i],) for i in 1:length(ψ⃗))...; tags=[tags(first(l⃗j))])
+  ϕj, (lj,) = directsum(
+    (ψ⃗[i][j] => (l⃗j[i],) for i in 1:length(ψ⃗))...; tags=[tags(first(l⃗j))]
+  )
   ljm_prev = lj
   ϕ[j] = ϕj
   for j in 2:(n - 1)
     l⃗jm = map(ψᵢ -> linkind(ψᵢ, j - 1), ψ⃗)
     l⃗j = map(ψᵢ -> linkind(ψᵢ, j), ψ⃗)
-    ϕj, (ljm, lj) = directsum((ψ⃗[i][j] => (l⃗jm[i], l⃗j[i]) for i in 1:length(ψ⃗))...; tags=[tags(first(l⃗jm)), tags(first(l⃗j))])
+    ϕj, (ljm, lj) = directsum(
+      (ψ⃗[i][j] => (l⃗jm[i], l⃗j[i]) for i in 1:length(ψ⃗))...;
+      tags=[tags(first(l⃗jm)), tags(first(l⃗j))],
+    )
     ϕj = replaceind(ϕj, ljm => dag(ljm_prev))
     ljm_prev = lj
     ϕ[j] = ϕj
   end
   j = n
   l⃗jm = map(ψᵢ -> linkind(ψᵢ, j - 1), ψ⃗)
-  ϕj, (ljm,) = directsum((ψ⃗[i][j] => (l⃗jm[i],) for i in 1:length(ψ⃗))...; tags=[tags(first(l⃗jm))])
+  ϕj, (ljm,) = directsum(
+    (ψ⃗[i][j] => (l⃗jm[i],) for i in 1:length(ψ⃗))...; tags=[tags(first(l⃗jm))]
+  )
   ϕj = replaceind(ϕj, ljm => dag(ljm_prev))
   ϕ[j] = ϕj
   return ϕ
 end
 
-+(ψ⃗::AbstractMPS...; alg=Algorithm"densitymatrix"(), kwargs...) = +(Algorithm(alg), ψ⃗...; kwargs...)
+function +(ψ⃗::AbstractMPS...; alg=Algorithm"densitymatrix"(), kwargs...)
+  return +(Algorithm(alg), ψ⃗...; kwargs...)
+end
 
 +(ψ::AbstractMPS) = ψ
 

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -664,8 +664,11 @@ function contract(::Algorithm"densitymatrix", A::MPO, ψ::MPS; kwargs...)::MPS
   return ψ_out
 end
 
-function contract(::Algorithm"naive", A::MPO, ψ::MPS; kwargs...)::MPS
+function _contract(::Algorithm"naive", A, ψ; kwargs...)
   truncate = get(kwargs, :truncate, true)
+
+  A = sim(linkinds, A)
+  ψ = sim(linkinds, ψ)
 
   N = length(A)
   if N != length(ψ)
@@ -678,11 +681,14 @@ function contract(::Algorithm"naive", A::MPO, ψ::MPS; kwargs...)::MPS
   end
 
   for b in 1:(N - 1)
-    Al = commonind(A[b], A[b + 1])
-    pl = commonind(ψ[b], ψ[b + 1])
-    C = combiner(Al, pl)
-    ψ_out[b] *= C
-    ψ_out[b + 1] *= dag(C)
+    Al = commoninds(A[b], A[b + 1])
+    ψl = commoninds(ψ[b], ψ[b + 1])
+    l = [Al..., ψl...]
+    if !isempty(l)
+      C = combiner(l)
+      ψ_out[b] *= C
+      ψ_out[b + 1] *= dag(C)
+    end
   end
 
   if truncate
@@ -692,7 +698,19 @@ function contract(::Algorithm"naive", A::MPO, ψ::MPS; kwargs...)::MPS
   return ψ_out
 end
 
-function contract(A::MPO, B::MPO; kwargs...)
+function contract(alg::Algorithm"naive", A::MPO, ψ::MPS; kwargs...)
+  return _contract(alg, A, ψ; kwargs...)
+end
+
+function contract(A::MPO, B::MPO; alg="zipup", kwargs...)
+  return contract(Algorithm(alg), A, B; kwargs...)
+end
+
+function contract(alg::Algorithm"naive", A::MPO, B::MPO; kwargs...)
+  return _contract(alg, A, B; kwargs...)
+end
+
+function contract(::Algorithm"zipup", A::MPO, B::MPO; kwargs...)
   if hassameinds(siteinds, A, B)
     error(
       "In `contract(A::MPO, B::MPO)`, MPOs A and B have the same site indices. The indices of the MPOs in the contraction are taken literally, and therefore they should only share on site index per site so the contraction results in an MPO. You may want to use `replaceprime(contract(A', B), 2 => 1)` or `apply(A, B)` which automatically adjusts the prime levels assuming the input MPOs have pairs of primed and unprimed indices.",
@@ -789,10 +807,22 @@ C = apply(A, B; cutoff=1e-12)
 ```
 which is the same as the code above.
 
+If you are contracting MPOs that have diverging norms, such as MPOs representing sums of local
+operators, the truncation can become numerically unstable (see https://arxiv.org/abs/1909.06341 for
+a more numerically stable alternative). For now, you can use the following options to contract
+MPOs like that:
+```julia
+C = contract(A, B; alg="naive", truncate=false)
+# Bring the indices back to pairs of primed and unprimed
+C = apply(A, B; alg="naive", truncate=false)
+```
+
 # Keywords
-- `cutoff::Float64=1e-13`: the cutoff value for truncating the density matrix eigenvalues. Note that the default is somewhat arbitrary and subject to change, in general you should set a `cutoff` value.
+- `cutoff::Float64=1e-14`: the cutoff value for truncating the density matrix eigenvalues. Note that the default is somewhat arbitrary and subject to change, in general you should set a `cutoff` value.
 - `maxdim::Int=maxlinkdim(A) * maxlinkdim(B))`: the maximal bond dimension of the results MPS.
 - `mindim::Int=1`: the minimal bond dimension of the resulting MPS.
+- `alg="zipup"`: Either `"zipup"` or `"naive"`. `"zipup"` contracts pairs of site tensors and truncates with SVDs in a sweep across the sites, while `"naive"` first contracts pairs of tensor exactly and then truncates at the end if `truncate=true`.
+- `truncate=true`: Enable or disable truncation. If `truncate=false`, ignore other truncation parameters like `cutoff` and `maxdim`. This is most relevant for the `"naive"` version, if you just want to contract the tensors pairwise exactly. This can be useful if you are contracting MPOs that have diverging norms, such as MPOs originating from sums of local operators.
 
 See also [`apply`](@ref) for details about the arguments available.
 """

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -444,6 +444,23 @@ include("util.jl")
     K12 = Ks[1] + Ks[2]
     K123 = K12 + Ks[3]
     @test inner(sum(Ks), K123) ≈ inner(K123, K123)
+
+    χ1 = 2
+    χ2 = 3
+    ψ1 = randomMPS(sites; linkdims=χ1)
+    ψ2 = 0.0 * randomMPS(sites; linkdims=χ2)
+
+    ϕ1 = +(ψ1, ψ2; alg="densitymatrix", cutoff=nothing)
+    for j in 2:7
+      @show linkdim(ϕ1, j) == χ1 + χ2
+    end
+    @show inner(ϕ1, ψ1) + inner(ϕ1, ψ2) ≈ inner(ϕ1, ϕ1)
+
+    ϕ2 = +(ψ1, ψ2; alg="directsum")
+    for j in 1:8
+      @show linkdim(ϕ2, j) == χ1 + χ2
+    end
+    @show inner(ϕ2, ψ1) + inner(ϕ2, ψ2) ≈ inner(ϕ2, ϕ2)
   end
 
   @testset "+ MPS with coefficients" begin


### PR DESCRIPTION
# Description

This adds a backend `alg="directsum"` for MPS/MPO addition as well as `alg="naive"` for MPO contraction. This makes it easier to perform MPS/MPO addition and contraction with orthogonalization and truncation, which can be useful in cases where the orthogonoalization causes trouble (like when the norm diverges, such as for MPOs representing sums of local operators).

In addition, this makes a few improvements to `svd`/`eigen` truncation. It adds the features that if `cutoff=nothing`, no truncation according to the singular values/eigenvalues is performed. Additionally, it fixes an issue that `mindim` wasn't be used in `eigen`. This makes it easier to control the truncation, and not perform truncation if you don't want to.

# How Has This Been Tested?

Tests have been added for the new behavior.

# Checklist:

- [ ] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
