### PR TITLE
Better error message if calling MPO constructor with opsum in wrong position

### DIFF
--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -92,6 +92,12 @@ end
 
 MPO(sites::Vector{<:Index}, ops) = MPO(Float64, sites, ops)
 
+function MPO(sites::Vector{<:Index}, os::OpSum)
+  return error(
+    "To construct an MPO from an OpSum `opsum` and a set of indices `sites`, you must use MPO(opsum, sites)",
+  )
+end
+
 """
     MPO([::Type{ElT} = Float64, ]sites, op::String)
 


### PR DESCRIPTION
# Description


Previously, calling
```julia
sites = siteinds(...)
opsum = OpSum()
...
H = MPO(sites,opsum)
```
would return a long and unhelpful error message and stack trace. See [this user's post on the forum](https://itensor.discourse.group/t/fermionic-operators/798/3).

This PR explicitly returns a helpful error message if the above constructor is called.

# How Has This Been Tested?

Will check if existing tests pass.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
