### PR TITLE
[ITensors] drop maxQNs, allow for dynamic setting of QN register

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -386,6 +386,7 @@ export
   isfermionic,
   modulus,
   val,
+  QNVal,
 
   # qn/qnindex.jl
   blockdim,

--- a/src/qn/qn.jl
+++ b/src/qn/qn.jl
@@ -239,7 +239,9 @@ function (a::QN + b::QN)
       ma_dict[bname] = ma_dict[bname] + b[nb]
     end
   end
-  ma = MVector{length(keys(ma_dict)),QNVal}(p[2] for p in sort(collect(ma_dict)))
+  ma = MVector{length(keys(ma_dict)),QNVal}(
+    p[2] for p in sort(collect(ma_dict); by=p -> p[1])
+  )
   return QN(ma)
 end
 

--- a/test/base/test_qn.jl
+++ b/test/base/test_qn.jl
@@ -64,6 +64,9 @@ import ITensors: nactive
 
     q = QN(("A", 1), ("B", 2), ("C", 3), ("D", 4))
     @test nactive(q) == 4
+
+    @test QN(("Sz", 0), ("Sx", 0), ("Sy", 2), ("X", 3), ("B", 4)) ==
+      QN(("B", 4), ("Sx", 0), ("Sy", 2), ("Sz", 0), ("X", 3))
   end
 
   @testset "Comparison" begin

--- a/test/base/test_qn.jl
+++ b/test/base/test_qn.jl
@@ -64,10 +64,6 @@ import ITensors: nactive
 
     q = QN(("A", 1), ("B", 2), ("C", 3), ("D", 4))
     @test nactive(q) == 4
-
-    @test_throws BoundsError begin
-      q = QN(("A", 1), ("B", 2), ("C", 3), ("D", 4), ("E", 5))
-    end
   end
 
   @testset "Comparison" begin
@@ -99,7 +95,7 @@ import ITensors: nactive
   end
 
   @testset "Ordering" begin
-    z = QN()
+    z = QN(("", 0))
     qa = QN(("Sz", 1), ("Nf", 1))
     qb = QN(("Sz", 0), ("Nf", 2))
     qc = QN(("Sz", 1), ("Nf", 2))


### PR DESCRIPTION
# Description

This is a draft PR to improve functionality for ITensor's QN registers to allow for more than values, currently hard-coded to `maxQNs=4`. This is needed for larger scale machine learning / optimization tasks. Rather than maintain our own fork, I want to see if this is something you'd be interested to have in the original repo. At larger register size, it is easier to handle much of the arithmetic with hash maps (`Dict` or `OrderedCollections.OrderedDict` type) rather than `StaticArray` types. If you are interested in merging this in, I can update the data struct to use Dict or OrderedDict entirely, rather than moving between `SVector`/`MVector` types. I wanted to post for feedback first before completing the full PR.

cc @yzcj105/@jingc769 and @ArtemStrashko

Fixes #(issue)

Allows for QN struct to have more than 4 QNVals

<details><summary>Previously, QN fails out for 5+ qnvals</summary><p>

```julia
julia> QN(("Sz", 0), ("Sx", 0), ("Sy", 2), ("X", 3), ("B", 4))
ERROR: BoundsError: attempt to access 4-element StaticArraysCore.MVector{4, ITensors.QNVal} with indices SOneTo(4) at index [5]
...
```
</p></details>

<details><summary>New implementation will succeed</summary><p>

```julia
julia> QN(("Sz", 0), ("Sx", 0), ("Sy", 2), ("X", 3), ("B", 4))
QN(("B",4),("Sx",0),("Sy",2),("Sz",0),("X",3))
```
</p></details>

# How Has This Been Tested?

Current tests already provide equality/inequality and ordering checks to ensure new code didn't break anything

- [x] Dropped `@test_throws BoundsError` when QN with 5 qnvals is created
- [x] Changed it to an equality check

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
