### PR TITLE
[NDTensors] [Enhancements] `SetParameters` module providing tools for setting type parameters

### DIFF
--- a/NDTensors/src/NDTensors.jl
+++ b/NDTensors/src/NDTensors.jl
@@ -18,6 +18,9 @@ using Strided
 using TimerOutputs
 using TupleTools
 
+include("SetParameters/src/SetParameters.jl")
+using .SetParameters
+
 using Base: @propagate_inbounds, ReshapedArray, DimOrInd, OneTo
 
 using Base.Cartesian: @nexprs

--- a/NDTensors/src/SetParameters/README.md
+++ b/NDTensors/src/SetParameters/README.md
@@ -1,0 +1,3 @@
+# SetParameters
+
+A module defining functionality for getting and setting the parameters of parametric types.

--- a/NDTensors/src/SetParameters/TODO.md
+++ b/NDTensors/src/SetParameters/TODO.md
@@ -1,0 +1,29 @@
+https://discourse.julialang.org/t/extract-type-name-only-from-parametric-type/14188/23
+```julia
+for type in subtypes(AbstractArray)
+  @eval getname(x::$type) = $type
+end
+```
+
+https://discourse.julialang.org/t/stripping-parameter-from-parametric-types/8293/16
+```julia
+getname(type::Type) = Base.typename(type).wrapper
+```
+
+https://docs.julialang.org/en/v1/manual/methods/#Extracting-the-type-parameter-from-a-super-type
+
+# Overloads needed for `AbstractArray` type
+```julia
+parameter(::Type{<:AbstractArray{P1}}, ::Position{1}) where {P1} = P1
+parameter(::Type{<:AbstractArray{<:Any,P2}}, ::Position{2}) where {P2} = P2
+
+set_parameter(::Type{<:AbstractArray}, ::Position{1}, P1) = AbstractArray{P1}
+set_parameter(::Type{<:AbstractArray{<:Any,P2}}, ::Position{1}, P1) where {P2} = AbstractArray{P1,P2}
+set_parameter(::Type{<:AbstractArray}, ::Position{2}, P2) = AbstractArray{<:Any,P2}
+set_parameter(::Type{<:AbstractArray{P1}}, ::Position{2}, P2) where {P1} = AbstractArray{P1,P2}
+
+default_parameter(::Type{<:AbstractArray}, ::Position{1}) = Float64
+default_parameter(::Type{<:AbstractArray}, ::Position{2}) = 1
+
+nparameters(::Type{<:AbstractArray}) = Val(2)
+```

--- a/NDTensors/src/SetParameters/src/Base/array.jl
+++ b/NDTensors/src/SetParameters/src/Base/array.jl
@@ -1,0 +1,13 @@
+# `SetParameters.jl` overloads.
+get_parameter(::Type{<:Array{P1}}, ::Position{1}) where {P1} = P1
+get_parameter(::Type{<:Array{<:Any,P2}}, ::Position{2}) where {P2} = P2
+
+set_parameter(::Type{<:Array}, ::Position{1}, P1) = Array{P1}
+set_parameter(::Type{<:Array{<:Any,P2}}, ::Position{1}, P1) where {P2} = Array{P1,P2}
+set_parameter(::Type{<:Array}, ::Position{2}, P2) = Array{<:Any,P2}
+set_parameter(::Type{<:Array{P1}}, ::Position{2}, P2) where {P1} = Array{P1,P2}
+
+default_parameter(::Type{<:Array}, ::Position{1}) = Float64
+default_parameter(::Type{<:Array}, ::Position{2}) = 1
+
+nparameters(::Type{<:Array}) = Val(2)

--- a/NDTensors/src/SetParameters/src/Base/val.jl
+++ b/NDTensors/src/SetParameters/src/Base/val.jl
@@ -1,0 +1,6 @@
+# `SetParameters.jl` overloads.
+get_parameter(::Type{<:Val{P1}}, ::Position{1}) where {P1} = P1
+
+set_parameter(::Type{<:Val}, ::Position{1}, P1) = Val{P1}
+
+nparameters(::Type{<:Val}) = Val(1)

--- a/NDTensors/src/SetParameters/src/SetParameters.jl
+++ b/NDTensors/src/SetParameters/src/SetParameters.jl
@@ -1,0 +1,22 @@
+module SetParameters
+  include("position.jl")
+  include("unspecifiedparameter.jl")
+  include("default_parameter.jl")
+  include("interface.jl")
+  include("get_parameter.jl")
+  include("set_parameters_generic.jl")
+  include("set_parameters.jl")
+  include("set_unspecified_parameters.jl")
+  include("set_default_parameters.jl")
+  include("Base/val.jl")
+  include("Base/array.jl")
+
+  export DefaultParameter,
+    DefaultParameters,
+    Position,
+    default_parameter,
+    get_parameter,
+    nparameters,
+    set_parameters,
+    set_unspecified_parameters
+end # module

--- a/NDTensors/src/SetParameters/src/SetParameters.jl
+++ b/NDTensors/src/SetParameters/src/SetParameters.jl
@@ -1,22 +1,22 @@
 module SetParameters
-  include("position.jl")
-  include("unspecifiedparameter.jl")
-  include("default_parameter.jl")
-  include("interface.jl")
-  include("get_parameter.jl")
-  include("set_parameters_generic.jl")
-  include("set_parameters.jl")
-  include("set_unspecified_parameters.jl")
-  include("set_default_parameters.jl")
-  include("Base/val.jl")
-  include("Base/array.jl")
+include("position.jl")
+include("unspecifiedparameter.jl")
+include("default_parameter.jl")
+include("interface.jl")
+include("get_parameter.jl")
+include("set_parameters_generic.jl")
+include("set_parameters.jl")
+include("set_unspecified_parameters.jl")
+include("set_default_parameters.jl")
+include("Base/val.jl")
+include("Base/array.jl")
 
-  export DefaultParameter,
-    DefaultParameters,
-    Position,
-    default_parameter,
-    get_parameter,
-    nparameters,
-    set_parameters,
-    set_unspecified_parameters
+export DefaultParameter,
+  DefaultParameters,
+  Position,
+  default_parameter,
+  get_parameter,
+  nparameters,
+  set_parameters,
+  set_unspecified_parameters
 end # module

