### PR TITLE
[ITensors] Add example of constructing GHZ as an MPS

### DIFF
--- a/examples/basic_ops/ghz_mps.ipynb
+++ b/examples/basic_ops/ghz_mps.ipynb
@@ -1,0 +1,578 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3fe90b57-60d0-4e50-872a-d54cadf12c45",
+   "metadata": {},
+   "source": [
+    "# GHZ state in MPS form\n",
+    "created by Viet Tran(v.thuongt@googlemail.com)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e95a59dd-c0b2-42bc-b1da-31fc968f6e7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using ITensors\n",
+    "using LinearAlgebra\n",
+    "using ITensorUnicodePlots\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d044f5d8-9683-4f12-ac6a-1db9308587eb",
+   "metadata": {},
+   "source": [
+    "We will now construct an MPS representation of the GHZ state for 4 qubits. Initially, we will express the ket vector in the computation basis. Then, we will transform the GHZ state into a tensor product representation using matrices. The MPS will be explicitly generated in ITensor, and we will contrast this approach with an alternative method that relies on bra-ket notation in ITensor. Finally, we will validate our approaches by converting the MPS into a vector and comparing it with the original ket vector in the computational basis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a429216-df18-44d8-bb04-8588aa3f8e07",
+   "metadata": {},
+   "source": [
+    "## GHZ in computational basis representation\n",
+    "\n",
+    "The GHZ state is a famous quantum state with interesting entanglement properties which however are not the focus of this notebook. The general form is as follows\n",
+    "$$\n",
+    "|\\mathrm{GHZ}\\rangle = \\frac{|0\\rangle^{\\otimes M} + |1\\rangle^{\\otimes M}}{\\sqrt{2}}.\n",
+    "$$\n",
+    "In our example we will just consider the unnormalized 4 qubit GHZ state $|\\mathrm{GHZ}\\rangle = |0000\\rangle+ |1111\\rangle$ but everything can be easily extended to higher number of qubits. We will use the usual compuational basis representation and will represent $|0\\rangle := \\begin{pmatrix} 1 \\\\ 0 \\end{pmatrix}$ and $|1\\rangle := \\begin{pmatrix} 0 \\\\ 1 \\end{pmatrix}$. \n",
+    "\n",
+    "To represent the 4-qubit system we will have to compute the tensor products:\n",
+    "\n",
+    "$$|0000\\rangle = |0\\rangle \\otimes |0\\rangle \\otimes |0\\rangle \\otimes |0\\rangle = \\begin{pmatrix} 1 \\\\ 0 \\\\ \\vdots \\\\ 0 \\end{pmatrix} \\in \\mathbb{C}^{16}$$\n",
+    "\n",
+    "$$|1111\\rangle = |1\\rangle \\otimes |1\\rangle \\otimes |1\\rangle \\otimes |1\\rangle = \\begin{pmatrix} 0 \\\\ \\vdots \\\\ 0 \\\\ 1 \\end{pmatrix} \\in \\mathbb{C}^{16}$$\n",
+    "\n",
+    "Thus we can write the GHZ state as:\n",
+    "$$|\\mathrm{GHZ}\\rangle =  \\begin{pmatrix} 1 \\\\ 0 \\\\ \\vdots \\\\ 0 \\\\ 1 \\end{pmatrix} \\in \\mathbb{C}^{16} $$\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1a84720-1cd9-4667-95c5-835f47a83263",
+   "metadata": {},
+   "source": [
+    "## Explicit MPS construction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78fb747b-7b38-4cb8-910c-a219e98246d0",
+   "metadata": {},
+   "source": [
+    "First we will prepare the 4 qubit sites and create a random mps which we will overwrite with our own tensors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "19da463a-4ec0-435a-87ac-dc4e699e9af6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "s = Index{Int64}[(dim=2|id=896|\"Qubit,Site,n=1\"), (dim=2|id=527|\"Qubit,Site,n=2\"), (dim=2|id=900|\"Qubit,Site,n=3\"), (dim=2|id=492|\"Qubit,Site,n=4\")]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "4-element Vector{Index{Int64}}:\n",
+       " (dim=2|id=896|\"Qubit,Site,n=1\")\n",
+       " (dim=2|id=527|\"Qubit,Site,n=2\")\n",
+       " (dim=2|id=900|\"Qubit,Site,n=3\")\n",
+       " (dim=2|id=492|\"Qubit,Site,n=4\")"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n = 4\n",
+    "s = siteinds(\"Qubit\",n)\n",
+    "@show s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "016aa1e7-5e8d-4744-b283-80598f494b86",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MPS\n",
+       "[1] ((dim=2|id=896|\"Qubit,Site,n=1\"), (dim=2|id=872|\"Link,l=1\"))\n",
+       "[2] ((dim=2|id=872|\"Link,l=1\"), (dim=2|id=527|\"Qubit,Site,n=2\"), (dim=2|id=529|\"Link,l=2\"))\n",
+       "[3] ((dim=2|id=529|\"Link,l=2\"), (dim=2|id=900|\"Qubit,Site,n=3\"), (dim=2|id=702|\"Link,l=3\"))\n",
+       "[4] ((dim=2|id=702|\"Link,l=3\"), (dim=2|id=492|\"Qubit,Site,n=4\"))\n"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# create the random mps to have physical site indices and virtual link inidces in place\n",
+    "mps = randomMPS(s, linkdims=2)"
+   ]
+  },
+  {
+   "attachments": {
+    "3d4ab42c-347d-4b40-a7e8-9b5d121f1388.png": {
+     "image/png": "iVBORw0KGgoAAAANSUhEUgAAAu0AAAJfCAYAAADLvOgZAAAABHNCSVQICAgIfAhkiAAAABl0RVh0U29mdHdhcmUAZ25vbWUtc2NyZWVuc2hvdO8Dvz4AAAAldEVYdENyZWF0aW9uIFRpbWUARnIgMjMgSnVuIDIwMjMgMTM6MjY6MzG9XKnSAAAgAElEQVR4nOzdeXBc12Hv+d+9fXvBDhAAV4ikCImLSFmiREqkKWuxJVlUbHlROfFTFEeVV5HfSyXPU6maVDnlSmoqM4mrUq5kJvPHTOyk4vGzHEexFkrUYsmkRMmUtZkUd4kQN4DYiK2xNrr73jt/9IJuECsJoA+a348KhaUbjQNLvv3F6XPPtXzf9wUAAADAWHahBwAAAABgakQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhnMKPQAAMJ3neXJdV8lkUq7ryvd9SZJlWbJtW47jyHEcWZYly7IKPFoAQDEi2gFgGt3d3WpubtaRI0fU2tqqvr4+2batyspKLV26VFu2bFFjY6Nqa2uJdgDAvCDaAWASw8PD6ujo0NGjR3X8+HGNjIzI8zyFQiH5vq/+/n719PSot7dXfX19uueeexQOh2XbrDwEAMwtoh0AJhGNRvX+++/r1Vdf1bFjx/R7v/d72rlzp2666SYNDw/rxIkTevPNN3Xw4EG1t7dr27ZtCgaDRDsAYM4R7QAwgcHBQTU1Nemll15SLBbTXXfdpc997nNqbGxUSUmJXNdVb2+v3n33XXV1dam+vl7Dw8MqLy+X43BoBQDMLaaDAGAC0WhUFy5c0OnTpxWLxbR8+XI1NDRoyZIl2ZNOR0dH1dnZqVAopOrq6uzXp+O6rkZHR+W67gL8JgCAYkC0A8AEOjs7deHCBY2MjCiRSCiRSMjzvOztmY8jkYhuuukm3XLLLaqpqVE4HJ72sePxuKLRqOLx+LyNHwBQXHgNFwAm4Lpudia8tbVVBw8elG3bWrt2rerr61VbW6v169fre9/7nqqrq7VixQoFg8HLHsf3fSUSCQ0NDSkajaqpqUlnz57Vp59+qm984xu6/fbbF/pXAwAsQkQ7AEwgEomorKxMwWBQXV1dGh4eViwW06pVq7Ry5UqtWbNG119/vTZt2qT6+npVVFRc9hiJRELDw8O6cOGC+vr6NDAwoA8++EAnTpzQ6dOntWvXLqIdADAjRDsATGDFihW64YYbVFlZmV3Kcu7cOTU3N8u2bdm2rXXr1umOO+7QI488oltuueWyxxgcHNSZM2f0k5/8RMPDw6qurtYnn3yirq6uvIs0AQAwHaIdACZQXl6uDRs26Bvf+IaOHj2qpqYmdXd3a3BwULFYTJLU3NysRCKhNWvWqLa2VitWrFAgEMg+RklJiVatWqUvf/nLSiQSCgQCGh4e1sDAgAYHBwv1qwEAFiGiHQByxONxDQ8Py3VdVVZW6otf/KLWrFmj48ePq7W1VV1dXerp6VFra6sGBgb0ySef6OTJk7rxxhu1dOnSvGiPRCJavny5li9fLkkaGhrSe++9p3PnzhXotwMALFZEOwDkGBgY0OnTpzU8PKyysjJt2rRJu3bt0rZt25RIJNTX16eWlhY99dRTOnr0qLq7u9Xb26vu7m6WuwAA5g3RDgBpPT09OnLkiF5++WUNDQ1p9erVqq2t1cqVK1VbWytJqq6uVmVlpbZs2ZKN9VAoNKOtHgEAuFJEOwCktbW16YMPPtDevXuVSCR066236p577lFtba1KS0slSeFwWEuWLNHKlStVV1cnx3FUV1enuro62TaXvgAAzA+eYQAgrb29Xa2trfI8TxUVFVq2bJnq6uqywZ7huq6am5vV3d2tyspKrVu3TmvXrs1bzw4AwFxiph0A0srKylRRUaFAIKDrr79eW7ZsyQZ7PB7XwMCAWltb1dTUpOPHjysSiehLX/qSNm7cqIqKClmWVeDfAABQrIh2AEhbunSpVq9erfr6eq1du1bLly9Xb2+vYrGYPM9TV1eXTpw4oUOHDqm3t1cbN27UI488ojVr1shxOJwCAOYPzzIAkLZ8+XLt2LFDnufp0qVL+vWvf63XX39dsVhM8XhcwWBQpaWlqq6u1o4dO3TjjTeqsbFRJSUlhR46AKDIEe0AkFZaWqo1a9YoHA6rublZbW1tikajGhkZUTKZVElJiWpqarRs2TKtX79edXV1Ki8vn/XP8X0/+wYAwEwQ7QCQo6KiQhUVFbrxxhvn9ecQ7ACA2WD3GAAAAMBwRDsALKDcpTGe58nzPGbdAQDTYnkMAMyTTJiPjo7K8zwNDw9rdHRUyWRSvu9raGhI0WhUjuMoGAwqGAzKtm22jgQAXMbymeIBgHkxOjqqrq4uPfvss+ro6FA8HtfRo0fV2dmpWCymTZs2ac2aNSotLdXtt9+urVu3asWKFQoGg4UeOgDAMMy0A8ACcRxHGzZsUGNjoyzLyr4BADAdZtoBAAAAw3EiKgAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABjOKfQAAGCxae8e1Pb/8n9Pevvy2nK9/7M/XcARAQCKHTPtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGcwo9gGI2NBLX6QvdGoklCj0UAHOop39kyttH40m989GFBRoNgIVSU1WijWvrCz0MXKMs3/f9Qg+i2PQPjeq7/+cr2vPGyUIPBcA88H3Jsq7mDgAWs//x2Gf1vz5xd6GHgWsMy2Pmwf/+z/sIdgAAitT/9dRB/ezljwo9DFxjiPZ58IvXjxV6CAAAYB49/cujhR4CrjGsaZ9j7V0DiifcQg8DwDyyJPmaemUhi2OA4nahra/QQ8A1hmifY0MjnHQKFD1LsqbKcoodKHpDsXihh4BrDMtjAAAAAMMR7QAAAIDhWB4zx2x76tfFg46jhlVLF2g0AADgSniur/MtbZPePuUSOWAeEO1zzPOmPjmtsrJc3/7Wows0GgAAcCVGYqP63/7+nye9fbqT0YG5xvIYAAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhnEIPAJiI7/uFHgIAYB5YllXoIQCLEtEOY0wW6gQ8ACxuuaGee0wn4IGZI9pRcOOjPO/zqW4DABjrslDP+TxzW+aYTrwD0yPaUVC5EZ79OP3e9335yv/a+O8BAJjHsqyxw7ZlyZIl+f5YrOfcT0od1wl3YGpEOwrmsmAfH+u+n/rY9yX52ftPGO2EPAAUxgSxnQnw1HtLlpV682Wl/0nxRbgDM0W0oyAmCvZMrPuel471sff5AS+NzdMAAMwyFuypN1uyLNm2rWzA23Y23gl3YGaIdiy4SYPd9+R5XirWPU/RgSG9e+iELnX1ajQeT39D5h3RDgAmsmRJOd1dWhLRsroluvP2m1QaicgOBCRP6Rl6+7JwBzAxoh0FM1Gwe54r3/fU1t6lf/33l5V03UIPEwBwlU41Neu9wyf17ce/rKqqCtl2QJZly7al8eHObDswMS6uhILKLInJBrvnyk0m9PpbHxLsAFBERmJx7T94SJ6blOcmx15d5ZVTYEaYaceCyjuZNG8Nu5cKdjcpN5lUW2d3gUcKAJhrbR09SiaTCgT89Dp3yfcs+fbl69sB5CPaUTBjy2NSa9g9z5XrpmbaR2LxQg8PADDHBoeG5SYTkiTLSp2M6lu2/PS+MhkskQEuR7SjoDI7wnieK8915blJxUZHCz0sAMA88OTLTSZkWZY825Zt2+mJm/RsO6EOTIpox4LLWxrjjy2P8TwvtTzGTRR6iACA+eArFe22LdsOyLMDsuyxLX+tcVdOBTCGE1FROJmLJuWciOql17QDAIqRL9dNpF5Z9cd2DMu99gZXvQYmxkw7CiL3hNSxmfbUEhlL3rTf/7kv/M58DxEAMEvxeFzvvvXalPdxXVcBNynfdaWAM3ZFa9/P298dQD6iHQXj51zl1Pf87Mmo8cTUy2Msy1bd0hULNEoAwEzFYiNT3u77kuemZtc935M37mrXnIAKTI7lMTBA5mTU9J697M8OAEUqvfGA58r3vJwL7PksiwGmQbSjsPyxE5Ay8Z5a3wgAKEa+7ym1H0Em1Il1YCaIdhRM3qxK5uCdeQMAFKXcWM/sIsZxH5ge0Y6C8CfYKSAz485LpABQxLIX1suPdY79wNSIdhRUJt7HhzsAoDhxnAeuDNEOAAAAGI5oBwAAC26i5TDMwAOTI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhnEIPAIU10WWk5/vnzfRtikdZ8HEDgIksyyr0EAAsEKL9GkLoAkBxmei4TsgDxYloL3ITHdAnjPcFCvrsTLrnXf7mj71J0820ewsyXgAwkaVxYZ4T6rnHeAIeKB5EexHLPXDnhXr648zX/KkCeY5jPhPtnudO8ObJSwe8poly33PndFwAYKZJojs3xi1L8v2xkB8X8IQ7UByI9iI0fiY9+3lmllvjPs+7//zOuE8c7ZlYd+WnP57qjwVfPtEO4NqUCXA/J9B9S5ZlpY7tliXLz78v4Q4UB6K9yPm+nx/r2VD3xoJ9XMjP93iy0e56ct2kXDchz03KTSblukl5blK+P3mUW/Llucl5HScAmMfKf2dZsiw7G+557zPxTrgDRYNoLzKXLYm5LNLTs9q+p76+AfVGByV5St3V19hM+/zEe3pI8n1XvuvJ89xUuCcTSiRGlUzEFYuNTPPHg69LHRfnZXwAYKaxmfXMMpiA46i0rELhSESWZWcj3pctS+l+J9yBokG0F6nxwZ4Jdc9zdfpsi1785UH1Dw4XepiTsoMlU97+3jtvL9BIAMBsS2rr9Znb7lBZeYUsy5dl+5JsWbIvC3cAixcXVyoi2RNLJwj21HKUpKLRAf3H8/uNDnYAwMz1dF/SofcOppYW5u3G5S/YzmAA5h/RXsR8+dlg99PLUI6dOqOky0mcAFBMotFeDfT3yfPGwl2ZZZEai3eu1wEsXkR7kcmbZc/MtmTXjSfV0xct9BABAPNgaLBfnptIhXvuNS8IdaAosKa9SPkaC3fP8+S6rtxkQqOjiUIPDQAwD5LxUXmumzoZ1bLlW5Ys305vBemzth1Y5Ij2IjHRrjGZK4dm1rMnkwmuJAoARcpzXXluQpad3kXGTgU7mQ4UB5bHFKnUXuhezpubPUkJAFB8UuvZk9mlkUq/2soSGaA4MNNebNInHY2tbc8Ee2pd+3Qz7eUVVYqUTL3dIgBg4fX39SoeH530dl+ePNeVHXCza9ot2algz5luZ792YHEi2otI/q4A/rh17alw96aZab9h42d0/Q0b5negAIBZe/et19Xacm7S2/2kK9935Xmu7JyrXmd2j6HTgcWN5THFKBPv2SuhpqPdc1MHbwBA0ckc6+V78j0/vUQm53aO/8CiRrQXqewMiz92YqqXPpADAIpPaovf9EWVctexs54dKApEe5GZ8MIZ6ZNSOXADQBHL7hqWe+Ipx32gWBDtRSz3QkvZAzkHcAAoUn7qEJ9Zx67885wALG5EexHys6F+2Q0ctwGgiE27bp1XXIFFi2gvcpl4T/U6B2sAKFbZJew569knnMABsCgR7dcADtoAcI3geA8ULaIdAIAixsQNUByIdgAAAMBwRDsAAABgOKK9qPGSKAAAQDEg2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAM5xR6AAAA4OoNDw2or8eREypRIBRRwAnLdoKybUeW7ciybVmyJMuSZVnzMoZ4PD4vjwuAaAcAoCicP/OxznlJWYGgLDskK+DIshzJtmVZtmRlXlyfv2ifjYnGYKnw4wJMxfIYAAAAwHBEOwAAuGJufEgtr31XrW/8zYzub1kWM+rAFSDaAQDAgrAkycpZV5+zRMaEJTuAyYh2AACwIEoiodRMu2UptYL98ngHMDGiHQAALIi66hJZlp2ebB+LdwDTI9oBAMC8CwUDuv2m62TbAdl2QJZtZ5fJWPO4DSVQLNjyEQCAIhAJWnJsyQ5YsgJW6r2djmE7N4rnNpCTjqU2pVa41JSl16vn7AcfDjlaUlmqzTesUHlZiexAQJZly7Zs2eOCnXAHJke0AwBQBBrqQqovD8kJpt4CTlCBgJOd1c4sS5nraI8NWzolyQlY2rmpOhXkgYACAUeBgCMnFFYwGFYoHEl/LSA74MgKBLInpUpiXTswDaIdAIAi4DghOSFbwVA4Fe5OUHbAkR1IL0eZp2h3PVfpR1UoXCLLsmTb6Wh3gtk/Ihwn9RYIBFNjsuzsuHLXtTPbDkyMaAcAoAg4TlDhcDAd7alwz8y0Z2fbpbHtFueI7yZTH1iWwpHS1B8Htp2daQ84TvoPirCcYHDsFYBAQLZtj61pF7vIAFMh2gEAKAIBJ6hguEShUDi7JMXOLEfJRrs159HupqPdsiyFI2XpdfR2doY/4ATlBILpYE8t27Ezy3YsOxv5zLADUyPaAQAoAk4wqFAoolA4kp1tDzhO/rr2uY52yxqLdknhkvRMe3qJjG0Hxta3O8Gxt0Dq65lYH3+FVAIeuBzRDgBAEQg4YYUiJenZ9khqiUzeuvbU2vG53l4xmUikPsjMtFvKmT2307PtTnbWP2/JTu4sO9s+AlMi2gEAKAKO4ygYCufNto+tH3fmLdoT8Zik1Ox45kRUy7LGdqyx7XSk29mZ90yw25nZfwDTItoBACgCAScoJ5ReGhOKpE78dEKpWe70zHbuxYzmSjA8kv5oLNpTPye1o8zYjLudXeueWUKTeZ87y85sOzAxoh0AgCJgBxwFnaCCwZBCwVAq3p3g2BaL8xTtoWA49YElBUMhZbZvHLvSaerKp3kz/ekZdpbFADNHtAMAUARsy06vX0+vH7cd2YFgei25M2/RXlW7XD96tSPva/mz5jk/M33SafbnjxsL8Q5MjmgHAKAI2Ll7oweCstOz7Lk7yMxHtE8k7/FzdofJjfXx9yPYgakR7QAAFIHUSZ8BWbknfWbfz9/ymMnHY43/wqS3EezA9Ih2AACKQe6uLZO8LWS05w9t4p9HrAMzR7QDAFAEsid+5lxAafxboaJ9/DgBzB7RDgBAMbAy4T7+vVnRDuDK2IUeAAAAWLwG+rr0+N3l+m9fXlPooQBFjWgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4or2osQ8vAABAMSDaAQAAAMMR7QAAAIDhnEIPAAvM8qe8uenUEbWcP71AgwEAzFR/X++Ut1vWxEsiJ/s6gMWFaL8G5B2w/akP3oMDUQ0OROd5RACAueb7vkSgA0WL5TFFLhPsliVZnJhqrP5PX1f/p78q9DAALGqZ472Vc+znuA8UC6K9COUesMfdwIYyBvJ9X/1nfqX+M68XeigAFrGZTM4Q8cDiRbQXMcuypGzAp94HHf6VA0AxCgYDY8f99D9ZxDqw6FFwRWayGXbbtiXLUkVZZOEHBQCYd5VlJdlgz0Y6sQ4UDU5ELVKZJTKpSZfUAdy2bK27rk4fnrwo1516FxksHMuy1PDA3xV6GAAWsdrKElVXlsq2bFm2nT3up8xvuFdU1+l/Hhic158BgJn24pQzw2JZtizLlm0HZNsBlZdGdN+261US5u81ACgGS5eU6r471qWO8wE757hvs0QGKCKUWxGxLCu15Vfqs9Q/liXLTkd7IKCAE9TqFUu0fEmpevsG1D80Ii+ZlOu58l1XnjzJ8yWfmXgAMEJ6E4FUjFvp47mjUDCoqsoyVZSXKRSOKBBwssd6y7aV/qbU8wC7EACLHtFebCxLlm/lnISaE+wBR04gKM9JyvFcVVeVq7w0KDeZUDKZlOe58n1PvudJUs4fAACAQsnuCJYJdttWwAnKcUIKhsJygkE5wZACTlB2JtzT5zJNtJsYO8gAixPRXqSs9AHbt1MvkWZmZgKOK8cPp4M8dZ9kwFHASUe758n3fflith0ACi6z37rSr5patqz0JEwgEFQwFJLjpN4CjpMKdzuQXteeetME4Q5g8SHai0Tu0hjLsuQrs83jWLA7jifJz97PtmwlAwEFHEducmyW3c+5D+EOAAWUc5GkbLjnvnoaTEd7MDXznor51DlMxDpQXIj2IpW3nt23FQgEJD+Yvd22bSXtgAJuUK6blBfMzLKnZ9qJ9QXj+77+j//xkCTpe//0aoFHA8A02aubpk8stdNRbgecVKQ7TnqmPb08JnN7ZnmMrHkN+IG+Lv33R9aqvKpW/88L5+flZwAg2otOapY9tcGXZduyfF+WHVAg/06pl03tgHzPkee58lxPnu9JOcHui3BfCLl/IIVLygo4EgAmypxEmpmIyewMk5ltz8R76hXV1PvM/ZhtB4oH0V7ErPSadUnypGy4W3bqZKaAm5Tne/JcNzvDLtazL7jcaI9ESgs4EgDGypkxtzPr1dNLZVK7xqQiPnMiaub28bPsBDyweBHtRSSzrj13tl2yle52+ZkdZVxbtu3JDwTkeZ58x7882rFgcqM9RLQDmEB2y8bshfPS0W6llstkzl/KnYnPLJMEUByI9iI1Ubj7/tjB3k8vhfG8sZNTM9EusTRmIeVGezAULuBIAJjq8mhPbTaQO+ueG/PZYGd5DFA0iPYic/kuMmPhLstP7+FuZ2fWLXvc7DrLYhZcXrQHiXYAk8jZ/jHzuZ2+iFLuXu6TBTvxDixuRHuRy4a7ZcnKxLnly5KdPek0f6cYon2h5f7vH3CCU9wTAPLXpueGeu7nufcZ/zGAxYloL0KZg3PejLvvj72smrMExrKmWQrDzPu8y4122w5McU8A15xJYjs7266cIJ/kZFOCHSgORHsRG79UJsPPuV1Kz9tMFucc6+cd0Q5g1mYY5gQ7UDyI9iKXF+sTBHzOHRdqSBgvJ9qtzFY/AHCFCHWgOBHt15CJDuRc+RQAFi8CHbh2EO3XOA74ZuHfBwAAmAivxQMAAACGI9oBAAAAwy2wiFcAABv0SURBVBHtAAAAgOGIdgAAAMBwnIgKFJhlWfqfBwYLPQwAuCIV1XUcw4AFwEw7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2oEC831fj99drsfvLi/0UABg1gb6uvT43eX6b19eU+ihAEWNaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4p9ADKDa2bU15e3//oP7f/+8XCzQaLAa+72c/5r8NAItNIjYgSYrFRovqGOa5/pS3W5r6+R6Ya5afWwy4ap829+je//rPhR4GAACYR+WlIZ187s8LPQxcQ1geAwAAABiOaAcAAAAMR7TPsbKSYKGHAAAA5llphOd7LCyifY4tr6tQKBgo9DAAAMA8WrOiptBDwDWGaJ8Hj96/pdBDAAAA8+gbD95c6CHgGkO0z4PvPfl5fe0Lmws9DCwSvu+r5bXvquW17xZ6KAAwa258SC2vfVetb/xNoYeyYP6Xx3fpv+y+pdDDwDWGLR/n0dBIXKcvdGsklij0UGAw3/e1a+taSdLBw+cLOxgAmKW+3h49fN9WVVZV65U3Pyr0cOZVTVWJNq6tL/QwcI0i2oEC831ftm1nPwaAxaSrq0v19fWqra1VV1dXoYcDFC2WxwAAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDjL932/0IMAAAAAMDlm2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOFJjv+7IsS5ZlFXooADBrXV1dsixLdXV1hR4KUNSIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDWb7v+4UeBAAAAIDJMdMOAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdqDAfN+XZVmyLKvQQwGAWevq6pJlWaqrqyv0UICiRrQDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2gEAAADDEe0AAACA4Yh2AAAAwHBEOwAAAGA4oh0AAAAwHNEOAAAAGM7yfd8v9CAAAAAATI6ZdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDin0AMAYJ7z58/r1KlTam1tVTweV1lZmZYtW6atW7eqpqZGgUCg0EMEgFlJJpPq7OxUc3OzNm7cqKqqqkIPCZgVy/d9v9CDAGAG13XV1NSkl19+Wc3NzfJ9X6FQSJZlKR6Pa926dbrnnnvU2NiokpKSQg8XACbleZ7i8biGh4fV29ur8+fP69ChQ+rs7NSTTz6pxsbGQg8RmBVm2gFISs1CtbW16ac//anef/993X///XrooYe0cuVKtbe3a+/evfrXf/1XtbS06A//8A/V2NioYDBY6GEDwGVc19XHH3+s5uZm9fb26sKFC3r33Xd1+PBhbdiwQSMjI4UeIjBrRDsA+b6vaDSqPXv26Omnn9bv/u7v6mtf+5rWrVsnSaqpqVF9fb0++eQTvfDCC1q/fr1qa2tVX19f4JEDwOUSiYT+5V/+Re+8844qKipUXl6u7u5usbgAixknogKQJHV3d+tnP/uZ4vG4duzYoaVLl+bdXlJSogcffFDhcFj79u3T2bNnCzRSAJhaKBTSn/7pn+rpp5/W888/rx/84Afatm1boYcFXBVm2gFoYGBAn3zyiTo6OuT7vpYtW6ZIJJJ3H8dx1NDQoEAgoBMnTqizs1Oe58m2+dsfgFksy1JDQ4Msy+LEeRQNoh2QtH//fv3yl79UWVmZvvjFL2r79u2FHtKCGhgYUFNTk1zXVSgUUiQSueyJzrIsVVVVybbt7BrRnp4e1dXVFWjUAMYbGRnRwYMH9fTTT0uSvv/976uysvKa++PasizOuUHRIdpxzbt06ZJefPFFvfHGG1q9erU2b958RdE+PDys06dP68MPP1RnZ6dGRka0cuVKbd68WRs2bDB6/ffQ0JAuXrwoSQqHwwoEArIsK+8+tm2rpKRElmXJdV11dnaqr6+PaAcMcvLkSe3du1dvvvmmIpGIenp6VF5ePutoTyQSOnv2rN577z1dvHhRiURCVVVVWr9+vbZu3XrZ8jkA8+/a+tMbmMDrr7+u3/72t+rt7dXQ0JAGBgZm/Ri9vb1644039Oyzz+rcuXMqLy9XTU2Nuru79cwzz+g3v/nNFT3uQonH4+rr68vOTo0P9ozc2/r7+zU0NLSQwwQwhd7eXr377rv6zW9+o9HRUSWTSfX19SmZTM7qcQYGBvSb3/xGP/rRj3TmzBmFw2FVVFQoGo3qwIED2rNnj5LJJCd1AguMmXZcs5LJpNrb2/XCCy+os7NTUuql5eHh4Vk/1uHDh/X8888rmUzq8ccf19atW+U4jn784x/rpZdeUmVlpW6++WZVVFRc8XgvXryoI0eOzFkoNzQ0qLGxUfX19Uomk9nfe6oZudyYj8ViisfjczIWAFfH93199NFHeuedd9Te3p79Wl9fn1zXnfHjJBIJnT9/Xj//+c/V1NSk73znO9q2bZsCgYB+9atf6ac//alOnTqlb37zmyorK7uisXqep7a2tjk7nlmWpeXLl2v79u0KhUJX/XiAqYh2XJN839fQ0JBefPFFnThxIrtnbywWm/WTSDwe14EDB3Tq1Cl96Utf0r333puN2yNHjiiRSMi2bXmeN+V4MrdPdtLUxYsX9eKLL2b/wJit8bPnO3fuVGVlperr6+X7fnY2bqYvo7uuO6sYADB/enp6tH//fh09ejT7tSuJ9sHBQR07dky//vWv9fDDD2vHjh2qqanR4OCgenp6slcTneoxfd9XIpGY9FU7z/PU2tqqF154QZcuXZrdL6rLj2W2bWvr1q269dZbZxztvEqAxYhoxzUpkUioublZP/7xj/MifWRkZNbR3t3drba2NvX19Skajaqjo0MlJSUKhUKqra3Vtm3bdMcdd2jVqlXZ78k8YXiep0QioYGBAY2OjqqkpES1tbUT/pzbbrtNmzdvntVL3Zknt9z3mbdgMDjhHwgzfTLLPA6AwvI8TwcOHNBvf/tbRaPR7NevJNr7+vp05swZxeNx9fb2qqurK3tF5LKyMm3dulV33323qqqq8r4vM/EQj8c1NDSktrY2bdiwYcKIDgQCuv3227Vx48YpJzPGG38cy/04EAgoHA7P6HEIdixWRDuuSZ2dnXr22WfV0dGRN7M8Ojo66yvlZdZ2DgwM6MUXX9Tp06e1fft23XrrrfrLv/xLlZWVTRq3PT09On78uPbu3auBgQF95Stf0e7duye8r+M4cpz5+b+sbdvZnRZm+gTvOA5bqQEGGBwc1J49e9TU1CTLsrJRmrlo2myi3fM8JZNJjYyM6JVXXlFHR4duu+023XLLLbr33nv1+OOPT/h9mcg/ceKEXnnlFe3bt0979uzRypUrL7tvJrSvZrng1SDasVgR7bjmjIyM6NSpU3r55Zf1mc98RuFwWKdOndLAwIBc11UsFtPIyIhKSkpm9HjLly9XY2OjPvzwQ/X29uqjjz7SqVOn9POf/1w333yz/uzP/kw33XRT3izQ6OiofvSjH+nChQvyPE/Hjx9XaWnpfP3K0woGg9knUNd1J31Sy53lLykpmfHMFoD58+///u/69NNPtWPHDg0MDOi3v/2tpCuL9vr6en3mM59RaWmphoeHdfz4cZ0+fVrPPvusNm7cqEcffVRf+9rX8r6ns7NTzzzzjI4dO6ZgMKijR4/O+uTXhUS0Y7Ei2nHNaWpq0osvvijP8/Ttb39bBw4c0JkzZ7K3x+NxDQ4OzjjaHcfRV7/6VVVUVGQfq6urS77v67333tOePXsUDAa1ZcuW7PcEg0F9+ctfViwWU2trq3p6etTT0zPnv+tMhcNh1dXVyfd9xWKxCV+yztyWecKrrq4u2EwZgNQf0RcvXtRLL72k2tpafeELX9Dx48fzon22y2PKysq0fft2/cVf/IVeffVVnT17Vl1dXRocHNShQ4dUWlqqG2+8Me94VlVVpYcfflh33323Ll68mP0eUxHtWKyIdlxTLl26pA8//FDHjx/XnXfeqc9+9rP6+OOP8y7CMTo6qoGBgWn3Vfc8Tx0dHWpra9OSJUu0e/dubd26VV1dXWppadHLL7+sU6dO6ejRo9q1a1fek1wgENCaNWuyH5eWlk4b7ceOHdMLL7wwZ3F/8803a9euXWpsbFRVVZU2bNggKbXef3R0VK7r5i1/8TxP/f398jxP4XBYDQ0N7NEOFNDg4KCeeuoptbS06IknntCOHTuy11uQxqJ9prPenZ2dam9vl+M42r17tzZs2KDe3l61trbqrbfe0ocffqgLFy7o9OnTecezcDis1atXS0otfZnuFTjXdXXq1Ck9//zz6u3tvYLfPJ9lWdq4caO++c1vzvgVS8IdixHRjmuG53k6fPiw3n77bUUiEX39619XVVWVampq8taKx+PxafdU9zxPg4OD+tnPfqampibt3LlTn//857Vjxw65rqve3l45jqMLFy7M2fjD4bBqamrm7OTPysrK7ElilZWVWr9+vWpqatTX16eenh6Njo7mPQG6rqu2tja5rqvVq1fruuuuu+It3wBcnczSlZdeekk33nijdu7cqYaGBpWUlMhxnOy5NjOdac/sPvPWW2/puuuu0x//8R/rzjvvlJS6JkMkElFXV5cSicScjD9zPJuLK7ValjWrq74S7FisiHZcM9ra2vT222+rublZd911l+644w5JqZd2c6N9dHRUg4ODUz5WMplUS0uLnnvuOXV0dGjp0qXasWOHpLGZ85UrV8pxHK1fv35Orh64bt06NTQ0zGq3hakEg8Hs7x0KhbRy5Upt27ZN+/fv1/Hjx7Vx48ZstGeWxrz//vuKx+Pavn27Ghoa2D0GKADP89Te3q69e/eqt7dXf/Inf6Lrr79ekUhEJSUlikQiGhwcnFW0nzt3Tm+88Yb27dunO+64I+8aDBUVFaqpqVFFRYUsy9K6deuuavy2bWvdunV64okn5ux45jgO59ig6BHtuCYkk0m9/fbbOnr0qFauXKndu3dn16xXV1fnLY+ZyUx7MplUV1eXksmk6uvrdcMNN6i2tja760JLS4v279+v2tpa3XXXXdmXjq9GIBCY8Tr7K1FVVaVHHnlEp06d0ltvvaWNGzeqvLxckUhEIyMjOnnypPbt26e6ujrdddddWrFixbyNBcDkMnup79+/X7fccovuueceVVdXS0qdIF5WVpaN9syJqL7vT/lHdjQa1dDQkGpra7Vp0yZVV1fL8zzFYjFdunRJx44dUzwe186dO7Vx48arGn9m95j5PJ5JqetuJJNJeZ6X/f2ksStAR6PR7M5Z4XCYSQgYj2jHNaGjo0Ovv/66hoaG9MADD+i2227L3jZ+pj1zIupUQqGQ1q1bp7Vr12r58uVasmSJenp6dOnSJTU3N+vdd9/V22+/rSeeeEK333579gl1OoV82baiokJf+MIX9PHHH2vv3r16+eWXlUwm1dDQoIsXL2rPnj1yXVe///u/r9tvv52TUIECcF1Xp0+f1iuvvKJAIKAnn3xSS5YsyS4NiUQi2WVrma1oZ7KkZc2aNWpsbJRt29q8ebNaWlrkOI5aW1u1b98+HT16VFu2bNFXv/rVRTOj3dTUpPb2dsViMZ0/f15nzpyRbduKRqP69a9/rd7eXpWUlGjZsmXatGkTV1OF8Yh2XBOeeeYZnTp1Svfff7+++MUv5q19rKysvGx5zHQz7Y7jaMWKFfqbv/kbPffcc/rJT36i8+fPa3h4WEuXLtUtt9yif/iHf9DWrVsXzROclHrC//M//3Pdeuutev755/V3f/d3ikajqqys1LZt2/RP//RPuvnmmxfV7wQUk/7+fh06dEgffPCBdu3apXvuuSfv9sxMe4bnedlwnypK161bp8cff1z79u3TL37xC/393/+9enp6VFdXp1tvvVXf+ta3tHPnTi1ZsmTefre59pOf/ESvvfaaksmkbNuWbduqqqqS7/v6j//4D7muq0Qiofvvv19/9Vd/Ne3mA0ChEe0oaq7r6vz583rjjTe0dOlSbdu2Le/KpNLl0Z5IJGZ0VVTbttXQ0KA/+IM/0KOPPqp4PC7f9+U4jkpKSlRVVZW37GYx2b59u9avX6+RkZHsLjKlpaWqqalZtL8TUAzeeecdvfnmm1q2bJkee+yxy24Ph8OXLTsZHBycNtolqaGhQV//+tf14IMPKh6PK5lMZo9nFRUVszrx3Pf9gp/w+Z3vfEd/9Ed/NOnSoMwYM2v2AdMR7Shavu8rHo/rqaeeUmtrqx577DHdeuutl80SV1RUzHr3GGlsa7O5OMk0d8wmqKioYPkLYJjm5mYdPHhQXV1duu+++7R58+bL7hOJRC7b9nCmS2TC4bDC4bBqa2uveqwmHMsmuhorsJhd/V5LgKFisZg++ugj/epXv9KGDRt05513ThjYoVBIJSUl2T3JZ7J7zFzyPE++72cvHw4A47muqzfffFPHjh1TQ0ODHnrooQn3JL+aaJ8LmWOZ53lTXl0ZwOwx046i5HmeLl26pGeeeUaDg4N66KGH1NjYOOHSDtu2VVZWpmAwKNd1Z3Qi6tVKJpM6ceKELly4oLNnz+rixYvq6+vTwYMHlUwmVV1drc9+9rPzvrsCgMWhqalJBw4cUCAQ0K5duybdwWWiaO/v75/XaI/H4zp27Fj2WJa5Gupzzz2nFStWaP369Vq3bh2v3gFXiWhHURoYGNCRI0f0+uuvq7KyUuFwWGfOnNHZs2cvW9vo+76GhoayJ6dmlsd4npfdmmyu+b6vixcv6vjx4+ru7tbatWt13XXXaXR0VIcPH9aqVauy+8gDuHZllvm98sorOnnypG644QZFIhEdOXJEki47Pl24cEHRaDTva/39/Xn7rs8113XV3Nysw4cPK5FIaMuWLbIsS2fOnFFHR4fKy8u1atUqoh24SkQ7io7rujp79qz27NmjaDQqx3H0wx/+UMFgcMIr5vm+r5aWFo2OjkpKzYIPDw/P6MStKxUMBrV7927t3r17Xh4fQHHwPE9nzpzRL3/5S7W3t8t1XXV1dWV3QxkvFotlZ7oz5numvaSkRF/5ylf0la98Zd5+BgCiHUWor69Phw4d0oEDB1RWVqbR0VFdvHhxyu/J7PySkUgkFI1GVVdXxwU3ABSE7/saGRnRv/3bv6mjo0ORSERDQ0PT7m41PtDnO9oBLAyiHUXn8OHD2rt3r66//nr94Ac/0MqVKyeckcr11FNP6emnn9bZs2clpWbbe3t752QXBQC4ErFYTEeOHNFrr72m2267TU8++eS0VyONxWJ67rnn9P3vfz/7tfleHgNgYRDtKCpnz57VwYMHFY1G9Tu/8zu64YYbFAwGp50tr62tVSQSyX6eSCTU19fHzgcACsL3fXV2duqHP/yhfN/Xo48+qk2bNk27Lry8vFw1NTWybVue50mSotEoM+1AEWDLRxSNZDKpgwcP6v3339eaNWv0pS99SaFQaEbLW8rLy/PWr2dm2ol2AIXQ3d2tt956S0ePHtWDDz6ozZs3z+jiRpnrR+TuPMVMO1AciHYUjePHj+vgwYOybVv33nuv1q5dO+PvLS8vz9sOMplMMtMOoCASiYROnz6tl156SeXl5fr617+u+vr6aZf5SaloD4VCeYHPmnagOBDtKAodHR169dVX9emnn+qmm27S5z73ubyrnE5n/Ex7IpFgph3AgvM8T+fOndP+/ft19uxZff7zn9eWLVvylu9NJxgMqry8PPv58PCwYrGYXNedjyEDWCCsacei5Xme4vG4Ll26pNdee0379u3T8PCwGhsbtXr16lk9VjAYzF4RVUpFe1dXV3ZNKADMJ9/3FYvF1NzcrFdeeUWvvfaaQqGQ7rvvvhkv88s8TiAQUDgczn4tmUxqYGBAo6OjE15FFcDiQLRj0RkaGlI0GtXAwIAuXbqkd999Vz/96U8VjUa1YsUK9fb26vTp06qsrNTy5csnfIzMlo6Dg4PyPE9NTU3q7+/P3h6LxXTu3Dl9+umnKisrk23bqqmpUUVFBVtAApgTnudpdHRUHR0dGh0dVVtbW3YCoqOjQytWrFBHR4fOnj2ruro6VVRUTHhVZ9d1denSJcViMcXjcV24cEEjIyN59zlz5oxOnjypJUuWKBQKqbKykosdAYuM5fP6PxaZgwcP6j//8z/1wQcfqLW19bLZ8FAopOXLl+u+++7TX//1X0/4GG1tbXrmmWf05ptvamBgQC0tLRoeHs5bDmPbtlatWqXq6mpVVFToscce04MPPjirZTcAMJlYLKaTJ0/qb//2b3Xu3DlFo1Elk8m8+wQCAV1//fX61re+pQceeEDLli277HGi0aj+8R//UceOHVNPT48uXbqkwcHBvPtEIhHV19dryZIlWrt2rR5++GE98MAD8/r7AZhb1AcWnTNnzuj9999XT0+PSkpKsjPfruvKdV15nqeBgQENDAxM+hjRaFQHDx7UkSNH5DiOLMvKO3Er8zidnZ1qb2/XkiVLNDw8nLeEBgCuxtDQkI4fP66jR4/KcRyFw2FFIhH5vi/P87LHtAsXLsjzvElPRG1padGhQ4f08ccfZ49n5eXlsixLvu9nj2cdHR1qb2+XJF4xBBYhZtqx6PT09Kirq0uu6172xJP5z9m2bZWXl2vVqlUTPkYsFlN7e7uGh4dlWdaET2CZx/J9X47jaOnSpaqurp7j3wbAtSqZTKq/v1/t7e0TBnnu0/OyZctUWVk54St9IyMjamtr0+jo6KQxnns8y8y6szwGWFyIdgAAAMBwbPkIAAAAGI5oBwAAAAxHtAMAAACGI9oBAAAAwxHtAAAAgOGIdgAAAMBwRDsAAABgOKIdAAAAMBzRDgAAABiOaAcAAAAMR7QDAAAAhiPaAQAAAMMR7QAAAIDhiHYAAADAcEQ7AAAAYDiiHQAAADAc0Q4AAAAYjmgHAAAADEe0AwAAAIYj2oH/v906FgAAAAAY5G89jR1FEQDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAnLQDAMCctAMAwJy0AwDAXPXiQaOUgHMoAAAAAElFTkSuQmCC"
+    }
+   },
+   "cell_type": "markdown",
+   "id": "122900ff-a0cc-4188-969d-90cb2f9acb81",
+   "metadata": {},
+   "source": [
+    "See the [Wikipedia entry](https://en.wikipedia.org/wiki/Matrix_product_state#Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state) for the MPS form of the GHZ state. We will derive this form following [theses lecture notes p.19](https://tu-dresden.de/mn/physik/itp/ket/ressourcen/dateien/teach_folder/ss2021/skript/Lecture4.pdf?lang=en)\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "|\\mathrm{GHZ}\\rangle &= |0000\\rangle + |1111\\rangle \\\\\n",
+    "&= |\\begin{pmatrix} |0\\rangle_1 & |1\\rangle_1 \\end{pmatrix} \\begin{pmatrix} |0\\rangle_2 & 0 \\\\ 0 & |1\\rangle_2 \\end{pmatrix}  \\begin{pmatrix} |0\\rangle_3 & 0 \\\\ 0 & |1\\rangle_3 \\end{pmatrix} \\begin{pmatrix} |0\\rangle_4 \\\\ |1\\rangle_4 \\end{pmatrix}\n",
+    "\\end{aligned}\n",
+    "$$ \n",
+    "Note that the product of ket vectors is shorthand for the tensorproduct. In this form we can see the 4 tensors for the 4 qubit sites. If we define the MPS form as usual: \n",
+    "$$|\\mathrm{GHZ}\\rangle = \\sum_{s_1 \\dots s_4} A^{s_1}A^{s_2}A^{s_3}A^{s_4}|s_1 s_2 s_3 s_4 \\rangle $$\n",
+    "\n",
+    "We can write the first site tensor $A^{s_1}$ as follows:\n",
+    "$$A^{s_1=0} = \\begin{pmatrix} 1 & 0 \\end{pmatrix} \\quad\\text{and}\\quad A^{s_1=1} = \\begin{pmatrix} 0 & 1 \\end{pmatrix}.$$\n",
+    "Here $A^{s_1=0}$ and $A^{s_1=1}$ are the slices of the first site tensor $A^{s_1}$ for when the physical site index $s_1$ is either 0 or 1:\n",
+    "<div style=\"margin-left:auto; margin-right:auto; width:300px;\">\n",
+    "<img src=\"attachment:3d4ab42c-347d-4b40-a7e8-9b5d121f1388.png\" width=\"300\">\n",
+    "</div>\n",
+    "\n",
+    "Analogously we rewrite the last site tensor $A^{s_4}$ as follows:\n",
+    "$$A^{s_4=0} = \\begin{pmatrix} 1 \\\\ 0 \\end{pmatrix} \\quad\\text{and}\\quad A^{s_4=1} = \\begin{pmatrix} 0 \\\\ 1 \\end{pmatrix}.$$\n",
+    "\n",
+    "For sites $s_2$ and $s_3$ the slices have the shape as given in wikipedia:\n",
+    "$$A^{s_i=0} = \\begin{pmatrix} 1 & 0\\\\ 0 & 0 \\end{pmatrix} \\quad \\text{and} \\quad A^{s_i=1} = \\begin{pmatrix} 0 & 0\\\\ 0 & 1 \\end{pmatrix}, \\quad \\text{for}\\quad i=2,3$$\n",
+    "\n",
+    "We can quickly check the coefficient of the state $|0000\\rangle = |s_1=0, s_2=0, s_3=0, s_4=0\\rangle$ which would be $$A^{s_1=0} A^{s_2=0} A^{s_3=0} A^{s_4=0} =  \\begin{pmatrix} 1 & 0 \\end{pmatrix} \\begin{pmatrix} 1 & 0 \\\\ 0 & 0 \\end{pmatrix} \\begin{pmatrix} 1 & 0 \\\\ 0 & 0 \\end{pmatrix} \\begin{pmatrix} 1 \\\\ 0 \\end{pmatrix} = 1 .$$ \n",
+    "Equally we can check that all other combinations of $s_1 \\dots s_4$ will result in a 0 coefficient except for $|1111\\rangle$. Thus we correctly found a MPS representation for the 4 qubit GHZ state. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2af60984-3ba8-4f8c-bacd-57e39d91d9d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mps[1] = ITensor ord=2\n",
+      "Dim 1: (dim=2|id=896|\"Qubit,Site,n=1\")\n",
+      "Dim 2: (dim=2|id=872|\"Link,l=1\")\n",
+      "NDTensors.Dense{Float64, Vector{Float64}}\n",
+      " 2×2\n",
+      " 0.3285646051280804   -0.8273833955424125\n",
+      " 0.36571917438952145   0.2715354535260242\n",
+      "mps[4] = ITensor ord=2\n",
+      "Dim 1: (dim=2|id=702|\"Link,l=3\")\n",
+      "Dim 2: (dim=2|id=492|\"Qubit,Site,n=4\")\n",
+      "NDTensors.Dense{Float64, Vector{Float64}}\n",
+      " 2×2\n",
+      " 0.5801894243103987  -0.8144815724854482\n",
+      " 0.8144815724854482   0.5801894243103985\n"
+     ]
+    }
+   ],
+   "source": [
+    "# for MPS form GHZ state see https://en.wikipedia.org/wiki/Matrix_product_state#Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state \n",
+    "# A0 = [1 0; 0 0]\n",
+    "# A1 = [0 0; 0 1]\n",
+    "# matrices A0 and A1 are slices of the tensor at site 2,...,N-1\n",
+    "# tensor at site 1 is 1x2x2  and contains [1 0] and [0 1]\n",
+    "# tensor at site N is 2x1x1 and contains [1; 0] and [0; 1]\n",
+    "\n",
+    "\n",
+    "@show mps[1] # tensor at site 1 gives ITensor ord=2 (dim=2|id=697|\"Qubit,Site,n=1\") (dim=2|id=843|\"Link,l=1\")\n",
+    "# thus create tensor at site 1, with physical index first then link index\n",
+    "T1 = ITensor([1 0; 0 1], inds(mps[1])) # inds(mps[1]) gets the physical and link index of the tensor at site 1\n",
+    "mps[1] = T1 # replace tensor at site 1 with T1\n",
+    "\n",
+    "\n",
+    "@show mps[4] # tensor at site 4 gives ITensor ord=2 (dim=2|id=56|\"Link,l=3\") (dim=2|id=19|\"Qubit,Site,n=4\")\n",
+    "# thus create tensor at site N, with link index first then physical index\n",
+    "TN = ITensor([1 0; 0 1], inds(mps[end])) # inds(mps[end]) gets the physical and link index of the tensor at site N\n",
+    "mps[end] = TN # replace tensor at site N with TN\n",
+    "\n",
+    "\n",
+    "# for inbetween tensors we set them to tensor with A1 and A0 slices\n",
+    "Tk = zeros(Float64, 2, 2, 2) # 2x2x2 tensor\n",
+    "# indices of inbetween tensors are link, site, link\n",
+    "Tk[:,1,:] = [1 0; 0 0] # A0 slice\n",
+    "Tk[:,2,:] = [0 0; 0 1] # A1 slice\n",
+    "for site in range(2, stop=n-1)\n",
+    "    mps[site] = ITensor(Tk, inds(mps[site])) # inds(mps[site]) gets the physical and link index of the tensor at site site\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3efad472-ad34-4eec-a533-2b91c1a22aa4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------------------------\n",
+      "MPS form of GHZ state\n",
+      "--------------------------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "    \u001b[38;5;8m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀mps₄⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢀\u001b[0m\u001b[38;5;4m⡠\u001b[0m\u001b[38;5;4m⠔\u001b[0m\u001b[38;5;4m⠉\u001b[0m\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢀\u001b[0m2\u001b[38;5;4m⠒\u001b[0m\u001b[38;5;4m⠁\u001b[0m⠀⠀⠀\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⣀\u001b[0m\u001b[38;5;4m⠔\u001b[0m\u001b[38;5;4m⠊\u001b[0m\u001b[38;5;4m⠁\u001b[0m⠀⠀⠀⠀⠀⠀2⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀mps₃\u001b[38;5;4m⠉\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢄\u001b[0m\u001b[38;5;4m⠠\u001b[0m\u001b[38;5;4m⠒\u001b[0m\u001b[38;5;4m⠁\u001b[0m\u001b[38;5;4m⡇\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⣀\u001b[0m\u001b[38;5;4m⠔\u001b[0m\u001b[38;5;4m⠊\u001b[0m\u001b[38;5;4m⠁\u001b[0m⠀⠀⠀\u001b[38;5;4m⡇\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢀\u001b[0m\u001b[38;5;4m⡠\u001b[0m\u001b[38;5;4m⠔\u001b[0m2⠀⠀⠀⠀⠀⠀⠀2⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⠈\u001b[0m⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢀\u001b[0m\u001b[38;5;4m⠤\u001b[0m\u001b[38;5;4m⠒\u001b[0m\u001b[38;5;4m⠁\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⡇\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀mps₂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⡇\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢀\u001b[0m\u001b[38;5;4m⡠\u001b[0m\u001b[38;5;4m⠔\u001b[0m\u001b[38;5;4m⠉\u001b[0m⠀⠀\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⡇\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢀\u001b[0m\u001b[38;5;4m⠤\u001b[0m2\u001b[38;5;4m⠁\u001b[0m⠀⠀⠀⠀⠀\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⠁\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀⠀\u001b[38;5;4m⣀\u001b[0m\u001b[38;5;4m⠤\u001b[0m\u001b[38;5;4m⠊\u001b[0m\u001b[38;5;4m⠁\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀2⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀mps₁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀\u001b[38;5;4m⡇\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⢸\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀\u001b[38;5;4m⡇\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;4m⠘\u001b[0m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀\u001b[0m⠀⠀⠀⠀2⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[38;5;8m⠀\u001b[0m\n",
+       "    \u001b[38;5;8m⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\u001b[0m"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "site 1\n",
+      "--------------------------------------------------\n",
+      "mps[n] = ITensor ord=2\n",
+      "Dim 1: (dim=2|id=896|\"Qubit,Site,n=1\")\n",
+      "Dim 2: (dim=2|id=872|\"Link,l=1\")\n",
+      "NDTensors.Dense{Float64, Vector{Float64}}\n",
+      " 2×2\n",
+      " 1.0  0.0\n",
+      " 0.0  1.0\n",
+      "site 2\n",
+      "--------------------------------------------------\n",
+      "mps[n] = ITensor ord=3\n",
+      "Dim 1: (dim=2|id=872|\"Link,l=1\")\n",
+      "Dim 2: (dim=2|id=527|\"Qubit,Site,n=2\")\n",
+      "Dim 3: (dim=2|id=529|\"Link,l=2\")\n",
+      "NDTensors.Dense{Float64, Vector{Float64}}\n",
+      " 2×2×2\n",
+      "[:, :, 1] =\n",
+      " 1.0  0.0\n",
+      " 0.0  0.0\n",
+      "\n",
+      "[:, :, 2] =\n",
+      " 0.0  0.0\n",
+      " 0.0  1.0\n",
+      "site 3\n",
+      "--------------------------------------------------\n",
+      "mps[n] = ITensor ord=3\n",
+      "Dim 1: (dim=2|id=529|\"Link,l=2\")\n",
+      "Dim 2: (dim=2|id=900|\"Qubit,Site,n=3\")\n",
+      "Dim 3: (dim=2|id=702|\"Link,l=3\")\n",
+      "NDTensors.Dense{Float64, Vector{Float64}}\n",
+      " 2×2×2\n",
+      "[:, :, 1] =\n",
+      " 1.0  0.0\n",
+      " 0.0  0.0\n",
+      "\n",
+      "[:, :, 2] =\n",
+      " 0.0  0.0\n",
+      " 0.0  1.0\n",
+      "site 4\n",
+      "--------------------------------------------------\n",
+      "mps[n] = ITensor ord=2\n",
+      "Dim 1: (dim=2|id=702|\"Link,l=3\")\n",
+      "Dim 2: (dim=2|id=492|\"Qubit,Site,n=4\")\n",
+      "NDTensors.Dense{Float64, Vector{Float64}}\n",
+      " 2×2\n",
+      " 1.0  0.0\n",
+      " 0.0  1.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "MPS\n",
+       "[1] ((dim=2|id=896|\"Qubit,Site,n=1\"), (dim=2|id=872|\"Link,l=1\"))\n",
+       "[2] ((dim=2|id=872|\"Link,l=1\"), (dim=2|id=527|\"Qubit,Site,n=2\"), (dim=2|id=529|\"Link,l=2\"))\n",
+       "[3] ((dim=2|id=529|\"Link,l=2\"), (dim=2|id=900|\"Qubit,Site,n=3\"), (dim=2|id=702|\"Link,l=3\"))\n",
+       "[4] ((dim=2|id=702|\"Link,l=3\"), (dim=2|id=492|\"Qubit,Site,n=4\"))\n"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "println(\"-\"^80)\n",
+    "println(\"MPS form of GHZ state\")\n",
+    "println(\"-\"^80)\n",
+    "@visualize mps\n",
+    "for n in range(1, stop=n)\n",
+    "    println(\"site $n\")\n",
+    "    println(\"-\"^50)\n",
+    "    @show mps[n]\n",
+    "end\n",
+    "mps1 = mps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f58343d0-66bb-48d7-ad6c-7c6018854107",
+   "metadata": {},
+   "source": [
+    "## MPS via ITensors string array constructor\n",
+    "ITensor can also create an MPS by giving an array of string, where each string identifies a state on a site. Thus we will create an MPS for the $|0000\\rangle$ state and one for the $|1111\\rangle$ state and add them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dfbbe7a6-1955-415e-9e30-8fdd6b29cad3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MPS\n",
+       "[1] ((dim=2|id=896|\"Qubit,Site,n=1\"), (dim=2|id=380|\"Link,l=1\"))\n",
+       "[2] ((dim=2|id=527|\"Qubit,Site,n=2\"), (dim=2|id=660|\"Link,l=2\"), (dim=2|id=380|\"Link,l=1\"))\n",
+       "[3] ((dim=2|id=900|\"Qubit,Site,n=3\"), (dim=2|id=989|\"Link,l=3\"), (dim=2|id=660|\"Link,l=2\"))\n",
+       "[4] ((dim=2|id=492|\"Qubit,Site,n=4\"), (dim=2|id=989|\"Link,l=3\"))\n"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "states_up = fill(\"Up\",n) # fill creates an array of n elements with the value \"Up\"\n",
+    "states_dn = fill(\"Dn\",n) # fill creates an array of n elements with the value \"Dn\"\n",
+    "mps_up = MPS(s,states_up)\n",
+    "mps_dn = MPS(s,states_dn)\n",
+    "mps2 = mps_up + mps_dn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64cbfa16-db02-4136-b8bb-7a20adf00726",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6cc929d-a52f-4d63-8196-1d7a692f7bb9",
+   "metadata": {},
+   "source": [
+    "## Evaluation\n",
+    "Now we try to evaluate our created MPS `mps1` and `mps2`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e12fa921-e186-4db6-b8cd-a7b67289c791",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "overlap of mps1 and mps2: 0.9999999999999998\n",
+      "mps are close to each other: true\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Overlap between mps1 and mps2\n",
+    "mps1_ = normalize(mps1)\n",
+    "mps2_ = normalize(mps2)\n",
+    "overlap = inner(mps1_, mps2_)\n",
+    "\n",
+    "println(\"overlap of mps1 and mps2: \", overlap)\n",
+    "println(\"mps are close to each other: \", isapprox(overlap, 1.0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "340d7046-e903-493d-94e2-dea32ce9dc04",
+   "metadata": {},
+   "source": [
+    "Now lets contract the MPSs and have a look at the corresponding tensor in the computational basis which as we know should be:\n",
+    "$$|\\mathrm{GHZ}\\rangle =  \\begin{pmatrix} 1 \\\\ 0 \\\\ \\vdots \\\\ 0 \\\\ 1 \\end{pmatrix} \\in \\mathbb{C}^{16} $$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a0204391-3d85-4a9c-bfd7-b3a65f3d0a32",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "combined_ket1 = ITensor ord=1\n",
+      "Dim 1: (dim=16|id=699|\"CMB,Link\")\n",
+      "NDTensors.Dense{Float64, Vector{Float64}}\n",
+      " 16-element\n",
+      " 1.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 1.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "ITensor ord=1 (dim=16|id=699|\"CMB,Link\")\n",
+       "NDTensors.Dense{Float64, Vector{Float64}}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ket1 = contract(mps1)\n",
+    "C = combiner(inds(ket1))\n",
+    "combined_ket1 = C * ket1\n",
+    "@show combined_ket1\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "30dcefac-97e7-499d-9e9b-db6cd7d7f492",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "combined_ket2 = ITensor ord=1\n",
+      "Dim 1: (dim=16|id=681|\"CMB,Link\")\n",
+      "NDTensors.Dense{Float64, Vector{Float64}}\n",
+      " 16-element\n",
+      " 1.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 0.0\n",
+      " 1.0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "ITensor ord=1 (dim=16|id=681|\"CMB,Link\")\n",
+       "NDTensors.Dense{Float64, Vector{Float64}}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ket2 = contract(mps2)\n",
+    "C = combiner(inds(ket2))\n",
+    "combined_ket2 = C * ket2\n",
+    "@show combined_ket2\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4422943-fdaf-440c-b75b-166316721eb1",
+   "metadata": {},
+   "source": [
+    "As we see both MPS equal our GHZ-state!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3af79464-87e1-49f1-bcd5-bce68ababfb0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.6.6",
+   "language": "julia",
+   "name": "julia-1.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/basic_ops/ghz_mps.jl
+++ b/examples/basic_ops/ghz_mps.jl
@@ -1,0 +1,165 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .jl
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.14.6
+#   kernelspec:
+#     display_name: Julia 1.6.6
+#     language: julia
+#     name: julia-1.6
+# ---
+
+# # GHZ state in MPS form
+# created by Viet Tran(v.thuongt@googlemail.com)
+
+using ITensors
+using LinearAlgebra
+using ITensorUnicodePlots
+
+
+# We will now construct an MPS representation of the GHZ state for 4 qubits. Initially, we will express the ket vector in the computation basis. Then, we will transform the GHZ state into a tensor product representation using matrices. The MPS will be explicitly generated in ITensor, and we will contrast this approach with an alternative method that relies on bra-ket notation in ITensor. Finally, we will validate our approaches by converting the MPS into a vector and comparing it with the original ket vector in the computational basis.
+
+# ## GHZ in computational basis representation
+#
+# The GHZ state is a famous quantum state with interesting entanglement properties which however are not the focus of this notebook. The general form is as follows
+# $$
+# |\mathrm{GHZ}\rangle = \frac{|0\rangle^{\otimes M} + |1\rangle^{\otimes M}}{\sqrt{2}}.
+# $$
+# In our example we will just consider the unnormalized 4 qubit GHZ state $|\mathrm{GHZ}\rangle = |0000\rangle+ |1111\rangle$ but everything can be easily extended to higher number of qubits. We will use the usual compuational basis representation and will represent $|0\rangle := \begin{pmatrix} 1 \\ 0 \end{pmatrix}$ and $|1\rangle := \begin{pmatrix} 0 \\ 1 \end{pmatrix}$. 
+#
+# To represent the 4-qubit system we will have to compute the tensor products:
+#
+# $$|0000\rangle = |0\rangle \otimes |0\rangle \otimes |0\rangle \otimes |0\rangle = \begin{pmatrix} 1 \\ 0 \\ \vdots \\ 0 \end{pmatrix} \in \mathbb{C}^{16}$$
+#
+# $$|1111\rangle = |1\rangle \otimes |1\rangle \otimes |1\rangle \otimes |1\rangle = \begin{pmatrix} 0 \\ \vdots \\ 0 \\ 1 \end{pmatrix} \in \mathbb{C}^{16}$$
+#
+# Thus we can write the GHZ state as:
+# $$|\mathrm{GHZ}\rangle =  \begin{pmatrix} 1 \\ 0 \\ \vdots \\ 0 \\ 1 \end{pmatrix} \in \mathbb{C}^{16} $$
+#
+#
+
+# ## Explicit MPS construction
+
+# First we will prepare the 4 qubit sites and create a random mps which we will overwrite with our own tensors.
+
+n = 4
+s = siteinds("Qubit",n)
+@show s
+
+# create the random mps to have physical site indices and virtual link inidces in place
+mps = randomMPS(s, linkdims=2)
+
+# See the [Wikipedia entry](https://en.wikipedia.org/wiki/Matrix_product_state#Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state) for the MPS form of the GHZ state. We will derive this form following [theses lecture notes p.19](https://tu-dresden.de/mn/physik/itp/ket/ressourcen/dateien/teach_folder/ss2021/skript/Lecture4.pdf?lang=en)
+#
+# $$
+# \begin{aligned}
+# |\mathrm{GHZ}\rangle &= |0000\rangle + |1111\rangle \\
+# &= |\begin{pmatrix} |0\rangle_1 & |1\rangle_1 \end{pmatrix} \begin{pmatrix} |0\rangle_2 & 0 \\ 0 & |1\rangle_2 \end{pmatrix}  \begin{pmatrix} |0\rangle_3 & 0 \\ 0 & |1\rangle_3 \end{pmatrix} \begin{pmatrix} |0\rangle_4 \\ |1\rangle_4 \end{pmatrix}
+# \end{aligned}
+# $$ 
+# Note that the product of ket vectors is shorthand for the tensorproduct. In this form we can see the 4 tensors for the 4 qubit sites. If we define the MPS form as usual: 
+# $$|\mathrm{GHZ}\rangle = \sum_{s_1 \dots s_4} A^{s_1}A^{s_2}A^{s_3}A^{s_4}|s_1 s_2 s_3 s_4 \rangle $$
+#
+# We can write the first site tensor $A^{s_1}$ as follows:
+# $$A^{s_1=0} = |0\rangle_1 = \begin{pmatrix} 1 & 0 \end{pmatrix} \quad\text{and}\quad A^{s_1=1} = |1\rangle_1 = \begin{pmatrix} 0 & 1 \end{pmatrix}.$$
+# Here $A^{s_1=0}$ and $A^{s_1=1}$ are the slices of the first site tensor $A^{s_1}$ for when the physical site index $s_1$ is either 0 or 1:
+# <div style="margin-left:auto; margin-right:auto; width:300px;">
+# <img src="attachment:3d4ab42c-347d-4b40-a7e8-9b5d121f1388.png" width="300">
+# </div>
+#
+# Analogously we rewrite the last site tensor $A^{s_4}$ as follows:
+# $$A^{s_4=0} = |0\rangle_4 = \begin{pmatrix} 1 \\ 0 \end{pmatrix} \quad\text{and}\quad A^{s_4=1} = |1\rangle_4 = \begin{pmatrix} 0 \\ 1 \end{pmatrix}.$$
+#
+# For sites $s_2$ and $s_3$ the slices have the shape as given in wikipedia:
+# $$A^{s_i=0} = \begin{pmatrix} 1 & 0\\ 0 & 0 \end{pmatrix} \quad \text{and} \quad A^{s_i=1} = \begin{pmatrix} 0 & 0\\ 0 & 1 \end{pmatrix}, \quad \text{for}\quad i=2,3$$
+#
+# We can quickly check the coefficient of the state $|0000\rangle = |s_1=0, s_2=0, s_3=0, s_4=0\rangle$ which would be $$A^{s_1=0} A^{s_2=0} A^{s_3=0} A^{s_4=0} =  \begin{pmatrix} 1 & 0 \end{pmatrix} \begin{pmatrix} 1 & 0 \\ 0 & 0 \end{pmatrix} \begin{pmatrix} 1 & 0 \\ 0 & 0 \end{pmatrix} \begin{pmatrix} 1 \\ 0 \end{pmatrix} = 1 .$$ 
+# Equally we can check that all other combinations of $s_1 \dots s_4$ will result in a 0 coefficient except for $|1111\rangle$. Thus we correctly found a MPS representation for the 4 qubit GHZ state. 
+
+# +
+# for MPS form GHZ state see https://en.wikipedia.org/wiki/Matrix_product_state#Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state 
+# A0 = [1 0; 0 0]
+# A1 = [0 0; 0 1]
+# matrices A0 and A1 are slices of the tensor at site 2,...,N-1
+# tensor at site 1 is 1x2x2  and contains [1 0] and [0 1]
+# tensor at site N is 2x1x1 and contains [1; 0] and [0; 1]
+
+
+@show mps[1] # tensor at site 1 gives ITensor ord=2 (dim=2|id=697|"Qubit,Site,n=1") (dim=2|id=843|"Link,l=1")
+# thus create tensor at site 1, with physical index first then link index
+T1 = ITensor([1 0; 0 1], inds(mps[1])) # inds(mps[1]) gets the physical and link index of the tensor at site 1
+mps[1] = T1 # replace tensor at site 1 with T1
+
+
+@show mps[4] # tensor at site 4 gives ITensor ord=2 (dim=2|id=56|"Link,l=3") (dim=2|id=19|"Qubit,Site,n=4")
+# thus create tensor at site N, with link index first then physical index
+TN = ITensor([1 0; 0 1], inds(mps[end])) # inds(mps[end]) gets the physical and link index of the tensor at site N
+mps[end] = TN # replace tensor at site N with TN
+
+
+# for inbetween tensors we set them to tensor with A1 and A0 slices
+Tk = zeros(Float64, 2, 2, 2) # 2x2x2 tensor
+# indices of inbetween tensors are link, site, link
+Tk[:,1,:] = [1 0; 0 0] # A0 slice
+Tk[:,2,:] = [0 0; 0 1] # A1 slice
+for site in range(2, stop=n-1)
+    mps[site] = ITensor(Tk, inds(mps[site])) # inds(mps[site]) gets the physical and link index of the tensor at site site
+end
+# -
+
+println("-"^80)
+println("MPS form of GHZ state")
+println("-"^80)
+@visualize mps
+for n in range(1, stop=n)
+    println("site $n")
+    println("-"^50)
+    @show mps[n]
+end
+mps1 = mps
+
+# ## MPS via ITensors string array constructor
+# ITensor can also create an MPS by giving an array of string, where each string identifies a state on a site. Thus we will create an MPS for the $|0000\rangle$ state and one for the $|1111\rangle$ state and add them.
+
+states_up = fill("Up",n) # fill creates an array of n elements with the value "Up"
+states_dn = fill("Dn",n) # fill creates an array of n elements with the value "Dn"
+mps_up = MPS(s,states_up)
+mps_dn = MPS(s,states_dn)
+mps2 = mps_up + mps_dn
+
+
+
+# ## Evaluation
+# Now we try to evaluate our created MPS `mps1` and `mps2`
+
+# +
+# Overlap between mps1 and mps2
+mps1_ = normalize(mps1)
+mps2_ = normalize(mps2)
+overlap = inner(mps1_, mps2_)
+
+println("overlap of mps1 and mps2: ", overlap)
+println("mps are close to each other: ", isapprox(overlap, 1.0))
+# -
+
+# Now lets contract the MPSs and have a look at the corresponding tensor in the computational basis which as we know should be:
+# $$|\mathrm{GHZ}\rangle =  \begin{pmatrix} 1 \\ 0 \\ \vdots \\ 0 \\ 1 \end{pmatrix} \in \mathbb{C}^{16} $$
+
+ket1 = contract(mps1)
+C = combiner(inds(ket1))
+combined_ket1 = C * ket1
+@show combined_ket1
+
+
+ket2 = contract(mps2)
+C = combiner(inds(ket2))
+combined_ket2 = C * ket2
+@show combined_ket2
+
+
+# As we see both MPS equal our GHZ-state!
+
+

--- a/examples/basic_ops/ghz_mps.jl
+++ b/examples/basic_ops/ghz_mps.jl
@@ -64,14 +64,14 @@ mps = randomMPS(s, linkdims=2)
 # $$|\mathrm{GHZ}\rangle = \sum_{s_1 \dots s_4} A^{s_1}A^{s_2}A^{s_3}A^{s_4}|s_1 s_2 s_3 s_4 \rangle $$
 #
 # We can write the first site tensor $A^{s_1}$ as follows:
-# $$A^{s_1=0} = |0\rangle_1 = \begin{pmatrix} 1 & 0 \end{pmatrix} \quad\text{and}\quad A^{s_1=1} = |1\rangle_1 = \begin{pmatrix} 0 & 1 \end{pmatrix}.$$
+# $$A^{s_1=0} = \begin{pmatrix} 1 & 0 \end{pmatrix} \quad\text{and}\quad A^{s_1=1} = \begin{pmatrix} 0 & 1 \end{pmatrix}.$$
 # Here $A^{s_1=0}$ and $A^{s_1=1}$ are the slices of the first site tensor $A^{s_1}$ for when the physical site index $s_1$ is either 0 or 1:
 # <div style="margin-left:auto; margin-right:auto; width:300px;">
 # <img src="attachment:3d4ab42c-347d-4b40-a7e8-9b5d121f1388.png" width="300">
 # </div>
 #
 # Analogously we rewrite the last site tensor $A^{s_4}$ as follows:
-# $$A^{s_4=0} = |0\rangle_4 = \begin{pmatrix} 1 \\ 0 \end{pmatrix} \quad\text{and}\quad A^{s_4=1} = |1\rangle_4 = \begin{pmatrix} 0 \\ 1 \end{pmatrix}.$$
+# $$A^{s_4=0} = \begin{pmatrix} 1 \\ 0 \end{pmatrix} \quad\text{and}\quad A^{s_4=1} = \begin{pmatrix} 0 \\ 1 \end{pmatrix}.$$
 #
 # For sites $s_2$ and $s_3$ the slices have the shape as given in wikipedia:
 # $$A^{s_i=0} = \begin{pmatrix} 1 & 0\\ 0 & 0 \end{pmatrix} \quad \text{and} \quad A^{s_i=1} = \begin{pmatrix} 0 & 0\\ 0 & 1 \end{pmatrix}, \quad \text{for}\quad i=2,3$$


### PR DESCRIPTION
# Description

I added a small example on how to construct the GHZ state as an MPS and how to check the correctness of the construction by comparing the contracted MPS with an exact vector in the computational basis. The example is availabe as a jupyter notebook and as an equivalent julia script. I found it especially instructive to check ones understanding of a MPS  and ITensors data format for an MPS. Also I think it is nicer to work with a physical example then with randomMPS where we can't compare it with a known vector in the computational basis. 

For the script only `ITensor, LinearAlgebra and ITensorUnicodePlots` are needed. For the notebook one would need a jupyter notebook with a julia kernel


# How Has This Been Tested?
I did not add any programmatic test but the correctness of the MPS construction is explicitly checked in the notebook/script.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.

I am not sure on how to add this code example to the docs.