### PR TITLE
site_range keyword for truncate!

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1612,7 +1612,7 @@ function truncate!(::Algorithm"frobenius", M::AbstractMPS; kwargs...)
   orthogonalize!(M, last(sites))
 
   # Perform truncations in a right-to-left sweep
-  for j in reverse(first(sites)+1:last(sites))
+  for j in reverse((first(sites) + 1):last(sites))
     rinds = uniqueinds(M[j], M[j - 1])
     ltags = tags(commonind(M[j], M[j - 1]))
     U, S, V = svd(M[j], rinds; lefttags=ltags, kwargs...)

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1605,13 +1605,14 @@ end
 
 function truncate!(::Algorithm"frobenius", M::AbstractMPS; kwargs...)
   N = length(M)
+  sites = get(kwargs, :site_range, 1:N)
 
   # Left-orthogonalize all tensors to make
   # truncations controlled
-  orthogonalize!(M, N)
+  orthogonalize!(M, last(sites))
 
   # Perform truncations in a right-to-left sweep
-  for j in reverse(2:N)
+  for j in reverse(first(sites)+1:last(sites))
     rinds = uniqueinds(M[j], M[j - 1])
     ltags = tags(commonind(M[j], M[j - 1]))
     U, S, V = svd(M[j], rinds; lefttags=ltags, kwargs...)

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1598,21 +1598,25 @@ end
 Perform a truncation of all bonds of an MPS/MPO,
 using the truncation parameters (cutoff,maxdim, etc.)
 provided as keyword arguments.
+
+Keyword arguments:
+* `site_range`=1:N - only truncate the MPS bonds between these sites
 """
 function truncate!(M::AbstractMPS; alg="frobenius", kwargs...)
   return truncate!(Algorithm(alg), M; kwargs...)
 end
 
-function truncate!(::Algorithm"frobenius", M::AbstractMPS; kwargs...)
+function truncate!(
+  ::Algorithm"frobenius", M::AbstractMPS; site_range=1:length(M), kwargs...
+)
   N = length(M)
-  sites = get(kwargs, :site_range, 1:N)
 
   # Left-orthogonalize all tensors to make
   # truncations controlled
-  orthogonalize!(M, last(sites))
+  orthogonalize!(M, last(site_range))
 
   # Perform truncations in a right-to-left sweep
-  for j in reverse((first(sites) + 1):last(sites))
+  for j in reverse((first(site_range) + 1):last(site_range))
     rinds = uniqueinds(M[j], M[j - 1])
     ltags = tags(commonind(M[j], M[j - 1]))
     U, S, V = svd(M[j], rinds; lefttags=ltags, kwargs...)

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -167,7 +167,9 @@ function dmrg(H::MPO, Ms::Vector{MPS}, psi0::MPS, sweeps::Sweeps; kwargs...)
   Ms .= permute.(Ms, Ref((linkind, siteinds, linkind)))
   weight = get(kwargs, :weight, 1.0)
   if weight <= 0.0
-    error("weight parameter should be > 0.0 in call to excited-state dmrg (value passed was weight=$weight)")
+    error(
+      "weight parameter should be > 0.0 in call to excited-state dmrg (value passed was weight=$weight)",
+    )
   end
   PMM = ProjMPO_MPS(H, Ms; weight=weight)
   return dmrg(PMM, psi0, sweeps; kwargs...)

--- a/test/mps.jl
+++ b/test/mps.jl
@@ -705,6 +705,12 @@ end
 
     @test inner(M, M0) > 0.1
   end
+
+  @testset "truncate! with site_range" begin
+    M = basicRandomMPS(10; dim=10)
+    truncate!(M; site_range=3:7, maxdim=2)
+    @test linkdims(M) == [2, 4, 2, 2, 2, 2, 8, 4, 2]
+  end
 end
 
 @testset "Other MPS methods" begin


### PR DESCRIPTION
# Description

Adds a `site_range` keyword argument for `truncate!`. This is helpful for algorithms where it is known that only part of the MPS was changed, so as to avoid doing extra work. (Recent application of this is a specialized routine for applying MPOs which only act on part of an MPS.)

# How Has This Been Tested?

Added a unit test to test/mps.jl

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
