### PR TITLE
[ITensors] Support for MPO*MPO contraction by densitymatrix method

### DIFF
--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -1071,10 +1071,3 @@ function HDF5.read(parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, ::
   v = [read(g, "MPO[$(i)]", ITensor) for i in 1:N]
   return MPO(v, llim, rlim)
 end
-
-function contract(::Algorithm"densitymatrix", M1::MPO, M2::MPO; kwargs...)::MPO
-  t1 = MPO([M1[v] for v in eachindex(M1)])
-  t2 = MPS([M2[v] for v in eachindex(M2)])
-  t12 = contract(t1, t2; alg="densitymatrix", kwargs...)
-  return MPO([t12[v] for v in eachindex(M1)])
-end

--- a/test/ITensorLegacyMPS/base/test_mpo.jl
+++ b/test/ITensorLegacyMPS/base/test_mpo.jl
@@ -814,4 +814,14 @@ end
   end
 end
 
+@testset "MPO*MPO contraction (densitymatrix)" begin
+  R = 3
+  sites = [Index(2, "Qubit,n=$n") for n in 1:R]
+  a = replaceprime(randomMPO(sites), 0 => 1, 1 => 2)
+  b = randomMPO(sites)
+  ab_ref = contract(a, b; alg="naive")
+  ab = contract(a, b; alg="densitymatrix")
+  @test ab_ref ≈ ab
+end
+
 nothing

--- a/test/ITensorLegacyMPS/base/test_mpo.jl
+++ b/test/ITensorLegacyMPS/base/test_mpo.jl
@@ -812,16 +812,22 @@ end
     result = sample(mt, L)
     @test result ≈ [1, 2, 1, 1, 2, 2]
   end
-end
 
-@testset "MPO*MPO contraction (densitymatrix)" begin
-  R = 3
-  sites = [Index(2, "Qubit,n=$n") for n in 1:R]
-  a = replaceprime(randomMPO(sites), 0 => 1, 1 => 2)
-  b = randomMPO(sites)
-  ab_ref = contract(a, b; alg="naive")
-  ab = contract(a, b; alg="densitymatrix")
-  @test ab_ref ≈ ab
+  @testset "MPO*MPO contraction (densitymatrix)" begin
+    R = 3
+    sites = [Index(2, "Qubit,n=$n") for n in 1:R]
+    a = replaceprime(randomMPO(sites), 0 => 1, 1 => 2)
+    b = randomMPO(sites)
+    ab_ref = contract(a, b; alg="naive")
+
+    # MPO-MPO contraction
+    ab = contract(a, b; alg="densitymatrix")
+    @test ab_ref ≈ ab
+
+    # MPO-MPS contraction
+    ab_MPS = contract(a, MPS([b[n] for n in eachindex(b)]); alg="densitymatrix")
+    @test ab_ref ≈ MPO([ab_MPS[n] for n in eachindex(ab_MPS)])
+  end
 end
 
 nothing


### PR DESCRIPTION
# Description

Based on discussions with Miles.

This small patch allows contracting an MPO and an MPS with a dangling bond at each site. This is intended to be a minimal and tentative patch that will eventually be replaced by ITensorNetworks.jl.

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
using ITensors

R = 3
sites = [Index(2, "Qubit,n=$n") for n in 1:R]
a = replaceprime(randomMPO(sites), 0 => 1, 1 => 2)
b = randomMPO(sites)
ab_ref = contract(a, b; alg="naive")
ab = contract(a, b; alg="densitymatrix")

ERROR: MethodError: no method matching contract(::NDTensors.Algorithm{:densitymatrix}, ::MPO, ::MPO)

Closest candidates are:
  contract(::NDTensors.Algorithm{:naive}, ::MPO, ::MPO; kwargs...)
   @ ITensors ~/.julia/packages/ITensors/HjjU3/src/mps/mpo.jl:801
  contract(::NDTensors.Algorithm{:densitymatrix}, ::MPO, ::MPS; kwargs...)
   @ ITensors ~/.julia/packages/ITensors/HjjU3/src/mps/mpo.jl:678
  contract(::NDTensors.Algorithm{:zipup}, ::MPO, ::MPO; kwargs...)
   @ ITensors ~/.julia/packages/ITensors/HjjU3/src/mps/mpo.jl:805
  ...

Stacktrace:
 [1] contract(A::MPO, B::MPO; alg::String, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ ITensors ~/.julia/packages/ITensors/HjjU3/src/mps/mpo.jl:798
 [2] top-level scope
   @ REPL[7]:1
```
</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
using ITensors

R = 3
sites = [Index(2, "Qubit,n=$n") for n in 1:R]
a = replaceprime(randomMPO(sites), 0 => 1, 1 => 2)
b = randomMPO(sites)
ab_ref = contract(a, b; alg="naive")
ab = contract(a, b; alg="densitymatrix")
ab_ref ≈ ab
```
</p></details>

# How Has This Been Tested?

A test will be added in `test_mpo.jl` that compares the results of contractions of an MPO and an MPS with a dangling bond.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
