### PR TITLE
ITensorGaussianMPS - Expand basic operators for hopping Hamiltonian

### DIFF
--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -1,5 +1,5 @@
 import Base: sortperm, size, length, eltype, conj, transpose, copy, *
-import ITensors: alias
+using ITensors: alias
 abstract type AbstractSymmetry end
 struct ConservesNfParity{T} <: AbstractSymmetry
   data::T

--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -1,4 +1,5 @@
 import Base: sortperm, size, length, eltype, conj, transpose, copy, *
+import ITensors: alias
 abstract type AbstractSymmetry end
 struct ConservesNfParity{T} <: AbstractSymmetry
   data::T
@@ -140,9 +141,9 @@ expand_to_ladder_operators(o::String) = expand_to_ladder_operators(OpName(o))
 expand_to_ladder_operators(opname::OpName) = opname # By default does nothing
 expand_to_ladder_operators(::OpName"N") = ["Cdag", "C"]
 expand_to_ladder_operators(::OpName"Nup") = ["Cdagup", "Cup"]
-expand_to_ladder_operators(::OpName"n↑") = ["Cdagup", "Cup"]
 expand_to_ladder_operators(::OpName"Ndn") = ["Cdagdn", "Cdn"]
-expand_to_ladder_operators(::OpName"n↓") = ["Cdagdn", "Cdn"]
+expand_to_ladder_operators(opname::OpName"n↑") = expand_to_ladder_operators(alias(opname))
+expand_to_ladder_operators(opname::OpName"n↓") = expand_to_ladder_operators(alias(opname))
 
 #interlaced_hamiltonian(h::AbstractMatrix) = h
 #blocked_hamiltonian(h::AbstractMatrix) = Hermitian(reverse_interleave(Matrix(h)))

--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -140,7 +140,9 @@ expand_to_ladder_operators(o::String) = expand_to_ladder_operators(OpName(o))
 expand_to_ladder_operators(opname::OpName) = opname # By default does nothing
 expand_to_ladder_operators(::OpName"N") = ["Cdag", "C"]
 expand_to_ladder_operators(::OpName"Nup") = ["Cdagup", "Cup"]
+expand_to_ladder_operators(::OpName"n↑") = ["Cdagup", "Cup"]
 expand_to_ladder_operators(::OpName"Ndn") = ["Cdagdn", "Cdn"]
+expand_to_ladder_operators(::OpName"n↓") = ["Cdagdn", "Cdn"]
 
 #interlaced_hamiltonian(h::AbstractMatrix) = h
 #blocked_hamiltonian(h::AbstractMatrix) = Hermitian(reverse_interleave(Matrix(h)))

--- a/ITensorGaussianMPS/src/gmps.jl
+++ b/ITensorGaussianMPS/src/gmps.jl
@@ -87,6 +87,12 @@ function LinearAlgebra.rmul!(A::AbstractMatrix, R::Circuit)
   return A
 end
 
+function Base.:*(A::AbstractMatrix, B::Adjoint{<:Any,<:Circuit})
+  AB = copy(A)
+  rmul!(AB, B)
+  return AB
+end
+
 function replace!(f, G::Circuit)
   for i in eachindex(G.rotations)
     G.rotations[i] = f(G.rotations[i])

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -226,4 +226,14 @@ end
     @test h_hop[1, 1] == 2
     @test h_hop[2, 2] == 3
   end
+  @testset "Spin $o" for o in ("↑", "↓")
+    os = OpSum()
+    os += -1.0, "c†$o", 1, "c$o", 2
+    os += -1.0, "c†$o", 2, "c$o", 1
+    os += 2, "n$o", 1
+    os += 3, "n$o", 2
+    h_hop = ITensorGaussianMPS.hopping_hamiltonian(os)
+    @test h_hop[1, 1] == 2
+    @test h_hop[2, 2] == 3
+  end
 end

--- a/ITensorGaussianMPS/test/gmps.jl
+++ b/ITensorGaussianMPS/test/gmps.jl
@@ -191,3 +191,39 @@ end
     @show "Completed test for: ", Delta, t
   end
 end
+
+@testset "Bad Terms" begin
+  @testset "Bad single" begin
+    os = OpSum()
+    os += -1.0, "Nupdn", 1
+    @test_throws Any h_hop = ITensorGaussianMPS.hopping_hamilontian(os)
+  end
+  @testset "Bad quadratic" begin
+    os = OpSum()
+    os += -1.0, "Ntot", 1, "Ntot", 2
+    @test_throws Any h_hop = ITensorGaussianMPS.hopping_hamilontian(os)
+  end
+end
+
+@testset "Rewrite Hamiltonians" begin
+  @testset "Spinless" begin
+    os = OpSum()
+    os += -1.0, "Cdag", 1, "C", 2
+    os += -1.0, "Cdag", 2, "C", 1
+    os += 2, "N", 1
+    os += 3, "N", 2
+    h_hop = ITensorGaussianMPS.hopping_hamiltonian(os)
+    @test h_hop[1, 1] == 2
+    @test h_hop[2, 2] == 3
+  end
+  @testset "Spin $o" for o in ("up", "dn")
+    os = OpSum()
+    os += -1.0, "Cdag$o", 1, "C$o", 2
+    os += -1.0, "Cdag$o", 2, "C$o", 1
+    os += 2, "N$o", 1
+    os += 3, "N$o", 2
+    h_hop = ITensorGaussianMPS.hopping_hamiltonian(os)
+    @test h_hop[1, 1] == 2
+    @test h_hop[2, 2] == 3
+  end
+end


### PR DESCRIPTION
# Description

This extends the ability in ITensorGaussianMPS to create a hopping Hamiltonian with density operators such as `N`, `Nup` and `Ndn`. Other operators (`Nupdn`, etc) will throw an error. 


<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
os = OpSum()
os += -1.0, "Cdag", 1, "C", 2
os += -1.0, "Cdag", 2, "C", 1
os += 2, "N", 1 # new!
os += 3, "N", 2
h_hop = hopping_hamilonian(os)
```
</p></details>

# How Has This Been Tested?

- [x] Test Bad Terms
- [x] Test Rewrite Hamiltonians

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

