### PR TITLE
Pass kwargs through to truncate in Dense factorizations

### DIFF
--- a/NDTensors/src/linearalgebra.jl
+++ b/NDTensors/src/linearalgebra.jl
@@ -166,13 +166,7 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT}; kwargs...) where {ElT,In
   P = MS .^ 2
   if truncate
     truncerr, _ = truncate!(
-      P;
-      mindim,
-      maxdim,
-      cutoff,
-      use_absolute_cutoff,
-      use_relative_cutoff,
-      kwargs...
+      P; mindim, maxdim, cutoff, use_absolute_cutoff, use_relative_cutoff, kwargs...
     )
   else
     truncerr = 0.0
@@ -237,13 +231,7 @@ function LinearAlgebra.eigen(
 
   if truncate
     truncerr, _ = truncate!(
-      DM;
-      mindim,
-      maxdim,
-      cutoff,
-      use_absolute_cutoff,
-      use_relative_cutoff,
-      kwargs...
+      DM; mindim, maxdim, cutoff, use_absolute_cutoff, use_relative_cutoff, kwargs...
     )
     dD = length(DM)
     if dD < size(VM, 2)
@@ -372,12 +360,7 @@ function LinearAlgebra.eigen(
 
   if truncate
     truncerr, _ = truncate!(
-      DM;
-      maxdim,
-      cutoff,
-      use_absolute_cutoff,
-      use_relative_cutoff,
-      kwargs...
+      DM; maxdim, cutoff, use_absolute_cutoff, use_relative_cutoff, kwargs...
     )
     dD = length(DM)
     if dD < size(VM, 2)

--- a/NDTensors/src/linearalgebra.jl
+++ b/NDTensors/src/linearalgebra.jl
@@ -167,11 +167,12 @@ function LinearAlgebra.svd(T::DenseTensor{ElT,2,IndsT}; kwargs...) where {ElT,In
   if truncate
     truncerr, _ = truncate!(
       P;
-      mindim=mindim,
-      maxdim=maxdim,
-      cutoff=cutoff,
-      use_absolute_cutoff=use_absolute_cutoff,
-      use_relative_cutoff=use_relative_cutoff,
+      mindim,
+      maxdim,
+      cutoff,
+      use_absolute_cutoff,
+      use_relative_cutoff,
+      kwargs...
     )
   else
     truncerr = 0.0
@@ -237,11 +238,12 @@ function LinearAlgebra.eigen(
   if truncate
     truncerr, _ = truncate!(
       DM;
-      mindim=mindim,
-      maxdim=maxdim,
-      cutoff=cutoff,
-      use_absolute_cutoff=use_absolute_cutoff,
-      use_relative_cutoff=use_relative_cutoff,
+      mindim,
+      maxdim,
+      cutoff,
+      use_absolute_cutoff,
+      use_relative_cutoff,
+      kwargs...
     )
     dD = length(DM)
     if dD < size(VM, 2)
@@ -371,10 +373,11 @@ function LinearAlgebra.eigen(
   if truncate
     truncerr, _ = truncate!(
       DM;
-      maxdim=maxdim,
-      cutoff=cutoff,
-      use_absolute_cutoff=use_absolute_cutoff,
-      use_relative_cutoff=use_relative_cutoff,
+      maxdim,
+      cutoff,
+      use_absolute_cutoff,
+      use_relative_cutoff,
+      kwargs...
     )
     dD = length(DM)
     if dD < size(VM, 2)


### PR DESCRIPTION
# Description

In NDTensors/src/linearalgebra.jl, changed the calls to `truncate!` to pass `kwargs...`. The reason for this is flexibility if a user wants to change the behavior of `truncate!` without editing the library code, as a user recently did here: https://itensor.discourse.group/t/cutoff-relative-to-maximum-singular-value/274

The downside might be if extra keyword args are passed to truncate which cause a bug, but I don't think we've seen many examples of this happening with the `kwargs...` pattern? (Also note that the BlockSparse version does  pass `kwargs...` without any problem.)

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
