### PR TITLE
HDF5 Support for Diag Storage

### DIFF
--- a/NDTensors/src/diag/diag.jl
+++ b/NDTensors/src/diag/diag.jl
@@ -566,3 +566,39 @@ function show(io::IO, mime::MIME"text/plain", T::DiagTensor)
   summary(io, T)
   return print_tensor(io, T)
 end
+
+function HDF5.write(
+  parent::Union{HDF5.File,HDF5.Group}, name::String, D::Store
+) where {Store<:Diag}
+  g = create_group(parent, name)
+  attributes(g)["type"] = "Diag{$(eltype(Store)),$(datatype(Store))}"
+  attributes(g)["version"] = 1
+  if eltype(D) != Nothing
+    write(g, "data", D.data)
+  end
+end
+
+function HDF5.read(
+  parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, ::Type{Store}
+) where {Store<:Diag}
+  g = open_group(parent, name)
+  ElT = eltype(Store)
+  VecT = datatype(Store)
+  typestr = "Diag{$ElT,$VecT}"
+  if read(attributes(g)["type"]) != typestr
+    error("HDF5 group or file does not contain $typestr data")
+  end
+  if ElT == Nothing
+    return Dense{Nothing}()
+  end
+  # Attribute __complex__ is attached to the "data" dataset
+  # by the h5 library used by C++ version of ITensor:
+  if haskey(attributes(g["data"]), "__complex__")
+    M = read(g, "data")
+    nelt = size(M, 1) * size(M, 2)
+    data = Vector(reinterpret(ComplexF64, reshape(M, nelt)))
+  else
+    data = read(g, "data")
+  end
+  return Diag{ElT,VecT}(data)
+end

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -678,7 +678,7 @@ function _contract(::Algorithm"naive", A, ψ; kwargs...)
     throw(DimensionMismatch("lengths of MPO ($N) and MPS ($(length(ψ))) do not match"))
   end
 
-  ψ_out = MPS(N)
+  ψ_out = typeof(ψ)(N)
   for j in 1:N
     ψ_out[j] = A[j] * ψ[j]
   end

--- a/test/mpo.jl
+++ b/test/mpo.jl
@@ -708,6 +708,17 @@ end
     @test inner(noprime(Apsi), Apply(A, psi)) ≈ inner(Apsi, Apsi)
   end
 
+  @testset "Other MPO contract algorithms" begin
+    # Regression test - ensure that output of "naive" algorithm is an 
+    # MPO not an MPS
+    N = 8
+    s = siteinds(2, N)
+    A = randomMPO(s)
+    B = randomMPO(s)
+    C = apply(A, B; alg="naive")
+    @test C isa MPO
+  end
+
   @testset "MPO with no link indices" for conserve_qns in [false, true]
     s = siteinds("S=1/2", 4; conserve_qns)
     H = MPO([op("Id", sn) for sn in s])

--- a/test/readwrite.jl
+++ b/test/readwrite.jl
@@ -95,6 +95,43 @@ include("util.jl")
     @test norm(rT - T) / norm(T) < 1E-10
   end
 
+  @testset "Diag ITensor" begin
+    #
+    # Delta ITensor
+    #
+    fo = h5open("data.h5", "w")
+    Δ = δ(i, i')
+    cΔ = δ(ComplexF64, i, i')
+    fo["delta_tensor"] = Δ
+    fo["c_delta_tensor"] = cΔ
+    close(fo)
+
+    fi = h5open("data.h5", "r")
+    rΔ = read(fi, "delta_tensor", ITensor)
+    rcΔ = read(fi, "c_delta_tensor", ITensor)
+    close(fi)
+    @test rΔ ≈ Δ
+    @test rcΔ ≈ cΔ
+
+    #
+    # Diag ITensor
+    #
+    fo = h5open("data.h5", "w")
+    dk = dim(k)
+    D = diagITensor(randn(dk), k, k')
+    C = diagITensor(randn(ComplexF64, dk), k, k')
+    fo["diag_tensor"] = D
+    fo["c_diag_tensor"] = C
+    close(fo)
+
+    fi = h5open("data.h5", "r")
+    rD = read(fi, "diag_tensor", ITensor)
+    rC = read(fi, "c_diag_tensor", ITensor)
+    close(fi)
+    @test rD ≈ D
+    @test rC ≈ C
+  end
+
   @testset "QN ITensor" begin
     i = Index(QN("A", -1) => 3, QN("A", 0) => 4, QN("A", +1) => 3; tags="i")
     j = Index(QN("A", -2) => 2, QN("A", 0) => 3, QN("A", +2) => 2; tags="j")


### PR DESCRIPTION
- Add HDF5 support for Diag storage
- Fix output of naive MPO MPO algorithm
- Add test for naive alg fix

# Description

Adds HDF5 support for ITensors with Diag storage (supporting various `datatypes` such as those used for `delta` versus diag ITensors). Also fixes a bug where the "naive" algorithm for MPO contraction was giving an MPS as output.

Fixes #972

</p></details>

# How Has This Been Tested?

- [X] Unit test writing various diag ITensors to HDF5 and reading them back
- [X] Test checking type of result of "naive" MPO contraction algorithm

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