--- a/NDTensors/src/SetParameters/src/default_parameter.jl
+++ b/NDTensors/src/SetParameters/src/default_parameter.jl
@@ -1,0 +1,74 @@
+"""
+Get the default parameter of an object at a specified position.
+"""
+default_parameter(object, position::Position) = default_parameter(typeof(object), position)
+
+"""
+Get the first default type parameter of a type.
+"""
+default_parameter(type::Type) = default_parameter(type, Position(1))
+
+"""
+Get the first default type parameter of an object.
+"""
+default_parameter(object) = default_parameter(typeof(object))
+
+"""
+Type to specify that some number of default parameters should be used.
+Can use in place of specifying some number of parameters to set.
+
+The type parameter `N` specifies the number of contiguous default parameters
+to set. A value of `Any` means that the value will be inferred from the
+type, using the `SetParameters.nparameters(type::Type)` function which
+should be overloaded by new types.
+"""
+struct DefaultParameters{N}
+  npositions::Val{N}
+end
+DefaultParameters() = DefaultParameters(Val(Any))
+DefaultParameters(nparameters) = DefaultParameters(Val(nparameters))
+
+(type::Type{<:DefaultParameters})() = DefaultParameters(get_parameter(type))
+
+# `SetParameters` overload.
+get_parameter(type::Type{<:DefaultParameters{P1}}, position::Position{1}) where {P1} = P1
+set_parameter(type::Type{<:DefaultParameters}, position::Position{1}, P1) = DefaultParameters{P1}
+
+"""
+`DefaultParameter` represents a single default parameter.
+"""
+const DefaultParameter = DefaultParameters{1}
+
+(parameter::DefaultParameter)(type::Type, position::Position) = default_parameter(type, position)
+
+function Base.iterate(parameters::DefaultParameters, state=1)
+  if state > get_parameter(parameters)
+    return nothing
+  end
+  return (DefaultParameter(), state + 1)
+end
+
+function Base.iterate(parameters::DefaultParameters{Any}, state=1)
+  return error("Can't iterate `$(parameters)`, must specify a number of parameters.")
+end
+
+# Specify the number of parameters.
+# TODO: Check if this is type stable!
+function set_nparameters(parameters::DefaultParameters{Any}, type::Type, position::Position)
+  return set_nparameters(parameters, nparameters(type), position)
+end
+
+# Specify the number of parameters.
+# TODO: Check if this is type stable!
+function set_nparameters(parameters::DefaultParameters{Any}, nparameters::Val, position::Position)
+  ndefault_parameters = Val(get_parameter(nparameters) - get_parameter(position) + 1)
+  return set_parameter(typeof(parameters), ndefault_parameters)()
+end
+
+function set_nparameters(parameters::DefaultParameters, type::Type, position::Position)
+  return parameters
+end
+
+function set_nparameters(parameters::DefaultParameters, nparameters::Val, position::Position)
+  return parameters
+end

--- a/NDTensors/src/SetParameters/src/default_parameter.jl
+++ b/NDTensors/src/SetParameters/src/default_parameter.jl
@@ -32,14 +32,18 @@ DefaultParameters(nparameters) = DefaultParameters(Val(nparameters))
 
 # `SetParameters` overload.
 get_parameter(type::Type{<:DefaultParameters{P1}}, position::Position{1}) where {P1} = P1
-set_parameter(type::Type{<:DefaultParameters}, position::Position{1}, P1) = DefaultParameters{P1}
+function set_parameter(type::Type{<:DefaultParameters}, position::Position{1}, P1)
+  return DefaultParameters{P1}
+end
 
 """
 `DefaultParameter` represents a single default parameter.
 """
 const DefaultParameter = DefaultParameters{1}
 
-(parameter::DefaultParameter)(type::Type, position::Position) = default_parameter(type, position)
+function (parameter::DefaultParameter)(type::Type, position::Position)
+  return default_parameter(type, position)
+end
 
 function Base.iterate(parameters::DefaultParameters, state=1)
   if state > get_parameter(parameters)
@@ -60,7 +64,9 @@ end
 
 # Specify the number of parameters.
 # TODO: Check if this is type stable!
-function set_nparameters(parameters::DefaultParameters{Any}, nparameters::Val, position::Position)
+function set_nparameters(
+  parameters::DefaultParameters{Any}, nparameters::Val, position::Position
+)
   ndefault_parameters = Val(get_parameter(nparameters) - get_parameter(position) + 1)
   return set_parameter(typeof(parameters), ndefault_parameters)()
 end
