### PR TITLE
[debug][NDTensors] In-place contraction bug

### DIFF
--- a/NDTensors/src/dense/tensoralgebra/contract.jl
+++ b/NDTensors/src/dense/tensoralgebra/contract.jl
@@ -375,9 +375,17 @@ function _contract!(
 
   # TODO: this logic may be wrong
   if props.permuteC
-    # Need to copy here since we will be permuting
-    # into C later
-    CM = reshape(copy(CT), (props.dleft, props.dright))
+    # if we are computing C = α * A B + β * C
+    # we need to make sure C is permuted to the same 
+    # ordering as A B
+    if β ≠ 0
+      pC = NTuple{NB,Int}(props.PC)
+      CM = reshape(permutedims(CT, pC), (props.dleft, props.dright))
+    else
+      # Need to copy here since we will be permuting
+      # into C later  
+      CM = reshape(copy(CT), (props.dleft, props.dright))
+    end
   else
     if Ctrans(props)
       CM = transpose(reshape(CT, (props.dright, props.dleft)))


### PR DESCRIPTION
# Description

When computing C = \alpha AB + \beta C, with \beta != 0 there was a bug found that sometimes the tensor C would be evaluated incorrectly. This bug was found to occur when the output labels of C were permuted from the output labels of AB. I.e. `C(5,2,4,3) = A(-1, 2,3,4) * B(-1,5) + C(5,2,4,3)`.  `A(-1,2,3,4) * B(-1,5) => R(5,2,3,4)` and was matricized to `R(5,234)` and added to the matricized `C(5,243)`. The addition `R(5,234) + C(5,243)` has no runtime errors because the size `(234) = (243)` however numerical errors occurred. This was fixed by permuting C when `\beta != 0`
Fixes #(issue)

This bug was discovered in this thread https://itensor.discourse.group/t/inplace-multiplication-of-tensors-with-the-same-shape-but-different-indicies/900/16