### PR TITLE
Add keyword arguments support for ITensors.state

### DIFF
--- a/src/physics/sitetype.jl
+++ b/src/physics/sitetype.jl
@@ -512,12 +512,12 @@ macro StateName_str(s)
   return StateName{SmallString(s)}
 end
 
-state(::StateName, ::SiteType) = nothing
-state(::StateName, ::SiteType, ::Index) = nothing
-state!(::ITensor, ::StateName, ::SiteType, ::Index) = nothing
+state(::StateName, ::SiteType; kwargs...) = nothing
+state(::StateName, ::SiteType, ::Index; kwargs...) = nothing
+state!(::ITensor, ::StateName, ::SiteType, ::Index; kwargs...) = nothing
 
 # Syntax `state("Up", Index(2, "S=1/2"))`
-state(sn::String, i::Index) = state(i, sn)
+state(sn::String, i::Index; kwargs...) = state(i, sn; kwargs...)
 
 """
     state(s::Index, name::String; kwargs...)
@@ -552,7 +552,7 @@ function state(s::Index, name::AbstractString; kwargs...)::ITensor
   stypes = _sitetypes(s)
   sname = StateName(name)
 
-  # Try calling state(::StateName"Name",::SiteType"Tag",s::Index)
+  # Try calling state(::StateName"Name",::SiteType"Tag",s::Index; kwargs...)
   for st in stypes
     v = state(sname, st, s; kwargs...)
     if !isnothing(v)
@@ -565,10 +565,10 @@ function state(s::Index, name::AbstractString; kwargs...)::ITensor
     end
   end
 
-  # Try calling state!(::ITensor,::StateName"Name",::SiteType"Tag",s::Index)
+  # Try calling state!(::ITensor,::StateName"Name",::SiteType"Tag",s::Index;kwargs...)
   T = ITensor(s)
   for st in stypes
-    state!(T, sname, st, s)
+    state!(T, sname, st, s; kwargs...)
     !isempty(T) && return T
   end
 
@@ -578,7 +578,7 @@ function state(s::Index, name::AbstractString; kwargs...)::ITensor
   # which returns a Julia vector
   #
   for st in stypes
-    v = state(sname, st)
+    v = state(sname, st; kwargs...)
     !isnothing(v) && return itensor(v, s)
   end
 
@@ -591,7 +591,7 @@ end
 
 state(s::Index, n::Integer) = onehot(s => n)
 
-state(sset::Vector{<:Index}, j::Integer, st) = state(sset[j], st)
+state(sset::Vector{<:Index}, j::Integer, st; kwargs...) = state(sset[j], st; kwargs...)
 
 #---------------------------------------
 #

--- a/test/sitetype.jl
+++ b/test/sitetype.jl
@@ -426,6 +426,12 @@ end
     @test_throws BoundsError state(s, "3")
   end
 
+  @testset "state with parameters" begin
+    ITensors.state(::StateName"phase", ::SiteType"Qubit"; θ::Real) = [cos(θ), sin(θ)]
+    s = siteind("Qubit")
+    @test state("phase", s; θ=π/6) ≈ itensor([cos(π/6), sin(π/6)], s)
+  end
+
   @testset "state with variable dimension (deprecated)" begin
     ITensors.space(::SiteType"MyQudit2"; dim=2) = dim
 


### PR DESCRIPTION
Edit definition of `ITensors.state` such that it forwards keyword arguments to the calls to the more "basic" forms of `ITensors.state`. This allows defining states with parameters, passed as keyword arguments.

See https://itensor.discourse.group/t/defining-states-with-parameters-as-keyword-arguments/343?u=phx

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