@@ -69,6 +75,8 @@ function set_nparameters(parameters::DefaultParameters, type::Type, position::Po
   return parameters
 end
 
-function set_nparameters(parameters::DefaultParameters, nparameters::Val, position::Position)
+function set_nparameters(
+  parameters::DefaultParameters, nparameters::Val, position::Position
+)
   return parameters
 end

--- a/NDTensors/src/SetParameters/src/deprecated/set_default_parameters.jl
+++ b/NDTensors/src/SetParameters/src/deprecated/set_default_parameters.jl
@@ -9,12 +9,14 @@ end
 ## Set the first parameter using the default parameters.
 ## """
 ## set_parameter(type::Type, parameters::DefaultParameters) = set_parameter(type, Position(1), DefaultParameters())
-  
+
 function set_parameters(type::Type, start_position::Position, parameters::DefaultParameters)
   # Needed to get `generic_set_parameters` to loop over all
   # the possible parameters.
   unspecified_parameters = ntuple(Returns(nothing), nparameters(type))
-  return generic_set_parameters(type, start_position, unspecified_parameters...) do type, position, new_parameter
+  return generic_set_parameters(
+    type, start_position, unspecified_parameters...
+  ) do type, position, new_parameter
     return set_parameter(type, position, DefaultParameters())
   end
 end

--- a/NDTensors/src/SetParameters/src/deprecated/set_default_parameters.jl
+++ b/NDTensors/src/SetParameters/src/deprecated/set_default_parameters.jl
@@ -1,0 +1,20 @@
+"""
+Set the specified parameter using the default parameters.
+"""
+function set_parameter(type::Type, position::Position, parameters::DefaultParameters)
+  return set_parameter(type, position, default_parameter(type, position))
+end
+
+## """
+## Set the first parameter using the default parameters.
+## """
+## set_parameter(type::Type, parameters::DefaultParameters) = set_parameter(type, Position(1), DefaultParameters())
+  
+function set_parameters(type::Type, start_position::Position, parameters::DefaultParameters)
+  # Needed to get `generic_set_parameters` to loop over all
+  # the possible parameters.
+  unspecified_parameters = ntuple(Returns(nothing), nparameters(type))
+  return generic_set_parameters(type, start_position, unspecified_parameters...) do type, position, new_parameter
+    return set_parameter(type, position, DefaultParameters())
+  end
+end

--- a/NDTensors/src/SetParameters/src/deprecated/set_unspecified_default_parameters.jl
+++ b/NDTensors/src/SetParameters/src/deprecated/set_unspecified_default_parameters.jl
@@ -14,7 +14,9 @@ function set_unspecified_default_parameter(type::Type)
 end
 
 # Set to the default if it is unspecified.
-function set_unspecified_parameter(type::Type, position::Position, parameters::DefaultParameters)
+function set_unspecified_parameter(
+  type::Type, position::Position, parameters::DefaultParameters
+)
   return set_unspecified_parameter(type, position, default_parameter(type, position))
 end
 
@@ -32,11 +34,15 @@ function set_unspecified_default_parameters(type::Type)
   return set_unspecified_parameters(type, Position(1), DefaultParameters())
 end
 
-function set_unspecified_parameters(type::Type, start_position::Position, parameters::DefaultParameters)
+function set_unspecified_parameters(
+  type::Type, start_position::Position, parameters::DefaultParameters
+)
   # Needed to get `generic_set_parameters` to loop over all
   # the possible parameters.
   unspecified_parameters = ntuple(Returns(UnspecifiedParameter), nparameters(type))
-  return generic_set_parameters(type, start_position, unspecified_parameters...) do type, position, new_parameter
+  return generic_set_parameters(
+    type, start_position, unspecified_parameters...
+  ) do type, position, new_parameter
     return set_unspecified_parameter(type, position, DefaultParameters())
   end
 end

--- a/NDTensors/src/SetParameters/src/deprecated/set_unspecified_default_parameters.jl
+++ b/NDTensors/src/SetParameters/src/deprecated/set_unspecified_default_parameters.jl
@@ -1,0 +1,46 @@
+## Set an unspecified parameter to its default value
+"""
+Set to the default if it is unspecified.
+"""
+function set_unspecified_default_parameter(type::Type, position::Position)
+  return set_unspecified_parameter(type, position, DefaultParameters())
+end
+
+"""
+Set the first parameter to the default if it is unspecified.
+"""
+function set_unspecified_default_parameter(type::Type)
+  return set_unspecified_parameter(type, Position(1), DefaultParameters())
+end
+
+# Set to the default if it is unspecified.
+function set_unspecified_parameter(type::Type, position::Position, parameters::DefaultParameters)
+  return set_unspecified_parameter(type, position, default_parameter(type, position))
+end
+
+# Set the first parameter to the default if it is unspecified.
+function set_unspecified_parameter(type::Type, parameters::DefaultParameters)
+  return set_unspecified_parameter(type, Position(1), parameters)
+end
+
+## Set unspecified parameters to their default values
+function set_unspecified_default_parameters(type::Type, start_position::Position)
+  return set_unspecified_parameters(type, start_position, DefaultParameters())
+end
+
+function set_unspecified_default_parameters(type::Type)
+  return set_unspecified_parameters(type, Position(1), DefaultParameters())
+end
+
+function set_unspecified_parameters(type::Type, start_position::Position, parameters::DefaultParameters)
+  # Needed to get `generic_set_parameters` to loop over all
+  # the possible parameters.
+  unspecified_parameters = ntuple(Returns(UnspecifiedParameter), nparameters(type))
+  return generic_set_parameters(type, start_position, unspecified_parameters...) do type, position, new_parameter
+    return set_unspecified_parameter(type, position, DefaultParameters())
+  end
+end
+
+function set_unspecified_parameters(type::Type, parameters::DefaultParameters)
+  return set_unspecified_parameters(type, Position(1), parameters)
+end

--- a/NDTensors/src/SetParameters/src/get_parameter.jl
+++ b/NDTensors/src/SetParameters/src/get_parameter.jl
@@ -1,0 +1,27 @@
+"""
+    get_parameter(object, position::Position)
+
+Get a type parameter of the object `object` at the position `position`.
+"""
+get_parameter(object, position::Position) = get_parameter(typeof(object), position)
+
+"""
+    get_parameter(type::Type)
+
+Get the first type parameter of the type `type`.
+"""
+get_parameter(type::Type) = get_parameter(type, Position(1))
+
+"""
+    get_parameter(object)
+
+Get the first type parameter of the object `object`.
+"""
+get_parameter(object) = get_parameter(typeof(object))
+
+# TODO: Define `get_parameters`?
+# function get_parameters(type::Type)
+#   return ntuple(nparameters(type)) do position
+#     get_parameter(type, Position(position))
+#   end
+# end

--- a/NDTensors/src/SetParameters/src/interface.jl
+++ b/NDTensors/src/SetParameters/src/interface.jl
@@ -1,0 +1,27 @@
+"""
+Required interface for getting parameters.
+"""
+get_parameter(type::Type, position::Position) = UnspecifiedParameter
+
+"""
+Required interface for setting parameters.
+"""
+function set_parameter(type::Type, position::Position, parameter)
+  return error("Setting the type parameter of the type `$(type)` at position `$(position)` to `$(parameter)` is not currently defined. Either that type parameter position doesn't exist in the type, or `set_parameter` has not been overloaded for this type.")
+end
+
+"""
+Required for setting one or more default parameters.
+"""
+function default_parameter(type::Type, position::Position)
+  return error("The default type parameter of the type `$(type)` at position `$(position)` has not been defined.")
+end
+
+"""
+Required for setting multiple default parameters.
+
+Should return a `Val`.
+"""
+function nparameters(type::Type)
+  return error("The number of type parameters of the type `$(type)` has not been defined.")
+end

--- a/NDTensors/src/SetParameters/src/interface.jl
+++ b/NDTensors/src/SetParameters/src/interface.jl
@@ -7,14 +7,18 @@ get_parameter(type::Type, position::Position) = UnspecifiedParameter
 Required interface for setting parameters.
 """
 function set_parameter(type::Type, position::Position, parameter)
-  return error("Setting the type parameter of the type `$(type)` at position `$(position)` to `$(parameter)` is not currently defined. Either that type parameter position doesn't exist in the type, or `set_parameter` has not been overloaded for this type.")
+  return error(
+    "Setting the type parameter of the type `$(type)` at position `$(position)` to `$(parameter)` is not currently defined. Either that type parameter position doesn't exist in the type, or `set_parameter` has not been overloaded for this type.",
+  )
 end
 
 """
 Required for setting one or more default parameters.
 """
 function default_parameter(type::Type, position::Position)
-  return error("The default type parameter of the type `$(type)` at position `$(position)` has not been defined.")
+  return error(
+    "The default type parameter of the type `$(type)` at position `$(position)` has not been defined.",
+  )
 end
 
 """

--- a/NDTensors/src/SetParameters/src/position.jl
+++ b/NDTensors/src/SetParameters/src/position.jl
@@ -1,0 +1,10 @@
+"""
+Represents the compile-time position of a type parameter.
+"""
+struct Position{x}
+end
+Position(x) = Position{x}()
+
+## `SetParameters` overloads for `Position`
+get_parameter(::Type{<:Position{P}}, ::Position{1}) where {P} = P
+set_parameter(::Type{<:Position}, ::Position{1}, P) = Position{P}

--- a/NDTensors/src/SetParameters/src/position.jl
+++ b/NDTensors/src/SetParameters/src/position.jl
@@ -1,8 +1,7 @@
 """
 Represents the compile-time position of a type parameter.
 """
-struct Position{x}
-end
+struct Position{x} end
 Position(x) = Position{x}()
 
 ## `SetParameters` overloads for `Position`

--- a/NDTensors/src/SetParameters/src/set_default_parameters.jl
+++ b/NDTensors/src/SetParameters/src/set_default_parameters.jl
@@ -1,0 +1,36 @@
+## Setting default type parameters.
+# Base case, only specify one default parameter. Actually extracts the defined default
+# parameter for the given type.
+# `DefaultParameter = DefaultParameters{1}`
+function set_parameters(type::Type, position::Position, parameter::DefaultParameter)
+  return set_parameters(type, position, parameter(type, position))
+end
+
+# Catch cases when number of default parameters aren't specified,
+# and determine them from the type and the position.
+function set_parameters(type::Type, position::Position, parameters::DefaultParameters{Any})
+  return set_parameters(set_parameters, type, position, parameters)
+end
+
+"""
+Set multiple default type parameters.
+"""
+function set_parameters(type::Type, position::Position, parameters::DefaultParameters)
+  return set_parameters(set_parameters, type, position, parameters)
+end
+
+# Set multiple default type parameters of any number.
+# Set automatically to `nparameters`.
+function set_parameters(set_parameter_function::Function, type::Type, position::Position, parameters::DefaultParameters{Any})
+  return set_parameters(set_parameter_function, type, position, set_nparameters(parameters, type, position))
+end
+
+# Set parameters starting from position `position`.
+function set_parameters(set_parameter_function::Function, type::Type, position::Position, parameters::DefaultParameters)
+  return set_parameters(set_parameter_function, type, position, parameters...)
+end
+
+# Base case.
+function set_parameters(set_parameter_function::Function, type::Type, position::Position, parameter::DefaultParameter)
+  return set_parameter_function(type, position, parameter)
+end

--- a/NDTensors/src/SetParameters/src/set_default_parameters.jl
+++ b/NDTensors/src/SetParameters/src/set_default_parameters.jl
@@ -21,16 +21,33 @@ end
 
 # Set multiple default type parameters of any number.
 # Set automatically to `nparameters`.
-function set_parameters(set_parameter_function::Function, type::Type, position::Position, parameters::DefaultParameters{Any})
-  return set_parameters(set_parameter_function, type, position, set_nparameters(parameters, type, position))
+function set_parameters(
+  set_parameter_function::Function,
+  type::Type,
+  position::Position,
+  parameters::DefaultParameters{Any},
+)
+  return set_parameters(
+    set_parameter_function, type, position, set_nparameters(parameters, type, position)
+  )
 end
 
 # Set parameters starting from position `position`.
-function set_parameters(set_parameter_function::Function, type::Type, position::Position, parameters::DefaultParameters)
+function set_parameters(
+  set_parameter_function::Function,
+  type::Type,
+  position::Position,
+  parameters::DefaultParameters,
+)
   return set_parameters(set_parameter_function, type, position, parameters...)
 end
 
 # Base case.
-function set_parameters(set_parameter_function::Function, type::Type, position::Position, parameter::DefaultParameter)
+function set_parameters(
+  set_parameter_function::Function,
+  type::Type,
+  position::Position,
+  parameter::DefaultParameter,
+)
   return set_parameter_function(type, position, parameter)
 end

--- a/NDTensors/src/SetParameters/src/set_parameters.jl
+++ b/NDTensors/src/SetParameters/src/set_parameters.jl
@@ -1,0 +1,25 @@
+"""
+Set the first type parameter.
+"""
+function set_parameter(type::Type, parameter)
+  return set_parameter(type, Position(1), parameter)
+end
+
+"""
+Set multiple type parameters starting from `position`.
+"""
+set_parameters(type::Type, position::Position, parameters...) = set_parameters(set_parameters, type, position, parameters...)
+
+# Generic case of 1 parameter. This is the base case, and types should overload:
+# ```julia
+# set_parameter(type::Type, position::Position, parameter)
+# ```
+set_parameters(type::Type, position::Position, parameter) = set_parameter(type, position, parameter)
+
+# Generic case of no parameters
+set_parameters(type::Type, position::Position) = type
+
+"""
+Set multiple type parameters.
+"""
+set_parameters(type::Type, parameters...) = set_parameters(type, Position(1), parameters...)

--- a/NDTensors/src/SetParameters/src/set_parameters.jl
+++ b/NDTensors/src/SetParameters/src/set_parameters.jl
@@ -8,13 +8,17 @@ end
 """
 Set multiple type parameters starting from `position`.
 """
-set_parameters(type::Type, position::Position, parameters...) = set_parameters(set_parameters, type, position, parameters...)
+function set_parameters(type::Type, position::Position, parameters...)
+  return set_parameters(set_parameters, type, position, parameters...)
+end
 
 # Generic case of 1 parameter. This is the base case, and types should overload:
 # ```julia
 # set_parameter(type::Type, position::Position, parameter)
 # ```
-set_parameters(type::Type, position::Position, parameter) = set_parameter(type, position, parameter)
+function set_parameters(type::Type, position::Position, parameter)
+  return set_parameter(type, position, parameter)
+end
 
 # Generic case of no parameters
 set_parameters(type::Type, position::Position) = type

--- a/NDTensors/src/SetParameters/src/set_parameters_generic.jl
+++ b/NDTensors/src/SetParameters/src/set_parameters_generic.jl
@@ -9,7 +9,13 @@ function set_parameters(set_parameter_function::Function, type::Type, parameters
 end
 
 # Set parameters starting from position `position`.
-function set_parameters(set_parameter_function::Function, type::Type, position::Position, parameter1, parameters_tail...)
+function set_parameters(
+  set_parameter_function::Function,
+  type::Type,
+  position::Position,
+  parameter1,
+  parameters_tail...,
+)
   new_type = set_parameter_function(type, position, parameter1)
   new_position = Position(get_parameter(position) + 1)
   return set_parameters(set_parameter_function, new_type, new_position, parameters_tail...)

--- a/NDTensors/src/SetParameters/src/set_parameters_generic.jl
+++ b/NDTensors/src/SetParameters/src/set_parameters_generic.jl
@@ -1,0 +1,19 @@
+# Generic `set_parameters` that sets the parameters one by one
+# using a custom parameter set function.
+# `set_parameter` should have the signature:
+# ```julia
+# set_parameter(type::Type, position::Position, parameter)
+# ```
+function set_parameters(set_parameter_function::Function, type::Type, parameters...)
+  return set_parameters(set_parameter_function, type, Position(1), parameters...)
+end
+
+# Set parameters starting from position `position`.
+function set_parameters(set_parameter_function::Function, type::Type, position::Position, parameter1, parameters_tail...)
+  new_type = set_parameter_function(type, position, parameter1)
+  new_position = Position(get_parameter(position) + 1)
+  return set_parameters(set_parameter_function, new_type, new_position, parameters_tail...)
+end
+
+# Stop recursion, no more parameters to set.
+set_parameters(set_parameter_function::Function, type::Type, position::Position) = type

--- a/NDTensors/src/SetParameters/src/set_unspecified_parameters.jl
+++ b/NDTensors/src/SetParameters/src/set_unspecified_parameters.jl
@@ -4,11 +4,15 @@ function set_unspecified_parameters(type::Type, position::Position, parameter)
   return replace_unspecified_parameters(type, position, current_parameter, parameter)
 end
 
-function replace_unspecified_parameters(type::Type, position::Position, current_parameter::Type{<:UnspecifiedParameter}, parameter)
+function replace_unspecified_parameters(
+  type::Type, position::Position, current_parameter::Type{<:UnspecifiedParameter}, parameter
+)
   return set_parameters(type, position, parameter)
 end
 
-function replace_unspecified_parameters(type::Type, position::Position, current_parameter, parameter)
+function replace_unspecified_parameters(
+  type::Type, position::Position, current_parameter, parameter
+)
   return type
 end
 

--- a/NDTensors/src/SetParameters/src/set_unspecified_parameters.jl
+++ b/NDTensors/src/SetParameters/src/set_unspecified_parameters.jl
@@ -1,0 +1,25 @@
+# Base case, set the type parameter at the position if it is unspecified.
+function set_unspecified_parameters(type::Type, position::Position, parameter)
+  current_parameter = get_parameter(type, position)
+  return replace_unspecified_parameters(type, position, current_parameter, parameter)
+end
+
+function replace_unspecified_parameters(type::Type, position::Position, current_parameter::Type{<:UnspecifiedParameter}, parameter)
+  return set_parameters(type, position, parameter)
+end
+
+function replace_unspecified_parameters(type::Type, position::Position, current_parameter, parameter)
+  return type
+end
+
+# Implementation in terms of generic version.
+function set_unspecified_parameters(type::Type, position::Position, parameters...)
+  return set_parameters(set_unspecified_parameters, type, position, parameters...)
+end
+
+"""
+Set parameters starting from the first one if they are unspecified.
+"""
+function set_unspecified_parameters(type::Type, parameter...)
+  return set_parameters(set_unspecified_parameters, type, Position(1), parameter...)
+end

--- a/NDTensors/src/SetParameters/src/unspecifiedparameter.jl
+++ b/NDTensors/src/SetParameters/src/unspecifiedparameter.jl
@@ -1,0 +1,5 @@
+"""
+Represents an unspecified type parameter
+"""
+struct UnspecifiedParameter
+end

--- a/NDTensors/src/SetParameters/src/unspecifiedparameter.jl
+++ b/NDTensors/src/SetParameters/src/unspecifiedparameter.jl
@@ -1,5 +1,4 @@
 """
 Represents an unspecified type parameter
 """
-struct UnspecifiedParameter
-end
+struct UnspecifiedParameter end

--- a/NDTensors/src/SetParameters/test/runtests.jl
+++ b/NDTensors/src/SetParameters/test/runtests.jl
@@ -4,52 +4,74 @@ using NDTensors.SetParameters
 @testset "Test NDTensors.SetParameters" begin
   @testset "Set parameter at position" begin
     @test @inferred(set_parameters(Array{Float32,3}, Float16)) == Array{Float16,3}
-    @test @inferred(set_parameters(Array{Float32,3}, Position(1), Float16)) == Array{Float16,3}
-    @test @inferred((() -> set_parameters(Array{Float32,3}, Position(2), 2))()) == Array{Float32,2}
+    @test @inferred(set_parameters(Array{Float32,3}, Position(1), Float16)) ==
+      Array{Float16,3}
+    @test @inferred((() -> set_parameters(Array{Float32,3}, Position(2), 2))()) ==
+      Array{Float32,2}
     @test @inferred(set_parameters(Array{Float32}, Float16)) == Array{Float16}
     @test @inferred(set_parameters(Array{Float32}, Position(1), Float16)) == Array{Float16}
-    @test @inferred((() -> set_parameters(Array{Float32}, Position(2), 2))()) == Array{Float32,2}
+    @test @inferred((() -> set_parameters(Array{Float32}, Position(2), 2))()) ==
+      Array{Float32,2}
     @test @inferred(set_parameters(Array{<:Any,3}, Float16)) == Array{Float16,3}
-    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), Float16)) == Array{Float16,3}
+    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), Float16)) ==
+      Array{Float16,3}
     # TODO: Inferrence is broken for this case
