### PR TITLE
Fix periodic square_lattice point

### DIFF
--- a/src/physics/lattices.jl
+++ b/src/physics/lattices.jl
@@ -86,7 +86,7 @@ function square_lattice(Nx::Int, Ny::Int; kwargs...)::Lattice
         latt[b += 1] = LatticeBond(n, n + 1, x, y, x, y + 1)
       end
       if yperiodic && y == 1
-        latt[b += 1] = LatticeBond(n, n + Ny - 1, x, y, x, y + Ny)
+        latt[b += 1] = LatticeBond(n, n + Ny - 1, x, y, x, y + Ny - 1)
       end
     end
   end


### PR DESCRIPTION
# Description

Fix `square_lattice` from https://itensor.discourse.group/t/multiple-exchange-interactions-in-2d-lattices/692
Previously the point pair was `(x,1)->(x,1+Ny)` and now will be `(x,1)->(x,Ny)`
