### PR TITLE
[ITensorGaussianMPS] [Enhancement] Constrain diagonalization to fermionic transformations. 

### DIFF
--- a/ITensorGaussianMPS/examples/spinless_fermion_pairing.jl
+++ b/ITensorGaussianMPS/examples/spinless_fermion_pairing.jl
@@ -52,14 +52,14 @@ let
   @assert ishermitian(h)
   e = eigvals(Hermitian(h))
   @show e
-  E, V = gaussian_eigen(h)
+  E, V = eigen_gaussian(h)
   @show sum(E[1:N])
   Φ = V[:, 1:N]
-  c = conj(Φ) * transpose(Φ)
-
+  c = real.(conj(Φ) * transpose(Φ))
+  
   #Get (G)MPS
   psi = ITensorGaussianMPS.correlation_matrix_to_mps(
-    sites, real.(c); eigval_cutoff=1e-10, maxblocksize=14, cutoff=1e-11
+    sites, c; eigval_cutoff=1e-10, maxblocksize=14, cutoff=1e-11
   )
   @show eltype(psi[1])
   cdagc = correlation_matrix(psi, "C", "Cdag")

--- a/ITensorGaussianMPS/examples/spinless_fermion_pairing.jl
+++ b/ITensorGaussianMPS/examples/spinless_fermion_pairing.jl
@@ -6,17 +6,17 @@ using ITensorGaussianMPS
 
 ITensors.disable_contraction_sequence_optimization()
 let
-  N = 10
-  sites = siteinds("Fermion", N; conserve_qns=false)
+  N = 8
+  sites = siteinds("Fermion", N; conserve_qns=false, conserve_nfparity=true)
   _maxlinkdim = 100
   # DMRG cutoff
   _cutoff = 1e-13
   # Hopping
-  t = -1.2
+  t = -1.0
   # Electron-electron on-site interaction
   U = 0.0
   # Pairing
-  Delta = 0.7
+  Delta = 1.00
   @show t, U, Delta
   # Free fermion Hamiltonian
   os_h = OpSum()
@@ -49,16 +49,22 @@ let
   H = ITensors.MPO(os_h + os_p, sites)
 
   #Get Ground state 
-  E, V = eigen(Hermitian(h))
-  @show E
+  @assert ishermitian(h)
+  e = eigvals(Hermitian(h))
+  @show e
+  E, V = gaussian_eigen(h)
+  @show sum(E[1:N])
   Φ = V[:, 1:N]
   c = conj(Φ) * transpose(Φ)
 
   #Get (G)MPS
   psi = ITensorGaussianMPS.correlation_matrix_to_mps(
-    sites, c; eigval_cutoff=1e-10, maxblocksize=14, cutoff=1e-11
+    sites, real.(c); eigval_cutoff=1e-10, maxblocksize=14, cutoff=1e-11
   )
+  @show eltype(psi[1])
   cdagc = correlation_matrix(psi, "C", "Cdag")
+  cc = correlation_matrix(psi, "C", "C")
+
   println("\nFree fermion starting energy")
   @show flux(psi)
   @show inner(psi, H, psi)
@@ -67,6 +73,12 @@ let
   setmaxdim!(sweeps, 10, 20, 40, _maxlinkdim)
   setcutoff!(sweeps, _cutoff)
   _, psidmrg = dmrg(H, psi, sweeps)
+  cdagc_dmrg = correlation_matrix(psidmrg, "C", "Cdag")
+  cc_dmrg = correlation_matrix(psidmrg, "C", "C")
+
+  @show norm(cdagc_dmrg - cdagc)
+  @show norm(cc_dmrg - cc)
+
   @show inner(psidmrg, H, psidmrg)
   @show(abs(inner(psidmrg, psi)))
 

--- a/ITensorGaussianMPS/examples/spinless_fermion_pairing.jl
+++ b/ITensorGaussianMPS/examples/spinless_fermion_pairing.jl
@@ -56,7 +56,7 @@ let
   @show sum(E[1:N])
   Φ = V[:, 1:N]
   c = real.(conj(Φ) * transpose(Φ))