-    @test @inferred(Any, (() -> set_parameters(Array{<:Any,3}, Position(2), 2))()) == Array{<:Any,2}
+    @test @inferred(Any, (() -> set_parameters(Array{<:Any,3}, Position(2), 2))()) ==
+      Array{<:Any,2}
     @test @inferred(set_parameters(Array, Float16)) == Array{Float16}
     @test @inferred(set_parameters(Array, Position(1), Float16)) == Array{Float16}
     @test @inferred((() -> set_parameters(Array, Position(2), 2))()) == Array{<:Any,2}
   end
 
   @testset "Set multiple parameters" begin
-    @test @inferred((() -> set_parameters(Array{<:Any,3}, Float16, 2))()) == Array{Float16,2}
-    @test @inferred((() -> set_parameters(Array{<:Any,3}, Position(1), Float16, 2))()) == Array{Float16,2}
+    @test @inferred((() -> set_parameters(Array{<:Any,3}, Float16, 2))()) ==
+      Array{Float16,2}
+    @test @inferred((() -> set_parameters(Array{<:Any,3}, Position(1), Float16, 2))()) ==
+      Array{Float16,2}
     @test @inferred(set_parameters(Array{<:Any,3}, Float16)) == Array{Float16,3}
-    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), Float16)) == Array{Float16,3}
+    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), Float16)) ==
+      Array{Float16,3}
     @test @inferred(set_parameters(Array{<:Any,3})) == Array{<:Any,3}
     @test @inferred(set_parameters(Array{<:Any,3}, Position(1))) == Array{<:Any,3}
     # TODO: Inferrence is broken for this case
