### PR TITLE
Kmp5/enhancements/inits

### DIFF
--- a/NDTensors/src/NDTensors.jl
+++ b/NDTensors/src/NDTensors.jl
@@ -31,6 +31,7 @@ include("imports.jl")
 # DenseTensor and DiagTensor
 #
 include("aliasstyle.jl")
+include("default_storage.jl")
 include("similar.jl")
 include("tupletools.jl")
 include("dims.jl")

--- a/NDTensors/src/NDTensors.jl
+++ b/NDTensors/src/NDTensors.jl
@@ -31,11 +31,11 @@ include("imports.jl")
 # DenseTensor and DiagTensor
 #
 include("aliasstyle.jl")
-include("default_storage.jl")
 include("similar.jl")
 include("tupletools.jl")
 include("dims.jl")
 include("tensorstorage.jl")
+include("default_storage.jl")
 include("tensor.jl")
 include("adapt.jl")
 include("generic_tensor_operations.jl")

--- a/NDTensors/src/default_storage.jl
+++ b/NDTensors/src/default_storage.jl
@@ -1,6 +1,6 @@
 ## This is a fil which specifies the default storage type provided some set of parameters
 ## The parameters are the element type and storage type
-function default_storage_type(storetype::Type{<:TensorStorage} = Dense, eltype::Type = Float64, datatype::Type{<:AbstractArray} = Vector, indextype::Type = Tuple{Int,})
+function default_storage_type(storetype::Type{<:TensorStorage} = Dense, eltype::Type = Float64, datatype::Type{<:AbstractArray} = Vector, index = Tuple{Int,})
   #TODO check if indices are block sparse or not
   type = nothing
   try
@@ -12,13 +12,10 @@ function default_storage_type(storetype::Type{<:TensorStorage} = Dense, eltype::
   return type
 end
 
-function default_storage_type(eltype::Type{<:Number})
-  default_storage_type(Dense, eltype)
-end
+default_storage_type(eltype::Type{<:Number}) =  default_storage_type(Dense, eltype)
 
-function default_storage_type(datatype::Type{<:AbstractArray})
+default_storage_type(datatype::Type{<:AbstractArray}) =
   default_storage_type(Dense, Float64, datatype)
-end
 
 ## This function needs to be defined for each vector type
 default_storage_type(datatype::Type{<:Vector{ElT}}) where {ElT} = default_storage_type(Dense, ElT, Vector)
@@ -27,4 +24,4 @@ default_storage_type(eltype::Type, datatype::Type{<:AbstractArray}) = default_st
 
 default_storage_type(datatype::Type{<:AbstractArray}, eltype::Type) = default_storage_type(Dense, eltype, datatype)
 
-function def
+default_storage_type(index) = default_storage_type(Dense, Float64, Vector, index)

--- a/NDTensors/src/default_storage.jl
+++ b/NDTensors/src/default_storage.jl
@@ -1,0 +1,30 @@
+## This is a fil which specifies the default storage type provided some set of parameters
+## The parameters are the element type and storage type
+function default_storage_type(storetype::Type{<:TensorStorage} = Dense, eltype::Type = Float64, datatype::Type{<:AbstractArray} = Vector, indextype::Type = Tuple{Int,})
+  #TODO check if indices are block sparse or not
+  type = nothing
+  try
+    type = storetype{eltype, datatype{eltype}}
+  catch e
+    println("Cannot construct storetype", storetype)
+    throw(e)
+  end
+  return type
+end
+
+function default_storage_type(eltype::Type{<:Number})
+  default_storage_type(Dense, eltype)
+end
+
+function default_storage_type(datatype::Type{<:AbstractArray})
+  default_storage_type(Dense, Float64, datatype)
+end
+
+## This function needs to be defined for each vector type
+default_storage_type(datatype::Type{<:Vector{ElT}}) where {ElT} = default_storage_type(Dense, ElT, Vector)
+
+default_storage_type(eltype::Type, datatype::Type{<:AbstractArray}) = default_storage_type(Dense, eltype, datatype)
+
+default_storage_type(datatype::Type{<:AbstractArray}, eltype::Type) = default_storage_type(Dense, eltype, datatype)
+
+function def

--- a/NDTensors/src/dense/dense.jl
+++ b/NDTensors/src/dense/dense.jl
@@ -18,6 +18,10 @@ struct Dense{ElT,VecT<:AbstractArray} <: TensorStorage{ElT}
   function Dense{ElT,VecT}(data::Array) where {ElT,VecT<:AbstractArray{ElT}}
     return new{ElT,VecT}(vec(data))
   end
+
+  function Dense{ElT, VecT}() where {ElT, VecT<:AbstractArray{ElT}}
+    return new{ElT, VecT}(VecT(undef, 0))
+  end
 end
 
 function Dense(data::VecT) where {VecT<:AbstractArray{ElT}} where {ElT}


### PR DESCRIPTION
# Description

With the goal to make more versatile code, create a default _storage_type function that take type and index information and returns the appropriate storage type. Any missing information will follow default behavior defined (for now) by me. Utilize this default_storage_type variable in all constructors of NDTensirs and ITensors

# Checklist:

- [ ] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
