### PR TITLE
Fix variable declaration warnings

### DIFF
--- a/NDTensors/src/blocksparse/block.jl
+++ b/NDTensors/src/blocksparse/block.jl
@@ -40,7 +40,7 @@ Block(t::NTuple{N,UInt}) where {N} = Block{N}(t)
 
 Block(t::Tuple{Vararg{<:Any,N}}) where {N} = Block{N}(t)
 
-Block(::Tuple{}) where {N} = Block{0}(())
+Block(::Tuple{}) = Block{0}(())
 
 Block(I::Union{Integer,Block{1}}...) = Block(I)
 
@@ -56,7 +56,7 @@ convert(::Type{Block}, I::CartesianIndex{N}) where {N} = Block{N}(I.I)
 
 convert(::Type{Block{N}}, I::CartesianIndex{N}) where {N} = Block{N}(I.I)
 
-convert(::Type{Block}, t::Tuple) where {N} = Block(t)
+convert(::Type{Block}, t::Tuple) = Block(t)
 
 convert(::Type{Block{N}}, t::Tuple) where {N} = Block{N}(t)
 

--- a/NDTensors/src/blocksparse/blockdims.jl
+++ b/NDTensors/src/blocksparse/blockdims.jl
@@ -176,7 +176,7 @@ end
 
 # Given a CartesianIndex in the range dims(T), get the block it is in
 # and the index within that block
-function blockindex(T, i::Vararg{Integer,N}) where {ElT,N}
+function blockindex(T, i::Vararg{Integer,N}) where {N}
   # Bounds check.
   # Do something more robust like:
   # @boundscheck Base.checkbounds_indices(Bool, map(Base.oneto, dims(T)), i) || throw_boundserror(T, i)

--- a/NDTensors/src/blocksparse/blocksparsetensor.jl
+++ b/NDTensors/src/blocksparse/blocksparsetensor.jl
@@ -407,7 +407,7 @@ function perm_blocks(blocks::Blocks{N}, dim::Int, perm) where {N}
 end
 
 # In the dimension dim, permute the block
-function perm_block(block::Block, dim::Int, perm) where {N}
+function perm_block(block::Block, dim::Int, perm)
   iperm = invperm(perm)
   return setindex(block, iperm[block[dim]], dim)
 end

--- a/NDTensors/src/blocksparse/diagblocksparse.jl
+++ b/NDTensors/src/blocksparse/diagblocksparse.jl
@@ -461,7 +461,7 @@ end
 
 function permutedims(
   T::UniformDiagBlockSparseTensor{ElT,N}, perm::NTuple{N,Int}, f::Function=identity
-) where {ElR,ElT,N}
+) where {ElT,N}
   R = tensor(DiagBlockSparse(f(getdiagindex(T, 1))), permute(inds(T), perm))
   return R
 end

--- a/NDTensors/src/combiner/combiner.jl
+++ b/NDTensors/src/combiner/combiner.jl
@@ -118,9 +118,7 @@ function contract!!(R::Tensor, labelsR, T1::CombinerTensor, labelsT1, T2::Tensor
   return R
 end
 
-function contract!!(
-  R::Tensor, labelsR, T1::Tensor, labelsT1, T2::CombinerTensor, labelsT2
-) where {NR,N1,N2}
+function contract!!(R::Tensor, labelsR, T1::Tensor, labelsT1, T2::CombinerTensor, labelsT2)
   return contract!!(R, labelsR, T2, labelsT2, T1, labelsT1)
 end
 

--- a/NDTensors/src/linearalgebra.jl
+++ b/NDTensors/src/linearalgebra.jl
@@ -9,7 +9,7 @@ export eigs, entropy, polar, random_orthog, random_unitary, Spectrum, svd, trunc
 
 function (
   T1::Tensor{ElT1,2,StoreT1} * T2::Tensor{ElT2,2,StoreT2}
-) where {ElT1,StoreT1<:Dense,IndsT1,ElT2,StoreT2<:Dense,IndsT2}
+) where {ElT1,StoreT1<:Dense,ElT2,StoreT2<:Dense}
   RM = matrix(T1) * matrix(T2)
   indsR = (ind(T1, 1), ind(T2, 2))
   return tensor(Dense(vec(RM)), indsR)

--- a/NDTensors/src/tensor.jl
+++ b/NDTensors/src/tensor.jl
@@ -350,7 +350,7 @@ end
 # (at least it is necessary for `diag(::DiagTensor)`).
 # TODO: Specialize this to the Tensor type, for example
 # block sparse to return a block sparse vector?
-function Base.similar(T::Tensor, ::Type{ElT}, dims::Tuple{Int}) where {ElT,N}
+function Base.similar(T::Tensor, ::Type{ElT}, dims::Tuple{Int}) where {ElT}
   return Tensor(ElT, dims)
 end
 