-    @test @inferred(Any, (() -> set_parameters(Array{<:Any,3}, Position(2), 2))()) == Array{<:Any,2}
+    @test @inferred(Any, (() -> set_parameters(Array{<:Any,3}, Position(2), 2))()) ==
+      Array{<:Any,2}
     @test @inferred(set_parameters(Array{<:Any,3}, Position(2))) == Array{<:Any,3}
   end
 
-  @testset  "Set a parameter if it is unspecified" begin
-    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Float16)) == Array{Float32,3}
-    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(1), Float16)) == Array{Float32,3}
-    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(2), 2)) == Array{Float32,3}
+  @testset "Set a parameter if it is unspecified" begin
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Float16)) ==
+      Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(1), Float16)) ==
+      Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(2), 2)) ==
+      Array{Float32,3}
     @test @inferred(set_unspecified_parameters(Array{Float32}, Float16)) == Array{Float32}
-    @test @inferred(set_unspecified_parameters(Array{Float32}, Position(1), Float16)) == Array{Float32}
-    @test @inferred((() -> set_unspecified_parameters(Array{Float32}, Position(2), 2))()) == Array{Float32,2}
+    @test @inferred(set_unspecified_parameters(Array{Float32}, Position(1), Float16)) ==
+      Array{Float32}
+    @test @inferred((() -> set_unspecified_parameters(Array{Float32}, Position(2), 2))()) ==
+      Array{Float32,2}
     @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Float16)) == Array{Float16,3}
