### PR TITLE
[ITensors] Ignore Tag and TagSet overflow

### DIFF
--- a/src/tagset.jl
+++ b/src/tagset.jl
@@ -86,8 +86,7 @@ function GenericTagSet{T,N}(str::AbstractString) where {T,N}
         nchar = 0
       end
     elseif current_char != ' ' # TagSet constructor ignores whitespace
-      nchar == length(current_tag) &&
-        error("Currently, tags can only have up to $(length(current_tag)) characters")
+      nchar == length(current_tag) && continue
       nchar += 1
       @inbounds current_tag[nchar] = current_char
     end
@@ -95,6 +94,9 @@ function GenericTagSet{T,N}(str::AbstractString) where {T,N}
   # Store the final tag
   if nchar != 0
     ntags = _addtag!(ts, ntags, cast_to_uint(current_tag))
+  end
+  if ntags > N
+    ntags = N
   end
   return GenericTagSet{T,N}(TagSetStorage(ts), ntags)
 end

--- a/test/base/test_tagset.jl
+++ b/test/base/test_tagset.jl
@@ -79,9 +79,13 @@ using ITensors, Test
   end
 
   @testset "Tag too long" begin
-    @test_throws ErrorException TagSet("ijklmnopqabcdefgh")
-    @test_throws ErrorException TagSet("abcd,ijklmnopqabcdefgh")
-    @test_throws ErrorException TagSet("ijklmnopqabcdefgh,abcd")
+    @test TagSet("ijklmnopqabcdefgh") == TagSet("ijklmnopqabcdefg")
+    @test TagSet("abcd,ijklmnopqabcdefgh") == TagSet("abcd,ijklmnopqabcdefg")
+    @test TagSet("ijklmnopqabcdefgh,abcd") == TagSet("abcd,ijklmnopqabcdefg")
+  end
+
+  @testset "Too many tags" begin
+    @test TagSet("a,b,c,d,e,f") == TagSet("a,b,c,d")
   end
 
   @testset "Integer Tags" begin


### PR DESCRIPTION
# Description

Tags currently have a limit of 16 characters and TagSets have a limit of 4 tags. We can investigate making these limits customizable or increasing their defaults, but before we do that it is a pain to run into errors from using too many tags or tags that are too long, which is becoming pretty common in high dimensional tensor networks in ITensorNetworks. This PR just ignores extra tag characters and tags, for example:
```julia
julia> TagSet("ijklmnopqabcdefgh")
"ijklmnopqabcdefg"

julia> TagSet("a,b,c,d,e")
"a,b,c,d"
```

@emstoudenmire curious what you think about this. I think the only downside is if someone is relying on making unique tags/TagSets that then don't end up unique because some tags or characters get ignored, but that is pretty easily avoidable in practice.