### PR TITLE
[ITensors][Enhancement] Add logarithmic inner product of two MPS with MPO

### DIFF
--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -354,7 +354,7 @@ function deprecate_make_inds_match!(
   return ydag, A, x
 end
 
-function _dot(
+function _log_or_not_dot(
   y::MPS, A::MPO, x::MPS, loginner::Bool; make_inds_match::Bool=true, kwargs...
 )::Number
   N = length(A)
@@ -393,7 +393,7 @@ end
 Same as [`inner`](@ref).
 """
 function dot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool=true, kwargs...)
-  return _dot(y, A, x, false; make_inds_match=make_inds_match, kwargs...)
+  return _log_or_not_dot(y, A, x, false; make_inds_match=make_inds_match, kwargs...)
 end
 
 """
@@ -403,7 +403,7 @@ end
     Same as [`loginner`](@ref).
 """
 function logdot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool=true, kwargs...)
-  return _dot(y, A, x, true; make_inds_match=make_inds_match, kwargs...)
+  return _log_or_not_dot(y, A, x, true; make_inds_match=make_inds_match, kwargs...)
 end
 
 """

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -354,8 +354,9 @@ function deprecate_make_inds_match!(
   return ydag, A, x
 end
 
-
-function _dot(y::MPS, A::MPO, x::MPS, loginner::Bool; make_inds_match::Bool=true, kwargs...)::Number
+function _dot(
+  y::MPS, A::MPO, x::MPS, loginner::Bool; make_inds_match::Bool=true, kwargs...
+)::Number
   N = length(A)
   check_hascommoninds(siteinds, A, x)
   ydag = dag(y)
@@ -391,7 +392,9 @@ end
 
 Same as [`inner`](@ref).
 """
-dot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool=true, kwargs...) = _dot(y, A, x, false; make_inds_match=make_inds_match, kwargs...)
+function dot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool=true, kwargs...)
+  return _dot(y, A, x, false; make_inds_match=make_inds_match, kwargs...)
+end
 
 """
     logdot(B::MPO, y::MPS, A::MPO, x::MPS)
@@ -399,7 +402,9 @@ dot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool=true, kwargs...) = _dot(y, A, 
     This is useful for larger MPS/MPO, where in the limit of large numbers of sites the inner product can diverge or approach zero.
     Same as [`loginner`](@ref).
 """
-logdot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool=true, kwargs...) = _dot(y, A, x, true; make_inds_match=make_inds_match, kwargs...)
+function logdot(y::MPS, A::MPO, x::MPS; make_inds_match::Bool=true, kwargs...)
+  return _dot(y, A, x, true; make_inds_match=make_inds_match, kwargs...)
+end
 
 """
     inner(y::MPS, A::MPO, x::MPS)
@@ -482,8 +487,6 @@ function dot(B::MPO, y::MPS, A::MPO, x::MPS; make_inds_match::Bool=true, kwargs.
   end
   return O[]
 end
-
-
 
 # TODO: maybe make these into tuple inputs?
 # Also can generalize to:

--- a/test/ITensorLegacyMPS/base/test_mpo.jl
+++ b/test/ITensorLegacyMPS/base/test_mpo.jl
@@ -147,6 +147,19 @@ end
     end
   end
 
+  @testset "loginner <y|A|x>" begin
+    n = 4
+    c = 2
+
+    s = siteinds("S=1/2", n)
+    ψ = c .* randomMPS(s; linkdims=4)
+    Φ = c .* randomMPS(s; linkdims=4)
+    K = randomMPO(sites)
+
+    @test log(inner(ψ,K,Φ)) ≈ loginner(ψ,K,Φ)
+  end
+
+
   @testset "inner <By|A|x>" begin
     phi = makeRandomMPS(sites)
 

--- a/test/ITensorLegacyMPS/base/test_mpo.jl
+++ b/test/ITensorLegacyMPS/base/test_mpo.jl
@@ -156,7 +156,7 @@ end
     Φ = c .* randomMPS(s; linkdims=4)
     K = randomMPO(s)
 
-    @test log(inner(ψ', K, Φ)) ≈ loginner(ψ', K, Φ)
+    @test log(complex(inner(ψ', K, Φ))) ≈ loginner(ψ', K, Φ)
   end
 
   @testset "inner <By|A|x>" begin

--- a/test/ITensorLegacyMPS/base/test_mpo.jl
+++ b/test/ITensorLegacyMPS/base/test_mpo.jl
@@ -154,9 +154,9 @@ end
     s = siteinds("S=1/2", n)
     ψ = c .* randomMPS(s; linkdims=4)
     Φ = c .* randomMPS(s; linkdims=4)
-    K = randomMPO(sites)
+    K = randomMPO(s)
 
-    @test log(inner(ψ,K,Φ)) ≈ loginner(ψ,K,Φ)
+    @test log(inner(ψ',K,Φ)) ≈ loginner(ψ',K,Φ)
   end
 
 

--- a/test/ITensorLegacyMPS/base/test_mpo.jl
+++ b/test/ITensorLegacyMPS/base/test_mpo.jl
@@ -156,9 +156,8 @@ end
     Φ = c .* randomMPS(s; linkdims=4)
     K = randomMPO(s)
 
-    @test log(inner(ψ',K,Φ)) ≈ loginner(ψ',K,Φ)
+    @test log(inner(ψ', K, Φ)) ≈ loginner(ψ', K, Φ)
   end
-
 
   @testset "inner <By|A|x>" begin
     phi = makeRandomMPS(sites)


### PR DESCRIPTION
# Description

This adds a logarithmic inner product `<x|A|y>`  as `logdot(x::MPS, A::MPO, y::MPS)` and with alias `loginner`. A test of the new functionality has been added. The implementation of `dot` in `mpo.jl` has been moved to `_dot`, with a boolean argument switching between either normal dot product or `logdot`.