### PR TITLE
Remove Sweeps object in examples and docs

### DIFF
--- a/docs/src/CodeTiming.md
+++ b/docs/src/CodeTiming.md
@@ -18,13 +18,6 @@ julis> using ITensors
 julia> using Profile
 
 julia> @profile include(joinpath(pkgdir(ITensors), "examples", "dmrg", "1d_heisenberg_conserve_spin.jl"))
-sweeps = Sweeps
-1 cutoff=1.0E-10, maxdim=10, mindim=1, noise=0.0E+00
-2 cutoff=1.0E-10, maxdim=20, mindim=1, noise=0.0E+00
-3 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
-4 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
-5 cutoff=1.0E-10, maxdim=200, mindim=1, noise=0.0E+00
-
 After sweep 1 energy=-137.995732867390 maxlinkdim=10 maxerr=1.93E-02 time=0.862
 After sweep 2 energy=-138.801057557054 maxlinkdim=20 maxerr=3.37E-05 time=1.126
 After sweep 3 energy=-138.940075984826 maxlinkdim=91 maxerr=9.99E-11 time=1.880
@@ -54,13 +47,6 @@ julia> using ITensors
 julia> using ProfileView
 
 julia> @profview include(joinpath(pkgdir(ITensors), "examples", "dmrg", "1d_heisenberg_conserve_spin.jl"));
-sweeps = Sweeps
-1 cutoff=1.0E-10, maxdim=10, mindim=1, noise=0.0E+00
-2 cutoff=1.0E-10, maxdim=20, mindim=1, noise=0.0E+00
-3 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
-4 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
-5 cutoff=1.0E-10, maxdim=200, mindim=1, noise=0.0E+00
-
 After sweep 1 energy=-137.995732867390 maxlinkdim=10 maxerr=1.93E-02 time=0.977
 After sweep 2 energy=-138.801057557054 maxlinkdim=20 maxerr=3.37E-05 time=1.252
 After sweep 3 energy=-138.940075984826 maxlinkdim=91 maxerr=9.99E-11 time=2.263
@@ -90,13 +76,6 @@ julia> ITensors.TimerOutputs.reset_timer!(ITensors.NDTensors.timer)
  ──────────────────────────────────────────────────────────────────
 
 julia> include("1d_heisenberg_conserve_spin.jl")
-sweeps = Sweeps
-1 cutoff=1.0E-10, maxdim=10, mindim=1, noise=0.0E+00
-2 cutoff=1.0E-10, maxdim=20, mindim=1, noise=0.0E+00
-3 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
-4 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
-5 cutoff=1.0E-10, maxdim=200, mindim=1, noise=0.0E+00
-
 After sweep 1 energy=-137.995732867390 maxlinkdim=10 maxerr=1.93E-02 time=0.597
 After sweep 2 energy=-138.801057557054 maxlinkdim=20 maxerr=3.37E-05 time=0.798
 After sweep 3 energy=-138.940075984826 maxlinkdim=91 maxerr=9.99E-11 time=1.285

