### PR TITLE
[ITensors] Fix `sum(::Vector{MPS})` for one MPS

### DIFF
--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1558,8 +1558,8 @@ truncation.
 - `maxdim::Int`: maximum MPS/MPO bond dimension
 """
 function sum(ψ⃗::Vector{T}; kwargs...) where {T<:AbstractMPS}
-  length(ψ⃗) == 0 && return T()
-  length(ψ⃗) == 1 && return A[1]
+  iszero(length(ψ⃗)) && return T()
+  isone(length(ψ⃗)) && return copy(only(ψ⃗))
   return +(ψ⃗...; kwargs...)
 end
 

--- a/test/ITensorLegacyMPS/base/test_mps.jl
+++ b/test/ITensorLegacyMPS/base/test_mps.jl
@@ -480,6 +480,8 @@ include(joinpath(@__DIR__, "utils", "util.jl"))
     K12 = add(Ks[1], Ks[2])
     K123 = add(K12, Ks[3])
     @test inner(sum(Ks), K123) ≈ inner(K123, K123)
+    # https://github.com/ITensor/ITensors.jl/issues/1000
+    @test sum([psi]) ≈ psi
   end
 
   @testset "+ MPS" begin


### PR DESCRIPTION
# Description

Fixes #1000.