### PR TITLE
[NDTensors] Improve checks in Combiner for undefined contractions

### DIFF
--- a/NDTensors/src/blocksparse/blocksparsetensor.jl
+++ b/NDTensors/src/blocksparse/blocksparsetensor.jl
@@ -549,12 +549,15 @@ end
 
 function uncombine_output(
   T::BlockSparseTensor{ElT,N},
+  T_labels,
   is,
+  is_labels,
   combdim::Int,
   blockperm::Vector{Int},
   blockcomb::Vector{Int},
 ) where {ElT<:Number,N}
-  ind_uncomb_perm = ⊗(setdiff(is, inds(T))...)
+  labels_uncomb_perm = setdiff(is_labels, T_labels)
+  ind_uncomb_perm = ⊗(is[map(x -> findfirst(==(x), is_labels), labels_uncomb_perm)]...)
   inds_uncomb_perm = insertat(inds(T), ind_uncomb_perm, combdim)
   # Uncombine the blocks of T
   blocks_uncomb = uncombine_blocks(nzblocks(T), combdim, blockcomb)
@@ -578,18 +581,20 @@ end
 
 function uncombine(
   T::BlockSparseTensor{<:Number,NT},
+  T_labels,
   is,
+  is_labels,
   combdim::Int,
   blockperm::Vector{Int},
   blockcomb::Vector{Int},
 ) where {NT}
   NR = length(is)
-  R = uncombine_output(T, is, combdim, blockperm, blockcomb)
+  R = uncombine_output(T, T_labels, is, is_labels, combdim, blockperm, blockcomb)
   invblockperm = invperm(blockperm)
-
   # This is needed for reshaping the block
-  # It is already calculated in uncombine_output, use it from there
-  ind_uncomb_perm = ⊗(setdiff(is, inds(T))...)
+  # TODO: It is already calculated in uncombine_output, use it from there
+  labels_uncomb_perm = setdiff(is_labels, T_labels)
+  ind_uncomb_perm = ⊗(is[map(x -> findfirst(==(x), is_labels), labels_uncomb_perm)]...)
   ind_uncomb = permuteblocks(ind_uncomb_perm, blockperm)
   # Same as inds(T) but with the blocks uncombined
   inds_uncomb = insertat(inds(T), ind_uncomb, combdim)

--- a/NDTensors/src/blocksparse/combiner.jl
+++ b/NDTensors/src/blocksparse/combiner.jl
@@ -1,65 +1,162 @@
 #<fermions>:
-before_combiner_signs(T, labelsT, indsT, C, labelsC, indsC, labelsR, indsR) = T
-after_combiner_signs(R, labelsR, indsR, C, labelsC, indsC) = R
+function before_combiner_signs(
+  tensor,
+  tensor_labels,
+  indstensor,
+  combiner_tensor,
+  combiner_tensor_labels,
+  indscombiner_tensor,
+  labelsoutput_tensor,
+  output_tensor_inds,
+)
+  return tensor
+end
+function after_combiner_signs(
+  output_tensor,
+  labelsoutput_tensor,
+  output_tensor_inds,
+  combiner_tensor,
+  combiner_tensor_labels,
+  indscombiner_tensor,
+)
+  return output_tensor
+end
 
-function contract(T::BlockSparseTensor, labelsT, C::CombinerTensor, labelsC)
+function contract(
+  tensor::BlockSparseTensor,
+  tensor_labels,
+  combiner_tensor::CombinerTensor,
+  combiner_tensor_labels,
+)
   #@timeit_debug timer "Block sparse (un)combiner" begin
   # Get the label marking the combined index
   # By convention the combined index is the first one
