### PR TITLE
[NDTensors] Only define sort(Tuple) below Julia 1.10

### DIFF
--- a/NDTensors/src/tupletools.jl
+++ b/NDTensors/src/tupletools.jl
@@ -167,12 +167,14 @@ function getindices(t::Tuple, I::NTuple{N,Int}) where {N}
 end
 
 # Taken from TupleTools.jl
-"""
-    sort(t::Tuple; lt=isless, by=identity, rev::Bool=false) -> ::Tuple
+if VERSION < v"1.10.0-DEV.1404"
+  """
+      sort(t::Tuple; lt=isless, by=identity, rev::Bool=false) -> ::Tuple
 
-Sorts the tuple `t`.
-"""
-Base.sort(t::Tuple; lt=isless, by=identity, rev::Bool=false) = _sort(t, lt, by, rev)
+  Sorts the tuple `t`.
+  """
+  Base.sort(t::Tuple; lt=isless, by=identity, rev::Bool=false) = _sort(t, lt, by, rev)
+end
 @inline function _sort(t::Tuple, lt=isless, by=identity, rev::Bool=false)
   t1, t2 = _split(t)
   t1s = _sort(t1, lt, by, rev)


### PR DESCRIPTION
This should fix #1164.

Once https://github.com/JuliaLang/Compat.jl/pull/804 is merged we can just remove our definition of `sort(::Tuple)` entirely, which isn't a good idea to have here anyway.