### PR TITLE
Set path for DMRG disk feature

### DIFF
--- a/src/mps/diskprojmpo.jl
+++ b/src/mps/diskprojmpo.jl
@@ -66,12 +66,20 @@ function DiskProjMPO(H::MPO)
   )
 end
 
-function disk(pm::ProjMPO)
+function disk(pm::ProjMPO; kwargs...)
   return DiskProjMPO(
-    pm.lpos, pm.rpos, pm.nsite, pm.H, disk(pm.LR), lproj(pm), pm.lpos, rproj(pm), pm.rpos
+    pm.lpos,
+    pm.rpos,
+    pm.nsite,
+    pm.H,
+    disk(pm.LR; kwargs...),
+    lproj(pm),
+    pm.lpos,
+    rproj(pm),
+    pm.rpos,
   )
 end
-disk(pm::DiskProjMPO) = pm
+disk(pm::DiskProjMPO; kwargs...) = pm
 
 # Special overload of lproj which uses the cached
 # version of the left projected MPO, and if the

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -197,6 +197,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
   write_when_maxdim_exceeds::Union{Int,Nothing} = get(
     kwargs, :write_when_maxdim_exceeds, nothing
   )
+  write_path = get(kwargs, :write_path, tempdir())
 
   # eigsolve kwargs
   eigsolve_tol::Number = get(kwargs, :eigsolve_tol, 1e-14)
@@ -256,7 +257,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
             "write_when_maxdim_exceeds = $write_when_maxdim_exceeds and maxdim(sweeps, sw) = $(maxdim(sweeps, sw)), writing environment tensors to disk",
           )
         end
-        PH = disk(PH)
+        PH = disk(PH; path=write_path)
       end
 
       for (b, ha) in sweepnext(N)


### PR DESCRIPTION
# Description

Based on [this forum question](https://itensor.discourse.group/t/the-problem-about-space-left-on-device/378/1), allow users to set a custom path for write-to-disk mode of DMRG.

# How Has This Been Tested?

Tested by modifying one of the example codes and verifying correct behavior, though didn't write a unit test for it.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
