### PR TITLE
[ITensorGaussianMPS] [Bug] Fix mismatched convention for single particle Hamiltonians.

### DIFF
--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -234,7 +234,7 @@ function hopping_operator(os::OpSum; drop_pairing_terms_tol=nothing)
   if !all(abs.(h[1:N, (N + 1):(2 * N)]) .< drop_pairing_terms_tol)
     error("Trying to convert hamiltonian with pairing terms to hopping hamiltonian!")
   end
-  return h[(N + 1):(2 * N), (N + 1):(2 * N)]
+  return 2 .* h[(N + 1):(2 * N), (N + 1):(2 * N)]
 end
 
 # Make a combined hopping Hamiltonian for spin up and down
@@ -249,7 +249,7 @@ function hopping_operator(os_up::OpSum, os_dn::OpSum; drop_pairing_terms_tol=not
   if !all(abs.(h[1:N, (N + 1):(2 * N)]) .< drop_pairing_terms_tol)
     error("Trying to convert hamiltonian with pairing terms to hopping hamiltonian!")
   end
-  return h[(N + 1):(2 * N), (N + 1):(2 * N)]
+  return 2 .* h[(N + 1):(2 * N), (N + 1):(2 * N)]
 end
 
 function hopping_hamiltonian(os::OpSum; drop_pairing_terms_tol=nothing)

--- a/ITensorGaussianMPS/test/electron.jl
+++ b/ITensorGaussianMPS/test/electron.jl
@@ -149,7 +149,7 @@ end
   Φ_up = slater_determinant_matrix(h_up, Nf_up)
   Φ_dn = slater_determinant_matrix(h_dn, Nf_dn)
   ψ = slater_determinant_to_mps(s, Φ_up, Φ_dn; eigval_cutoff=0.0, cutoff=0.0)
-  @test inner(ψ', H, ψ) ≈ tr(Φ_up'h_up * Φ_up) + tr(Φ_dn'h_dn * Φ_dn)
+  @test inner(ψ', H, ψ) ≈ tr(Φ_up' * h_up * Φ_up) + tr(Φ_dn' * h_dn * Φ_dn)
   @test maxlinkdim(ψ) == 2
   @test flux(ψ) == QN(("Nf", 1, -1), ("Sz", 1))
   ns_up = expect_compat(ψ, "Nup")

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -48,9 +48,9 @@ end
 
   @test all(
     abs.(
-      ITensorGaussianMPS.reverse_interleave(Matrix(h_hopandpair))[
+      (2 .* ITensorGaussianMPS.reverse_interleave(Matrix(h_hopandpair))[
         (N + 1):end, (N + 1):end
-      ] - h_hop
+      ]) - h_hop
     ) .< eps(Float32),
   )
 end

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -48,9 +48,11 @@ end
 
   @test all(
     abs.(
-      (2 .* ITensorGaussianMPS.reverse_interleave(Matrix(h_hopandpair))[
-        (N + 1):end, (N + 1):end
-      ]) - h_hop
+      (
+        2 .* ITensorGaussianMPS.reverse_interleave(Matrix(h_hopandpair))[
+          (N + 1):end, (N + 1):end
+        ]
+      ) - h_hop
     ) .< eps(Float32),
   )
 end


### PR DESCRIPTION
# Description
This adds a missing factor of 2 converting the single-particle operator (Hamiltonian) returned from `quadratic_operator` to its number-conserving single-particle operator (Hamiltonian) form within `hopping-operator`. Ensures full consistency between the operator generated in the many-body picture via `MPO(os::OpSum)` and the single-particle picture via `quadratic_operator(os::OpSum)` and `hopping_operator(os::OpSum)`. The tests have been adjusted accordingly.
Fixes failing tests in previous PR #1038 .