### PR TITLE
[ITensors] Reorganize and improve OneITensor

### DIFF
--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -130,6 +130,7 @@ include("indexset.jl")
 # ITensor
 #
 include("itensor.jl")
+include("oneitensor.jl")
 include("tensor_operations/tensor_algebra.jl")
 include("tensor_operations/matrix_algebra.jl")
 include("tensor_operations/permutations.jl")

--- a/src/mps/abstractprojmpo.jl
+++ b/src/mps/abstractprojmpo.jl
@@ -1,22 +1,6 @@
-
-# Scalar identity ITensor
-struct OneITensor end
-
-(::OneITensor * A::ITensor) = A
-(A::ITensor * ::OneITensor) = A
-
-inds(::OneITensor) = ()
-
 abstract type AbstractProjMPO end
 
 copy(::AbstractProjMPO) = error("Not implemented")
-
-# This is to help with generic promote_type code
-# in eltype(::AbstractProjMPO)
-eltype(::OneITensor) = Bool
-dim(::OneITensor) = 1
-isoneitensor(::OneITensor) = true
-isoneitensor(::ITensor) = false
 
 """
     nsite(P::ProjMPO)

--- a/src/oneitensor.jl
+++ b/src/oneitensor.jl
@@ -1,0 +1,19 @@
+# Scalar identity ITensor
+# TODO: Implement as a new `Scalar` storage type.
+struct OneITensor end
+
+inds(::OneITensor) = ()
+
+# This is to help with generic promote_type code
+# in eltype(::AbstractProjMPO)
+eltype(::OneITensor) = Bool
+dim(::OneITensor) = 1
+isoneitensor(::OneITensor) = true
+isoneitensor(::ITensor) = false
+
+dag(t::OneITensor) = t
+
+(::OneITensor * A::ITensor) = A
+(A::ITensor * ::OneITensor) = A
+*(t::OneITensor) = t
+deepcontract(ts::Union{ITensor,OneITensor}...) = *(ts...)

--- a/test/base/test_oneitensor.jl
+++ b/test/base/test_oneitensor.jl
@@ -1,0 +1,18 @@
+using ITensors
+using Test
+
+@testset "OneITensor" begin
+  let i = Index(2), it = ITensor(i), OneITensor = ITensors.OneITensor
+    @test OneITensor() isa OneITensor
+    @test inds(OneITensor()) == ()
+    @test eltype(OneITensor()) <: Bool
+    @test isone(dim(OneITensor()))
+    @test ITensors.isoneitensor(OneITensor())
+    @test !ITensors.isoneitensor(it)
+    @test dag(OneITensor()) == OneITensor()
+    @test OneITensor() * it == it
+    @test it * OneITensor() == it
+    @test *(OneITensor()) == OneITensor()
+    @test contract([it, OneITensor(), OneITensor()]) == it
+  end
+end


### PR DESCRIPTION
`OneITensor` acts as a scalar ITensor with a value of one, which performs a no-op when contracted with other ITensors. This puts it in its own file and expands its functionality a little.

Ideally in the future it would be replace by a storage type, such as a `Scalar` type with a special element type, like `One` from [Zeros.jl](https://github.com/perrutquist/Zeros.jl).