-    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(1), Float16)) == Array{Float16,3}
-    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(2), 2)) == Array{<:Any,3}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(1), Float16)) ==
+      Array{Float16,3}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(2), 2)) ==
+      Array{<:Any,3}
     @test @inferred(set_unspecified_parameters(Array, Float16)) == Array{Float16}
-    @test @inferred(set_unspecified_parameters(Array, Position(1), Float16)) == Array{Float16}
-    @test @inferred((() -> set_unspecified_parameters(Array, Position(2), 2))()) == Array{<:Any,2}
+    @test @inferred(set_unspecified_parameters(Array, Position(1), Float16)) ==
+      Array{Float16}
+    @test @inferred((() -> set_unspecified_parameters(Array, Position(2), 2))()) ==
+      Array{<:Any,2}
   end
 
   @testset "Set multiple parameters if they are unspecified" begin
-    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Float16, 2)) == Array{Float32,3}
-    @test @inferred((() -> set_unspecified_parameters(Array{Float32}, Float16, 2))()) == Array{Float32,2}
-    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Float16, 2)) == Array{Float16,3}
-    @test @inferred((() -> set_unspecified_parameters(Array, Float16, 2))()) == Array{Float16,2}
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Float16, 2)) ==
+      Array{Float32,3}
+    @test @inferred((() -> set_unspecified_parameters(Array{Float32}, Float16, 2))()) ==
+      Array{Float32,2}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Float16, 2)) ==
+      Array{Float16,3}
+    @test @inferred((() -> set_unspecified_parameters(Array, Float16, 2))()) ==
+      Array{Float16,2}
   end
 
   @testset "Default parameters" begin
@@ -58,41 +80,69 @@ using NDTensors.SetParameters
   end
 
   @testset "Set to the default parameter" begin
-    @test @inferred(set_parameters(Array{Float32,3}, Position(1), DefaultParameter())) == Array{Float64,3}
-    @test @inferred(set_parameters(Array{Float32,3}, Position(2), DefaultParameter())) == Array{Float32,1}
-    @test @inferred(set_parameters(Array{Float32}, Position(1), DefaultParameter())) == Array{Float64}
-    @test @inferred(set_parameters(Array{Float32}, Position(2), DefaultParameter())) == Array{Float32,1}
-    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), DefaultParameter())) == Array{Float64,3}
+    @test @inferred(set_parameters(Array{Float32,3}, Position(1), DefaultParameter())) ==
+      Array{Float64,3}
+    @test @inferred(set_parameters(Array{Float32,3}, Position(2), DefaultParameter())) ==
+      Array{Float32,1}
+    @test @inferred(set_parameters(Array{Float32}, Position(1), DefaultParameter())) ==
+      Array{Float64}
+    @test @inferred(set_parameters(Array{Float32}, Position(2), DefaultParameter())) ==
+      Array{Float32,1}
+    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), DefaultParameter())) ==
+      Array{Float64,3}
     # TODO: Inferrence is broken for this case
-    @test @inferred(Any, set_parameters(Array{<:Any,3}, Position(2), DefaultParameter())) == Array{<:Any,1}
-    @test @inferred(set_parameters(Array, Position(1), DefaultParameter())) == Array{Float64}
+    @test @inferred(Any, set_parameters(Array{<:Any,3}, Position(2), DefaultParameter())) ==
+      Array{<:Any,1}
+    @test @inferred(set_parameters(Array, Position(1), DefaultParameter())) ==
+      Array{Float64}
     # TODO: Inferrence is broken for this case
-    @test @inferred(Any, set_parameters(Array, Position(2), DefaultParameter())) == Array{<:Any,1}
+    @test @inferred(Any, set_parameters(Array, Position(2), DefaultParameter())) ==
+      Array{<:Any,1}
   end
 
   @testset "Set to the default parameters" begin
-    @test @inferred(set_parameters(Array{Float32,3}, DefaultParameters())) == Array{Float64,1}
+    @test @inferred(set_parameters(Array{Float32,3}, DefaultParameters())) ==
+      Array{Float64,1}
     @test @inferred(set_parameters(Array{Float32}, DefaultParameters())) == Array{Float64,1}
     @test @inferred(set_parameters(Array{<:Any,3}, DefaultParameters())) == Array{Float64,1}
     @test @inferred(set_parameters(Array, DefaultParameters())) == Array{Float64,1}
   end
 
   @testset "Set to the default parameter if unspecified" begin
