### PR TITLE
[ITensorGPU] Make it possible to use metal with ITensorGPU

### DIFF
--- a/ITensorGPU/Project.toml
+++ b/ITensorGPU/Project.toml
@@ -18,6 +18,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
+Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 
 [compat]
 Adapt = "3.5"
@@ -33,6 +34,7 @@ Strided = "1.1.2"
 TimerOutputs = "0.5.13"
 cuTENSOR = "1.0.1"
 julia = "1.6"
+Metal = "0.2.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/ITensorGPU/src/ITensorGPU.jl
+++ b/ITensorGPU/src/ITensorGPU.jl
@@ -14,6 +14,7 @@ using StaticArrays
 using Strided
 using TimerOutputs
 using cuTENSOR
+using Metal
 
 using NDTensors: setdata, setstorage, cpu, IsWrappedArray, parenttype
 
@@ -93,6 +94,7 @@ include("tensor/cucombiner.jl")
 include("tensor/cudiag.jl")
 include("cuitensor.jl")
 include("mps/cumps.jl")
+include("mtlarray/set_types.jl")
 
 export cu,
   cpu, cuITensor, randomCuITensor, cuMPS, randomCuMPS, productCuMPS, randomCuMPO, cuMPO

--- a/ITensorGPU/src/mtlarray/set_types.jl
+++ b/ITensorGPU/src/mtlarray/set_types.jl
@@ -1,0 +1,7 @@
+function set_eltype(arraytype::Type{<:MtlArray}, eltype::Type)
+  return MtlArray{eltype,ndims(arraytype)}
+end
+
+function set_ndims(arraytype::Type{<:MtlArray}, ndims)
+  return MtlArray{eltype(arraytype),ndims}
+end


### PR DESCRIPTION
# Description

This is a change which shows how simple it now is to use different Array backends.  I have added functionality to ITensorGPU and it is now possible to use Metal based GPU arrays as a backend to `TensorStorage` objects, such as dense.


Fixes #(issue)

# How Has This Been Tested?

This will be tested with new unit tests added for metal. As well I will add a readme guide of the necessary steps to create a new datatype backend.  

# Checklist:

- [ ] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
