### PR TITLE
[NDTensors] Reducing compilation time of dense tensor contraction

### DIFF
--- a/ITensorGPU/src/tensor/cudense.jl
+++ b/ITensorGPU/src/tensor/cudense.jl
@@ -235,7 +235,7 @@ function _contract!(
   contracted = commoninds(Ainds, Binds)
   A_only = uniqueinds(Ainds, Binds)
   B_only = uniqueinds(Binds, Ainds)
-  ind_dict = Vector{Index}()
+  ind_dict = Vector{Union{Index,Int}}()
   for (idx, i) in enumerate(contracted)
     push!(ind_dict, i)
   end

--- a/NDTensors/src/dense/dense.jl
+++ b/NDTensors/src/dense/dense.jl
@@ -1131,12 +1131,12 @@ function contract!(
   ) where {Elα,Elβ,ElR,ElT1,ElT2,NR,N1,N2}
 
   labelsT1_, labelsT2_, labelsR_, sizeT1_, sizeT2_, sizeR_ = combine_alllabels(
-      collect(labelsT1),
-      collect(labelsT2),
-      collect(labelsR),
-      collect(size(T1)),
-      collect(size(T2)),
-      collect(size(R))
+      collect(Int, labelsT1),
+      collect(Int, labelsT2),
+      collect(Int, labelsR),
+      collect(Int, size(T1)),
+      collect(Int, size(T2)),
+      collect(Int, size(R))
     )
   R_ = reshape((R), sizeR_...)
   T1_ = reshape((T1), sizeT1_...)

--- a/NDTensors/test/dense.jl
+++ b/NDTensors/test/dense.jl
@@ -256,6 +256,32 @@ using Test
       backend_auto()
     end
   end
+
+  @testset "Combine labels" begin
+    ai, bi, ci, sizea, sizeb, sizec = NDTensors.combine_alllabels([2,3,4,5], [1,2,3], [1,4,5], [20,30,40,50], [10,20,30], [10,40,50])
+
+    @test ai == [2, 4]
+    @test bi == [1, 2]
+    @test ci == [1, 4]
+    @test sizea == [600, 2000]
+    @test sizeb == [10, 600]
+    @test sizec == [10, 2000]
+  end
+
+  @testset "contract with combining labels" begin
+    R = randomTensor(2, 2, 1, 1, 1)
+    R2 = randomTensor(2, 2, 1, 1, 1)
+    T1 = randomTensor(2, 3, 3, 1, 1, 1)
+    T2 = randomTensor(3, 3, 2)
+
+    # without combining indices
+    NDTensors._contract!(R, (1, 2, 3, 4, 5), T1, (1, -1, -2, 3, 4, 5), T2, (-1, -2, 2))
+
+    # with combining indices
+    NDTensors.contract!(R2, (1, 2, 3, 4, 5), T1, (1, -1, -2, 3, 4, 5), T2, (-1, -2, 2))
+
+    @test R ≈ R2
+  end
 end
 
 nothing

--- a/NDTensors/test/dense.jl
+++ b/NDTensors/test/dense.jl
@@ -258,7 +258,9 @@ using Test
   end
 
   @testset "Fuse labels" begin
-    ai, bi, ci, sizea, sizeb, sizec = NDTensors._fuse_labels([2,3,4,5], [1,2,3], [1,4,5], [20,30,40,50], [10,20,30], [10,40,50])
+    ai, bi, ci, sizea, sizeb, sizec = NDTensors._fuse_labels(
+      [2, 3, 4, 5], [1, 2, 3], [1, 4, 5], [20, 30, 40, 50], [10, 20, 30], [10, 40, 50]
+    )
 
     @test ai == [2, 4]
     @test bi == [1, 2]

--- a/NDTensors/test/dense.jl
+++ b/NDTensors/test/dense.jl
@@ -257,8 +257,8 @@ using Test
     end
   end
 
-  @testset "Combine labels" begin
-    ai, bi, ci, sizea, sizeb, sizec = NDTensors.combine_alllabels([2,3,4,5], [1,2,3], [1,4,5], [20,30,40,50], [10,20,30], [10,40,50])
+  @testset "Fuse labels" begin
+    ai, bi, ci, sizea, sizeb, sizec = NDTensors._fuse_labels([2,3,4,5], [1,2,3], [1,4,5], [20,30,40,50], [10,20,30], [10,40,50])
 
     @test ai == [2, 4]
     @test bi == [1, 2]
@@ -268,16 +268,16 @@ using Test
     @test sizec == [10, 2000]
   end
 
-  @testset "contract with combining labels" begin
+  @testset "contract with fusion of labels" begin
     R = randomTensor(2, 2, 1, 1, 1)
     R2 = randomTensor(2, 2, 1, 1, 1)
     T1 = randomTensor(2, 3, 3, 1, 1, 1)
     T2 = randomTensor(3, 3, 2)
 
-    # without combining indices
+    # without fusing indices
     NDTensors._contract!(R, (1, 2, 3, 4, 5), T1, (1, -1, -2, 3, 4, 5), T2, (-1, -2, 2))
 
-    # with combining indices
+    # with fusing indices
     NDTensors.contract!(R2, (1, 2, 3, 4, 5), T1, (1, -1, -2, 3, 4, 5), T2, (-1, -2, 2))
 
     @test R ≈ R2


### PR DESCRIPTION
This PR is based on the discussion [here](https://itensor.discourse.group/t/strange-compilation-behavior-for-the-function-mps/391/15).

# Description

As summarized in the above page, ITensors.jl suffers from a long compilation time when decomposing a tensor into MPS. The compilation time increases as the number of indices is increased. Furthermore, even after naive code for a small number of indices is generated, the compilation time for a larger number of indices is not reduced. The same applies to reconstructing a tensor from an MPS.

I found that a substantial portion of the compilation time is spent on *compiling the code for analyzing contraction labels* in `contraction_logic.jl`. To address this issue with a minimal change, I fuse contraction labels before the actual contraction code is called.

Original labels:

```
(1, 2, -1, -2) * (-1, -2, 3, 4) =>  (1, 2, 3, 4)
```

After fusion:
```
(1, 2) * (2, 3) =>  (1, 3)
```

This fusing trick substantially reduces the number of concrete types for `ContractionProperties{NA,NB,NC}`.
The following benchmarks were performed on Macbook Pro 14 (M1) with a single thread.

## Benchmark 1

```Julia
using ITensors
ITensors.disable_warn_order()

function run1(ElemType::Type{T}, nbit) where {T}
    sites = siteinds("Qubit", nbit)
    M = randomMPS(sites)
    fulltensor = reduce(*, M)
    return nothing
end

for nbit in [4, 8, 16, 24]
    @time run1(Float64, nbit)
end
```

v0.3.24:
```
7.673702 seconds (48.42 M allocations: 2.709 GiB, 8.71% gc time, 99.98% compilation time)
10.310319 seconds (51.52 M allocations: 3.140 GiB, 6.30% gc time, 99.99% compilation time)
21.941443 seconds (111.89 M allocations: 6.543 GiB, 6.95% gc time, 99.99% compilation time)
26.910477 seconds (134.17 M allocations: 7.751 GiB, 6.21% gc time, 99.70% compilation time)
```

New code:
```
 4.346442 seconds (28.34 M allocations: 1.551 GiB, 9.49% gc time, 99.96% compilation time)
 0.753839 seconds (4.43 M allocations: 229.441 MiB, 4.92% gc time, 99.85% compilation time)
 2.053619 seconds (11.85 M allocations: 595.432 MiB, 4.50% gc time, 99.90% compilation time)
 3.446269 seconds (17.43 M allocations: 1.075 GiB, 5.84% gc time, 96.90% compilation time)
```

## Benchmark 2

```Julia
using Pkg
@time Pkg.test("ITensors")
```

v0.3.24:

* 1167.520032 seconds
* 1178.514122 seconds

New code:

* 973.487310 seconds
* 977.637775 seconds


# How Has This Been Tested?

- [x] [Fuse label](https://github.com/shinaoka/ITensors.jl/blob/contract_opt2/NDTensors/test/dense.jl#L260) Check if labels are fused correctly
- [x] [contract with fusion](https://github.com/shinaoka/ITensors.jl/blob/contract_opt2/NDTensors/test/dense.jl#L271) Check if `contract!` returns the correct value with fusion.
- [x] All other tests in `NDTensors.jl` and `ITensors.jl` pass.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation. (No change in behavior!)
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