--- a/src/LazyApply/LazyApply.jl
+++ b/src/LazyApply/LazyApply.jl
@@ -79,8 +79,8 @@ end
 (os::Sum{A} + o::A) where {A} = Applied(sum, (vcat(os.args[1], [o]),))
 (o::A + os::Sum{A}) where {A} = Applied(sum, (vcat([o], os.args[1]),))
 
-(a1::Sum{A} - a2::A) where {C,A} = a1 + (-a2)
-(a1::A - a2::Sum{A}) where {C,A} = a1 + (-a2)
+(a1::Sum{A} - a2::A) where {A} = a1 + (-a2)
+(a1::A - a2::Sum{A}) where {A} = a1 + (-a2)
 
 (a1::Sum{A} - a2::Prod{A}) where {A} = a1 + (-a2)
 (a1::Sum{A} - a2::Scaled{C,Prod{A}}) where {C,A} = a1 + (-a2)
@@ -164,7 +164,7 @@ function (co1::Scaled{C,Prod{A}} + co2::Scaled{C,A}) where {C,A}
   return co1 + coefficient(co2) * Applied(prod, ([argument(co2)],))
 end
 
-function (a1::Scaled - a2::Scaled) where {C,A}
+function (a1::Scaled - a2::Scaled)
   return a1 + (-a2)
 end
 

--- a/src/Ops/Ops.jl
+++ b/src/Ops/Ops.jl
@@ -297,7 +297,7 @@ function show(io::IO, ::MIME"text/plain", o::Prod{Op})
   end
   return nothing
 end
-show(io::IO, o::Prod{Op}) where {C} = show(io, MIME("text/plain"), o)
+show(io::IO, o::Prod{Op}) = show(io, MIME("text/plain"), o)
 
 function show(io::IO, m::MIME"text/plain", o::Scaled{C,O}) where {C,O<:Union{Op,Prod{Op}}}
   c = coefficient(o)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -811,25 +811,10 @@ dir(A::ITensor, i::Index) = dir(inds(A), i)
 
 dirs(A::ITensor, is) = dirs(inds(A), is)
 
-# TODO: add iscombiner(::Tensor) to NDTensors
-iscombiner(T::ITensor)::Bool = (storage(T) isa Combiner)
-
 # TODO: add isdiag(::Tensor) to NDTensors
 isdiag(T::ITensor)::Bool = (storage(T) isa Diag || storage(T) isa DiagBlockSparse)
 
 diaglength(T::ITensor) = diaglength(tensor(T))
-
-"""
-    ishermitian(T::ITensor; kwargs...)
-
-Test whether an ITensor is a Hermitian operator,
-that is whether taking `dag` of the ITensor and
-transposing its indices returns numerically
-the same ITensor.
-"""
-function ishermitian(T::ITensor; kwargs...)
-  return isapprox(T, dag(transpose(T)); kwargs...)
-end
 
 #
 # Block sparse related functions

--- a/src/physics/autompo/opsum_to_mpo_generic.jl
+++ b/src/physics/autompo/opsum_to_mpo_generic.jl
@@ -266,11 +266,11 @@ function MPO(o::Scaled{C,Op}, s::Vector{<:Index}; kwargs...) where {C}
   return MPO(OpSum{C}() + o, s; kwargs...)
 end
 
-function MPO(o::Sum{Op}, s::Vector{<:Index}; kwargs...) where {C}
+function MPO(o::Sum{Op}, s::Vector{<:Index}; kwargs...)
   return MPO(OpSum{Float64}() + o, s; kwargs...)
 end
 
-function MPO(o::Prod{Op}, s::Vector{<:Index}; kwargs...) where {C}
+function MPO(o::Prod{Op}, s::Vector{<:Index}; kwargs...)
   return MPO(OpSum{Float64}() + o, s; kwargs...)
 end
 

--- a/src/physics/fermions.jl
+++ b/src/physics/fermions.jl
@@ -313,7 +313,7 @@ end #NDTensors.before_combiner_signs
 
 function NDTensors.after_combiner_signs(
   R, labelsR, indsR::NTuple{NR,QNIndex}, C, labelsC, indsC::NTuple{NC,QNIndex}
-) where {NC,NT,NR}
+) where {NC,NR}
   ci = NDTensors.cinds(store(C))[1]
   combining = (labelsC[ci] > 0)
   combining && error("NDTensors.after_combiner_signs only for uncombining")


### PR DESCRIPTION
# Description

After installing v1.8.2 of Julia, I got a number of warnings about ITensors.jl and related packages referring to variables that were declared (where {A,B,C}) but not used in many functions. This PR removes those unused variable declarations.

# How Has This Been Tested?

Testing by running CI. No tests were added or changed.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