-  # TODO: consider storing the location of the combined
-  # index in preperation for multiplce combined indices
-  cpos_in_labelsC = 1
-  clabel = labelsC[cpos_in_labelsC]
-  c = combinedindex(C)
-  labels_uc = deleteat(labelsC, cpos_in_labelsC)
-  if labelsC[1] ∉ labelsT
-    # Combine
-    labelsRc = contract_labels(labelsC, labelsT)
-    cpos_in_labelsRc = findfirst(==(clabel), labelsRc)
-    labelsRuc = insertat(labelsRc, labels_uc, cpos_in_labelsRc)
-    indsRc = contract_inds(inds(C), labelsC, inds(T), labelsT, labelsRc)
+  # TODO: Consider storing the location of the combined
+  # index in preperation for multiple combined indices
+  # TODO: Use `combinedind_label(...)`, `uncombinedind_labels(...)`, etc.
+  cpos_in_combiner_tensor_labels = 1
+  clabel = combiner_tensor_labels[cpos_in_combiner_tensor_labels]
+  c = combinedind(combiner_tensor)
+  labels_uc = deleteat(combiner_tensor_labels, cpos_in_combiner_tensor_labels)
+  is_combining_contraction = is_combining(
+    tensor, tensor_labels, combiner_tensor, combiner_tensor_labels
+  )
+  if is_combining_contraction
+    output_tensor_labels = contract_labels(combiner_tensor_labels, tensor_labels)
+    cpos_in_output_tensor_labels = findfirst(==(clabel), output_tensor_labels)
+    output_tensor_labels_uc = insertat(
+      output_tensor_labels, labels_uc, cpos_in_output_tensor_labels
+    )
+    output_tensor_inds = contract_inds(
+      inds(combiner_tensor),
+      combiner_tensor_labels,
+      inds(tensor),
+      tensor_labels,
+      output_tensor_labels,
+    )
 
     #<fermions>:
-    T = before_combiner_signs(T, labelsT, inds(T), C, labelsC, inds(C), labelsRc, indsRc)
+    tensor = before_combiner_signs(
+      tensor,
+      tensor_labels,
+      inds(tensor),
+      combiner_tensor,
+      combiner_tensor_labels,
+      inds(combiner_tensor),
+      output_tensor_labels,
+      output_tensor_inds,
+    )
 
-    perm = getperm(labelsRuc, labelsT)
-    ucpos_in_labelsT = Tuple(findall(x -> x in labels_uc, labelsT))
-    Rc = permutedims_combine(T, indsRc, perm, ucpos_in_labelsT, blockperm(C), blockcomb(C))
-    return Rc
-  else
-    # Uncombine
-    labelsRc = labelsT
-    cpos_in_labelsRc = findfirst(==(clabel), labelsRc)
+    perm = getperm(output_tensor_labels_uc, tensor_labels)
+    ucpos_in_tensor_labels = Tuple(findall(x -> x in labels_uc, tensor_labels))
+    output_tensor = permutedims_combine(
+      tensor,
+      output_tensor_inds,
+      perm,
+      ucpos_in_tensor_labels,
+      blockperm(combiner_tensor),
+      blockcomb(combiner_tensor),
+    )
+    return output_tensor
+  else # Uncombining
+    output_tensor_labels = tensor_labels
+    cpos_in_output_tensor_labels = findfirst(==(clabel), output_tensor_labels)
     # Move combined index to first position
-    if cpos_in_labelsRc != 1
-      labelsRc_orig = labelsRc
-      labelsRc = deleteat(labelsRc, cpos_in_labelsRc)
-      labelsRc = insertafter(labelsRc, clabel, 0)
-      cpos_in_labelsRc = 1
-      perm = getperm(labelsRc, labelsRc_orig)
-      T = permutedims(T, perm)
-      labelsT = permute(labelsT, perm)
+    if cpos_in_output_tensor_labels != 1
+      output_tensor_labels_orig = output_tensor_labels
+      output_tensor_labels = deleteat(output_tensor_labels, cpos_in_output_tensor_labels)
+      output_tensor_labels = insertafter(output_tensor_labels, clabel, 0)
+      cpos_in_output_tensor_labels = 1
+      perm = getperm(output_tensor_labels, output_tensor_labels_orig)
+      tensor = permutedims(tensor, perm)
+      tensor_labels = permute(tensor_labels, perm)
     end
-    labelsRuc = insertat(labelsRc, labels_uc, cpos_in_labelsRc)
-    indsRuc = contract_inds(inds(C), labelsC, inds(T), labelsT, labelsRuc)
+    output_tensor_labels_uc = insertat(
+      output_tensor_labels, labels_uc, cpos_in_output_tensor_labels
+    )
+    output_tensor_inds_uc = contract_inds(
+      inds(combiner_tensor),
+      combiner_tensor_labels,
+      inds(tensor),
+      tensor_labels,
+      output_tensor_labels_uc,
+    )
 
     # <fermions>:
