### PR TITLE
[Debug][NDTensors] Unwrap reshapedArray function

### DIFF
--- a/NDTensors/src/dense/tensoralgebra/contract.jl
+++ b/NDTensors/src/dense/tensoralgebra/contract.jl
@@ -334,6 +334,20 @@ function _contract!(
   return _contract!(C, A, B, props, α, β)
 end
 
+function _contract!(C::ReshapedArray{El}, 
+  A::ReshapedArray{El},
+  B::ReshapedArray{El},
+  props::ContractionProperties,
+  α::Number=one(El),
+  β::Number=zero(El)) where {El}
+  Cp = copy(C)
+  _contract!(Cp, copy(A), copy(B), props, α, β)
+  Cp = reshape(Cp, (length(C)))
+  for i in 1:length(C)
+    C.parent[i] = Cp[i]
+  end
+end
+
 function _contract!(
   CT::AbstractArray{El,NC},
   AT::AbstractArray{El,NA},

--- a/NDTensors/src/dense/tensoralgebra/contract.jl
+++ b/NDTensors/src/dense/tensoralgebra/contract.jl
@@ -334,18 +334,18 @@ function _contract!(
   return _contract!(C, A, B, props, α, β)
 end
 
-function _contract!(C::ReshapedArray{El}, 
+function _contract!(
+  C::ReshapedArray{El},
   A::ReshapedArray{El},
   B::ReshapedArray{El},
   props::ContractionProperties,
   α::Number=one(El),
-  β::Number=zero(El)) where {El}
+  β::Number=zero(El),
+) where {El}
   Cp = copy(C)
   _contract!(Cp, copy(A), copy(B), props, α, β)
   Cp = reshape(Cp, (length(C)))
-  for i in 1:length(C)
-    C.parent[i] = Cp[i]
-  end
+  return copy!(C, Cp)
 end
 
 function _contract!(


### PR DESCRIPTION
Currently reshapedarrays with non-CPU backend do not work properly in the mul! function (they are considered CPU arrays and `BLAS.gemm!` is called on them which results in an addressing error) Created a simple function which unwraps the ReshapedArrays computes the gemm and then rewrites the data back to the correct piece of memory. This is especially important in views.