### PR TITLE
[ITensors] [ENHANCEMENT] Add `rrule`s for addition and subtraction of MPOs

### DIFF
--- a/src/ITensorChainRules/mps/mpo.jl
+++ b/src/ITensorChainRules/mps/mpo.jl
@@ -33,6 +33,22 @@ function rrule(::typeof(*), x1::MPO, x2::MPO; kwargs...)
   return y, contract_pullback
 end
 
+function ChainRulesCore.rrule(::typeof(+), x1::MPO, x2::MPO; kwargs...)
+  y = +(x1, x2; kwargs...)
+  function add_pullback(ȳ)
+    return (NoTangent(), ȳ, ȳ)
+  end
+  return y, add_pullback
+end
+
+function ChainRulesCore.rrule(::typeof(-), x1::MPO, x2::MPO; kwargs...)
+  y = -(x1, x2; kwargs...)
+  function add_pullback(ȳ)
+    return (NoTangent(), ȳ, -ȳ)
+  end
+  return y, add_pullback
+end
+
 function rrule(::typeof(tr), x::MPO; kwargs...)
   y = tr(x; kwargs...)
   function contract_pullback(ȳ)


### PR DESCRIPTION
# Description

Added `+` and `-` functions between two MPOs for auto differentiation.

Fixes #934

<details><summary>Minimal demonstration of previous behavior</summary><p>

See #934 

</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
using ITensors
using Zygote
using Random

Random.seed!(1234)

L = 4
sites = siteinds("S=1/2",L)
x = randomMPS(sites)
y = randomMPS(sites)
A₀ = outer(x',y)

x = randomMPS(sites)
y = randomMPS(sites)
B₀ = outer(x',y)

function fun1(A::MPO, B::MPO)
    return tr(A+B)
end

function fun2(A::MPO, B::MPO)
    return tr(B-A)
end

function matricize(M::MPO)
    sites = siteinds(M; plev=0)
    C = combiner(sites)
    return matrix(prod(M) * C' * C)
end

fun1wrap(A) = fun1(A,B)
∂fun1(A) = fun1wrap'(A)
∂fun1x = ∂fun1(A)

@show matricize(∂fun1x)

fun2wrap(A) = fun2(A,B)
∂fun2(A) = fun2wrap'(A)
∂fun2x = ∂fun2(A)

@show matricize(∂fun2x)
```
produces

```julia
matricize(∂fun1x) = [1.0000000000000002 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 1.0000000000000002 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.9999999999999998 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.9999999999999998 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 1.0000000000000004 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 1.0000000000000004 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.9999999999999996 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.9999999999999996 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0000000000000002 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0000000000000002 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.9999999999999998 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 
0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.9999999999999998]
matricize(∂fun2x) = [-1.0000000000000002 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 -1.0000000000000002 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 -0.9999999999999998 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 -0.9999999999999998 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 -1.0000000000000004 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 -1.0000000000000004 0.0 0.0 
0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -0.9999999999999996 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -0.9999999999999996 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -1.0000000000000002 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -1.0000000000000002 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -0.9999999999999998 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 -0.9999999999999998]
```
</p></details>

As expected, d(tr(A+X))/dA is simply the identity I and d(tr(B-A))/dA is simply -I.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
