### PR TITLE
[ITensors] [ENHANCMENT] Implement `nullspace` function for ITensors

### DIFF
--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -141,6 +141,7 @@ include("qn/qn.jl")
 include("qn/qnindex.jl")
 include("qn/qnindexset.jl")
 include("qn/qnitensor.jl")
+include("nullspace.jl")
 
 #####################################
 # Ops to ITensor conversions

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -1,6 +1,7 @@
 export
   # From external modules
   # LinearAlgebra
+  nullspace,
   tr,
 
   # Modules

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -99,6 +99,7 @@ import LinearAlgebra:
   norm,
   normalize,
   normalize!,
+  nullspace,
   qr,
   rmul!,
   svd,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -114,6 +114,9 @@ ITensor(as::AliasStyle, is, st::TensorStorage)::ITensor = ITensor(as, st, is)
 ITensor(st::TensorStorage, is)::ITensor = itensor(Tensor(NeverAlias(), st, Tuple(is)))
 ITensor(is, st::TensorStorage)::ITensor = ITensor(NeverAlias(), st, is)
 
+itensor(T::ITensor) = T
+ITensor(T::ITensor) = copy(T)
+
 """
     itensor(args...; kwargs...)
 

--- a/src/nullspace.jl
+++ b/src/nullspace.jl
@@ -1,0 +1,147 @@
+#
+# NDTensors functionality
+#
+
+# XXX: generalize this function
+function _getindex(T::DenseTensor{ElT,N}, I1::Colon, I2::UnitRange{Int64}) where {ElT,N}
+  A = array(T)[I1, I2]
+  return tensor(Dense(vec(A)), setdims(inds(T), size(A)))
+end
+
+function getblock_preserve_qns(T::Tensor, b::Block)
+  # TODO: make `T[b]` preserve QNs
+  Tb = T[b]
+  indsTb = getblock.(inds(T), Tuple(b)) .* dir.(inds(T))
+  return ITensors.setinds(Tb, indsTb)
+end
+
+function blocksparsetensor(blocks::Dict{B,TB}) where {B,TB}
+  b1, Tb1 = first(pairs(blocks))
+  N = length(b1)
+  indstypes = typeof.(inds(Tb1))
+  blocktype = eltype(Tb1)
+  indsT = getindex.(indstypes)
+  # Determine the indices from the blocks
+  for (b, Tb) in pairs(blocks)
+    indsTb = inds(Tb)
+    for n in 1:N
+      bn = b[n]
+      indsTn = indsT[n]
+      if bn > length(indsTn)
+        resize!(indsTn, bn)
+      end
+      indsTn[bn] = indsTb[n]
+    end
+  end
+  T = BlockSparseTensor(blocktype, indsT)
+  for (b, Tb) in pairs(blocks)
+    if !isempty(Tb)
+      T[b] = Tb
+    end
+  end
+  return T
+end
+
+default_atol() = 0.0
+
+function _nullspace_hermitian(M::DenseTensor; atol::Real=default_atol())
+  tol = atol
+  #D, U = eigen(Hermitian(M))
+  Dᵢₜ, Uᵢₜ = eigen(itensor(M); ishermitian=true)
+  D = tensor(Dᵢₜ)
+  U = tensor(Uᵢₜ)
+  indstart = sum(d -> abs(d) .> tol, storage(D)) + 1
+  indstop = lastindex(U, 2)
+  Nb = _getindex(U, :, indstart:indstop)
+  return Nb
+end
+
+function _nullspace_hermitian(M::BlockSparseTensor; atol::Real=default_atol())
+  tol = atol
+  # Insert any missing diagonal blocks
+  insert_diag_blocks!(M)
+  #D, U = eigen(Hermitian(M))
+  Dᵢₜ, Uᵢₜ = eigen(itensor(M); ishermitian=true)
+  D = tensor(Dᵢₜ)
+  U = tensor(Uᵢₜ)
+  nullspace_blocks = Dict()
+  for bU in nzblocks(U)
+    bM = Block(bU[1], bU[1])
+    bD = Block(bU[2], bU[2])
+    # Assume sorted from largest to smallest
+    indstart = sum(d -> abs(d) .> tol, storage(D[bD])) + 1
+    Ub = getblock_preserve_qns(U, bU)
+    indstop = lastindex(Ub, 2)
+    # Drop zero dimensional blocks
+    Nb = _getindex(Ub, :, indstart:indstop)
+    nullspace_blocks[bU] = Nb
+  end
+  return blocksparsetensor(nullspace_blocks)
+end
+
+function LinearAlgebra.nullspace(M::Hermitian{<:Number,<:Tensor}; atol=default_atol())
+  return _nullspace_hermitian(parent(M); atol)
+end
+
+#
+# QN functionality
+#
+
+function setdims(t::NTuple{N,Pair{QN,Int}}, dims::NTuple{N,Int}) where {N}
+  return first.(t) .=> dims
+end
+
+function setdims(t::NTuple{N,Index{Int}}, dims::NTuple{N,Int}) where {N}
+  return dims
+end
+
+function getblock(i::Index, n::Integer)
+  return ITensors.space(i)[n]
+end
+
+# Make `Pair{QN,Int}` act like a regular `dim`
+NDTensors.dim(qnv::Pair{QN,Int}) = last(qnv)
+
+Base.:*(qnv::Pair{QN,Int}, d::ITensors.Arrow) = qn(qnv) * d => dim(qnv)
+
+#
+# ITensors functionality
+#
+
+# Reshape into an order-2 ITensor
+matricize(T::ITensor, inds::Index...) = matricize(T, inds)
+
+function matricize(T::ITensor, inds)
+  left_inds = commoninds(T, inds)
+  right_inds = uniqueinds(T, inds)
+  return matricize(T, left_inds, right_inds)
+end
+
+function matricize(T::ITensor, left_inds, right_inds)
+  CL = combiner(left_inds; dir=ITensors.Out, tags="CL")
+  CR = combiner(right_inds; dir=ITensors.In, tags="CR")
+  M = (T * CL) * CR
+  return M, CL, CR
+end
+
+function nullspace(::Order{2}, M::ITensor, left_inds, right_inds; atol=default_atol(), tags="n")
+  @assert order(M) == 2
+  M² = prime(dag(M), right_inds) * M
+  M² = permute(M², right_inds'..., right_inds...)
+  M²ₜ = tensor(M²)
+  Nₜ = nullspace(Hermitian(M²ₜ); atol)
+  indsN = (Index(ind(Nₜ, 1); dir=ITensors.In), Index(ind(Nₜ, 2); dir=ITensors.In, tags))
+  N = dag(itensor(ITensors.setinds(Nₜ, indsN)))
+  # Make the index match the input index
+  Ñ = replaceinds(N, (ind(N, 1),) => right_inds)
+  return Ñ
+end
+
+function nullspace(T::ITensor, is...; atol=default_atol(), tags="n")
+  M, CL, CR = matricize(T, is...)
+  @assert order(M) == 2
+  cL = commoninds(M, CL)
+  cR = commoninds(M, CR)
+  N₂ = nullspace(Order(2), M, cL, cR; atol, tags)
+  return N₂ * CR
+end

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -1666,6 +1666,11 @@ end
     @test eltype(As2_f32[1][2]) == new_eltype
     @test eltype(As2_f32[2][1]) == new_eltype
   end
+
+  @testset "nullspace" for (ss, sl, sr) in [([QN(-1) => 2, QN(1) => 3], [QN(-1) => 2], [QN(0) => 3]),
+                                            (5, 2, 3)]
+
+  end
 end # End Dense ITensor basic functionality
 
 # Disable debug checking once tests are completed

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -1670,15 +1670,17 @@ end
   @testset "nullspace $eltype" for (ss, sl, sr) in [
       ([QN(-1) => 2, QN(1) => 3], [QN(-1) => 2], [QN(0) => 3]), (5, 2, 3)
     ],
-    eltype in (Float64, ComplexF64)
+    eltype in (Float32, Float64, ComplexF32, ComplexF64),
+    nullspace_kwargs in ((; atol=eps(real(eltype)) * 100), (;))
 
     s, l, r = Index.((ss, sl, sr), ("s", "l", "r"))
     A = randomITensor(eltype, dag(l), s, r)
-    N = nullspace(A, dag(l); tags="n", atol=1e-12)
+    N = nullspace(A, dag(l); nullspace_kwargs...)
+    @test Base.eltype(N) === eltype
     n = uniqueind(N, A)
     @test op("I", n) ≈ N * dag(prime(N, n))
     @test hassameinds(N, (s, r, n))
-    @test norm(A * N) ≈ 0 atol = 1e-14
+    @test norm(A * N) ≈ 0 atol = eps(real(eltype)) * 100
     @test dim(l) + dim(n) == dim((s, r))
     A′, (rn,) = ITensors.directsum(A => (l,), dag(N) => (n,); tags=["⊕"])
     @test dim(rn) == dim((s, r))

--- a/test/itensor.jl
+++ b/test/itensor.jl
@@ -1667,9 +1667,22 @@ end
     @test eltype(As2_f32[2][1]) == new_eltype
   end
 
-  @testset "nullspace" for (ss, sl, sr) in [([QN(-1) => 2, QN(1) => 3], [QN(-1) => 2], [QN(0) => 3]),
-                                            (5, 2, 3)]
+  @testset "nullspace $eltype" for (ss, sl, sr) in [
+      ([QN(-1) => 2, QN(1) => 3], [QN(-1) => 2], [QN(0) => 3]), (5, 2, 3)
+    ],
+    eltype in (Float64, ComplexF64)
 
+    s, l, r = Index.((ss, sl, sr), ("s", "l", "r"))
+    A = randomITensor(eltype, dag(l), s, r)
+    N = nullspace(A, dag(l); tags="n", atol=1e-12)
+    n = uniqueind(N, A)
+    @test op("I", n) ≈ N * dag(prime(N, n))
+    @test hassameinds(N, (s, r, n))
+    @test norm(A * N) ≈ 0 atol = 1e-14
+    @test dim(l) + dim(n) == dim((s, r))
+    A′, (rn,) = ITensors.directsum(A => (l,), dag(N) => (n,); tags=["⊕"])
+    @test dim(rn) == dim((s, r))
+    @test norm(A * dag(prime(A, l))) ≈ norm(A * dag(A′))
   end
 end # End Dense ITensor basic functionality
 


### PR DESCRIPTION
# Description

Introduce `nullspace` function for ITensors. `N = nullspace(A, leftinds)` returns the right null space of `A` such that `norm(A * N) ≈ 0`.

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
julia> i = Index(2, "i");

julia> j = Index(5, "j");

julia> A = randomITensor(i, j);

julia> N = nullspace(A, i);

julia> @show A;
A = ITensor ord=2
Dim 1: (dim=2|id=461|"i")
Dim 2: (dim=5|id=264|"j")
NDTensors.Dense{Float64, Vector{Float64}}
 2×5
 -0.8956461522879086   -1.307426777606188    -1.183017393132791   0.42804746715565123   1.0067816789927337
 -0.30151201210578105   0.13842633768630438  -2.1493406941276363  0.4325272175953745   -0.4194927860970461

julia> @show N;
N = ITensor ord=2
Dim 1: (dim=5|id=264|"j")
Dim 2: (dim=2|id=556|"n")
NDTensors.Dense{Float64, Vector{Float64}}
 5×2
  0.6398829286994586    0.6011454104802291
 -0.4196363844156095   -0.21150374148882833
 -0.23722632242302866   0.05671041495093003
 -0.5984804210525552    0.7685533759153473
  0.0                   0.0

julia> @show A * N;
A * N = ITensor ord=2
Dim 1: (dim=2|id=461|"i")
Dim 2: (dim=2|id=556|"n")
NDTensors.Dense{Float64, Vector{Float64}}
 2×2
 1.27153235179493e-16    -1.7122712480695045e-17
 1.6736216109314283e-16  -9.843718547769363e-17

julia> n = uniqueind(N, A)
(dim=2|id=556|"n")

julia> @show prime(N, n) * dag(N);
prime(N, n) * dag(N) = ITensor ord=2
Dim 1: (dim=2|id=556|"n")'
Dim 2: (dim=2|id=556|"n")
NDTensors.Dense{Float64, Vector{Float64}}
 2×2
 1.0                    5.584038566649346e-19
 5.584038566649346e-19  1.0
```

</p></details>

# How Has This Been Tested?

Add tests for computing the nullspace of QN and non-QN ITensors, both real and complex.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
