### PR TITLE
Define F operator for Qudit and Boson

### DIFF
--- a/src/physics/site_types/qudit.jl
+++ b/src/physics/site_types/qudit.jl
@@ -39,6 +39,7 @@ function op(::OpName"Id", ::SiteType"Qudit", ds::Int...)
   return Matrix(1.0I, d, d)
 end
 op(on::OpName"I", st::SiteType"Qudit", ds::Int...) = op(alias(on), st, ds...)
+op(on::OpName"F", st::SiteType"Qudit", ds::Int...) = op(OpName"Id"(), st, ds...)
 
 function op(::OpName"Adag", ::SiteType"Qudit", d::Int)
   mat = zeros(d, d)

--- a/test/phys_site_types.jl
+++ b/test/phys_site_types.jl
@@ -459,6 +459,7 @@ using ITensors, Test
     @test v == 3
     @test op(s, "Id", 2) == itensor([1 0 0; 0 1 0; 0 0 1], s[2]', dag(s[2]))
     @test op(s, "I", 2) == itensor([1 0 0; 0 1 0; 0 0 1], s[2]', dag(s[2]))
+    @test op(s, "F", 2) == itensor([1 0 0; 0 1 0; 0 0 1], s[2]', dag(s[2]))
     @test op("Id", s, 1, 2) ==
       itensor(Matrix(I, d^2, d^2), s[2]', s[1]', dag(s[2]), dag(s[1]))
     @test op("I", s, 1, 2) ==


### PR DESCRIPTION
# Description

Responding to [this forum post](https://itensor.discourse.group/t/mixed-site-fermion-boson-model-error-calling-mpo-ampo-sites/398), this PR defines the "F" operator for the "Boson" and "Qudit" site types by defining it just for "Qudit". 

I explored getting the "Qudit" site type to use the "Generic" fallback approach, but it was fairly complicated to do without changing a lot of the pattern that "Qudit" currently uses. Currently, we aren't using "Generic" for many things anyway and might want to do away with it in the future since it's something of a 'magical' feature (though there's something also to be said for "Id" to be defined for any new site type).

# How Has This Been Tested?

Added a new test to phys_site_types.jl

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
