### PR TITLE
[ITensors] Fix OpSum issue when a site operator has no blocks

### DIFF
--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -197,6 +197,7 @@ function qn_svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
       for (q_op, M) in block
         op_prod = q_op[2]
         Op = computeSiteProd(sites, Prod(op_prod))
+        (nnzblocks(Op) == 0) && continue
 
         rq = q_op[1]
         sq = flux(Op)

--- a/test/ITensorLegacyMPS/base/test_autompo.jl
+++ b/test/ITensorLegacyMPS/base/test_autompo.jl
@@ -1141,6 +1141,22 @@ end
     @test all(linkdims(H) .<= 2)
     @test_broken all(linkdims(H) .== 1)
   end
+
+  @testset "Regression test (Issue 1150): Zero blocks operator" begin
+    N = 4
+    sites = siteinds("Fermion", N; conserve_qns=true)
+    os = OpSum()
+    os += (1.111, "Cdag", 3, "Cdag", 4, "C", 2, "C", 1)
+    os += (2.222, "Cdag", 4, "Cdag", 1, "C", 3, "C", 2)
+    os += (3.333, "Cdag", 1, "Cdag", 4, "C", 4, "C", 1)
+    os += (4.444, "Cdag", 2, "Cdag", 3, "C", 1, "C", 4)
+    # The following operator has C on site 2 twice, resulting
+    # in a local operator with no blocks (exactly zero),
+    # causing a certain logical step in working out the column qn
+    # to fail:
+    os += (5.555, "Cdag", 4, "Cdag", 4, "C", 2, "C", 2)
+    @test_nowarn H = MPO(os, sites)
+  end
 end
 
 nothing


### PR DESCRIPTION
# Description

There was a bug in the QN version of OpSum where if one of the site operators making up a term had no blocks (was exactly zero), then the logic of figuring out which block of the column index which was based on finding the operator's flux, could break. (I.e. the intended operator might have a non-zero flux, but if it has no blocks, the `flux` function returns `nothing`. This can happen when the operator is something like "C*C" which goes outside the local Hilbert space.)

This fix checks for the `nnzblocks(Op)==0` case and just skips such operators.

Fixes #1150

If practical and applicable, please include a minimal demonstration of the previous behavior and new behavior below.

<details><summary>Minimal demonstration of previous behavior</summary><p>

See #1150 for a minimal example code that throws an exception.

# How Has This Been Tested?

Added a new "regression test" to the `test_autompo.jl` file.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
