### PR TITLE
Fix auto fermion system for non-QN tensors

### DIFF
--- a/src/physics/fermions.jl
+++ b/src/physics/fermions.jl
@@ -34,9 +34,9 @@ end
 
 isfermionic(i::Index) = has_fermionic_subspaces(i)
 
-has_fermionic_subspaces(is::Union{IndexSet,NTuple{N,Index}}) where {N} = false
+has_fermionic_subspaces(is::Indices) = false
 
-function has_fermionic_subspaces(is::Union{QNIndexSet,NTuple{N,QNIndex}}) where {N}
+function has_fermionic_subspaces(is::QNIndices)
   for i in is, b in 1:nblocks(i)
     isfermionic(qn(i, b)) && (return true)
   end
@@ -101,7 +101,7 @@ function NDTensors.permfactor(p, ivs::Vararg{Pair{QNIndex},N}; kwargs...) where 
 end
 
 function NDTensors.permfactor(
-  perm, block::NDTensors.Block{N}, inds::Union{QNIndexSet,NTuple{N,QNIndex}}; kwargs...
+  perm, block::NDTensors.Block{N}, inds::QNIndices; kwargs...
 ) where {N}
   using_auto_fermion() || return 1
   qns = ntuple(n -> qn(inds[n], block[n]), N)
@@ -137,8 +137,8 @@ end
   end
 
   # the "indsR" argument to compute_alpha from NDTensors
-  # may be a tuple of QNIndex, so convert to an IndexSet
-  indsR = IndexSet(input_indsR)
+  # may be a tuple of QNIndex, so convert to a Vector{Index}
+  indsR = collect(input_indsR)
 
   nlabelsT1 = NDTensors.sort(labelsT1; rev=true)
   nlabelsT2 = NDTensors.sort(labelsT2)

--- a/src/physics/fermions.jl
+++ b/src/physics/fermions.jl
@@ -34,7 +34,7 @@ end
 
 isfermionic(i::Index) = has_fermionic_subspaces(i)
 
-has_fermionic_subspaces(is::IndexSet) = false
+has_fermionic_subspaces(is::Union{IndexSet,NTuple{N,Index}}) where {N} = false
 
 function has_fermionic_subspaces(is::Union{QNIndexSet,NTuple{N,QNIndex}}) where {N}
   for i in is, b in 1:nblocks(i)
@@ -43,7 +43,7 @@ function has_fermionic_subspaces(is::Union{QNIndexSet,NTuple{N,QNIndex}}) where 
   return false
 end
 
-has_fermionic_subspaces(T) = has_fermionic_subspaces(inds(T))
+has_fermionic_subspaces(T::Tensor) = has_fermionic_subspaces(inds(T))
 
 """
     fparity(qn::QN)

--- a/test/fermions.jl
+++ b/test/fermions.jl
@@ -8,7 +8,7 @@ using ITensors, Test
     # for dense tensors:
     n = 10
     s = siteinds("Electron", n)
-    psi = randomMPS(s, j -> isodd(j) ? "Up" : "Dn", linkdims=20)
+    psi = randomMPS(s, j -> isodd(j) ? "Up" : "Dn"; linkdims=20)
   end
 
   @testset "parity_sign function" begin

--- a/test/fermions.jl
+++ b/test/fermions.jl
@@ -3,6 +3,14 @@ using ITensors, Test
 @testset "Fermions" begin
   ITensors.enable_auto_fermion()
 
+  @testset "Test system without QNs" begin
+    # Just testing that no bugs are encountered with enable_auto_fermion
+    # for dense tensors:
+    n = 10
+    s = siteinds("Electron", n)
+    psi = randomMPS(s, j -> isodd(j) ? "Up" : "Dn", linkdims=20)
+  end
+
   @testset "parity_sign function" begin
 
     # Full permutations


### PR DESCRIPTION
# Description

Fixes #1002, by removing an ambiguous (or self-calling) function overload and replacing it with some more constrained versions.

# How Has This Been Tested?

Added a small new test that reproduces the issue in #1002.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
