### PR TITLE
Reduce bond dimension of `MPO`s generated from `OpSum`s consisting of one-site operators

### DIFF
--- a/test/autompo.jl
+++ b/test/autompo.jl
@@ -1121,6 +1121,25 @@ end
     H2 = MPO(opsum2, sites)
     @test H1 ≈ H2
   end
+
+  @testset "One-site ops bond dimension test" begin
+    sites = siteinds("S=1/2", N)
+
+    # one-site operator on every site
+    os = OpSum()
+    for j in 1:N
+      os += "Z", j
+    end
+    H = MPO(os, sites)
+    @test all(linkdims(H) .== 2)
+
+    # one-site operator on a single site
+    os = OpSum()
+    os += "Z", rand(1:N)
+    H = MPO(os, sites)
+    @test all(linkdims(H) .<= 2)
+    @test_broken all(linkdims(H) .== 1)
+  end
 end
 
 nothing


### PR DESCRIPTION
# Description

In the current implementation of the `OpSum` to `MPO` converter every bond of the `MPO` is initialized with a dimension of at least 3, even if there are no interactions passed along that bond. I added a small change here that checks if there is actually something passed along each bond, and sets the bond dimension to 2 (for one-site operators and the identities) if this is not the case.

This is related to #526 in the sense that the bond dimension for product `MPO`s is now reduced from 3 to 2 as a side effect, but the bond dimension = 1 case would still need to be handled as a special case to get a real product `MPO`.

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
using ITensors
s = siteinds("S=1/2", 4)
os = OpSum()
for i in 1:4
    os += "X", i
end
H = MPO(os, s)
@show linkdims(H)
```
returns:
```julia
linkdims(H) = [3, 3, 3]
```

</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
using ITensors
s = siteinds("S=1/2", 4)
os = OpSum()
for i in 1:4
    os += "X", i
end
H = MPO(os, s)
@show linkdims(H)
```
returns:
```julia
linkdims(H) = [2, 2, 2]
```

</p></details>

# How Has This Been Tested?

I added a small test for the specific case of Hamiltonians consisting of only one-site operators at the end of test/autompo.jl.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
