### PR TITLE
[ITensors] Test error throwing for bad site name

### DIFF
--- a/test/base/test_phys_site_types.jl
+++ b/test/base/test_phys_site_types.jl
@@ -77,6 +77,9 @@ using ITensors, LinearAlgebra, Test
     Z = op("Z", s, 5)
     @test hasinds(Z, s[5]', s[5])
 
+    @test_throws ArgumentError(
+      "Overload of \"state\" or \"state!\" functions not found for state name \"Fake\" and Index tags $(tags(s[3]))",
+    ) state("Fake", s[3])
     @test Vector(state("Up", s[3])) ≈ [1, 0]
     @test Vector(state("↑", s[3])) ≈ [1, 0]
     @test Vector(state("Dn", s[3])) ≈ [0, 1]


### PR DESCRIPTION
# Description

Missed error path when the state name isn't present for a particular site type.

# How Has This Been Tested?

Tests passed locally.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
