### PR TITLE
[NDTensors] [BUG] Fix norm for UniformDiag

### DIFF
--- a/NDTensors/src/diag/diagtensor.jl
+++ b/NDTensors/src/diag/diagtensor.jl
@@ -43,6 +43,9 @@ function zeros(tensortype::Type{<:DiagTensor}, inds::Tuple{})
   return tensor(generic_zeros(storagetype(tensortype), mindim(inds)), inds)
 end
 
+# Compute the norm of Uniform diagonal tensor
+norm(S::UniformDiagTensor) = sqrt(mindim(S) * data(S))
+
 """
 getdiagindex(T::DiagTensor,i::Int)
 

--- a/NDTensors/test/diag.jl
+++ b/NDTensors/test/diag.jl
@@ -26,7 +26,7 @@ end
     @test complex(D) == Diag(one(ComplexF64))
     @test similar(D) == Diag(0.0)
 
-    D = Tensor(Diag(1), (2,2))
+    D = Tensor(Diag(1), (2, 2))
     @test norm(D) == √2
     d = 3
     vr = rand(d)

--- a/NDTensors/test/diag.jl
+++ b/NDTensors/test/diag.jl
@@ -26,6 +26,8 @@ end
     @test complex(D) == Diag(one(ComplexF64))
     @test similar(D) == Diag(0.0)
 
+    D = Tensor(Diag(1), (2,2))
+    @test norm(D) == √2
     d = 3
     vr = rand(d)
     D = dev(tensor(Diag(vr), (d, d)))


### PR DESCRIPTION
# Description

fix the issue found [here](https://github.com/ITensor/ITensors.jl/issues/1140)

Fixes #1140

Make a function for uniform diagonal tensors that correctly computes the norm of the tensor

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
using ITensors
i, j = Index(2), Index(2)
norm(delta(i,j)) == √(2) # returns false
```
</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
using ITensors
i, j = Index(2), Index(2)
norm(delta(i,j)) == √(2) # returns true
```
</p></details>

# How Has This Been Tested?

Added a test to `diag.jl`
