### PR TITLE
[CI] Add example of an improved comment trigger workflow

### DIFF
--- a/.github/workflows/comment_trigger_example.yml
+++ b/.github/workflows/comment_trigger_example.yml
@@ -1,0 +1,60 @@
+name: Example comment trigger
+
+# https://dev.to/zirkelc/trigger-github-workflow-for-comment-on-pull-request-45l2
+
+jobs:
+  deploy:
+    name: Deploy
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/deploy')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR branch
+        uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+
+      - name: Set latest commit status as pending
+        uses: myrotvorets/set-commit-status-action@master
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+
+      - name: Setup Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Deploy
+        run: |
+          echo "Deploying..."
+
+      - name: Set latest commit status as ${{ job.status }}
+        uses: myrotvorets/set-commit-status-action@master
+        if: always()
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+
+      - name: Add comment to PR
+        uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            const name = '${{ github.workflow   }}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const success = '${{ job.status }}' === 'success';
+            const body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })

--- a/ITensorUnicodePlots/src/ITensorUnicodePlots.jl
+++ b/ITensorUnicodePlots/src/ITensorUnicodePlots.jl
@@ -1,5 +1,7 @@
 module ITensorUnicodePlots
 
+error("An error in ITensorUnicodePlots!")
+
 using Graphs
 using NetworkLayout
 using Reexport

--- a/ITensorUnicodePlots/src/ITensorUnicodePlots.jl
+++ b/ITensorUnicodePlots/src/ITensorUnicodePlots.jl
@@ -1,7 +1,5 @@
 module ITensorUnicodePlots
 
-error("An error in ITensorUnicodePlots!")
-
 using Graphs
 using NetworkLayout
 using Reexport


### PR DESCRIPTION
This adds an example of an improved comment trigger workflow, based on https://dev.to/zirkelc/trigger-github-workflow-for-comment-on-pull-request-45l2.

Currently the comment triggers only run on the latest commit of the `main` branch (see #1100), this new design would hopefully fix that. Additionally, the new design should show the tests running in the PR, and make a comment about the results of the workflow. I think it only runs once it is actually on `main` so I'll merge this and test it in future PRs.