--- a/docs/src/Multithreading.md
+++ b/docs/src/Multithreading.md
@@ -185,15 +185,9 @@ function main(; Nx::Int = 6, Ny::Int = 3, U::Float64 = 4.0, t::Float64 = 1.0,
 
   N = Nx * Ny
 
-  sweeps = Sweeps(nsweeps)
   maxdims = min.([100, 200, 400, 800, 2000, 3000, maxdim], maxdim)
-  maxdim!(sweeps, maxdims...)
-  cutoff!(sweeps, 1e-6)
-  noise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
-
-  if outputlevel > 0
-    @show sweeps
-  end
+  cutoff = 1E-6
+  noise = [1E-6, 1E-7, 1E-8, 0.0]
 
   sites = siteinds("ElecK", N; conserve_qns = true,
                    conserve_ky = conserve_ky, modulus_ky = Ny)
@@ -242,7 +236,7 @@ function main(; Nx::Int = 6, Ny::Int = 3, U::Float64 = 4.0, t::Float64 = 1.0,
 
   psi0 = randomMPS(sites, state, 10)
 
-  energy, psi = @time dmrg(H, psi0, sweeps; outputlevel = outputlevel)
+  energy, psi = @time dmrg(H, psi0; nsweeps, maxdims, cutoff, noise, outputlevel = outputlevel)
 
   if outputlevel > 0
     @show Nx, Ny
@@ -272,18 +266,6 @@ ITensors.blas_get_num_threads() = 1
 ITensors.Strided.get_num_threads() = 1
 ITensors.using_threaded_blocksparse() = false
 
-sweeps = Sweeps
-1 cutoff=1.0E-06, maxdim=100, mindim=1, noise=1.0E-06
-2 cutoff=1.0E-06, maxdim=200, mindim=1, noise=1.0E-07
-3 cutoff=1.0E-06, maxdim=400, mindim=1, noise=1.0E-08
-4 cutoff=1.0E-06, maxdim=800, mindim=1, noise=0.0E+00
-5 cutoff=1.0E-06, maxdim=2000, mindim=1, noise=0.0E+00
-6 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-7 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-8 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-9 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-10 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-
 use_splitblocks = true
 nnz(H[end ÷ 2]) = 67
 nnzblocks(H[end ÷ 2]) = 67
@@ -311,18 +293,6 @@ Sys.CPU_THREADS = 6
 ITensors.blas_get_num_threads() = 1
 ITensors.Strided.get_num_threads() = 1
 ITensors.using_threaded_blocksparse() = true
-
-sweeps = Sweeps
-1 cutoff=1.0E-06, maxdim=100, mindim=1, noise=1.0E-06
-2 cutoff=1.0E-06, maxdim=200, mindim=1, noise=1.0E-07
-3 cutoff=1.0E-06, maxdim=400, mindim=1, noise=1.0E-08
-4 cutoff=1.0E-06, maxdim=800, mindim=1, noise=0.0E+00
-5 cutoff=1.0E-06, maxdim=2000, mindim=1, noise=0.0E+00
-6 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-7 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-8 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-9 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
-10 cutoff=1.0E-06, maxdim=3000, mindim=1, noise=0.0E+00
 
 use_splitblocks = true
 nnz(H[end ÷ 2]) = 67

--- a/docs/src/Observer.md
+++ b/docs/src/Observer.md
@@ -183,14 +183,14 @@ let
   H = MPO(a,s)
   psi0 = randomMPS(s,4)
 
-  sweeps = Sweeps(5)
-  cutoff!(sweeps,1E-8)
-  maxdim!(sweeps,10,20,100)
+  nsweeps = 5
+  cutoff = 1E-8
+  maxdim = [10,20,100]
 
   obs = DemoObserver(etol)
 
   println("Starting DMRG")
-  energy, psi = dmrg(H,psi0,sweeps; observer=obs, outputlevel=1)
+  energy, psi = dmrg(H,psi0; nsweeps, cutoff, maxdim, observer=obs, outputlevel=1)
 
   return
 end

--- a/docs/src/examples/DMRG.md
+++ b/docs/src/examples/DMRG.md
@@ -34,12 +34,12 @@ In the last line above we convert the OpSum helper object to an actual MPO.
 
 Before beginning the calculation, we need to specify how many DMRG sweeps to do and
 what schedule we would like for the parameters controlling the accuracy.
-These parameters are stored within a sweeps object:
+These parameters can be specified as follows:
 
 ```julia
-sweeps = Sweeps(5) # number of sweeps is 5
-maxdim!(sweeps,10,20,100,100,200) # gradually increase states kept
-cutoff!(sweeps,1E-10) # desired truncation error
+nsweeps = 5 # number of sweeps is 5
+maxdim = [10,20,100,100,200] # gradually increase states kept
+cutoff = [1E-10] # desired truncation error
 ```
 
 The random starting wavefunction `psi0` must be defined in the same Hilbert space
@@ -57,7 +57,7 @@ function `productMPS`, which is actually required if we were conserving QNs.
 Finally, we are ready to call DMRG:
 
 ```julia
-energy,psi = dmrg(H,psi0,sweeps)
+energy,psi = dmrg(H,psi0; nsweeps, maxdim, cutoff)
 ```
 
 When the algorithm is done, it returns the ground state energy as the variable `energy` and an MPS 
@@ -80,13 +80,13 @@ let
   end
   H = MPO(ampo,sites)
 
-  sweeps = Sweeps(5) # number of sweeps is 5
-  maxdim!(sweeps,10,20,100,100,200) # gradually increase states kept
-  cutoff!(sweeps,1E-10) # desired truncation error
+  nsweeps = 5 # number of sweeps is 5
+  maxdim = [10,20,100,100,200] # gradually increase states kept
+  cutoff = [1E-10] # desired truncation error
 
   psi0 = randomMPS(sites,2)
 
-  energy,psi = dmrg(H,psi0,sweeps)
+  energy,psi = dmrg(H,psi0; nsweeps, maxdim, cutoff)
 
   return
 end
@@ -153,13 +153,13 @@ let
   end
   H = MPO(ampo,sites)
 
-  sweeps = Sweeps(10)
-  maxdim!(sweeps,10,10,20,40,80,100,140,180,200)
-  cutoff!(sweeps,1E-8)
+  nsweeps = 10
+  maxdim = [10,10,20,40,80,100,140,180,200]
+  cutoff = [1E-8]
 
   psi0 = randomMPS(sites,4)
 
-  energy,psi = dmrg(H,psi0,sweeps)
+  energy,psi = dmrg(H,psi0; nsweeps, maxdim, cutoff)
 
   return
 end
@@ -224,12 +224,11 @@ let
   # numbers as `state`
   psi0 = randomMPS(sites,state,20)
 
-  sweeps = Sweeps(10)
-  maxdim!(sweeps,20,60,100,100,200,400,800)
-  cutoff!(sweeps,1E-8)
-  @show sweeps
+  nsweeps = 10
+  maxdim = [20,60,100,100,200,400,800]
+  cutoff = [1E-8]
 
-  energy,psi = dmrg(H,psi0,sweeps)
+  energy,psi = dmrg(H,psi0; nsweeps, maxdim, cutoff)
 
   return
 end
@@ -242,7 +241,7 @@ These additional 'penalty states' are provided as an array of MPS just
 after the Hamiltonian, like this:
 
 ```julia
-energy,psi3 = dmrg(H,[psi0,psi1,psi2],psi3_init,sweeps)
+energy,psi3 = dmrg(H,[psi0,psi1,psi2],psi3_init; nsweeps, maxdim, cutoff)
 ```
 
 Here the penalty states are `[psi0,psi1,psi2]`. 
@@ -305,16 +304,16 @@ let
   # Make sure to do lots of sweeps
   # when finding excited states
   #
-  sweeps = Sweeps(30)
-  maxdim!(sweeps,10,10,10,20,20,40,80,100,200,200)
-  cutoff!(sweeps,1E-8)
-  noise!(sweeps,1E-6)
+  nsweeps = 30
+  maxdim = [10,10,10,20,20,40,80,100,200,200]
+  cutoff = [1E-8]
+  noise = [1E-6]
 
   #
   # Compute the ground state psi0
   #
   psi0_init = randomMPS(sites,linkdims=2)
-  energy0,psi0 = dmrg(H,psi0_init,sweeps)
+  energy0,psi0 = dmrg(H,psi0_init; nsweeps, maxdim, cutoff, noise)
 
   println()
 
@@ -322,7 +321,7 @@ let
   # Compute the first excited state psi1
   #
   psi1_init = randomMPS(sites,linkdims=2)
-  energy1,psi1 = dmrg(H,[psi0],psi1_init,sweeps; weight)
+  energy1,psi1 = dmrg(H,[psi0],psi1_init; nsweeps, maxdim, cutoff, noise, weight)
 
   # Check psi1 is orthogonal to psi0
   @show inner(psi1,psi0)
@@ -343,7 +342,7 @@ let
   # Compute the second excited state psi2
   #
   psi2_init = randomMPS(sites,linkdims=2)
-  energy2,psi2 = dmrg(H,[psi0,psi1],psi2_init,sweeps;weight)
+  energy2,psi2 = dmrg(H,[psi0,psi1],psi2_init; nsweeps, maxdim, cutoff, noise, weight)
 
   # Check psi2 is orthogonal to psi0 and psi1
   @show inner(psi2,psi0)

--- a/docs/src/faq/DMRG.md
+++ b/docs/src/faq/DMRG.md
@@ -69,14 +69,15 @@ When DMRG is failing to converge, here are some of the steps you can take to imp
   To do this, just set the `noise` parameter of each sweep to a small, non-zero value, making
   this value very small (1E-11, say) or zero by the last sweep. (Experiment with different
   values on small systems to see which noise magnitudes help.) Here is an example of 
-  a `Sweeps` parameter object with setting the noise of each sweep:
+  defining DMRG accuracy or sweep parameters with a non-zero noise set for the first three sweeps:
 
   ```julia
-  sweeps = Sweeps(10)
-  setmaxdim!(sweeps, 100, 200, 400, 800, 1600)
-  setcutoff!(sweeps, 1e-6)
-  setnoise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
-  @show sweeps
+  nsweeps = 10
+  maxdim = [100, 200, 400, 800, 1600]
+  cutoff = [1E-6]
+  noise = [1E-6, 1E-7, 1E-8, 0.0]
+  ...
+  energy, psi = dmrg(H,psi0; nsweeps, maxdim, cutoff, noise)
   ```
 
 * Try using a initial MPS with properties close to the ground state you are looking for.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -123,13 +123,6 @@ julia> readdir()
  "input_files"
 
 julia> include("1d_heisenberg.jl")
-sweeps = Sweeps
-1 cutoff=1.0E-11, maxdim=10, mindim=1, noise=0.0E+00
-2 cutoff=1.0E-11, maxdim=20, mindim=1, noise=0.0E+00
-3 cutoff=1.0E-11, maxdim=100, mindim=1, noise=0.0E+00
-4 cutoff=1.0E-11, maxdim=100, mindim=1, noise=0.0E+00
-5 cutoff=1.0E-11, maxdim=200, mindim=1, noise=0.0E+00
-
 After sweep 1 energy=-138.837988775764 maxlinkdim=10 time=13.760
 After sweep 2 energy=-138.937408365962 maxlinkdim=20 time=0.249
 After sweep 3 energy=-138.940084788852 maxlinkdim=100 time=1.867
@@ -342,27 +335,19 @@ let
   # setting maximum MPS internal dimensions
   # for each sweep and maximum truncation cutoff
   # used when adapting internal dimensions:
-  sweeps = Sweeps(5)
-  setmaxdim!(sweeps, 10,20,100,100,200)
-  setcutoff!(sweeps, 1E-10)
-  @show sweeps
+  nsweeps = 5
+  maxdim = [10,20,100,100,200]
+  cutoff = 1E-10
 
   # Run the DMRG algorithm, returning energy
   # (dominant eigenvalue) and optimized MPS
-  energy, psi = dmrg(H,psi0, sweeps)
+  energy, psi = dmrg(H,psi0; nsweeps, maxdim, cutoff)
   println("Final energy = $energy")
 
   nothing
 end
 
 # output
-
-sweeps = Sweeps
-1 cutoff=1.0E-10, maxdim=10, mindim=1, noise=0.0E+00
-2 cutoff=1.0E-10, maxdim=20, mindim=1, noise=0.0E+00
-3 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
-4 cutoff=1.0E-10, maxdim=100, mindim=1, noise=0.0E+00
-5 cutoff=1.0E-10, maxdim=200, mindim=1, noise=0.0E+00
 
 After sweep 1 energy=-137.954199761732 maxlinkdim=9 maxerr=2.43E-16 time=9.356
 After sweep 2 energy=-138.935058943878 maxlinkdim=20 maxerr=4.97E-06 time=0.671

--- a/docs/src/tutorials/DMRG.md
+++ b/docs/src/tutorials/DMRG.md
@@ -40,11 +40,11 @@ let
 
   psi0 = randomMPS(sites,10)
 
-  sweeps = Sweeps(5)
-  setmaxdim!(sweeps, 10,20,100,100,200)
-  setcutoff!(sweeps, 1E-10)
+  nsweeps = 5
+  maxdim = [10,20,100,100,200]
+  cutoff = [1E-10]
 
-  energy, psi = dmrg(H,psi0, sweeps)
+  energy, psi = dmrg(H,psi0; nsweeps, maxdim, cutoff)
 
   return
 end
@@ -102,20 +102,21 @@ This choice can help prevent the DMRG calculation from getting stuck in a local 
 The lines
 
 ```julia
-sweeps = Sweeps(5)
-setmaxdim!(sweeps, 10,20,100,100,200)
-setcutoff!(sweeps, 1E-10)
+nsweeps = 5
+maxdim = [10,20,100,100,200]
+cutoff = [1E-10]
 ```
 
-construct a `Sweeps` objects which is initialized to define 5 sweeps of DMRG. The
-call to `setmaxdim!` sets the maximum dimension allowed for each sweep and the call
-to `setcutoff!` sets the truncation error goal of each sweep (if fewer values are
+define the number of DMRG sweeps (five) we will instruct the code to do, as well as the
+parameters that will control the speed and accuracy of the DMRG algorithm within 
+each sweep. The array `maxdim` limits the maximum MPS bond dimension allowed during
+each sweep and `cutoff` defines the truncation error goal of each sweep (if fewer values are
 specified than sweeps, the last value is used for all remaining sweeps).
 
 Finally the call 
 
 ```julia
-energy, psi = dmrg(H,psi0,sweeps)
+energy, psi = dmrg(H,psi0; nsweeps, maxdim, cutoff)
 ```
 
 runs the DMRG algorithm included in ITensor, using `psi0` as an

--- a/docs/src/tutorials/QN_DMRG.md
+++ b/docs/src/tutorials/QN_DMRG.md
@@ -170,11 +170,11 @@ let
   psi0 = productMPS(sites,state)
   @show flux(psi0)
 
-  sweeps = Sweeps(5)
-  setmaxdim!(sweeps, 10,20,100,100,200)
-  setcutoff!(sweeps, 1E-10)
+  nsweeps = 5
+  maxdim = [10,20,100,100,200]
+  cutoff = [1E-10]
 
-  energy, psi = dmrg(H,psi0, sweeps)
+  energy, psi = dmrg(H,psi0; nsweeps, maxdim, cutoff)
 
   return
 end

--- a/examples/TBLIS/1d_heisenberg.jl
+++ b/examples/TBLIS/1d_heisenberg.jl
@@ -20,14 +20,9 @@ let
   H = MPO(ampo, sites)
   psi0 = randomMPS(sites, 10)
 
-  sweeps_compile = Sweeps(2)
-  maxdim!(sweeps_compile, 10)
-  cutoff!(sweeps_compile, 1E-15)
-
-  sweeps = Sweeps(6)
-  maxdim!(sweeps, 20, 100, 200, 300)
-  cutoff!(sweeps, 0.0)
-  @show sweeps
+  nsweeps = 6
+  maxdim = [20, 100, 200, 300]
+  cutoff = 1E-15
 
   #
   # Using BLAS backend
@@ -37,10 +32,10 @@ let
   BLAS.set_num_threads(nthreads)
 
   # Compile
-  dmrg(H, psi0, sweeps_compile; outputlevel=0)
+  dmrg(H, psi0; nsweeps=2, maxdim=10, outputlevel=0)
 
   println("Using BLAS with $nthreads threads\n")
-  energy, psi = @time dmrg(H, psi0, sweeps)
+  energy, psi = @time dmrg(H, psi0; nsweeps,maxdim,cutoff)
   @printf("Final energy = %.12f\n", energy)
   println()
 
@@ -53,9 +48,9 @@ let
   TBLIS.set_num_threads(nthreads)
 
   # Compile
-  dmrg(H, psi0, sweeps_compile; outputlevel=0)
+  dmrg(H, psi0; nsweeps=2, maxdim=10, outputlevel=0)
 
   println("Using TBLIS with $(TBLIS.get_num_threads()) threads (and 1 BLAS thread)\n")
-  energy, psi = @time dmrg(H, psi0, sweeps)
+  energy, psi = @time dmrg(H, psi0; nsweeps,maxdim,cutoff)
   @printf("Final energy = %.12f\n", energy)
 end

--- a/examples/TBLIS/1d_heisenberg.jl
+++ b/examples/TBLIS/1d_heisenberg.jl
@@ -35,7 +35,7 @@ let
   dmrg(H, psi0; nsweeps=2, maxdim=10, outputlevel=0)
 
   println("Using BLAS with $nthreads threads\n")
-  energy, psi = @time dmrg(H, psi0; nsweeps,maxdim,cutoff)
+  energy, psi = @time dmrg(H, psi0; nsweeps, maxdim, cutoff)
   @printf("Final energy = %.12f\n", energy)
   println()
 
@@ -51,6 +51,6 @@ let
   dmrg(H, psi0; nsweeps=2, maxdim=10, outputlevel=0)
 
   println("Using TBLIS with $(TBLIS.get_num_threads()) threads (and 1 BLAS thread)\n")
-  energy, psi = @time dmrg(H, psi0; nsweeps,maxdim,cutoff)
+  energy, psi = @time dmrg(H, psi0; nsweeps, maxdim, cutoff)
   @printf("Final energy = %.12f\n", energy)
 end

--- a/examples/autodiff/circuit_optimization/vqe.jl
+++ b/examples/autodiff/circuit_optimization/vqe.jl
@@ -73,9 +73,7 @@ algorithm = LBFGS(; gradtol=1e-3, verbosity=2)
 
 println("\nRun DMRG as a comparison")
 
-sweeps = Sweeps(5)
-setmaxdim!(sweeps, 10)
-e_dmrg, ψ_dmrg = dmrg(H, ψ0, sweeps)
+e_dmrg, ψ_dmrg = dmrg(H, ψ0; nsweeps=5, maxdim=10)
 
 println("\nCompare variational circuit energy to DMRG energy")
 @show loss(θ⃗ₒₚₜ), e_dmrg

--- a/examples/dmrg/1d_heisenberg.jl
+++ b/examples/dmrg/1d_heisenberg.jl
@@ -26,14 +26,13 @@ let
   psi0 = randomMPS(sites, 10)
 
   # Plan to do 5 DMRG sweeps:
-  sweeps = Sweeps(5)
+  nsweeps = 5
   # Set maximum MPS bond dimensions for each sweep
-  setmaxdim!(sweeps, 10, 20, 100, 100, 200)
+  maxdim = [10, 20, 100, 100, 200]
   # Set maximum truncation error allowed when adapting bond dimensions
-  setcutoff!(sweeps, 1E-11)
-  @show sweeps
+  cutoff = [1E-11]
 
   # Run the DMRG algorithm, returning energy and optimized MPS
-  energy, psi = dmrg(H, psi0, sweeps)
+  energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff)
   @printf("Final energy = %.12f\n", energy)
 end

--- a/examples/dmrg/1d_heisenberg_conserve_spin.jl
+++ b/examples/dmrg/1d_heisenberg_conserve_spin.jl
@@ -33,14 +33,13 @@ let
   psi0 = randomMPS(sites, state, 10)
 
   # Plan to do 5 DMRG sweeps:
-  sweeps = Sweeps(5)
+  nsweeps = 5
   # Set maximum MPS bond dimensions for each sweep
-  setmaxdim!(sweeps, 10, 20, 100, 100, 200)
+  maxdim = [10, 20, 100, 100, 200]
   # Set maximum truncation error allowed when adapting bond dimensions
-  setcutoff!(sweeps, 1E-10)
-  @show sweeps
+  cutoff = [1E-11]
 
   # Run the DMRG algorithm, returning energy and optimized MPS
-  energy, psi = dmrg(H, psi0, sweeps)
+  energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff)
   @printf("Final energy = %.12f\n", energy)
 end

--- a/examples/dmrg/1d_hubbard_extended.jl
+++ b/examples/dmrg/1d_hubbard_extended.jl
@@ -34,10 +34,9 @@ let
   end
   H = MPO(ampo, sites)
 
-  sweeps = Sweeps(6)
-  setmaxdim!(sweeps, 50, 100, 200, 400, 800, 800)
-  setcutoff!(sweeps, 1E-12)
-  @show sweeps
+  nsweeps = 6
+  maxdim = [50, 100, 200, 400, 800, 800]
+  cutoff = [1E-12]
 
   state = ["Emp" for n in 1:N]
   p = Npart
@@ -61,7 +60,7 @@ let
   @show flux(psi0)
 
   # Start DMRG calculation:
-  energy, psi = dmrg(H, psi0, sweeps)
+  energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff)
 
   upd = fill(0.0, N)
   dnd = fill(0.0, N)

