### PR TITLE
[ITensors] add tests for Rn and CRn and conserve_number

### DIFF
--- a/test/base/test_phys_site_types.jl
+++ b/test/base/test_phys_site_types.jl
@@ -198,15 +198,16 @@ using ITensors, LinearAlgebra, Test
       0 0 exp(-im * θ / 2) 0
       0 0 0 exp(im * θ / 2)
     ]
-    @test reshape(Array(op("CRn", s, 3, 5; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈
-      [
+    @test reshape(
+      Array(op("CRn", s, 3, 5; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)
+      ) ≈ [
       1 0 0 0
       0 1 0 0
       0 0 cos(θ / 2) -exp(im * λ)*sin(θ / 2)
       0 0 exp(im * φ)*sin(θ / 2) exp(im * (φ + λ))*cos(θ / 2)
     ]
     @test reshape(
-      Array(op("CRn̂", s, 3;, 5 θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)
+      Array(op("CRn̂", s, 3, 5; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)
     ) ≈ [
       1 0 0 0
       0 1 0 0

--- a/test/base/test_phys_site_types.jl
+++ b/test/base/test_phys_site_types.jl
@@ -198,7 +198,8 @@ using ITensors, LinearAlgebra, Test
       0 0 exp(-im * θ / 2) 0
       0 0 0 exp(im * θ / 2)
     ]
-    @test reshape(Array(op("CRn", s, 3; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈ [
+    @test reshape(Array(op("CRn", s, 3; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈
+      [
       1 0 0 0
       0 1 0 0
       0 0 cos(θ / 2) -exp(im * λ)*sin(θ / 2)

--- a/test/base/test_phys_site_types.jl
+++ b/test/base/test_phys_site_types.jl
@@ -204,7 +204,9 @@ using ITensors, LinearAlgebra, Test
       0 0 cos(θ / 2) -exp(im * λ)*sin(θ / 2)
       0 0 exp(im * φ)*sin(θ / 2) exp(im * (φ + λ))*cos(θ / 2)
     ]
-    @test reshape(Array(op("CRn̂", s, 3; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈ [
+    @test reshape(
+      Array(op("CRn̂", s, 3; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)
+    ) ≈ [
       1 0 0 0
       0 1 0 0
       0 0 cos(θ / 2) -exp(im * λ)*sin(θ / 2)

--- a/test/base/test_phys_site_types.jl
+++ b/test/base/test_phys_site_types.jl
@@ -198,7 +198,7 @@ using ITensors, LinearAlgebra, Test
       0 0 exp(-im * θ / 2) 0
       0 0 0 exp(im * θ / 2)
     ]
-    @test reshape(Array(op("CRn", s, 3; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈
+    @test reshape(Array(op("CRn", s, 3, 5; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈
       [
       1 0 0 0
       0 1 0 0
@@ -206,7 +206,7 @@ using ITensors, LinearAlgebra, Test
       0 0 exp(im * φ)*sin(θ / 2) exp(im * (φ + λ))*cos(θ / 2)
     ]
     @test reshape(
-      Array(op("CRn̂", s, 3; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)
+      Array(op("CRn̂", s, 3;, 5 θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)
     ) ≈ [
       1 0 0 0
       0 1 0 0

--- a/test/base/test_phys_site_types.jl
+++ b/test/base/test_phys_site_types.jl
@@ -58,6 +58,13 @@ using ITensors, LinearAlgebra, Test
     @test qn(s, 1) == QN("Parity", 0, 2)
     @test qn(s, 2) == QN("Parity", 1, 2)
 
+    s = siteind("Qubit"; conserve_number=true)
+    @test hastags(s, "Qubit,Site")
+    @test dim(s) == 2
+    @test nblocks(s) == 2
+    @test qn(s, 1) == QN("Number", 0)
+    @test qn(s, 2) == QN("Number", 1)
+
     s = siteind("Qubit"; conserve_number=true, conserve_parity=true)
     @test hastags(s, "Qubit,Site")
     @test dim(s) == 2
@@ -130,6 +137,10 @@ using ITensors, LinearAlgebra, Test
       cos(θ / 2) -exp(im * λ)*sin(θ / 2)
       exp(im * φ)*sin(θ / 2) exp(im * (φ + λ))*cos(θ / 2)
     ]
+    @test Array(op("Rn̂", s, 3; θ=θ, λ=λ, ϕ=φ), s[3]', s[3]) ≈ [
+      cos(θ / 2) -exp(im * λ)*sin(θ / 2)
+      exp(im * φ)*sin(θ / 2) exp(im * (φ + λ))*cos(θ / 2)
+    ]
     @test Array(op("Splus", s, 3), s[3]', s[3]) ≈ [0 1; 0 0]
     @test Array(op("Sminus", s, 3), s[3]', s[3]) ≈ [0 0; 1 0]
     @test Array(op("S²", s, 3), s[3]', s[3]) ≈ [0.75 0; 0 0.75]
@@ -186,6 +197,18 @@ using ITensors, LinearAlgebra, Test
       0 1 0 0
       0 0 exp(-im * θ / 2) 0
       0 0 0 exp(im * θ / 2)
+    ]
+    @test reshape(Array(op("CRn", s, 3; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈ [
+      1 0 0 0
+      0 1 0 0
+      0 0 cos(θ / 2) -exp(im * λ)*sin(θ / 2)
+      0 0 exp(im * φ)*sin(θ / 2) exp(im * (φ + λ))*cos(θ / 2)
+    ]
+    @test reshape(Array(op("CRn̂", s, 3; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈ [
+      1 0 0 0
+      0 1 0 0
+      0 0 cos(θ / 2) -exp(im * λ)*sin(θ / 2)
+      0 0 exp(im * φ)*sin(θ / 2) exp(im * (φ + λ))*cos(θ / 2)
     ]
     @test reshape(Array(op("CX", s, 3, 5), s[5]', s[3]', s[5], s[3]), (4, 4)) ≈ [
       1 0 0 0

--- a/test/base/test_phys_site_types.jl
+++ b/test/base/test_phys_site_types.jl
@@ -200,7 +200,7 @@ using ITensors, LinearAlgebra, Test
     ]
     @test reshape(
       Array(op("CRn", s, 3, 5; θ=θ, λ=λ, ϕ=φ), s[5]', s[3]', s[5], s[3]), (4, 4)
-      ) ≈ [
+    ) ≈ [
       1 0 0 0
       0 1 0 0
       0 0 cos(θ / 2) -exp(im * λ)*sin(θ / 2)


### PR DESCRIPTION
# Description

Add tests for the Rn fallbacks and conserve_number for Qubit.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
