### PR TITLE
[ITensors] Add prime indices for inner in documentation

### DIFF
--- a/docs/src/examples/MPSandMPO.md
+++ b/docs/src/examples/MPSandMPO.md
@@ -162,7 +162,7 @@ A key example could be the Hamiltonian defining a quantum system.
 Given an MPO `W` and an MPS `psi`, you can compute ``\langle\psi|W|\psi\rangle``
 by using the function `inner` as follows:
 ```julia
-ex_W = inner(psi,W,psi)
+ex_W = inner(psi',W,psi)
 ```
 which will return a scalar that may be either real or complex, depending on the properties of
 `psi` and `W`.

--- a/src/mps/mpo.jl
+++ b/src/mps/mpo.jl
@@ -421,7 +421,7 @@ MPOs. In general it is more efficient and accurate than `inner(y, apply(A, x))`.
 This is helpful for computing the expectation value of an operator `A`, which would be:
 
 ```julia
-inner(x, A, x)
+inner(x', A, x)
 ```
 
 assuming `x` is normalized.
@@ -431,7 +431,7 @@ If you want to compute `⟨By|Ax⟩` you can use `inner(B::MPO, y::MPS, A::MPO, 
 This is helpful for computing the variance of an operator `A`, which would be:
 
 ```julia
-inner(A, x, A, x) - inner(x, A, x) ^ 2
+inner(A, x, A, x) - inner(x', A, x) ^ 2
 ```
 
 assuming `x` is normalized.


### PR DESCRIPTION
# Description

`inner(x,A,x)` was [deprecated](https://github.com/ITensor/ITensors.jl/blob/1ef8f05566711127fc5d6aaad5b3d9c7e39ee582/src/mps/mpo.jl#L285) but the docs aren't updated to show this. I added this to the docs and `inner` documentation page. I left out the `Apply(A,x)` option but can add that in if you want to mention it. 

I should also note that `inner(A,x,A,x)` only works without primes at the moment (#696 )

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
