### PR TITLE
[NDTensors] Change definition of `backend_octavian` to avoid method overwrite warning

### DIFF
--- a/NDTensors/src/NDTensors.jl
+++ b/NDTensors/src/NDTensors.jl
@@ -224,9 +224,7 @@ function disable_tblis()
   return nothing
 end
 
-function backend_octavian()
-  throw(UndefVarError)
-end
+function backend_octavian end
 
 function __init__()
   @static if !isdefined(Base, :get_extension)


### PR DESCRIPTION
With the current definition of `backend_octavian` in NDTensors.jl, it generates a warning:
```julia
┌ NDTensorOctavian [741af968-7ee1-5a7b-8fdc-4e972246587f]
│  WARNING: Method definition backend_octavian() in module NDTensors at /Users/mfishman/.julia/dev/ITensors/NDTensors/src/NDTensors.jl:227 overwritten in module NDTensorOctavian at /Users/mfishman/.julia/dev/ITensors/NDTensors/ext/NDTensorOctavian/octavian.jl:1.
│    ** incremental compilation may be fatally broken for this module **
└  
```
This PR changes it from being explicitly defined to being defined without any methods, so it should generate a method overwrite warning.

@kmp5VT