--- a/examples/dmrg/1d_ising_with_observer.jl
+++ b/examples/dmrg/1d_ising_with_observer.jl
@@ -26,9 +26,9 @@ let
   psi0 = randomMPS(sites; linkdims=10)
 
   # define parameters for DMRG sweeps
-  sweeps = Sweeps(15)
-  setmaxdim!(sweeps, 10, 20, 100, 100, 200)
-  setcutoff!(sweeps, 1E-10)
+  nsweeps = 15
+  maxdim = [10, 20, 100, 100, 200]
+  cutoff = [1E-10]
 
   #=
   create observer which will measure Sᶻ at each
@@ -46,7 +46,7 @@ let
     println("Running DMRG for TFIM with h=0.1")
     println("================================")
     H = tfimMPO(sites, 0.1)
-    energy, psi = dmrg(H, psi0, sweeps; observer=Sz_observer)
+    energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff, observer=Sz_observer)
 
     for (i, Szs) in enumerate(measurements(Sz_observer)["Sz"])
       println("<Σ Sz> after sweep $i = ", sum(Szs) / N)
@@ -58,7 +58,7 @@ let
     println("================================")
     Sz_observer = DMRGObserver(["Sz"], sites; energy_tol=1E-7)
     H = tfimMPO(sites, 1.0)
