### PR TITLE
Pass projected operator to Observer measure function

### DIFF
--- a/docs/src/Observer.md
+++ b/docs/src/Observer.md
@@ -95,12 +95,13 @@ the current observer object and a set of keyword arguments
 which include:
    - energy: the energy after the current step of DMRG
    - psi: the current wavefunction MPS 
-   - bond: the bond `b` that was just optimized, corresponding to sites `(b,b+1)` in the two-site DMRG algorihtm
+   - bond: the bond `b` that was just optimized, corresponding to sites `(b,b+1)` in the two-site DMRG algorithm
    - sweep: the current sweep number
    - sweep\_is\_done: true if at the end of the current sweep, otherwise false
    - half_sweep: the half-sweep number, equal to 1 for a left-to-right, first half sweep, or 2 for the second, right-to-left half sweep
    - spec: the Spectrum object returned from factorizing the local superblock wavefunction tensor in two-site DMRG
    - outputlevel: an integer specifying the amount of output to show
+   - projected_operator: projection of the linear operator into the current MPS basis
 
 For our minimal `DemoObserver` example here, we will just make a `measure!` function
 that prints out some of the information above, but in a more realistic setting one 

--- a/docs/src/Observer.md
+++ b/docs/src/Observer.md
@@ -101,6 +101,7 @@ which include:
    - half_sweep: the half-sweep number, equal to 1 for a left-to-right, first half sweep, or 2 for the second, right-to-left half sweep
    - spec: the Spectrum object returned from factorizing the local superblock wavefunction tensor in two-site DMRG
    - outputlevel: an integer specifying the amount of output to show
+   - operator: linear operator H (e.g. Hamiltonian) passed to `dmrg`
    - projected_operator: projection of the linear operator into the current MPS basis
 
 For our minimal `DemoObserver` example here, we will just make a `measure!` function

--- a/docs/src/Observer.md
+++ b/docs/src/Observer.md
@@ -101,7 +101,6 @@ which include:
    - half_sweep: the half-sweep number, equal to 1 for a left-to-right, first half sweep, or 2 for the second, right-to-left half sweep
    - spec: the Spectrum object returned from factorizing the local superblock wavefunction tensor in two-site DMRG
    - outputlevel: an integer specifying the amount of output to show
-   - operator: linear operator H (e.g. Hamiltonian) passed to `dmrg`
    - projected_operator: projection of the linear operator into the current MPS basis
 
 For our minimal `DemoObserver` example here, we will just make a `measure!` function

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -388,6 +388,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
         measure!(
           obs;
           energy=energy,
+          operator=H,
           psi=psi,
           projected_operator=PH,
           bond=b,

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -388,7 +388,6 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
         measure!(
           obs;
           energy=energy,
-          operator=H,
           psi=psi,
           projected_operator=PH,
           bond=b,

--- a/src/mps/dmrg.jl
+++ b/src/mps/dmrg.jl
@@ -389,6 +389,7 @@ function dmrg(PH, psi0::MPS, sweeps::Sweeps; kwargs...)
           obs;
           energy=energy,
           psi=psi,
+          projected_operator=PH,
           bond=b,
           sweep=sw,
           half_sweep=ha,


### PR DESCRIPTION
# Description

Pass the "PH" object to the observer system `measure!` function. This can be useful for e.g. monitoring
 the memory usage of `dmrg`.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