-    T = before_combiner_signs(T, labelsT, inds(T), C, labelsC, inds(C), labelsRuc, indsRuc)
+    tensor = before_combiner_signs(
+      tensor,
+      tensor_labels,
+      inds(tensor),
+      combiner_tensor,
+      combiner_tensor_labels,
+      inds(combiner_tensor),
+      output_tensor_labels_uc,
+      output_tensor_inds_uc,
+    )
 
-    Ruc = uncombine(T, indsRuc, cpos_in_labelsRc, blockperm(C), blockcomb(C))
+    output_tensor = uncombine(
+      tensor,
+      tensor_labels,
+      output_tensor_inds_uc,
+      output_tensor_labels_uc,
+      cpos_in_output_tensor_labels,
+      blockperm(combiner_tensor),
+      blockcomb(combiner_tensor),
+    )
 
     # <fermions>:
-    Ruc = after_combiner_signs(Ruc, labelsRuc, indsRuc, C, labelsC, inds(C))
+    output_tensor = after_combiner_signs(
+      output_tensor,
+      output_tensor_labels_uc,
+      output_tensor_inds_uc,
+      combiner_tensor,
+      combiner_tensor_labels,
+      inds(combiner_tensor),
+    )
 
-    return Ruc
+    return output_tensor
   end
-  #end # @timeit
+  return invalid_combiner_contraction_error(
+    combiner_tensor, tensor_labels, tensor, tensor_labels
+  )
 end
 
-function contract(C::CombinerTensor, labelsC, T::BlockSparseTensor, labelsT)
-  return contract(T, labelsT, C, labelsC)
+function contract(
+  combiner_tensor::CombinerTensor,
+  combiner_tensor_labels,
+  tensor::BlockSparseTensor,
+  tensor_labels,
+)
+  return contract(tensor, tensor_labels, combiner_tensor, combiner_tensor_labels)
 end
 
 # Special case when no indices are combined
-# XXX: no copy
-contract(T::BlockSparseTensor, labelsT, C::CombinerTensor{<:Any,0}, labelsC) = copy(T)
+# TODO: No copy? Maybe use `AllowAlias`.
+function contract(
+  tensor::BlockSparseTensor,
+  tensor_labels,
+  combiner_tensor::CombinerTensor{<:Any,0},
+  combiner_tensor_labels,
+)
+  return copy(tensor)
+end

--- a/NDTensors/src/combiner/combiner.jl
+++ b/NDTensors/src/combiner/combiner.jl
@@ -235,31 +235,31 @@ function invalid_combiner_contraction_error(
   tensor::Tensor, tensor_labels, combiner_tensor::CombinerTensor, combiner_tensor_labels
 )
   return error(
-"""
-Trying to contract a tensor with indices:
+    """
+    Trying to contract a tensor with indices:
 
-$(inds(tensor))
+    $(inds(tensor))
 
-and labels:
+    and labels:
 
-$(tensor_labels)
+    $(tensor_labels)
 
-with a combiner tensor with indices:
+    with a combiner tensor with indices:
 
-$(inds(combiner_tensor))
+    $(inds(combiner_tensor))
 
-and labels:
+    and labels:
 
-$(combiner_tensor_labels).
+    $(combiner_tensor_labels).
 
-This is not a valid combiner contraction.
+    This is not a valid combiner contraction.
 
-If you are combining, the combined index of the combiner should be the only one uncontracted.
+    If you are combining, the combined index of the combiner should be the only one uncontracted.
 
-If you are uncombining, the combined index of the combiner should be the only one contracted.
+    If you are uncombining, the combined index of the combiner should be the only one contracted.
 
-By convention, the combined index should be the index in position $(combinedind_position(combiner_tensor)) of the combiner tensor.
-"""
+    By convention, the combined index should be the index in position $(combinedind_position(combiner_tensor)) of the combiner tensor.
+    """,
   )
 end
 

--- a/NDTensors/test/Project.toml
+++ b/NDTensors/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/NDTensors/test/combiner.jl
+++ b/NDTensors/test/combiner.jl
@@ -12,7 +12,7 @@ using ITensors: QN, Index
     combiner_tensor_inds = (d^2, d, d)
     output_tensor_inds = (d, d^2)
 