-    energy, psi = dmrg(H, psi0, sweeps; observer=Sz_observer)
+    energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff, observer=Sz_observer)
 
     for (i, Szs) in enumerate(measurements(Sz_observer)["Sz"])
       println("<Σ Sz> after sweep $i = ", sum(Szs) / N)
@@ -70,7 +70,7 @@ let
     println("================================")
     Sz_Sx_observer = DMRGObserver(["Sz", "Sx"], sites; energy_tol=1E-7)
     H = tfimMPO(sites, 5.0)
-    energy, psi = dmrg(H, psi0, sweeps; observer=Sz_Sx_observer)
+    energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff, observer=Sz_Sx_observer)
 
     for (i, Szs) in enumerate(measurements(Sz_Sx_observer)["Sz"])
       println("<Σ Sz> after sweep $i = ", sum(Szs) / N)

--- a/examples/dmrg/2d_heisenberg_conserve_spin.jl
+++ b/examples/dmrg/2d_heisenberg_conserve_spin.jl
@@ -24,12 +24,11 @@ let
   # numbers as `state`
   psi0 = randomMPS(sites, state, 20)
 
-  sweeps = Sweeps(10)
-  setmaxdim!(sweeps, 20, 60, 100, 100, 200, 400, 800)
-  setcutoff!(sweeps, 1E-8)
-  @show sweeps
+  nsweeps = 10
+  maxdim = [20, 60, 100, 100, 200, 400, 800]
+  cutoff = [1E-8]
 
