### PR TITLE
[NDTensors] Remove sort(Tuple) in favor of version in Compat

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -23,7 +23,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
 [compat]
 Adapt = "3.5"
-Compat = "2.1, 3, 4"
+Compat = "4.9"
 Dictionaries = "0.3.5"
 FLoops = "0.2.1"
 Folds = "0.2.8"

--- a/NDTensors/src/tupletools.jl
+++ b/NDTensors/src/tupletools.jl
@@ -166,43 +166,6 @@ function getindices(t::Tuple, I::NTuple{N,Int}) where {N}
   return ntuple(i -> t[I[i]], Val(N))
 end
 
-# Taken from TupleTools.jl
-if VERSION < v"1.10.0-DEV.1404"
-  """
-      sort(t::Tuple; lt=isless, by=identity, rev::Bool=false) -> ::Tuple
-
-  Sorts the tuple `t`.
-  """
-  Base.sort(t::Tuple; lt=isless, by=identity, rev::Bool=false) = _sort(t, lt, by, rev)
-end
-@inline function _sort(t::Tuple, lt=isless, by=identity, rev::Bool=false)
-  t1, t2 = _split(t)
-  t1s = _sort(t1, lt, by, rev)
-  t2s = _sort(t2, lt, by, rev)
-  return _merge(t1s, t2s, lt, by, rev)
-end
-_sort(t::Tuple{Any}, lt=isless, by=identity, rev::Bool=false) = t
-_sort(t::Tuple{}, lt=isless, by=identity, rev::Bool=false) = t
-
-function _split(t::NTuple{N}) where {N}
-  M = N >> 1
-  return ntuple(i -> t[i], M), ntuple(i -> t[i + M], N - M)
-end
-
-function _merge(t1::Tuple, t2::Tuple, lt, by, rev)
-  if lt(by(first(t1)), by(first(t2))) != rev
-    return (first(t1), _merge(Base.tail(t1), t2, lt, by, rev)...)
-  else
-    return (first(t2), _merge(t1, Base.tail(t2), lt, by, rev)...)
-  end
-end
-_merge(t1::Tuple{}, t2::Tuple, lt, by, rev) = t2
-_merge(t1::Tuple, t2::Tuple{}, lt, by, rev) = t1
-
-#function tail(t::NTuple{N})
-#  return ntuple(i -> t[i+1],Val(N-1))
-#end
-
 function _insertat(t, pos, n_insert, val, i)
   if i < pos
     return t[i]


### PR DESCRIPTION
# Description

`sort(::NTuple)` was introduced in Julia 1.10 (https://github.com/JuliaLang/julia/pull/46104), and can be added to older Julia versions using Compat.jl 4.9 (https://github.com/JuliaLang/Compat.jl/pull/804), so we can now remove our own version of it, which wasn't a good idea to have anyway since it is type piracy (see also #1164).