### PR TITLE
[ITensors] Exclude precompile.jl from coverage

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,3 +1,4 @@
+# COV_EXCL_START
 const __bodyfunction__ = Dict{Method,Any}()
 
 # Find keyword "body functions" (the function that contains the body
@@ -3961,3 +3962,4 @@ function _precompile_()
     },
   )
 end
+# COV_EXCL_STOP


### PR DESCRIPTION
# Description

Try excluding `src/precompile.jl`, which it doesn't really make sense to track coverage of, from coverage reports using [this method](https://github.com/JuliaCI/Coverage.jl#exclude-specific-lines-or-sections-from-coverage).

# How Has This Been Tested?

Tests passed locally.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