-  energy, psi = dmrg(H, psi0, sweeps)
+  energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff)
 
-  return nothing
+  return 
 end

--- a/examples/dmrg/2d_heisenberg_conserve_spin.jl
+++ b/examples/dmrg/2d_heisenberg_conserve_spin.jl
@@ -30,5 +30,5 @@ let
 
   energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff)
 
-  return 
+  return nothing
 end

--- a/examples/dmrg/2d_hubbard_conserve_momentum.jl
+++ b/examples/dmrg/2d_hubbard_conserve_momentum.jl
@@ -65,7 +65,9 @@ function main(;
 
   psi0 = randomMPS(sites, state, 10)
 
-  energy, psi = @time dmrg(H, psi0; nsweeps, maxdims, cutoff, noise, svd_alg="divide_and_conquer")
+  energy, psi = @time dmrg(
+    H, psi0; nsweeps, maxdims, cutoff, noise, svd_alg="divide_and_conquer"
+  )
   @show Nx, Ny
   @show t, U
   @show flux(psi)

--- a/examples/dmrg/2d_hubbard_conserve_momentum.jl
+++ b/examples/dmrg/2d_hubbard_conserve_momentum.jl
@@ -20,12 +20,10 @@ function main(;
 
   N = Nx * Ny
 
-  sweeps = Sweeps(10)
+  nsweeps = 10
   maxdims = min.([100, 200, 400, 800, 2000, 3000, maxdim], maxdim)
-  setmaxdim!(sweeps, maxdims...)
-  setcutoff!(sweeps, 1e-6)
-  setnoise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
-  @show sweeps
+  cutoff = [1E-6]
+  noise = [1E-6, 1E-7, 1E-8, 0.0]
 
   sites = siteinds("ElecK", N; conserve_qns=true, conserve_ky=conserve_ky, modulus_ky=Ny)
 
@@ -67,7 +65,7 @@ function main(;
 
   psi0 = randomMPS(sites, state, 10)
 
-  energy, psi = @time dmrg(H, psi0, sweeps; svd_alg="divide_and_conquer")
+  energy, psi = @time dmrg(H, psi0; nsweeps, maxdims, cutoff, noise, svd_alg="divide_and_conquer")
   @show Nx, Ny
   @show t, U
   @show flux(psi)

--- a/examples/dmrg/2d_hubbard_conserve_particles.jl
+++ b/examples/dmrg/2d_hubbard_conserve_particles.jl
@@ -3,11 +3,10 @@ using ITensors
 function main(; Nx=6, Ny=3, U=4.0, t=1.0)
   N = Nx * Ny
 
-  sweeps = Sweeps(10)
-  setmaxdim!(sweeps, 100, 200, 400, 800, 1600)
-  setcutoff!(sweeps, 1e-6)
-  setnoise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
-  @show sweeps
+  nsweeps = 10
+  maxdim = [100, 200, 400, 800, 1600]
+  cutoff = [1E-6]
+  noise = [1E-6, 1E-7, 1E-8, 0.0]
 
   sites = siteinds("Electron", N; conserve_qns=true)
 
@@ -33,7 +32,7 @@ function main(; Nx=6, Ny=3, U=4.0, t=1.0)
   # numbers as `state`
   psi0 = randomMPS(sites, state)
 
-  energy, psi = dmrg(H, psi0, sweeps)
+  energy, psi = dmrg(H, psi0; nsweeps, maxdim, cutoff, noise)
   @show t, U
   @show flux(psi)
   @show maxlinkdim(psi)

--- a/examples/dmrg/input_files/ArgParse/1d_hubbard_extended.jl
+++ b/examples/dmrg/input_files/ArgParse/1d_hubbard_extended.jl
@@ -78,13 +78,6 @@ noise = args["noise"]
 #  @eval $(Symbol(arg)) = $val
 #end
 
-sweeps = Sweeps(nsweep)
-maxdim!(sweeps, maxdim...)
-mindim!(sweeps, mindim...)
-cutoff!(sweeps, cutoff...)
-noise!(sweeps, noise...)
-
-@show sweeps
 @show N, Npart
 
 sites = siteinds("Electron", N; conserve_qns=true)
@@ -130,7 +123,7 @@ psi0 = randomMPS(sites, state, 10)
 @show flux(psi0)
 
 # Start DMRG calculation:
-energy, psi = dmrg(H, psi0, sweeps)
+energy, psi = dmrg(H, psi0; nsweeps=nsweep, maxdim, mindim, cutoff, noise)
 
 upd = fill(0.0, N)
 dnd = fill(0.0, N)

--- a/examples/dmrg/threaded_blocksparse/2d_hubbard_conserve_momentum.jl
+++ b/examples/dmrg/threaded_blocksparse/2d_hubbard_conserve_momentum.jl
@@ -90,7 +90,9 @@ function main(;
 
   psi0 = randomMPS(sites, state, 10)
 
-  energy, psi = @time dmrg(H, psi0; nsweeps, maxdims, cutoff, noise, outputlevel=outputlevel)
+  energy, psi = @time dmrg(
+    H, psi0; nsweeps, maxdims, cutoff, noise, outputlevel=outputlevel
+  )
 
   if outputlevel > 0
     @show Nx, Ny

--- a/examples/dmrg/threaded_blocksparse/2d_hubbard_conserve_momentum.jl
+++ b/examples/dmrg/threaded_blocksparse/2d_hubbard_conserve_momentum.jl
@@ -40,15 +40,9 @@ function main(;
 
   N = Nx * Ny
 
-  sweeps = Sweeps(nsweeps)
   maxdims = min.([100, 200, 400, 800, 2000, 3000, maxdim], maxdim)
-  maxdim!(sweeps, maxdims...)
-  cutoff!(sweeps, 1e-6)
-  noise!(sweeps, 1e-6, 1e-7, 1e-8, 0.0)
-
-  if outputlevel > 0
-    @show sweeps
-  end
+  cutoff = [1E-6]
+  noise = [1E-6, 1E-7, 1E-8, 0.0]
 
   sites = siteinds("ElecK", N; conserve_qns=true, conserve_ky=conserve_ky, modulus_ky=Ny)
 
@@ -96,7 +90,7 @@ function main(;
 
   psi0 = randomMPS(sites, state, 10)
 
-  energy, psi = @time dmrg(H, psi0, sweeps; outputlevel=outputlevel)
+  energy, psi = @time dmrg(H, psi0; nsweeps, maxdims, cutoff, noise, outputlevel=outputlevel)
 
   if outputlevel > 0
     @show Nx, Ny

--- a/examples/dmrg/write_to_disk/1d_heisenberg.jl
+++ b/examples/dmrg/write_to_disk/1d_heisenberg.jl
@@ -30,14 +30,14 @@ let
   psi0 = randomMPS(sites, state, 10)
 
   # Plan to do 5 DMRG sweeps:
-  sweeps = Sweeps(5)
+  nsweeps = 5
   # Set maximum MPS bond dimensions for each sweep
-  setmaxdim!(sweeps, 10, 20, 100, 100, 200)
+  maxdim = [10, 20, 100, 100, 200]
   # Set maximum truncation error allowed when adapting bond dimensions
-  setcutoff!(sweeps, 1E-10)
+  cutoff = 1E-10
   @show sweeps
 
   # Run the DMRG algorithm, returning energy and optimized MPS
-  energy, psi = dmrg(H, psi0, sweeps; write_when_maxdim_exceeds=25)
+  energy, psi = dmrg(H, psi0; nsweeps, cutoff, maxdim, write_when_maxdim_exceeds=25)
   @printf("Final energy = %.12f\n", energy)
 end

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -18,21 +18,37 @@ function permute(
 end
 
 """
+    dmrg(H::MPO,psi0::MPS;kwargs...)
     dmrg(H::MPO,psi0::MPS,sweeps::Sweeps;kwargs...)
                     
 Use the density matrix renormalization group (DMRG) algorithm
 to optimize a matrix product state (MPS) such that it is the
 eigenvector of lowest eigenvalue of a Hermitian matrix H,
 represented as a matrix product operator (MPO).
-The MPS `psi0` is used to initialize the MPS to be optimized,
-and the `sweeps` object determines the parameters used to 
-control the DMRG algorithm.
+The MPS `psi0` is used to initialize the MPS to be optimized.
+
+The number of sweeps of thd DMRG algorithm is controlled by
+passing the `nsweeps` keyword argument. The keyword arguments
+`maxdim`, `cutoff`, `noise`, and `mindim` can also be passed
+to control the cost versus accuracy of the algorithm - see below
+for details.
+
+Alternatively the number of sweeps and accuracy parameters can
+be passed through a `Sweeps` object, though this interface is 
+no longer preferred.
 
 Returns:
 * `energy::Complex` - eigenvalue of the optimized MPS
 * `psi::MPS` - optimized MPS
 
+Keyword arguments:
+* `nsweeps::Int` - number of "sweeps" of DMRG to perform
+
 Optional keyword arguments:
+* `maxdim` - integer or array of integers specifying the maximum size allowed for the bond dimension or rank of the MPS being optimized
+* `cutoff` - float or array of floats specifying the truncation error cutoff or threshold to use for truncating the bond dimension or rank of the MPS
+* `noise` - float or array of floats specifying strength of the "noise term" to use to aid convergence
+* `mindim` - integer or array of integers specifying the minimum size of the bond dimension or rank, if possible
 * `outputlevel::Int = 1` - larger outputlevel values make DMRG print more information and 0 means no output
 * `observer` - object implementing the [Observer](@ref observer) interface which can perform measurements and stop DMRG early
 * `write_when_maxdim_exceeds::Int` - when the allowed maxdim exceeds this value, begin saving tensors to disk to free memory in large calculations
@@ -48,14 +64,23 @@ function dmrg(H::MPO, psi0::MPS, sweeps::Sweeps; kwargs...)
 end
 
 """
+    dmrg(Hs::Vector{MPO},psi0::MPS;kwargs...)
     dmrg(Hs::Vector{MPO},psi0::MPS,sweeps::Sweeps;kwargs...)
                     
 Use the density matrix renormalization group (DMRG) algorithm
 to optimize a matrix product state (MPS) such that it is the
 eigenvector of lowest eigenvalue of a Hermitian matrix H.
-The MPS `psi0` is used to initialize the MPS to be optimized,
-and the `sweeps` object determines the parameters used to 
-control the DMRG algorithm.
+The MPS `psi0` is used to initialize the MPS to be optimized.
+
+The number of sweeps of thd DMRG algorithm is controlled by
+passing the `nsweeps` keyword argument. The keyword arguments
+`maxdim`, `cutoff`, `noise`, and `mindim` can also be passed
+to control the cost versus accuracy of the algorithm - see below
+for details.
+
+Alternatively the number of sweeps and accuracy parameters can
+be passed through a `Sweeps` object, though this interface is 
+no longer preferred.
 
 This version of `dmrg` accepts a representation of H as a
 Vector of MPOs, Hs = [H1,H2,H3,...] such that H is defined
@@ -67,6 +92,18 @@ each step of the DMRG algorithm when optimizing the MPS.
 Returns:
 * `energy::Complex` - eigenvalue of the optimized MPS
 * `psi::MPS` - optimized MPS
+
+Keyword arguments:
+* `nsweeps::Int` - number of "sweeps" of DMRG to perform
+
+Optional keyword arguments:
+* `maxdim` - integer or array of integers specifying the maximum size allowed for the bond dimension or rank of the MPS being optimized
+* `cutoff` - float or array of floats specifying the truncation error cutoff or threshold to use for truncating the bond dimension or rank of the MPS
+* `noise` - float or array of floats specifying strength of the "noise term" to use to aid convergence
+* `mindim` - integer or array of integers specifying the minimum size of the bond dimension or rank, if possible
+* `outputlevel::Int = 1` - larger outputlevel values make DMRG print more information and 0 means no output
+* `observer` - object implementing the [Observer](@ref observer) interface which can perform measurements and stop DMRG early
+* `write_when_maxdim_exceeds::Int` - when the allowed maxdim exceeds this value, begin saving tensors to disk to free memory in large calculations
 """
 function dmrg(Hs::Vector{MPO}, psi0::MPS, sweeps::Sweeps; kwargs...)
   for H in Hs
@@ -79,6 +116,7 @@ function dmrg(Hs::Vector{MPO}, psi0::MPS, sweeps::Sweeps; kwargs...)
 end
 
 """
+    dmrg(H::MPO,Ms::Vector{MPS},psi0::MPS;kwargs...)
     dmrg(H::MPO,Ms::Vector{MPS},psi0::MPS,sweeps::Sweeps;kwargs...)
                     
 Use the density matrix renormalization group (DMRG) algorithm
@@ -90,13 +128,33 @@ constraint is approximately enforced by adding to H terms of
 the form w|M1><M1| + w|M2><M2| + ... where Ms=[M1,M2,...] and
 w is the "weight" parameter, which can be adjusted through the
 optional `weight` keyword argument.
-The MPS `psi0` is used to initialize the MPS to be optimized,
-and the `sweeps` object determines the parameters used to 
-control the DMRG algorithm.
+The MPS `psi0` is used to initialize the MPS to be optimized.
+
+The number of sweeps of thd DMRG algorithm is controlled by
+passing the `nsweeps` keyword argument. The keyword arguments
+`maxdim`, `cutoff`, `noise`, and `mindim` can also be passed
+to control the cost versus accuracy of the algorithm - see below
+for details.
+
+Alternatively the number of sweeps and accuracy parameters can
+be passed through a `Sweeps` object, though this interface is 
+no longer preferred.
 
 Returns:
 * `energy::Complex` - eigenvalue of the optimized MPS
 * `psi::MPS` - optimized MPS
+
+Keyword arguments:
+* `nsweeps::Int` - number of "sweeps" of DMRG to perform
+
+Optional keyword arguments:
+* `maxdim` - integer or array of integers specifying the maximum size allowed for the bond dimension or rank of the MPS being optimized
+* `cutoff` - float or array of floats specifying the truncation error cutoff or threshold to use for truncating the bond dimension or rank of the MPS
+* `noise` - float or array of floats specifying strength of the "noise term" to use to aid convergence
+* `mindim` - integer or array of integers specifying the minimum size of the bond dimension or rank, if possible
+* `outputlevel::Int = 1` - larger outputlevel values make DMRG print more information and 0 means no output
+* `observer` - object implementing the [Observer](@ref observer) interface which can perform measurements and stop DMRG early
+* `write_when_maxdim_exceeds::Int` - when the allowed maxdim exceeds this value, begin saving tensors to disk to free memory in large calculations
 """
 function dmrg(H::MPO, Ms::Vector{MPS}, psi0::MPS, sweeps::Sweeps; kwargs...)
   check_hascommoninds(siteinds, H, psi0)


### PR DESCRIPTION
# Description

This PR removes the use of the Sweeps object throughout the documentation and (almost all of) the examples, in favor of just passing keyword arguments to the `dmrg` function. This was prompted by a forum user asking about how to define more complicated settings of maxdim for a large number of sweeps.

# How Has This Been Tested?

I ran the edited codes to make sure their behavior was the same afterward.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