-    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(1), DefaultParameter())) == Array{Float32,3}
-    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(2), DefaultParameter())) == Array{Float32,3}
-    @test @inferred(set_unspecified_parameters(Array{Float32}, Position(1), DefaultParameter())) == Array{Float32}
-    @test @inferred(set_unspecified_parameters(Array{Float32}, Position(2), DefaultParameter())) == Array{Float32,1}
-    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(1), DefaultParameter())) == Array{Float64,3}
-    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(2), DefaultParameter())) == Array{<:Any,3}
-    @test @inferred(set_unspecified_parameters(Array, Position(1), DefaultParameter())) == Array{Float64}
+    @test @inferred(
+      set_unspecified_parameters(Array{Float32,3}, Position(1), DefaultParameter())
+    ) == Array{Float32,3}
+    @test @inferred(
+      set_unspecified_parameters(Array{Float32,3}, Position(2), DefaultParameter())
+    ) == Array{Float32,3}
+    @test @inferred(
+      set_unspecified_parameters(Array{Float32}, Position(1), DefaultParameter())
+    ) == Array{Float32}
+    @test @inferred(
+      set_unspecified_parameters(Array{Float32}, Position(2), DefaultParameter())
+    ) == Array{Float32,1}
+    @test @inferred(
+      set_unspecified_parameters(Array{<:Any,3}, Position(1), DefaultParameter())
+    ) == Array{Float64,3}
+    @test @inferred(
+      set_unspecified_parameters(Array{<:Any,3}, Position(2), DefaultParameter())
+    ) == Array{<:Any,3}
+    @test @inferred(set_unspecified_parameters(Array, Position(1), DefaultParameter())) ==
+      Array{Float64}
     # TODO: Inferrence is broken for this case
-    @test @inferred(Any, set_unspecified_parameters(Array, Position(2), DefaultParameter())) == Array{<:Any,1}
+    @test @inferred(
+      Any, set_unspecified_parameters(Array, Position(2), DefaultParameter())
+    ) == Array{<:Any,1}
   end
 
   @testset "Set to the default parameters if unspecified" begin
-    @test @inferred(set_unspecified_parameters(Array{Float32,3}, DefaultParameters())) == Array{Float32,3}
-    @test @inferred(set_unspecified_parameters(Array{Float32}, DefaultParameters())) == Array{Float32,1}
-    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, DefaultParameters())) == Array{Float64,3}
-    @test @inferred(set_unspecified_parameters(Array, DefaultParameters())) == Array{Float64,1}
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, DefaultParameters())) ==
+      Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32}, DefaultParameters())) ==
+      Array{Float32,1}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, DefaultParameters())) ==
+      Array{Float64,3}
+    @test @inferred(set_unspecified_parameters(Array, DefaultParameters())) ==
+      Array{Float64,1}
   end
 end

--- a/NDTensors/src/SetParameters/test/runtests.jl
+++ b/NDTensors/src/SetParameters/test/runtests.jl
@@ -1,0 +1,98 @@
+using Test
+using NDTensors.SetParameters
+
+@testset "Test NDTensors.SetParameters" begin
+  @testset "Set parameter at position" begin
+    @test @inferred(set_parameters(Array{Float32,3}, Float16)) == Array{Float16,3}
+    @test @inferred(set_parameters(Array{Float32,3}, Position(1), Float16)) == Array{Float16,3}
+    @test @inferred((() -> set_parameters(Array{Float32,3}, Position(2), 2))()) == Array{Float32,2}
+    @test @inferred(set_parameters(Array{Float32}, Float16)) == Array{Float16}
+    @test @inferred(set_parameters(Array{Float32}, Position(1), Float16)) == Array{Float16}
+    @test @inferred((() -> set_parameters(Array{Float32}, Position(2), 2))()) == Array{Float32,2}
+    @test @inferred(set_parameters(Array{<:Any,3}, Float16)) == Array{Float16,3}
+    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), Float16)) == Array{Float16,3}
+    # TODO: Inferrence is broken for this case
+    @test @inferred(Any, (() -> set_parameters(Array{<:Any,3}, Position(2), 2))()) == Array{<:Any,2}
+    @test @inferred(set_parameters(Array, Float16)) == Array{Float16}
+    @test @inferred(set_parameters(Array, Position(1), Float16)) == Array{Float16}
+    @test @inferred((() -> set_parameters(Array, Position(2), 2))()) == Array{<:Any,2}
+  end
+
+  @testset "Set multiple parameters" begin
+    @test @inferred((() -> set_parameters(Array{<:Any,3}, Float16, 2))()) == Array{Float16,2}
+    @test @inferred((() -> set_parameters(Array{<:Any,3}, Position(1), Float16, 2))()) == Array{Float16,2}
+    @test @inferred(set_parameters(Array{<:Any,3}, Float16)) == Array{Float16,3}
+    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), Float16)) == Array{Float16,3}
+    @test @inferred(set_parameters(Array{<:Any,3})) == Array{<:Any,3}
+    @test @inferred(set_parameters(Array{<:Any,3}, Position(1))) == Array{<:Any,3}
+    # TODO: Inferrence is broken for this case
+    @test @inferred(Any, (() -> set_parameters(Array{<:Any,3}, Position(2), 2))()) == Array{<:Any,2}
+    @test @inferred(set_parameters(Array{<:Any,3}, Position(2))) == Array{<:Any,3}
+  end
+
+  @testset  "Set a parameter if it is unspecified" begin
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Float16)) == Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(1), Float16)) == Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(2), 2)) == Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32}, Float16)) == Array{Float32}
+    @test @inferred(set_unspecified_parameters(Array{Float32}, Position(1), Float16)) == Array{Float32}
+    @test @inferred((() -> set_unspecified_parameters(Array{Float32}, Position(2), 2))()) == Array{Float32,2}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Float16)) == Array{Float16,3}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(1), Float16)) == Array{Float16,3}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(2), 2)) == Array{<:Any,3}
+    @test @inferred(set_unspecified_parameters(Array, Float16)) == Array{Float16}
+    @test @inferred(set_unspecified_parameters(Array, Position(1), Float16)) == Array{Float16}
+    @test @inferred((() -> set_unspecified_parameters(Array, Position(2), 2))()) == Array{<:Any,2}
+  end
+
+  @testset "Set multiple parameters if they are unspecified" begin
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Float16, 2)) == Array{Float32,3}
+    @test @inferred((() -> set_unspecified_parameters(Array{Float32}, Float16, 2))()) == Array{Float32,2}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Float16, 2)) == Array{Float16,3}
+    @test @inferred((() -> set_unspecified_parameters(Array, Float16, 2))()) == Array{Float16,2}
+  end
+
+  @testset "Default parameters" begin
+    @test @inferred(default_parameter(Array{Float32,3}, Position(1))) == Float64
+    @test @inferred(default_parameter(Array{Float32,3}, Position(2))) == 1
+  end
+
+  @testset "Set to the default parameter" begin
+    @test @inferred(set_parameters(Array{Float32,3}, Position(1), DefaultParameter())) == Array{Float64,3}
+    @test @inferred(set_parameters(Array{Float32,3}, Position(2), DefaultParameter())) == Array{Float32,1}
+    @test @inferred(set_parameters(Array{Float32}, Position(1), DefaultParameter())) == Array{Float64}
+    @test @inferred(set_parameters(Array{Float32}, Position(2), DefaultParameter())) == Array{Float32,1}
+    @test @inferred(set_parameters(Array{<:Any,3}, Position(1), DefaultParameter())) == Array{Float64,3}
+    # TODO: Inferrence is broken for this case
+    @test @inferred(Any, set_parameters(Array{<:Any,3}, Position(2), DefaultParameter())) == Array{<:Any,1}
+    @test @inferred(set_parameters(Array, Position(1), DefaultParameter())) == Array{Float64}
+    # TODO: Inferrence is broken for this case
+    @test @inferred(Any, set_parameters(Array, Position(2), DefaultParameter())) == Array{<:Any,1}
+  end
+
+  @testset "Set to the default parameters" begin
+    @test @inferred(set_parameters(Array{Float32,3}, DefaultParameters())) == Array{Float64,1}
+    @test @inferred(set_parameters(Array{Float32}, DefaultParameters())) == Array{Float64,1}
+    @test @inferred(set_parameters(Array{<:Any,3}, DefaultParameters())) == Array{Float64,1}
+    @test @inferred(set_parameters(Array, DefaultParameters())) == Array{Float64,1}
+  end
+
+  @testset "Set to the default parameter if unspecified" begin
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(1), DefaultParameter())) == Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, Position(2), DefaultParameter())) == Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32}, Position(1), DefaultParameter())) == Array{Float32}
+    @test @inferred(set_unspecified_parameters(Array{Float32}, Position(2), DefaultParameter())) == Array{Float32,1}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(1), DefaultParameter())) == Array{Float64,3}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, Position(2), DefaultParameter())) == Array{<:Any,3}
+    @test @inferred(set_unspecified_parameters(Array, Position(1), DefaultParameter())) == Array{Float64}
+    # TODO: Inferrence is broken for this case
+    @test @inferred(Any, set_unspecified_parameters(Array, Position(2), DefaultParameter())) == Array{<:Any,1}
+  end
+
+  @testset "Set to the default parameters if unspecified" begin
+    @test @inferred(set_unspecified_parameters(Array{Float32,3}, DefaultParameters())) == Array{Float32,3}
+    @test @inferred(set_unspecified_parameters(Array{Float32}, DefaultParameters())) == Array{Float32,1}
+    @test @inferred(set_unspecified_parameters(Array{<:Any,3}, DefaultParameters())) == Array{Float64,3}
+    @test @inferred(set_unspecified_parameters(Array, DefaultParameters())) == Array{Float64,1}
+  end
+end

