### PR TITLE
Directsum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.3.34"
+version = "0.3.341"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1448,6 +1448,8 @@ function +(::Algorithm"directsum", ψ⃗::MPST...) where {MPST<:AbstractMPS}
 
 
   # Output tensor
+
+  #Make sure that the output tensor is the same type as the input one
   if typeof(first(ψ⃗)) == MPO
     ϕ = MPO(n)
   else

--- a/src/mps/abstractmps.jl
+++ b/src/mps/abstractmps.jl
@@ -1445,8 +1445,14 @@ function +(::Algorithm"directsum", ψ⃗::MPST...) where {MPST<:AbstractMPS}
   n = length(first(ψ⃗))
   @assert all(ψᵢ -> length(first(ψ⃗)) == length(ψᵢ), ψ⃗)
 
+
+
   # Output tensor
-  ϕ = MPS(n)
+  if typeof(first(ψ⃗)) == MPO
+    ϕ = MPO(n)
+  else
+    ϕ = MPS(n)
+  end
 
   # Direct sum first tensor
   j = 1

--- a/test/base/test_sum.jl
+++ b/test/base/test_sum.jl
@@ -1,0 +1,15 @@
+using ITensors
+@testset "directsum test" begin
+    @testset "Sum of MPS" begin
+     sites = siteinds("Boson",5,dim=5)
+     psis = [randomMPS(sites) for i in 1:10]
+     directsum = sum(psis,alg="directsum")
+      @test typeof(directsum) == MPS
+    end
+    @testset "Sum of MPO" begin
+        sites = siteinds("Boson",5,dim=5)
+        H_s = [randomMPO(sites) for i in 1:10]
+        directsum = sum(H_s,alg="directsum")
+         @test typeof(directsum) == MPO
+       end
+end


### PR DESCRIPTION
# Description

+(::MPO,::MPO,alg="directsum")
 

Fixes #(issue)

If practical and applicable, please include a minimal demonstration of the previous behavior and new behavior below.

<details><summary>summing two mpos with directsum alg was returning an MPO</summary><p>

```julia
sites = siteinds("Boson",5,dim=5)
H1 = randomMPO(sites)
H2 = randomMPO(sites)
res = sum(H1,H2; alg = "directsum")
typeof(res)
```
</p></details>

<details><summary>Now the output is an MPO</summary><p>

```julia
sites = siteinds("Boson",5,dim=5)
H1 = randomMPO(sites)
H2 = randomMPO(sites)
res = sum(H1,H2; alg = "directsum")
typeof(res)
```
</p></details>

# How Has This Been Tested?

Please add tests that verify your changes to a file in the `test` directory.
added to a file named test_sum
Please give a summary of the tests that you added to verify your changes.

- [ ] directsum test
It just tests that the sum of an array of MPS returns an MPS and same for MPO



- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