-    input_tensor = tensor(Dense(randn(input_tensor_inds)),  input_tensor_inds)
+    input_tensor = tensor(Dense(randn(input_tensor_inds)), input_tensor_inds)
     combiner_tensor = tensor(Combiner([1], [1]), combiner_tensor_inds)
 
     output_tensor = contract(input_tensor, (1, -1, -2), combiner_tensor, (2, -1, -2))
@@ -25,18 +25,15 @@ using ITensors: QN, Index
     # Test uncombining
     new_input_tensor = contract(output_tensor, (1, -1), combiner_tensor, (-1, 2, 3))
     @test new_input_tensor == input_tensor
- 
+
     # Catch invalid combining
     input_tensor_inds = (d,)
-    input_tensor = tensor(Dense(randn(input_tensor_inds)),  input_tensor_inds)
+    input_tensor = tensor(Dense(randn(input_tensor_inds)), input_tensor_inds)
     combiner_tensor = tensor(Combiner([1], [1]), combiner_tensor_inds)
     @test_throws ErrorException contract(input_tensor, (-1,), combiner_tensor, (1, -1, -2))
   end
 
-  ind_constructors = (
-    dim -> [dim],
-    dim -> Index([QN() => dim]),
-  )
+  ind_constructors = (dim -> [dim], dim -> Index([QN() => dim]))
   @testset "BlockSparse * Combiner" for ind_constructor in ind_constructors
     d = 2
     i, j, k = map(ind_constructor, (d, d, d))
@@ -46,7 +43,10 @@ using ITensors: QN, Index
     combiner_tensor_inds = (c, j, k)
     output_tensor_inds = (c, i)
 
-    input_tensor = tensor(BlockSparse(randn(dim(input_tensor_inds)), BlockOffsets{3}([Block(1, 1, 1)], [0])), input_tensor_inds)
+    input_tensor = tensor(
+      BlockSparse(randn(dim(input_tensor_inds)), BlockOffsets{3}([Block(1, 1, 1)], [0])),
+      input_tensor_inds,
+    )
     combiner_tensor = tensor(Combiner([1], [1]), combiner_tensor_inds)
 
     output_tensor = contract(input_tensor, (1, -1, -2), combiner_tensor, (2, -1, -2))
@@ -64,9 +64,13 @@ using ITensors: QN, Index
 
     # Catch invalid combining
     invalid_input_tensor_inds = (k,)
-    invalid_input_tensor = tensor(BlockSparse(randn(dim(invalid_input_tensor_inds)), BlockOffsets{1}([Block(1)], [0])), invalid_input_tensor_inds)
+    invalid_input_tensor = tensor(
+      BlockSparse(randn(dim(invalid_input_tensor_inds)), BlockOffsets{1}([Block(1)], [0])),
+      invalid_input_tensor_inds,
+    )
     combiner_tensor = tensor(Combiner([1], [1]), combiner_tensor_inds)
-    @test_throws ErrorException contract(invalid_input_tensor, (-1,), combiner_tensor, (1, 2, -1))
+    @test_throws ErrorException contract(
+      invalid_input_tensor, (-1,), combiner_tensor, (1, 2, -1)
+    )
   end
-
 end