--- a/NDTensors/test/SetParameters.jl
+++ b/NDTensors/test/SetParameters.jl
@@ -1,0 +1,4 @@
+using Test
+using NDTensors
+
+include(joinpath(pkgdir(NDTensors), "src", "SetParameters", "test", "runtests.jl"))

--- a/NDTensors/test/runtests.jl
+++ b/NDTensors/test/runtests.jl
@@ -3,6 +3,7 @@ using NDTensors
 
 @testset "NDTensors" begin
   @testset "$filename" for filename in [
+    "SetParameters.jl",
     "linearalgebra.jl",
     "dense.jl",
     "blocksparse.jl",


### PR DESCRIPTION
The aim of this is to provide some basic tools and common interfaces for getting and setting type parameters, with the hopes of making parts of #1059 easier to implement.

The basic idea is that a new type needs to define overloads for accessing and setting type parameters, for example for `Array`:
```julia
get_parameter(::Type{<:Array{P1}}, ::Position{1}) where {P1} = P1
get_parameter(::Type{<:Array{<:Any,P2}}, ::Position{2}) where {P2} = P2

set_parameter(::Type{<:Array}, ::Position{1}, P1) = Array{P1}
set_parameter(::Type{<:Array{<:Any,P2}}, ::Position{1}, P1) where {P2} = Array{P1,P2}
set_parameter(::Type{<:Array}, ::Position{2}, P2) = Array{<:Any,P2}
set_parameter(::Type{<:Array{P1}}, ::Position{2}, P2) where {P1} = Array{P1,P2}
```
Additionally, if you want to work with default type parameters, you can overload functions like this:
```julia
default_parameter(::Type{<:Array}, ::Position{1}) = Float64
default_parameter(::Type{<:Array}, ::Position{2}) = 1

nparameters(::Type{<:Array}) = Val(2)
```

Then, a number of generic functions become available for manipulating the parameters of that type, for example setting multiple parameters, setting only unspecified parameters, setting default parameters, etc., for example:
```julia
# Set parameters
set_parameters(Array{<:Any,3}, Float32, 1) = Vector{Float32}
set_parameters(Array{<:Any,3}, Float32) = Array{Float32,3}
set_parameters(Array{Float32,3}, Position(2), 2) = Matrix{Float32}

# Set only unspecified parameters
set_unspecified_parameters(Array{Float32}, Float64, 2) = Matrix{Float32}

# Set default parameters
set_parameters(Array{Float32}, Position(2), DefaultParameters()) = Vector{Float32}
set_unspecified_parameters(Matrix, DefaultParameters()) = Matrix{Float64}
```
@kmp5VT @emstoudenmire

These functions only work for a single layer of type parameters. Tools for working with nested type parameters would be left for future work. A possibility would be to have an `Adapt.jl`-like interface for working with nested type structures (`AdaptParameters.jl`) which would help with functionality like recursively modifying the element type of a wrapper type. In general we would have to define an interface for defining how to unwrap and rewrap a type, which is something I started working on in the context of the `IsWrappedArray` trait in https://github.com/ITensor/ITensors.jl/blob/v0.3.26/NDTensors/src/abstractarray/similar.jl. Hopefully even without that, the current functionality can be used to simplify some code in `NDTensors`, such as using it to help implement `eltype` definitions.