-  
+
   #Get (G)MPS
   psi = ITensorGaussianMPS.correlation_matrix_to_mps(
     sites, c; eigval_cutoff=1e-10, maxblocksize=14, cutoff=1e-11

--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -16,8 +16,9 @@ export slater_determinant_to_mps,
   quadratic_operator,
   slater_determinant_matrix,
   slater_determinant_to_gmera,
-  fermionic_eigen,
-  fermionic_diag_corr
+  gaussian_eigen,
+  gaussian_diag_corr,
+  get_gaussian_GS_corr
 
 include("gmps.jl")
 include("gmera.jl")

--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -4,7 +4,6 @@ using Compat
 using ITensors
 using ITensors.NDTensors
 using LinearAlgebra
-using F_utilities
 import LinearAlgebra: Givens
 
 export slater_determinant_to_mps,
@@ -16,9 +15,12 @@ export slater_determinant_to_mps,
   quadratic_hamiltonian,
   quadratic_operator,
   slater_determinant_matrix,
-  slater_determinant_to_gmera
+  slater_determinant_to_gmera,
+  fermionic_eigen,
+  fermionic_diag_corr
 
 include("gmps.jl")
 include("gmera.jl")
+include("linalg.jl")
 
 end

--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -16,9 +16,7 @@ export slater_determinant_to_mps,
   quadratic_operator,
   slater_determinant_matrix,
   slater_determinant_to_gmera,
-  gaussian_eigen,
-  gaussian_diag_corr,
-  get_gaussian_GS_corr
+  eigen_gaussian
 
 include("gmps.jl")
 include("gmera.jl")

--- a/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
+++ b/ITensorGaussianMPS/src/ITensorGaussianMPS.jl
@@ -4,7 +4,7 @@ using Compat
 using ITensors
 using ITensors.NDTensors
 using LinearAlgebra
-
+using F_utilities
 import LinearAlgebra: Givens
 
 export slater_determinant_to_mps,

--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -234,7 +234,7 @@ function hopping_operator(os::OpSum; drop_pairing_terms_tol=nothing)
   if !all(abs.(h[1:N, (N + 1):(2 * N)]) .< drop_pairing_terms_tol)
     error("Trying to convert hamiltonian with pairing terms to hopping hamiltonian!")
   end
-  return h[(N + 1):(2 * N), (N + 1):(2 * N)]
+  return 2 .* h[(N + 1):(2 * N), (N + 1):(2 * N)]
 end
 
 # Make a combined hopping Hamiltonian for spin up and down
@@ -249,7 +249,7 @@ function hopping_operator(os_up::OpSum, os_dn::OpSum; drop_pairing_terms_tol=not
   if !all(abs.(h[1:N, (N + 1):(2 * N)]) .< drop_pairing_terms_tol)
     error("Trying to convert hamiltonian with pairing terms to hopping hamiltonian!")
   end
-  return h[(N + 1):(2 * N), (N + 1):(2 * N)]
+  return 2 .* h[(N + 1):(2 * N), (N + 1):(2 * N)]
 end
 
 function hopping_hamiltonian(os::OpSum; drop_pairing_terms_tol=nothing)

--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -339,20 +339,34 @@ function givens_rotations(_v0::ConservesNfParity;)
   ElT = eltype(v0)
   gs = Circuit{ElT}([])
   v = copy(v0)
-  @show v
+  # detect if v is actually number-conserving because only defined in terms of annihilation operators
+  if norm(v[2:2:end])<10*eps(real(ElT))
+    r=v[1]
+    gsca, _ = givens_rotations(v[1:2:end])
+    replace_indices!(i -> 2 * i-1, gsca)
+    gscc = Circuit(copy(gsca.rotations))
+    replace_indices!(i -> i + 1, gsca)
+    conj!(gscc)
+    gsc = interleave(gscc, gsca)
+    LinearAlgebra.lmul!(gsc, gs)
+    return gs,r
+  end
   r = v[2]
-  ##Given's rotations from creation-operator coefficients
+  # Given's rotations from creation-operator coefficients
   gscc, _ = givens_rotations(v[2:2:end])
   replace_indices!(i -> 2 * i, gscc)
   gsca = Circuit(copy(gscc.rotations))
   replace_indices!(i -> i - 1, gsca)
   conj!(gsca)
   gsc = interleave(gscc, gsca)
-  v = gsc * v
-  @show v
   LinearAlgebra.lmul!(gsc, gs)
-
-  ##Given's rotations from annihilation-operator coefficients
+  # detect if v is actually number-conserving because only defined in terms of creation operators
+  if norm(v[1:2:end])<10*eps(real(ElT))
+    return gs,r
+  end
+  v = gsc * v
+  # if we get here, v was actually number-non conserving, so procedure
+  # Given's rotations from annihilation-operator coefficients
   gsaa, _ = givens_rotations(v[3:2:end])
   replace_indices!(i -> 2 * i + 1, gsaa)
   gsac = Circuit(copy(gsaa.rotations))
@@ -362,10 +376,8 @@ function givens_rotations(_v0::ConservesNfParity;)
   v = gsa * v
   LinearAlgebra.lmul!(gsa, gs)
 
-  ##Boguliobov rotation for remaining Bell pair
-  @show v[1:4]
+  # Boguliobov rotation for remaining Bell pair
   g1, r = givens(v, 2, 3)
-  @show g1.c,g1.s
   g2 = Givens(1, 4, g1.c, g1.s')
   v = g1 * v
   v = g2 * v #should have no effect
@@ -377,9 +389,9 @@ end
 function maybe_drop_pairing_correlations(Λ0::AbstractMatrix{ElT}) where {ElT<:Number}
   Λblocked = reverse_interleave(Λ0)
   N = div(size(Λblocked, 1), 2)
-  if all(x -> abs(x) <= eps(real(eltype(Λ0))), @view Λblocked[1:N, (N + 1):end])
-    #return ConservesNf(Λblocked[(N + 1):end, (N + 1):end])
-    return ConservesNfParity(Λ0)
+  if all(x -> abs(x) <= 10*eps(real(eltype(Λ0))), @view Λblocked[1:N, (N + 1):end])
+    return ConservesNf(Λblocked[(N + 1):end, (N + 1):end])
+    #return ConservesNfParity(Λ0)
   else
     return ConservesNfParity(Λ0)
   end
@@ -407,7 +419,7 @@ function isolate_subblock_eig(
   _Λ::AbstractSymmetry,
   startind::Int;
   eigval_cutoff::Float64=1e-8,
-  minblocksize::Int=1,
+  minblocksize::Int=2,
   maxblocksize::Int=div(size(_Λ.data, 1), 2),
 )
   blocksize = 0
@@ -425,29 +437,32 @@ function isolate_subblock_eig(
       (site_stride(_Λ) * i + 1 - site_stride(_Λ)):j,
       (site_stride(_Λ) * i + 1 - site_stride(_Λ)):j,
     ]
-    if typeof(_Λ) <: ConservesNf 
+    
+    if typeof(_Λ) <: ConservesNf
       nB, uB = eigen(Hermitian(ΛB))
     elseif typeof(_Λ) <: ConservesNfParity
-      nB, uB = Fu.Diag_gamma(Hermitian(reverse_interleave(ΛB)))
-      nB = diag(nB)
-      @show nB
-      nB = convert(Vector{eltype(_Λ.data)}, nB)
-      uB = convert(Matrix{eltype(_Λ.data)}, uB)
-      
-
-      #@show size(nB)
+      m=similar(ΛB)
+      m.=ΛB
+      _ΛB=maybe_drop_pairing_correlations(m)
+      if typeof(_ΛB) <: ConservesNf
+        nB, uB = eigen(Hermitian(_ΛB.data))
+        #promote basis uB to non-conserving frame
+        N2=size(nB,1) * 2
+        nuB=zeros(eltype(uB),N2,N2)
+        nuB[2:2:N2,1:2:N2] .= uB
+        nuB[1:2:N2,2:2:N2] .= conj(uB)
+        uB=nuB
+        nB=interleave(1 .- nB,nB,)
+      elseif typeof(_ΛB) <: ConservesNfParity
+        nB, uB = ITensorGaussianMPS.fermionic_diag_corr(Hermitian(ΛB))
+      end
     end
     nB = set_data(_Λ, abs.(nB))
     p = sortperm(nB)
     err = get_error(nB, p)
     err ≤ eigval_cutoff && break
   end
-  if typeof(_Λ) <: ConservesNf 
-    v = set_data(_Λ, @view uB[:, p[1]])
-  elseif typeof(_Λ) <: ConservesNfParity
-    n=div(length(nB),2)
-    v = set_data(_Λ, interleave(uB[1:n, p[1]],uB[n+1:end, p[1]]))
-  end
+  v = set_data(_Λ, @view uB[:, p[1]])
   return v, nB, err
 end
 
@@ -538,23 +553,28 @@ function correlation_matrix_to_gmps(
   minblocksize::Int=1,
   maxblocksize::Int=size(Λ0.data, 1),
 ) where {T<:AbstractSymmetry}
-  Λ = T(Hermitian(copy(Λ0.data)))
-  ElT = eltype(Λ.data)
+  ElT = eltype(Λ0.data)
+  if T<:ConservesNfParity && ElT<:Real && false
+    ElT=complex(ElT)
+    ##FIXME: is there a way to not hardcode Matrix type here? More generally, how to best handle nested parametric types?
+    newT=ConservesNfParity{Matrix{complex(eltype(Λ0.data))}} 
+    Λ = newT(Hermitian(ElT.(copy(Λ0.data))))
+  else
+    Λ = T(Hermitian(copy((Λ0.data))))
+  end
   V = Circuit{ElT}([])
   err_tot = 0.0 ### FIXME: keep track of error below
-  Λ = maybe_drop_pairing_correlations(Λ)
   N = size(Λ.data, 1)
-  ns = set_data(Λ, Vector{real(ElT)}(undef, N))
+  #ns = set_data(Λ, Vector{real(ElT)}(undef, N))
   for i in 1:div(N, site_stride(Λ))
     err = 0.0
-    v, nB, err = isolate_subblock_eig(
+    v, _, err = isolate_subblock_eig(
       Λ,
       i;
       eigval_cutoff=eigval_cutoff,
       minblocksize=minblocksize,
       maxblocksize=maxblocksize,
     )
-    set_occupations!(ns, nB, v, i)
     if stop_gmps_sweep(v)
       break
     end
@@ -567,7 +587,10 @@ function correlation_matrix_to_gmps(
     Λ = set_data(Λ, Hermitian(g * Matrix(Λ.data) * g'))
   end
   ###return non-wrapped occupations for backwards compatibility
-  return ns.data, V
+  ns=diag(Λ.data)
+  @assert norm(imag.(ns))<=sqrt(eps(real(ElT)))
+
+  return real(real.(ns)), V
 end
 
 function (x::AbstractSymmetry * y::AbstractSymmetry)

--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -420,7 +420,7 @@ function isolate_subblock_eig(
   startind::Int;
   eigval_cutoff::Float64=1e-8,
   minblocksize::Int=2,
-  maxblocksize::Int=div(size(_Λ.data, 1), 2),
+  maxblocksize::Int=div(size(_Λ.data, 1), 1),
 )
   blocksize = 0
   err = 0.0
@@ -455,7 +455,7 @@ function isolate_subblock_eig(
         uB = nuB
         nB = interleave(1 .- nB, nB)
       elseif typeof(_ΛB) <: ConservesNfParity
-        nB, uB = ITensorGaussianMPS.gaussian_diag_corr(Hermitian(ΛB))
+        nB, uB = ITensorGaussianMPS.diag_corr_gaussian(Hermitian(ΛB))
         #try to rotate to real
         uB = ITensorGaussianMPS.make_real_if_possible(uB, nB .- 0.5)
         if ElT <: Real

--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -1,7 +1,5 @@
 import Base: sortperm, size, length, eltype, conj, transpose, copy, *
 abstract type AbstractSymmetry end
-const Fu=F_utilities
-
 struct ConservesNfParity{T} <: AbstractSymmetry
   data::T
 end

--- a/ITensorGaussianMPS/src/linalg.jl
+++ b/ITensorGaussianMPS/src/linalg.jl
@@ -1,30 +1,58 @@
-const Fu=F_utilities
 
-function build_Ω(N::Int)
-    return Fu.Build_Omega(div(N,2))
+"""Takes a single-particle Hamiltonian in blocked Dirac format and finds the fermionic transformation U that diagonalizes it"""
+function _fermionic_eigen(H)
+    #make sure H is Hermitian
+    H=Hermitian(H)
+    ElT=eltype(H)
+    #convert from Dirac to Majorana picture
+    N=size(H,1)
+    Ω=build_Ω(ElT,N)
+    h = real(-im .* (Ω * H * Ω'))
+    h = (h-h') ./ 2
+    # Schur diagonalize including reordering
+    _,O,vals=order_schur(schur(h))
+    # convert back to Dirac Frame
+    Fxpxx=build_Fxpxx(N)
+    U= Ω' * O * (Fxpxx') *  Ω
+    d=vcat(-vals,vals)
+    if ElT<:Real
+        U = make_real_if_possible(U,d)
+        # make another pass with rotation in the complex plane per eigenvector
+        U .*= exp.(-im*angle.(U[1:1,:]))
+        @assert norm(imag.(U))<sqrt(eps(real(ElT)))
+        U=real(real.(U))
+    end
+    return d,U
 end
 
-
-
-function build_Fxpxx(N::Int)
-    return Fu.Build_FxpTxx(div(N,2))
+"""Takes a single-particle Hamiltonian in interlaced Dirac format and finds the fermionic transformation U that diagonalizes it"""
+function fermionic_eigen(H)
+    d,U=_fermionic_eigen(ITensorGaussianMPS.reverse_interleave(H))
+    nU=similar(U)
+    n=div(size(H,1),2)
+    nU[1:2:end,:]=U[1:n,:]
+    nU[2:2:end,:]=U[n+1:end,:]
+    return d,nU
 end
 
-function get_ordered_Schur(h::AbstractMatrix)
-    T,O,vals=order_schur(schur(h))
-    
+"""Takes a single-particle correlation matrix in interlaced Dirac format and finds the fermionic transformation U that diagonalizes it"""
+function fermionic_diag_corr(Λ::Hermitian)
+    #shift correlation matrix by half so spectrum is symmetric around 0
+    populations, U = fermionic_eigen(Λ-0.5*I)
+    n = diag(U'*Λ*U)
+    @assert all(abs.(populations- (n -0.5*ones(size(n)))) .< 1e-8)
+    return n,U
 end
 
-function compare_schur(h)
-    T,O,vals=get_ordered_Schur(h)
-    T2,O2=Fu.Diag_real_skew(h)
-    @show T
-    @show T2
-    @show O
-    @show O2
+"""Takes a single-particle correlation matrix in interlaced Dirac format and finds the fermionic transformation U that diagonalizes it"""
+function fermionic_diag_corr(Γ::AbstractMatrix)
+    #enforcing hermitianity
+    Γ = (Γ+Γ')/2.
+    return fermionic_diag_corr(Hermitian(Γ))
 end
 
-function order_schur(F::Schur)
+"""Schur decomposition of skew-hermitian matrix"""
+function order_schur(F::LinearAlgebra.Schur)
     T=F.Schur
     O=F.vectors #column vectors are Schur vectors
     
@@ -33,55 +61,112 @@ function order_schur(F::Schur)
     shuffled_inds=Vector{Int}[]
     ElT=eltype(T)
     vals=ElT[]
-    ###build a permutation matrix that takes care of the ordering
-    ###build block local rotation first
-    ###then permute blocks for overall ordering
+    # build a permutation matrix that takes care of the ordering
     for i in 1:n
         ind=2*i-1
         val=T[ind,ind+1]
-        if val>=0
+        if real(val)>=0
             push!(shuffled_inds,[ind,ind+1])
         else
             push!(shuffled_inds,[ind+1,ind])
         end
         push!(vals,abs(val))
     end
-    perm=sortperm(vals,rev=true)    ##we want the upper left corner to be the largest absolute value eigval pair?
-    sort!(vals)
+    # build block local rotation first
+    perm=sortperm(real.(vals),rev=true)    ##we want the upper left corner to be the largest absolute value eigval pair?
+    vals=vals[perm]
     shuffled_inds=reduce(vcat,shuffled_inds[perm])
-
+    # then permute blocks for overall ordering
     T=T[shuffled_inds,shuffled_inds]
     O=O[:,shuffled_inds]
-    return T,O,vals ##vals being only positive, and of length n and not N
+    return T,O,vals #vals are only positive, and of length n and not N
 end
 
-"""
-function Build_Omega(N_f)
-    #Build the matrix omega of dimension 2*N_f, that is for N_f fermions.
-     Omega                                 = zeros(Complex{Float64}, 2*N_f, 2*N_f);
-     Omega[1:N_f,1:N_f]                    = (1/(sqrt(2)))*eye(N_f);
-     Omega[1:N_f,(1:N_f)+N_f]              = (1/(sqrt(2)))*eye(N_f);
-     Omega[(1:N_f)+N_f,1:N_f]              = im*(1/(sqrt(2)))*eye(N_f);
-     Omega[(1:N_f)+N_f,(1:N_f)+N_f]        = -im*(1/(sqrt(2)))*eye(N_f);
-     return Omega
+
+"""Checks if we can make degenerate subspaces of a U0 real by multiplying columns or rows with a phase"""
+function make_real_if_possible(U0::AbstractMatrix,spectrum::Vector;sigdigits=14)
+    # only apply to first half of spectrum due to symmetry around 0
+    # assumes spectrum symmetric around zero and ordered as vcat(-E,E) where E is ordered in descending magnitude
+    U=copy(U0)
+    n=div(length(spectrum),2)
+    # Round spectrum for comparison within finite floating point precision.
+    # Not the cleanest way to compare floating point numbers for approximate equality but should be sufficient here.
+    rounded_halfspectrum=round.(spectrum[1:n], sigdigits=sigdigits)
+    approx_unique_eigvals=unique(rounded_halfspectrum)
+    # loop over degenerate subspaces
+    for e in approx_unique_eigvals        
+        mask = rounded_halfspectrum .== e
+        if abs(e)<eps(real(eltype(U0)))
+            # handle values close to zero separately
+            # rotate subspace for both positive and negative eigenvalue if they are close enough to zero
+            mask=vcat(mask,mask)
+            subspace=copy(U[:,:][:,mask])
+            subspace=make_subspace_real_if_possible(subspace)
+            v=@views U[:,:][:,mask]
+            v .= subspace
+        else
+            mask = rounded_halfspectrum .== e
+            # rotate suspace for the negative eigenvalue
+            subspace=copy(U[:,1:n][:,mask])
+            subspace=make_subspace_real_if_possible(subspace)
+            v=@views U[:,1:n][:,mask]
+            v .= subspace
+            # rotate suspace for the positive eigenvalue
+            subspace=copy(U[:,n+1:end][:,mask])
+            subspace=make_subspace_real_if_possible(subspace)
+            v=@views U[:,n+1:end][:,mask]
+            v .= subspace
+        end
     end
+    return U
+end
+
+"""Checks if we can make a degenerate subspace of the eigenbasis of an operator real by multiplying columns or rows with a phase"""
+function make_subspace_real_if_possible(U::AbstractMatrix;atol=1e-11)
+    if eltype(U) <: Real
+        return U
+    end
+    if size(U,2)==1
+        nU = U .* exp(-im*angle(U[1,1]))
+        if all(abs.(imag.(nU)) .<= atol)
+            return nU
+        else
+            return U
+        end
+    else
+        n=size(U,2)
+        gram= U * U'
+        if all(abs.(imag.(gram)) .<= atol)
+            D,V=eigen(Hermitian(real.(gram)))
+            proj=V[:,size(U,1)-n+1:end] * (V[:,size(U,1)-n+1:end])'
+            @assert norm(proj*U - U) < atol
+            return complex(V[:,size(U,1)-n+1:end]) 
+        else
+            return U
+        end
+    end
+end
+
+
     
-function Build_FxxTxp(N_f)
-    FxxTxp = zeros(Int64, 2*N_f, 2*N_f);
-    for iiter=1:N_f
-    FxxTxp[2*iiter-1,iiter]    = 1;
-    FxxTxp[2*iiter, iiter+N_f] = 1;
-    end
-    return FxxTxp
+
+# transformation matrices (in principle sparse) between and within Majorana and Dirac picture
+
+function build_Ω(T,N::Int)
+    n=div(N,2)
+    nElT= T<:Real ? Complex{T} : T
+    Ω=zeros(nElT,N,N)
+    Ω[1:n,1:n] .= diagm(ones(nElT,n) ./ sqrt(2))
+    Ω[1:n,n+1:N] .= diagm(ones(nElT,n) ./ sqrt(2))
+    Ω[n+1:N,1:n] .= diagm(ones(nElT,n) * (im/sqrt(2)))
+    Ω[n+1:N,n+1:N] .= diagm(ones(nElT,n) * (-im/sqrt(2)))
+    return Ω
 end
 
-function Build_FxpTxx(N_f)
-    FxpTxx = zeros(Int64, 2*N_f, 2*N_f)
-    for iiter=1:N_f
-    FxpTxx[iiter,2*iiter-1]    = 1;
-    FxpTxx[iiter+N_f, 2*iiter] = 1;
-    end
-
-    return FxpTxx
+function build_Fxpxx(N::Int)
+    Fxpxx = zeros(Int8, N, N)
+    n=div(N,2)
+    Fxpxx[1:n,1:2:N] .= diagm(ones(Int8,n))
+    Fxpxx[n+1:N,2:2:N] .= diagm(ones(Int8,n))
+    return Fxpxx
 end
-"""

--- a/ITensorGaussianMPS/src/linalg.jl
+++ b/ITensorGaussianMPS/src/linalg.jl
@@ -135,7 +135,7 @@ function make_real_if_possible(U0::AbstractMatrix, spectrum::Vector; sigdigits=1
       subspace = U[:, mask]
       subspace = make_subspace_real_if_possible(subspace)
       U[:, mask] = subspace
-      
+
     else
       mask = rounded_halfspectrum .== e
       # rotate suspace for the negative eigenvalue

--- a/ITensorGaussianMPS/src/linalg.jl
+++ b/ITensorGaussianMPS/src/linalg.jl
@@ -1,0 +1,87 @@
+const Fu=F_utilities
+
+function build_Ω(N::Int)
+    return Fu.Build_Omega(div(N,2))
+end
+
+
+
+function build_Fxpxx(N::Int)
+    return Fu.Build_FxpTxx(div(N,2))
+end
+
+function get_ordered_Schur(h::AbstractMatrix)
+    T,O,vals=order_schur(schur(h))
+    
+end
+
+function compare_schur(h)
+    T,O,vals=get_ordered_Schur(h)
+    T2,O2=Fu.Diag_real_skew(h)
+    @show T
+    @show T2
+    @show O
+    @show O2
+end
+
+function order_schur(F::Schur)
+    T=F.Schur
+    O=F.vectors #column vectors are Schur vectors
+    
+    N=size(T,1)
+    n=div(N,2)
+    shuffled_inds=Vector{Int}[]
+    ElT=eltype(T)
+    vals=ElT[]
+    ###build a permutation matrix that takes care of the ordering
+    ###build block local rotation first
+    ###then permute blocks for overall ordering
+    for i in 1:n
+        ind=2*i-1
+        val=T[ind,ind+1]
+        if val>=0
+            push!(shuffled_inds,[ind,ind+1])
+        else
+            push!(shuffled_inds,[ind+1,ind])
+        end
+        push!(vals,abs(val))
+    end
+    perm=sortperm(vals,rev=true)    ##we want the upper left corner to be the largest absolute value eigval pair?
+    sort!(vals)
+    shuffled_inds=reduce(vcat,shuffled_inds[perm])
+
+    T=T[shuffled_inds,shuffled_inds]
+    O=O[:,shuffled_inds]
+    return T,O,vals ##vals being only positive, and of length n and not N
+end
+
+"""
+function Build_Omega(N_f)
+    #Build the matrix omega of dimension 2*N_f, that is for N_f fermions.
+     Omega                                 = zeros(Complex{Float64}, 2*N_f, 2*N_f);
+     Omega[1:N_f,1:N_f]                    = (1/(sqrt(2)))*eye(N_f);
+     Omega[1:N_f,(1:N_f)+N_f]              = (1/(sqrt(2)))*eye(N_f);
+     Omega[(1:N_f)+N_f,1:N_f]              = im*(1/(sqrt(2)))*eye(N_f);
+     Omega[(1:N_f)+N_f,(1:N_f)+N_f]        = -im*(1/(sqrt(2)))*eye(N_f);
+     return Omega
+    end
+    
+function Build_FxxTxp(N_f)
+    FxxTxp = zeros(Int64, 2*N_f, 2*N_f);
+    for iiter=1:N_f
+    FxxTxp[2*iiter-1,iiter]    = 1;
+    FxxTxp[2*iiter, iiter+N_f] = 1;
+    end
+    return FxxTxp
+end
+
+function Build_FxpTxx(N_f)
+    FxpTxx = zeros(Int64, 2*N_f, 2*N_f)
+    for iiter=1:N_f
+    FxpTxx[iiter,2*iiter-1]    = 1;
+    FxpTxx[iiter+N_f, 2*iiter] = 1;
+    end
+
+    return FxpTxx
+end
+"""

--- a/ITensorGaussianMPS/src/linalg.jl
+++ b/ITensorGaussianMPS/src/linalg.jl
@@ -1,7 +1,14 @@
+"""
+Some of the functionality in this script is closely related to routines in the following package
+https://github.com/Jacupo/F_utilities
+and the associated publication
+10.21468/SciPostPhysLectNotes.54
+"""
 
 """Takes a single-particle Hamiltonian in blocked Dirac format and finds the fermionic transformation U that diagonalizes it"""
 function _fermionic_eigen(H)
     #make sure H is Hermitian
+    @assert ishermitian(H)
     H=Hermitian(H)
     ElT=eltype(H)
     #convert from Dirac to Majorana picture
@@ -40,7 +47,7 @@ function fermionic_diag_corr(Λ::Hermitian)
     #shift correlation matrix by half so spectrum is symmetric around 0
     populations, U = fermionic_eigen(Λ-0.5*I)
     n = diag(U'*Λ*U)
-    @assert all(abs.(populations- (n -0.5*ones(size(n)))) .< 1e-8)
+    @assert all(abs.(populations- (n -0.5*ones(size(n)))) .< sqrt(eps(real(eltype(Λ)))))
     return n,U
 end
 
@@ -122,7 +129,7 @@ function make_real_if_possible(U0::AbstractMatrix,spectrum::Vector;sigdigits=14)
 end
 
 """Checks if we can make a degenerate subspace of the eigenbasis of an operator real by multiplying columns or rows with a phase"""
-function make_subspace_real_if_possible(U::AbstractMatrix;atol=1e-11)
+function make_subspace_real_if_possible(U::AbstractMatrix;atol=sqrt(eps(real(eltype(U)))))
     if eltype(U) <: Real
         return U
     end

--- a/ITensorGaussianMPS/src/linalg.jl
+++ b/ITensorGaussianMPS/src/linalg.jl
@@ -6,174 +6,196 @@ and the associated publication
 """
 
 """Takes a single-particle Hamiltonian in blocked Dirac format and finds the fermionic transformation U that diagonalizes it"""
-function _fermionic_eigen(H)
-    #make sure H is Hermitian
-    @assert ishermitian(H)
-    H=Hermitian(H)
-    ElT=eltype(H)
-    #convert from Dirac to Majorana picture
-    N=size(H,1)
-    Ω=build_Ω(ElT,N)
-    h = real(-im .* (Ω * H * Ω'))
-    h = (h-h') ./ 2
-    # Schur diagonalize including reordering
-    _,O,vals=order_schur(schur(h))
-    # convert back to Dirac Frame
-    Fxpxx=build_Fxpxx(N)
-    U= Ω' * O * (Fxpxx') *  Ω
-    d=vcat(-vals,vals)
-    if ElT<:Real
-        U = make_real_if_possible(U,d)
-        # make another pass with rotation in the complex plane per eigenvector
-        U .*= exp.(-im*angle.(U[1:1,:]))
-        @assert norm(imag.(U))<sqrt(eps(real(ElT)))
-        U=real(real.(U))
-    end
-    return d,U
+function _gaussian_eigen_blocked(H; pert=nothing)
+  #make sure H is Hermitian
+  @assert ishermitian(H)
+  H = Hermitian(H)
+  ElT = eltype(H)
+  #convert from Dirac to Majorana picture
+  N = size(H, 1)
+  Ω = build_Ω(ElT, N)
+  h = real(-im .* (Ω * H * Ω'))
+  h = (h - h') ./ 2
+  #@show size(h)
+  if !isnothing(pert)
+    noise = rand(size(h)...) * pert
+    noise = (noise - noise') ./ 2
+    h = h + noise
+  end
+  # Schur diagonalize including reordering
+  _, O, vals = order_schur(schur(h))
+  # convert back to Dirac Frame
+  Fxpxx = build_Fxpxx(N)
+  U = Ω' * O * (Fxpxx') * Ω
+  d = vcat(-vals, vals)
+  if ElT <: Real
+    U = make_real_if_possible(U, d)
+    # make another pass with rotation in the complex plane per eigenvector
+    U .*= exp.(-im * angle.(U[1:1, :]))
+    @assert norm(imag.(U)) < sqrt(eps(real(ElT)))
+    U = real(real.(U))
+  end
+  return d, U
 end
 
-"""Takes a single-particle Hamiltonian in interlaced Dirac format and finds the fermionic transformation U that diagonalizes it"""
-function fermionic_eigen(H)
-    d,U=_fermionic_eigen(ITensorGaussianMPS.reverse_interleave(H))
-    nU=similar(U)
-    n=div(size(H,1),2)
-    nU[1:2:end,:]=U[1:n,:]
-    nU[2:2:end,:]=U[n+1:end,:]
-    return d,nU
+"""Takes a single-particle Hamiltonian in interlaced Dirac format and finds the complex fermionic transformation U that diagonalizes it."""
+function gaussian_eigen(H; pert=nothing)
+  d, U = _gaussian_eigen_blocked(
+    ITensorGaussianMPS.reverse_interleave(complex(H)); pert=pert
+  )
+  nU = similar(U)
+  n = div(size(H, 1), 2)
+  nU[1:2:end, :] = U[1:n, :]
+  nU[2:2:end, :] = U[(n + 1):end, :]
+  return d, nU
+end
+
+"""Takes a single-particle Hamiltonian in interlaced Dirac format and outputs the ground state correlation matrix (with the input Hamiltonians element type)."""
+function get_gaussian_GS_corr(H::AbstractMatrix; pert=nothing)
+  ElT = eltype(H)
+  d, U = gaussian_eigen(H; pert=pert)
+  n = div(size(H, 1), 2)
+  c = conj(U[:, 1:n]) * transpose(U[:, 1:n])
+  if ElT <: Real && norm(imag.(c)) <= sqrt(eps(real(ElT)))
+    c = real(real.(c))
+  end
+  return c
 end
 
 """Takes a single-particle correlation matrix in interlaced Dirac format and finds the fermionic transformation U that diagonalizes it"""
-function fermionic_diag_corr(Λ::Hermitian)
-    #shift correlation matrix by half so spectrum is symmetric around 0
-    populations, U = fermionic_eigen(Λ-0.5*I)
-    n = diag(U'*Λ*U)
-    @assert all(abs.(populations- (n -0.5*ones(size(n)))) .< sqrt(eps(real(eltype(Λ)))))
-    return n,U
+function gaussian_diag_corr(Λ::Hermitian; pert=nothing)
+  #shift correlation matrix by half so spectrum is symmetric around 0
+  populations, U = gaussian_eigen(Λ - 0.5 * I; pert=pert)
+  n = diag(U' * Λ * U)
+  if !all(abs.(populations - (n - 0.5 * ones(size(n)))) .< sqrt(eps(real(eltype(Λ)))))
+    @show n
+    @show populations .+ 0.5
+    @error(
+      "The natural orbital populations are not consistent, see above. Try adding symmetric noise to the input matrix."
+    )
+  end
+  return populations .+ 0.5, U
 end
 
 """Takes a single-particle correlation matrix in interlaced Dirac format and finds the fermionic transformation U that diagonalizes it"""
-function fermionic_diag_corr(Γ::AbstractMatrix)
-    #enforcing hermitianity
-    Γ = (Γ+Γ')/2.
-    return fermionic_diag_corr(Hermitian(Γ))
+function gaussian_diag_corr(Γ::AbstractMatrix; pert=nothing)
+  #enforcing hermitianity
+  Γ = (Γ + Γ') / 2.0
+  return gaussian_diag_corr(Hermitian(Γ); pert=pert)
 end
 
 """Schur decomposition of skew-hermitian matrix"""
 function order_schur(F::LinearAlgebra.Schur)
-    T=F.Schur
-    O=F.vectors #column vectors are Schur vectors
-    
-    N=size(T,1)
-    n=div(N,2)
-    shuffled_inds=Vector{Int}[]
-    ElT=eltype(T)
-    vals=ElT[]
-    # build a permutation matrix that takes care of the ordering
-    for i in 1:n
-        ind=2*i-1
-        val=T[ind,ind+1]
-        if real(val)>=0
-            push!(shuffled_inds,[ind,ind+1])
-        else
-            push!(shuffled_inds,[ind+1,ind])
-        end
-        push!(vals,abs(val))
+  T = F.Schur
+  O = F.vectors #column vectors are Schur vectors
+
+  N = size(T, 1)
+  n = div(N, 2)
+  shuffled_inds = Vector{Int}[]
+  ElT = eltype(T)
+  vals = ElT[]
+  # build a permutation matrix that takes care of the ordering
+  for i in 1:n
+    ind = 2 * i - 1
+    val = T[ind, ind + 1]
+    if real(val) >= 0
+      push!(shuffled_inds, [ind, ind + 1])
+    else
+      push!(shuffled_inds, [ind + 1, ind])
     end
-    # build block local rotation first
-    perm=sortperm(real.(vals),rev=true)    ##we want the upper left corner to be the largest absolute value eigval pair?
-    vals=vals[perm]
-    shuffled_inds=reduce(vcat,shuffled_inds[perm])
-    # then permute blocks for overall ordering
-    T=T[shuffled_inds,shuffled_inds]
-    O=O[:,shuffled_inds]
-    return T,O,vals #vals are only positive, and of length n and not N
+    push!(vals, abs(val))
+  end
+  # build block local rotation first
+  perm = sortperm(real.(vals); rev=true)    ##we want the upper left corner to be the largest absolute value eigval pair?
+  vals = vals[perm]
+  shuffled_inds = reduce(vcat, shuffled_inds[perm])
+  # then permute blocks for overall ordering
+  T = T[shuffled_inds, shuffled_inds]
+  O = O[:, shuffled_inds]
+  return T, O, vals #vals are only positive, and of length n and not N
 end
 
-
 """Checks if we can make degenerate subspaces of a U0 real by multiplying columns or rows with a phase"""
-function make_real_if_possible(U0::AbstractMatrix,spectrum::Vector;sigdigits=14)
-    # only apply to first half of spectrum due to symmetry around 0
-    # assumes spectrum symmetric around zero and ordered as vcat(-E,E) where E is ordered in descending magnitude
-    U=copy(U0)
-    n=div(length(spectrum),2)
-    # Round spectrum for comparison within finite floating point precision.
-    # Not the cleanest way to compare floating point numbers for approximate equality but should be sufficient here.
-    rounded_halfspectrum=round.(spectrum[1:n], sigdigits=sigdigits)
-    approx_unique_eigvals=unique(rounded_halfspectrum)
-    # loop over degenerate subspaces
-    for e in approx_unique_eigvals        
-        mask = rounded_halfspectrum .== e
-        if abs(e)<eps(real(eltype(U0)))
-            # handle values close to zero separately
-            # rotate subspace for both positive and negative eigenvalue if they are close enough to zero
-            mask=vcat(mask,mask)
-            subspace=copy(U[:,:][:,mask])
-            subspace=make_subspace_real_if_possible(subspace)
-            v=@views U[:,:][:,mask]
-            v .= subspace
-        else
-            mask = rounded_halfspectrum .== e
-            # rotate suspace for the negative eigenvalue
-            subspace=copy(U[:,1:n][:,mask])
-            subspace=make_subspace_real_if_possible(subspace)
-            v=@views U[:,1:n][:,mask]
-            v .= subspace
-            # rotate suspace for the positive eigenvalue
-            subspace=copy(U[:,n+1:end][:,mask])
-            subspace=make_subspace_real_if_possible(subspace)
-            v=@views U[:,n+1:end][:,mask]
-            v .= subspace
-        end
+function make_real_if_possible(U0::AbstractMatrix, spectrum::Vector; sigdigits=12)
+  # only apply to first half of spectrum due to symmetry around 0
+  # assumes spectrum symmetric around zero and ordered as vcat(-E,E) where E is ordered in descending magnitude
+  U = copy(U0)
+  n = div(length(spectrum), 2)
+  # Round spectrum for comparison within finite floating point precision.
+  # Not the cleanest way to compare floating point numbers for approximate equality but should be sufficient here.
+  rounded_halfspectrum = round.(spectrum[1:n], sigdigits=sigdigits)
+  approx_unique_eigvals = unique(rounded_halfspectrum)
+  # loop over degenerate subspaces
+  for e in approx_unique_eigvals
+    mask = rounded_halfspectrum .== e
+    if abs(e) < eps(real(eltype(U0)))
+      # handle values close to zero separately
+      # rotate subspace for both positive and negative eigenvalue if they are close enough to zero
+      mask = vcat(mask, mask)
+      subspace = copy(U[:, :][:, mask])
+      subspace = make_subspace_real_if_possible(subspace)
+      v = @views U[:, :][:, mask]
+      v .= subspace
+    else
+      mask = rounded_halfspectrum .== e
+      # rotate suspace for the negative eigenvalue
+      subspace = copy(U[:, 1:n][:, mask])
+      subspace = make_subspace_real_if_possible(subspace)
+      v = @views U[:, 1:n][:, mask]
+      v .= subspace
+      # rotate suspace for the positive eigenvalue
+      subspace = copy(U[:, (n + 1):end][:, mask])
+      subspace = make_subspace_real_if_possible(subspace)
+      v = @views U[:, (n + 1):end][:, mask]
+      v .= subspace
     end
-    return U
+  end
+  return U
 end
 
 """Checks if we can make a degenerate subspace of the eigenbasis of an operator real by multiplying columns or rows with a phase"""
-function make_subspace_real_if_possible(U::AbstractMatrix;atol=sqrt(eps(real(eltype(U)))))
-    if eltype(U) <: Real
-        return U
-    end
-    if size(U,2)==1
-        nU = U .* exp(-im*angle(U[1,1]))
-        if all(abs.(imag.(nU)) .<= atol)
-            return nU
-        else
-            return U
-        end
+function make_subspace_real_if_possible(U::AbstractMatrix; atol=sqrt(eps(real(eltype(U)))))
+  if eltype(U) <: Real
+    return U
+  end
+  if size(U, 2) == 1
+    nU = U .* exp(-im * angle(U[1, 1]))
+    if norm(imag.(nU)) .<= atol
+      return nU
     else
-        n=size(U,2)
-        gram= U * U'
-        if all(abs.(imag.(gram)) .<= atol)
-            D,V=eigen(Hermitian(real.(gram)))
-            proj=V[:,size(U,1)-n+1:end] * (V[:,size(U,1)-n+1:end])'
-            @assert norm(proj*U - U) < atol
-            return complex(V[:,size(U,1)-n+1:end]) 
-        else
-            return U
-        end
+      return U
     end
+  else
+    n = size(U, 2)
+    gram = U * U'
+    if norm(imag.(gram)) .<= atol
+      D, V = eigen(Hermitian(real.(gram)))
+      proj = V[:, (size(U, 1) - n + 1):end] * (V[:, (size(U, 1) - n + 1):end])'
+      @assert norm(proj * U - U) < atol
+      return complex(V[:, (size(U, 1) - n + 1):end])
+    else
+      return U
+    end
+  end
 end
-
-
-    
 
 # transformation matrices (in principle sparse) between and within Majorana and Dirac picture
 
-function build_Ω(T,N::Int)
-    n=div(N,2)
-    nElT= T<:Real ? Complex{T} : T
-    Ω=zeros(nElT,N,N)
-    Ω[1:n,1:n] .= diagm(ones(nElT,n) ./ sqrt(2))
-    Ω[1:n,n+1:N] .= diagm(ones(nElT,n) ./ sqrt(2))
-    Ω[n+1:N,1:n] .= diagm(ones(nElT,n) * (im/sqrt(2)))
-    Ω[n+1:N,n+1:N] .= diagm(ones(nElT,n) * (-im/sqrt(2)))
-    return Ω
+function build_Ω(T, N::Int)
+  n = div(N, 2)
+  nElT = T <: Real ? Complex{T} : T
+  Ω = zeros(nElT, N, N)
+  Ω[1:n, 1:n] .= diagm(ones(nElT, n) ./ sqrt(2))
+  Ω[1:n, (n + 1):N] .= diagm(ones(nElT, n) ./ sqrt(2))
+  Ω[(n + 1):N, 1:n] .= diagm(ones(nElT, n) * (im / sqrt(2)))
+  Ω[(n + 1):N, (n + 1):N] .= diagm(ones(nElT, n) * (-im / sqrt(2)))
+  return Ω
 end
 
 function build_Fxpxx(N::Int)
-    Fxpxx = zeros(Int8, N, N)
-    n=div(N,2)
-    Fxpxx[1:n,1:2:N] .= diagm(ones(Int8,n))
-    Fxpxx[n+1:N,2:2:N] .= diagm(ones(Int8,n))
-    return Fxpxx
+  Fxpxx = zeros(Int8, N, N)
+  n = div(N, 2)
+  Fxpxx[1:n, 1:2:N] .= diagm(ones(Int8, n))
+  Fxpxx[(n + 1):N, 2:2:N] .= diagm(ones(Int8, n))
+  return Fxpxx
 end

--- a/ITensorGaussianMPS/test/electron.jl
+++ b/ITensorGaussianMPS/test/electron.jl
@@ -149,7 +149,7 @@ end
   Φ_up = slater_determinant_matrix(h_up, Nf_up)
   Φ_dn = slater_determinant_matrix(h_dn, Nf_dn)
   ψ = slater_determinant_to_mps(s, Φ_up, Φ_dn; eigval_cutoff=0.0, cutoff=0.0)
-  @test inner(ψ', H, ψ) ≈ tr(Φ_up'h_up * Φ_up) + tr(Φ_dn'h_dn * Φ_dn)
+  @test inner(ψ', H, ψ) ≈ tr(Φ_up' * h_up * Φ_up) + tr(Φ_dn' * h_dn * Φ_dn)
   @test maxlinkdim(ψ) == 2
   @test flux(ψ) == QN(("Nf", 1, -1), ("Sz", 1))
   ns_up = expect_compat(ψ, "Nup")

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -68,11 +68,10 @@ end
 
     # Hopping Hamiltonian
     h = Hermitian(diagm(1 => fill(-t, N - 1), -1 => fill(-conj(t), N - 1)))
-    if θ ==0.0
-      h=real(h)
+    if θ == 0.0
+      h = real(h)
     end
     e, u = eigen(h)
-    
 
     @test h * u ≈ u * Diagonal(e)
 
@@ -120,17 +119,16 @@ end
 end
 
 @testset "Fermion BCS (real,real - no pairing, complex)" begin
-  N = 8
+  N = 12
   Nf = N ÷ 2
-  t = -1.0
-  taus = [0.0, 0.0, 1.0]
-  Deltas = [1.3, 0.0, 0.7]
-  ElTs = [Real, Real, Complex]
-  for (tau, Delta, ElT) in zip(taus, Deltas, ElTs)
+  ts = [1.0, exp(im * pi / 3.0), 1.0]
+  Deltas = [1.0, 1.0, 0.0]
+  for (Delta, t) in zip(Deltas, ts)
+    t = isreal(t) ? real(t) : t
     os_h = OpSum()
     for n in 1:(N - 1)
       os_h .+= -t, "Cdag", n, "C", n + 1
-      os_h .+= -t, "Cdag", n + 1, "C", n
+      os_h .+= -t', "Cdag", n + 1, "C", n
     end
     os_p = OpSum()
     for n in 1:(N - 1)
@@ -139,66 +137,45 @@ end
       os_p .+= -Delta / 2.0, "C", n, "C", n + 1
       os_p .+= Delta / 2.0, "C", n + 1, "C", n
     end
-    Delta2 = Delta + 0.2
-    os_p2 = OpSum()
-    for n in 1:(N - 1)
-      os_p2 .+= Delta2 / 2.0, "Cdag", n, "Cdag", n + 1
-      os_p2 .+= -Delta2 / 2.0, "Cdag", n + 1, "Cdag", n
-      os_p2 .+= -Delta2 / 2.0, "C", n, "C", n + 1
-      os_p2 .+= Delta2 / 2.0, "C", n + 1, "C", n
-    end
-    h = ITensorGaussianMPS.quadratic_hamiltonian(os_h + os_p)
-    h2 = ITensorGaussianMPS.quadratic_hamiltonian(os_h + os_p2)
-    e, u = ITensorGaussianMPS.fermionic_eigen(real.(h))
 
-    
-    order=sortperm(real.(e))
-    e=e[order]
-    u=u[:,order]
-    E = sum(e[1:N-1])
+    h = ITensorGaussianMPS.quadratic_hamiltonian(os_h + os_p)
+    @assert ishermitian(h)
+    ElT = eltype(h)
+    e, u = ITensorGaussianMPS.gaussian_eigen(h)
+    E = sum(e[1:(N)])
     Φ = (u[:, 1:N])
     @test h * Φ ≈ Φ * Diagonal(e[1:N])
     c = conj(Φ) * transpose(Φ)
-    c=ITensorGaussianMPS.reverse_interleave(c)
-    if Delta==0.0
-      c[1:N,N+1:end].=0
-      c[N+1:end,1:N].=0
+    c2 = ITensorGaussianMPS.get_gaussian_GS_corr(h)
+    @test norm(c - c2) <= sqrt(eps(real(eltype(h))))
+    if ElT <: Real
+      @assert norm(imag.(c)) <= sqrt(eps())
+      c = real.(c)
     end
-    c-=imag.(c)
-    c=ITensorGaussianMPS.interleave(c)
-    if tau != 0.0
-      Ud = exp(-tau * 1im * h2) ##generate complex state by time-evolving with perturbed Hamiltonian
-      c = Ud' * c * Ud
-    elseif ElT<:Real 
-      c=real.(c)
-    end
-    n, gmps = correlation_matrix_to_gmps(ElT.(c), N; maxblocksize=12, eigval_cutoff=1e-12)
+    n, gmps = correlation_matrix_to_gmps(ElT.(c), N; eigval_cutoff=1e-10, maxblocksize=14)
     ns = round.(Int, n)
     @test sum(ns) == N
-    
+
     Λ = ITensorGaussianMPS.ConservesNfParity(c)
     @test gmps * Λ.data * gmps' ≈ Diagonal(ns) rtol = 1e-2
     @test gmps' * Diagonal(ns) * gmps ≈ Λ.data rtol = 1e-2
-    
+
     # Form the MPS
     s = siteinds("Fermion", N; conserve_qns=false)
     h_mpo = MPO(os_h + os_p, s)
     psi = correlation_matrix_to_mps(
       s, ElT.(c); eigval_cutoff=1e-10, maxblocksize=14, cutoff=1e-11
     )
-    @test eltype(psi[1])<:ElT
-    
-    if tau == 0.0
-      sweeps = Sweeps(5)
-      _maxlinkdim = 60
-      _cutoff = 1e-10
-      setmaxdim!(sweeps, 10, 20, 40, _maxlinkdim)
-      setcutoff!(sweeps, _cutoff)
-      E_dmrg, psidmrg = dmrg(h_mpo, psi, sweeps; outputlevel=0)
-      E_ni_mpo = inner(psi', h_mpo, psi)
-      @test E_dmrg ≈ E_ni_mpo rtol = 1e-4
-      @test inner(psidmrg, psi) ≈ 1 rtol = 1e-4
-    end
+    @test eltype(psi[1]) <: ElT
+    sweeps = Sweeps(5)
+    _maxlinkdim = 60
+    _cutoff = 1e-10
+    setmaxdim!(sweeps, 10, 20, 40, _maxlinkdim)
+    setcutoff!(sweeps, _cutoff)
+    E_dmrg, psidmrg = dmrg(h_mpo, psi, sweeps; outputlevel=0)
+    E_ni_mpo = inner(psi', h_mpo, psi)
+    @test E_dmrg ≈ E_ni_mpo rtol = 1e-4
+    @test inner(psidmrg, psi) ≈ 1 rtol = 1e-4
 
     # compare entries of the correlation matrix
     cdagc = correlation_matrix(psi, "Cdag", "C")
@@ -211,6 +188,6 @@ end
     @test all(abs.(cblocked[1:N, 1:N] - ccdag[:, :]) .< tol)
     @test all(abs.(cblocked[1:N, (N + 1):end] - cc[:, :]) .< tol)
     @test all(abs.(cblocked[(N + 1):end, 1:N] - cdagcdag[:, :]) .< tol)
-    @show "Completed test for: ", tau, Delta, ElT
+    @show "Completed test for: ", Delta, t
   end
 end

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -48,9 +48,9 @@ end
 
   @test all(
     abs.(
-      ITensorGaussianMPS.reverse_interleave(Matrix(h_hopandpair))[
+      (2 .* ITensorGaussianMPS.reverse_interleave(Matrix(h_hopandpair))[
         (N + 1):end, (N + 1):end
-      ] - h_hop
+      ]) - h_hop
     ) .< eps(Float32),
   )
 end

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -48,9 +48,11 @@ end
 
   @test all(
     abs.(
-      (2 .* ITensorGaussianMPS.reverse_interleave(Matrix(h_hopandpair))[
-        (N + 1):end, (N + 1):end
-      ]) - h_hop
+      (
+        2 .* ITensorGaussianMPS.reverse_interleave(Matrix(h_hopandpair))[
+          (N + 1):end, (N + 1):end
+        ]
+      ) - h_hop
     ) .< eps(Float32),
   )
 end

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -2,10 +2,7 @@ using ITensorGaussianMPS
 using ITensors
 using LinearAlgebra
 using Test
-using F_utilities
-const Fu = F_utilities
-using PyPlot
-matplotlib.use("QtAgg")
+
 @testset "Basic" begin
   # Test Givens rotations
   v = randn(6)
@@ -152,27 +149,14 @@ end
     end
     h = ITensorGaussianMPS.quadratic_hamiltonian(os_h + os_p)
     h2 = ITensorGaussianMPS.quadratic_hamiltonian(os_h + os_p2)
-   # e, u = Fu.Diag_h(ITensorGaussianMPS.reverse_interleave(real.(h)))
     e, u = ITensorGaussianMPS.fermionic_eigen(real.(h))
-   # e = diag(e)
-   # @test e ≈ e2
+
     
     order=sortperm(real.(e))
     e=e[order]
     u=u[:,order]
-    @show e
-    plot(e)
-    show()
-    iu = similar(u)
-    n=div(length(e),2)
-    #iu[1:2:end,:]=u[1:n,:]
-    #iu[2:2:end,:]=u[n+1:end,:]
-    #u=iu
-    #e, u = eigen(h)
-    #E = sum(vcat(e[1:N-1],e[N+3:N+3]))
     E = sum(e[1:N-1])
     Φ = (u[:, 1:N])
-    #Φ = hcat(u[:, 1:N-1],u[:, N+3:N+3])
     @test h * Φ ≈ Φ * Diagonal(e[1:N])
     c = conj(Φ) * transpose(Φ)
     c=ITensorGaussianMPS.reverse_interleave(c)
@@ -182,51 +166,28 @@ end
     end
     c-=imag.(c)
     c=ITensorGaussianMPS.interleave(c)
-    
-    nex,_=Fu.Diag_h(ITensorGaussianMPS.reverse_interleave(c))
-    #@show sort(diag(nex))
-    #matshow(ITensorGaussianMPS.reverse_interleave(real.(c)))
-    #matshow(ITensorGaussianMPS.reverse_interleave(imag.(c)))
-    
-    show()
     if tau != 0.0
       Ud = exp(-tau * 1im * h2) ##generate complex state by time-evolving with perturbed Hamiltonian
       c = Ud' * c * Ud
     elseif ElT<:Real 
       c=real.(c)
-      
     end
-    matshow(abs.(c))
-    show()
     n, gmps = correlation_matrix_to_gmps(ElT.(c), N; maxblocksize=12, eigval_cutoff=1e-12)
     ns = round.(Int, n)
-
-    #if Delta == 0.0
-    #  @test sum(ns) == Nf
-    #else
     @test sum(ns) == N
-    #end
-
-    #Λ = ITensorGaussianMPS.maybe_drop_pairing_correlations(c)
+    
     Λ = ITensorGaussianMPS.ConservesNfParity(c)
-    @show eltype(Λ)
-    @show size(ns), size(Λ.data)
-    matshow(real.(gmps * Λ.data * gmps'))
-    matshow(real.(Diagonal(ns)))
-    show()
     @test gmps * Λ.data * gmps' ≈ Diagonal(ns) rtol = 1e-2
     @test gmps' * Diagonal(ns) * gmps ≈ Λ.data rtol = 1e-2
-    @show eltype(gmps' * Diagonal(ns) * gmps)
-    @show eltype(gmps * Λ.data * gmps')
     
     # Form the MPS
     s = siteinds("Fermion", N; conserve_qns=false)
     h_mpo = MPO(os_h + os_p, s)
-
     psi = correlation_matrix_to_mps(
       s, ElT.(c); eigval_cutoff=1e-10, maxblocksize=14, cutoff=1e-11
     )
-    @show eltype(psi[1])
+    @test eltype(psi[1])<:ElT
+    
     if tau == 0.0
       sweeps = Sweeps(5)
       _maxlinkdim = 60
@@ -235,9 +196,7 @@ end
       setcutoff!(sweeps, _cutoff)
       E_dmrg, psidmrg = dmrg(h_mpo, psi, sweeps; outputlevel=0)
       E_ni_mpo = inner(psi', h_mpo, psi)
-      #@test E_dmrg*2 ≈ E rtol = 1e-4
       @test E_dmrg ≈ E_ni_mpo rtol = 1e-4
-
       @test inner(psidmrg, psi) ≈ 1 rtol = 1e-4
     end
 
@@ -248,8 +207,6 @@ end
     cc = correlation_matrix(psi, "C", "C")
     cblocked = ITensorGaussianMPS.reverse_interleave(c)
     tol = 1e-5
-    #@show maximum(abs.(cblocked[(N + 1):end, (N + 1):end] - cdagc[:, :]))
-    #@show maximum(abs.(cblocked[1:N, (N + 1):end] - cc[:, :]))
     @test all(abs.(cblocked[(N + 1):end, (N + 1):end] - cdagc[:, :]) .< tol)
     @test all(abs.(cblocked[1:N, 1:N] - ccdag[:, :]) .< tol)
     @test all(abs.(cblocked[1:N, (N + 1):end] - cc[:, :]) .< tol)

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -141,7 +141,7 @@ end
     h = ITensorGaussianMPS.quadratic_hamiltonian(os_h + os_p)
     @assert ishermitian(h)
     ElT = eltype(h)
-    e, u = ITensorGaussianMPS.gaussian_eigen(h)
+    e, u = ITensorGaussianMPS.eigen_gaussian(h)
     E = sum(e[1:(N)])
     Φ = (u[:, 1:N])
     @test h * Φ ≈ Φ * Diagonal(e[1:N])

--- a/ITensorGaussianMPS/test/linalg.jl
+++ b/ITensorGaussianMPS/test/linalg.jl
@@ -18,7 +18,7 @@ const GMPS = ITensorGaussianMPS
   H[(N + 1):end, (N + 1):end] = hd
   H = (H + H') ./ 2
   # compare spectrum, which can also accurately be computed via standard eigendecomposition   
-  d, U = GMPS._gaussian_eigen(Hermitian(H))
+  d, U = GMPS._gaussian_eigen_blocked(Hermitian(H))
   d2, _ = eigen(Hermitian(H))
   d3, _ = GMPS.gaussian_eigen(Hermitian(GMPS.interleave(H)))
   @test sort(d) ≈ sort(d2)

--- a/ITensorGaussianMPS/test/linalg.jl
+++ b/ITensorGaussianMPS/test/linalg.jl
@@ -18,9 +18,9 @@ const GMPS = ITensorGaussianMPS
   H[(N + 1):end, (N + 1):end] = hd
   H = (H + H') ./ 2
   # compare spectrum, which can also accurately be computed via standard eigendecomposition   
-  d, U = GMPS._gaussian_eigen_blocked(Hermitian(H))
+  d, U = GMPS._eigen_gaussian_blocked(Hermitian(H))
   d2, _ = eigen(Hermitian(H))
-  d3, _ = GMPS.gaussian_eigen(Hermitian(GMPS.interleave(H)))
+  d3, _ = GMPS.eigen_gaussian(Hermitian(GMPS.interleave(H)))
   @test sort(d) ≈ sort(d2)
   @test sort(d) ≈ sort(d3)
 end

--- a/ITensorGaussianMPS/test/linalg.jl
+++ b/ITensorGaussianMPS/test/linalg.jl
@@ -2,37 +2,35 @@ using ITensorGaussianMPS
 using ITensors
 using LinearAlgebra
 using Test
-const GMPS=ITensorGaussianMPS
+const GMPS = ITensorGaussianMPS
 
 @testset "Fermionic Hamiltonian diagonalization in parity-conserving frame" begin
-    N=10
-    # generate random Hamiltonian in non-number-conserving space
-    H=zeros(ComplexF64,2*N,2*N)
-    hoffd=rand(N,N) .- 0.5 + im*(rand(N,N) .- 0.5)
-    hoffd = (hoffd-transpose(hoffd)) ./ 2
-    H[1:N,N+1:end]=hoffd
-    H[N+1:end,1:N]=-conj.(hoffd)
-    hd=rand(N,N) .-0.5 + im*(rand(N,N) .- 0.5)
-    hd=(hd+hd') ./ 2
-    H[1:N,1:N]= -1 .* conj.(hd)
-    H[N+1:end,N+1:end]=hd
-    H=(H+H') ./ 2
-    # compare spectrum, which can also accurately be computed via standard eigendecomposition   
-    d,U=GMPS._fermionic_eigen(Hermitian(H))
-    d2,_=eigen(Hermitian(H))
-    d3,_=GMPS.fermionic_eigen(Hermitian(GMPS.interleave(H)))
-    @test sort(d) ≈ sort(d2)
-    @test sort(d) ≈ sort(d3)
-    end
-
-@testset "Undoing arbitrary complex rotation within degenerate subspaces" begin
-    A = (x -> Matrix(qr(x).Q))(randn(5, 3))
-    U = (x -> Matrix(qr(x).Q))(randn(ComplexF64, 3, 3))
-    AU = A*U
-    B = GMPS.make_subspace_real_if_possible(AU)
-    # verify that same subspace is spanned by real eigenvectors B as original eigenvectors A or AU 
-    @test norm(( (B * B' * A) .- A)) <= eps(Float64)*10
-    @test norm(( (B * B' * AU) .- AU)) <= eps(Float64)*10
+  N = 10
+  # generate random Hamiltonian in non-number-conserving space
+  H = zeros(ComplexF64, 2 * N, 2 * N)
+  hoffd = rand(N, N) .- 0.5 + im * (rand(N, N) .- 0.5)
+  hoffd = (hoffd - transpose(hoffd)) ./ 2
+  H[1:N, (N + 1):end] = hoffd
+  H[(N + 1):end, 1:N] = -conj.(hoffd)
+  hd = rand(N, N) .- 0.5 + im * (rand(N, N) .- 0.5)
+  hd = (hd + hd') ./ 2
+  H[1:N, 1:N] = -1 .* conj.(hd)
+  H[(N + 1):end, (N + 1):end] = hd
+  H = (H + H') ./ 2
+  # compare spectrum, which can also accurately be computed via standard eigendecomposition   
+  d, U = GMPS._gaussian_eigen(Hermitian(H))
+  d2, _ = eigen(Hermitian(H))
+  d3, _ = GMPS.gaussian_eigen(Hermitian(GMPS.interleave(H)))
+  @test sort(d) ≈ sort(d2)
+  @test sort(d) ≈ sort(d3)
 end
 
-
+@testset "Undoing arbitrary complex rotation within degenerate subspaces" begin
+  A = (x -> Matrix(qr(x).Q))(randn(5, 3))
+  U = (x -> Matrix(qr(x).Q))(randn(ComplexF64, 3, 3))
+  AU = A * U
+  B = GMPS.make_subspace_real_if_possible(AU)
+  # verify that same subspace is spanned by real eigenvectors B as original eigenvectors A or AU 
+  @test norm(((B * B' * A) .- A)) <= eps(Float64) * 10
+  @test norm(((B * B' * AU) .- AU)) <= eps(Float64) * 10
+end

--- a/ITensorGaussianMPS/test/linalg.jl
+++ b/ITensorGaussianMPS/test/linalg.jl
@@ -1,0 +1,38 @@
+using ITensorGaussianMPS
+using ITensors
+using LinearAlgebra
+using Test
+const GMPS=ITensorGaussianMPS
+
+@testset "Fermionic Hamiltonian diagonalization in parity-conserving frame" begin
+    N=10
+    # generate random Hamiltonian in non-number-conserving space
+    H=zeros(ComplexF64,2*N,2*N)
+    hoffd=rand(N,N) .- 0.5 + im*(rand(N,N) .- 0.5)
+    hoffd = (hoffd-transpose(hoffd)) ./ 2
+    H[1:N,N+1:end]=hoffd
+    H[N+1:end,1:N]=-conj.(hoffd)
+    hd=rand(N,N) .-0.5 + im*(rand(N,N) .- 0.5)
+    hd=(hd+hd') ./ 2
+    H[1:N,1:N]= -1 .* conj.(hd)
+    H[N+1:end,N+1:end]=hd
+    H=(H+H') ./ 2
+    # compare spectrum, which can also accurately be computed via standard eigendecomposition   
+    d,U=GMPS._fermionic_eigen(Hermitian(H))
+    d2,_=eigen(Hermitian(H))
+    d3,_=GMPS.fermionic_eigen(Hermitian(GMPS.interleave(H)))
+    @test sort(d) ≈ sort(d2)
+    @test sort(d) ≈ sort(d3)
+    end
+
+@testset "Undoing arbitrary complex rotation within degenerate subspaces" begin
+    A = (x -> Matrix(qr(x).Q))(randn(5, 3))
+    U = (x -> Matrix(qr(x).Q))(randn(ComplexF64, 3, 3))
+    AU = A*U
+    B = GMPS.make_subspace_real_if_possible(AU)
+    # verify that same subspace is spanned by real eigenvectors B as original eigenvectors A or AU 
+    @test norm(( (B * B' * A) .- A)) <= eps(Float64)*10
+    @test norm(( (B * B' * AU) .- AU)) <= eps(Float64)*10
+end
+
+

--- a/ITensorGaussianMPS/test/runtests.jl
+++ b/ITensorGaussianMPS/test/runtests.jl
@@ -5,4 +5,5 @@ using Test
 @testset "ITensorGaussianMPS.jl" begin
   include("gmps.jl")
   include("electron.jl")
+  include("linalg.jl")
 end


### PR DESCRIPTION
# Description

This PR implements diagonalization of quadratic operators via Schur decomposition in the Majorana representation. This improves numerical stability across all of parameter space, especially in cases where standard eigendecomposition does not result in gaussian fermionic eigenstates due to spectral (quasi)degeneracies. Furthermore, `correlation_matrix_to_gmps` is now returning a circuit which diagonalizes the input correlation matrix even when a number-conserving correlation matrix is input as a parity-conserving correlation matrix.
A few non-exhaustive tests for the newly introduced linear algebra routines are added (the functionality being otherwise tested indirectly in the `*gmps` routine tests).
