### PR TITLE
[ITensors] Make `replacebond!` more customizable

### DIFF
--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -350,7 +350,6 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
 
         @timeit_debug timer "dmrg: replacebond!" begin
           spec = replacebond!(
-            PH,
             psi,
             b,
             phi;

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -350,6 +350,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
 
         @timeit_debug timer "dmrg: replacebond!" begin
           spec = replacebond!(
+            PH,
             psi,
             b,
             phi;

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -521,6 +521,12 @@ function replacebond(M0::MPS, b::Int, phi::ITensor; kwargs...)
   return M
 end
 
+# Allows overloading `replacebond!` based on the projected
+# MPO type. By default just calls `replacebond!` on the MPS.
+function replacebond!(PH, M::MPS, b::Int, phi::ITensor; kwargs...)
+  return replacebond!(M, b, phi; kwargs...)
+end
+
 """
     sample!(m::MPS)
 

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -521,12 +521,6 @@ function replacebond(M0::MPS, b::Int, phi::ITensor; kwargs...)
   return M
 end
 
-# Allows overloading `replacebond!` based on the projected
-# MPO type. By default just calls `replacebond!` on the MPS.
-function replacebond!(PH, M::MPS, b::Int, phi::ITensor; kwargs...)
-  return replacebond!(M, b, phi; kwargs...)
-end
-
 """
     sample!(m::MPS)
 


### PR DESCRIPTION
Make `replacebond!` more customizable by allowing it to be overloaded for certain projected MPO inputs. This is helpful for the `MPISum` backend in https://github.com/ITensor/ITensorParallel.jl/pull/15, where it makes sense to broadcast the results of `replacebond!` from one process to the rest of the processes.