--- a/NDTensors/test/combiner.jl
+++ b/NDTensors/test/combiner.jl
@@ -1,0 +1,72 @@
+using NDTensors
+using LinearAlgebra
+using Test
+
+# Testing generic block indices
+using ITensors: QN, Index
+
+@testset "CombinerTensor basic functionality" begin
+  @testset "Dense * Combiner" begin
+    d = 2
+    input_tensor_inds = (d, d, d)
+    combiner_tensor_inds = (d^2, d, d)
+    output_tensor_inds = (d, d^2)
+
+    input_tensor = tensor(Dense(randn(input_tensor_inds)),  input_tensor_inds)
+    combiner_tensor = tensor(Combiner([1], [1]), combiner_tensor_inds)
+
+    output_tensor = contract(input_tensor, (1, -1, -2), combiner_tensor, (2, -1, -2))
+    @test output_tensor isa DenseTensor
+    @test dims(output_tensor) == output_tensor_inds
+    for i in 1:length(input_tensor)
+      @test input_tensor[i] == output_tensor[i]
+    end
+
+    # Test uncombining
+    new_input_tensor = contract(output_tensor, (1, -1), combiner_tensor, (-1, 2, 3))
+    @test new_input_tensor == input_tensor
+ 
+    # Catch invalid combining
+    input_tensor_inds = (d,)
+    input_tensor = tensor(Dense(randn(input_tensor_inds)),  input_tensor_inds)
+    combiner_tensor = tensor(Combiner([1], [1]), combiner_tensor_inds)
+    @test_throws ErrorException contract(input_tensor, (-1,), combiner_tensor, (1, -1, -2))
+  end
+
+  ind_constructors = (
+    dim -> [dim],
+    dim -> Index([QN() => dim]),
+  )
+  @testset "BlockSparse * Combiner" for ind_constructor in ind_constructors
+    d = 2
+    i, j, k = map(ind_constructor, (d, d, d))
+    c = ind_constructor(d^2)
+
+    input_tensor_inds = (i, j, k)
+    combiner_tensor_inds = (c, j, k)
+    output_tensor_inds = (c, i)
+
+    input_tensor = tensor(BlockSparse(randn(dim(input_tensor_inds)), BlockOffsets{3}([Block(1, 1, 1)], [0])), input_tensor_inds)
+    combiner_tensor = tensor(Combiner([1], [1]), combiner_tensor_inds)
+
+    output_tensor = contract(input_tensor, (1, -1, -2), combiner_tensor, (2, -1, -2))
+    @test output_tensor isa BlockSparseTensor
+    @test dims(output_tensor) == dims(output_tensor_inds)
+    output_tensor = permutedims(output_tensor, (2, 1))
+    for i in 1:length(input_tensor)
+      @test input_tensor[i] == output_tensor[i]
+    end
+
+    # Test uncombining. Broken for inds that are not `Index`.
+    new_input_tensor = contract(output_tensor, (1, -1), combiner_tensor, (-1, 2, 3))
+    new_input_tensor = permutedims(new_input_tensor, (3, 1, 2))
+    @test new_input_tensor == input_tensor
+
+    # Catch invalid combining
+    invalid_input_tensor_inds = (k,)
+    invalid_input_tensor = tensor(BlockSparse(randn(dim(invalid_input_tensor_inds)), BlockOffsets{1}([Block(1)], [0])), invalid_input_tensor_inds)
+    combiner_tensor = tensor(Combiner([1], [1]), combiner_tensor_inds)
+    @test_throws ErrorException contract(invalid_input_tensor, (-1,), combiner_tensor, (1, 2, -1))
+  end
+
+end

--- a/NDTensors/test/runtests.jl
+++ b/NDTensors/test/runtests.jl
@@ -10,6 +10,7 @@ using NDTensors
     "diag.jl",
     "emptynumber.jl",
     "emptystorage.jl",
+    "combiner.jl",
   ]
     println("Running $filename")
     include(filename)


### PR DESCRIPTION
# Description

- Fixes #1034 by adding better checks for catching that case and throwing an informative error (in both the Dense and BlockSparse cases).
- Add a new test file for Combiner in NDTensors, including testing this new behavior.
- Fixes an issue in BlockSparse Combiner uncombining contraction where it was assuming the indices had unique identifiers (i.e. implicitly assumed they were `Index`), so failed with more general block dimensions.

So now:
```julia
using ITensors
i, j = Index.((2, 2))
T = randomITensor(i)
C = combiner(i, j)
C * T
```
outputs:
```julia
ERROR: Trying to contract a tensor with indices:

((dim=2|id=69),)

and labels:

(-1,)

with a combiner tensor with indices:

((dim=4|id=989|"CMB,Link"), (dim=2|id=69), (dim=2|id=866))

and labels:

(2, -1, 3).

This is not a valid combiner contraction.

If you are combining, the combined index of the combiner should be the only one uncontracted.

If you are uncombining, the combined index of the combiner should be the only one contracted.

By convention, the combined index should be the index in position 1 of the combiner tensor.

Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] invalid_combiner_contraction_error(tensor::DenseTensor{Float64, 1, Tuple{Index{Int64}}, Dense{Float64, Vector{Float64}}}, tensor_labels::Tuple{Int64}, combiner_tensor::Tensor{Number, 3, Combiner, Tuple{Index{Int64}, Index{Int64}, Index{Int64}}}, combiner_tensor_labels::Tuple{Int64, Int64, Int64})
    @ NDTensors ~/.julia/dev/ITensors/NDTensors/src/combiner/combiner.jl:237
[...]
```

@kmp5VT @christopherdavidwhite