### PR TITLE
[NDTensors] Define `blockoffsets` for Empty tensors/storage

### DIFF
--- a/NDTensors/src/empty/EmptyTensor.jl
+++ b/NDTensors/src/empty/EmptyTensor.jl
@@ -114,6 +114,8 @@ end
 
 insertblock!!(T::EmptyTensor{<:Number,N}, block) where {N} = insertblock(T, block)
 
+blockoffsets(tensor::EmptyTensor) = BlockOffsets{ndims(tensor)}()
+
 # Special case with element type of EmptyNumber: storage takes the type
 # of the input.
 @propagate_inbounds function _setindex(T::EmptyTensor{EmptyNumber}, x, I...)

--- a/NDTensors/src/empty/empty.jl
+++ b/NDTensors/src/empty/empty.jl
@@ -116,6 +116,8 @@ real(S::EmptyStorage) = real(typeof(S))()
 
 complex(S::EmptyStorage) = complex(typeof(S))()
 
+blockoffsets(storage::EmptyStorage) = BlockOffsets{ndims(storage)}()
+
 function show(io::IO, mime::MIME"text/plain", S::EmptyStorage)
   return println(io, typeof(S))
 end

--- a/NDTensors/test/emptystorage.jl
+++ b/NDTensors/test/emptystorage.jl
@@ -18,5 +18,10 @@ using Test
     @test eltype(Tc) == Complex{NDTensors.EmptyNumber}
     @test Tc[1, 1] == Complex(NDTensors.EmptyNumber(), NDTensors.EmptyNumber())
     @test Tc[1, 2] == Complex(NDTensors.EmptyNumber(), NDTensors.EmptyNumber())
+
+    T = dev(EmptyTensor(Float64, (2, 2)))
+    @test blockoffsets(T) == BlockOffsets{2}()
+    T = dev(EmptyBlockSparseTensor(Float64, ([1, 1], [1, 1])))
+    @test blockoffsets(T) == BlockOffsets{2}()
   end
 end

--- a/test/base/test_emptyitensor.jl
+++ b/test/base/test_emptyitensor.jl
@@ -88,4 +88,10 @@ end
   @test_broken A + B
 end
 
+@testset "blockoffsets" for space in (2, [QN(0) => 1, QN(1) => 1])
+  i = Index(space)
+  A = ITensor(i', dag(i))
+  @test blockoffsets(A) == NDTensors.BlockOffsets{2}()
+end
+
 nothing


### PR DESCRIPTION
`blockoffsets` will now return an empty `BlockOffsets` list, while previously it errored.

Part of the motivation is making generic code work better in https://github.com/ITensor/ITensorInfiniteMPS.jl/pull/77, but I think this definition makes sense independent of that.