### PR TITLE
[ITensors] Allow optionally passing desired output indices of `directsum`

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -542,6 +542,7 @@ end
 # Non-qn Index
 # TODO: add ⊕ alias
 directsum(i::Index, j::Index; tags="sum") = Index(dim(i) + dim(j); tags=tags)
+directsum(i::Index, j::Index, k::Index, inds::Index...; tags="sum") = directsum(directsum(i, j; tags), k, inds...; tags)
 
 #
 # QN related functions

--- a/src/index.jl
+++ b/src/index.jl
@@ -542,7 +542,9 @@ end
 # Non-qn Index
 # TODO: add ⊕ alias
 directsum(i::Index, j::Index; tags="sum") = Index(dim(i) + dim(j); tags=tags)
-directsum(i::Index, j::Index, k::Index, inds::Index...; tags="sum") = directsum(directsum(i, j; tags), k, inds...; tags)
+function directsum(i::Index, j::Index, k::Index, inds::Index...; tags="sum")
+  return directsum(directsum(i, j; tags), k, inds...; tags)
+end
 
 #
 # QN related functions

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -375,6 +375,8 @@ end
 """
     directsum(A::Pair{ITensor}, B::Pair{ITensor}, ...; tags)
 
+    directsum(output_inds, A::Pair{ITensor}, B::Pair{ITensor}, ...; tags)
+
 Given a list of pairs of ITensors and indices, perform a partial
 direct sum of the tensors over the specified indices. Indices that are
 not specified to be summed must match between the tensors.
@@ -385,6 +387,10 @@ a block diagonal tensor.
 Returns the ITensor representing the partial direct sum as well as the new
 direct summed indices. The tags of the direct summed indices are specified
 by the keyword arguments.
+
+Optionally, pass the new direct summed indices of the output tensor as the
+first argument (either a single Index or a collection), which must be proper
+direct sums of the input indices that are specified to be direct summed.
 
 See Section 2.3 of https://arxiv.org/abs/1405.7786 for a definition of a partial
 direct sum of tensors.
@@ -401,6 +407,10 @@ A1 = randomITensor(x, i1)
 A2 = randomITensor(x, i2)
 S, s = directsum(A1 => i1, A2 => i2)
 dim(s) == dim(i1) + dim(i2)
+
+i1i2 = directsum(i1, i2)
+S = directsum(i1i2, A1 => i1, A2 => i2)
+hasind(S, i1i2)
 
 A3 = randomITensor(x, j1)
 S, s = directsum(A1 => i1, A2 => i2, A3 => j1)

--- a/test/base/test_index.jl
+++ b/test/base/test_index.jl
@@ -174,9 +174,13 @@ import ITensors: In, Out, Neither
   @testset "directsum" begin
     i = Index(2, "i")
     j = Index(3, "j")
-    ij = ITensors.directsum(i, j; tags="test")
-    @test dim(ij) == 5
+    ij = directsum(i, j; tags="test")
+    @test dim(ij) == dim(i) + dim(j)
     @test hastags(ij, "test")
+    k = Index(4, "k")
+    ijk = directsum(i, j, k; tags="test2")
+    @test dim(ijk) == dim(i) + dim(j) + dim(k)
+    @test hastags(ijk, "test2")
   end
 end
 


### PR DESCRIPTION
# Description

Allow optionally passing desired output indices of `directsum`. See the updated docstring and tests for examples.

Helps with network operations like those in https://github.com/mtfishman/ITensorNetworks.jl/pull/110, where you often want to direct sum indices that are shared by neighboring tensors of a tensor network and make sure they still match with each other.