### PR TITLE
[ITensors] Fix bugs in QN directsum and fermionic SVD

### DIFF
--- a/NDTensors/src/NDTensors.jl
+++ b/NDTensors/src/NDTensors.jl
@@ -206,6 +206,24 @@ $(enable_threaded_blocksparse_docstring(@__MODULE__))
 disable_threaded_blocksparse() = _disable_threaded_blocksparse()
 
 #####################################
+# Optional auto fermion system
+#
+
+const _using_auto_fermion = Ref(false)
+
+using_auto_fermion() = _using_auto_fermion[]
+
+function enable_auto_fermion()
+  _using_auto_fermion[] = true
+  return nothing
+end
+
+function disable_auto_fermion()
+  _using_auto_fermion[] = false
+  return nothing
+end
+
+#####################################
 # Optional backends
 #
 

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -184,7 +184,7 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
     # This sign (sVP) accounts for the fact that
     # V is transposed, i.e. the index connecting to S
     # is the second index:
-    sVP = block_parity(vind, blockV[2]) == 1 ? -1 : +1
+    sVP = block_parity(vind, blockV[2])
 
     if (sV * sVP) == -1
       blockview(V, blockV) .= -Vb

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -184,9 +184,9 @@ function LinearAlgebra.svd(T::BlockSparseMatrix{ElT}; kwargs...) where {ElT}
     # This sign (sVP) accounts for the fact that
     # V is transposed, i.e. the index connecting to S
     # is the second index:
-    sVP = block_parity(vind, blockV[2])
+    sVP = using_auto_fermion() ? -block_parity(vind, blockV[2]) : 1
 
-    if (sV * sVP) == -1
+    if (sV * sV) == -1
       blockview(V, blockV) .= -Vb
     else
       blockview(V, blockV) .= Vb

--- a/src/global_variables.jl
+++ b/src/global_variables.jl
@@ -229,24 +229,6 @@ function disable_contraction_sequence_optimization()
 end
 
 #
-# Turn the auto fermion system on and off
-#
-
-const _using_auto_fermion = Ref(false)
-
-using_auto_fermion() = _using_auto_fermion[]
-
-function enable_auto_fermion()
-  _using_auto_fermion[] = true
-  return nothing
-end
-
-function disable_auto_fermion()
-  _using_auto_fermion[] = false
-  return nothing
-end
-
-#
 # Turn the strict tags checking on and off
 #
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -120,14 +120,17 @@ using ITensors.NDTensors:
   blas_get_num_threads,
   cpu,
   cu,
+  disable_auto_fermion,
   double_precision,
   eachblock,
   eachdiagblock,
+  enable_auto_fermion,
   fill!!,
   randn!!,
   set_eltype,
   single_precision,
-  timer
+  timer,
+  using_auto_fermion
 
 using ITensors.NDTensors.SetParameters: get_parameters, set_unspecified_parameters
 

--- a/src/physics/fermions.jl
+++ b/src/physics/fermions.jl
@@ -77,7 +77,7 @@ odd undergo an odd permutation (odd number of swaps)
 according to p, then return -1. Otherwise return +1.
 """
 function compute_permfactor(p, iv_or_qn...; range=1:length(iv_or_qn))::Int
-  using_auto_fermion() || return 1
+  !using_auto_fermion() && return 1
   N = length(iv_or_qn)
   # XXX: Bug https://github.com/ITensor/ITensors.jl/issues/931
   # oddp = @MVector zeros(Int, N)
@@ -93,14 +93,14 @@ function compute_permfactor(p, iv_or_qn...; range=1:length(iv_or_qn))::Int
 end
 
 function NDTensors.permfactor(p, ivs::Vararg{Pair{QNIndex},N}; kwargs...) where {N}
-  using_auto_fermion() || return 1
+  !using_auto_fermion() && return 1
   return compute_permfactor(p, ivs...; kwargs...)
 end
 
 function NDTensors.permfactor(
   perm, block::NDTensors.Block{N}, inds::QNIndices; kwargs...
 ) where {N}
-  using_auto_fermion() || return 1
+  !using_auto_fermion() && return 1
   qns = ntuple(n -> qn(inds[n], block[n]), N)
   return compute_permfactor(perm, qns...; kwargs...)
 end
@@ -108,7 +108,7 @@ end
 NDTensors.block_parity(i::QNIndex, block::Integer) = fparity(qn(i, block))
 
 function NDTensors.right_arrow_sign(i::QNIndex, block::Integer)
-  using_auto_fermion() || return 1
+  !using_auto_fermion() && return 1
   if dir(i) == Out && NDTensors.block_parity(i, block) == 1
     return -1
   end
@@ -116,7 +116,7 @@ function NDTensors.right_arrow_sign(i::QNIndex, block::Integer)
 end
 
 function NDTensors.left_arrow_sign(i::QNIndex, block::Integer)
-  using_auto_fermion() || return 1
+  !using_auto_fermion() && return 1
   if dir(i) == In && NDTensors.block_parity(i, block) == 1
     return -1
   end

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -316,18 +316,13 @@ function _directsum(
   (N != length(J)) &&
     error("In directsum(::ITensor, ::ITensor, ...), must sum equal number of indices")
   check_directsum_inds(A, I, B, J)
-  I = collect(I)
-  J = collect(J)
+  # Fix the Index direction for QN indices
+  # TODO: Define `getfirstind`?
+  I = map(In -> getfirst(==(In), inds(A)), I)
+  J = map(Jn -> getfirst(==(Jn), inds(B)), J)
   IJ = Vector{Base.promote_eltype(I, J)}(undef, N)
   for n in 1:N
-    In = I[n]
-    Jn = J[n]
-    In = dir(A, In) != dir(In) ? dag(In) : In
-    Jn = dir(B, Jn) != dir(Jn) ? dag(Jn) : Jn
-    IJn = directsum(In, Jn; tags=tags[n])
-    I[n] = In
-    J[n] = Jn
-    IJ[n] = IJn
+    IJ[n] = directsum(I[n], J[n]; tags=tags[n])
   end
   return _directsum(IJ, A, I, B, J)
 end
@@ -337,11 +332,12 @@ function _directsum(IJ, A::ITensor, I, B::ITensor, J; tags=nothing)
   (N != length(J)) &&
     error("In directsum(::ITensor, ::ITensor, ...), must sum equal number of indices")
   check_directsum_inds(A, I, B, J)
+  # Fix the Index direction for QN indices
+  # TODO: Define `getfirstind`?
+  I = map(In -> getfirst(==(In), inds(A)), I)
+  J = map(Jn -> getfirst(==(Jn), inds(B)), J)
   for n in 1:N
-    In = I[n]
-    Jn = J[n]
-    IJn = IJ[n]
-    D1, D2 = directsum_itensors(In, Jn, IJn)
+    D1, D2 = directsum_itensors(I[n], J[n], IJ[n])
     A *= D1
     B *= D2
   end

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -267,11 +267,11 @@ end
 function directsum_itensors(i::Index, j::Index, ij::Index)
   S1 = zeros(dim(i), dim(ij))
   for ii in 1:dim(i)
-    S1[ii, ii] = 1
+    S1[ii, ii] = true
   end
   S2 = zeros(dim(j), dim(ij))
   for jj in 1:dim(j)
-    S2[jj, dim(i) + jj] = 1
+    S2[jj, dim(i) + jj] = true
   end
   D1 = itensor(S1, dag(i), ij)
   D2 = itensor(S2, dag(j), ij)
@@ -316,6 +316,8 @@ function _directsum(
   (N != length(J)) &&
     error("In directsum(::ITensor, ::ITensor, ...), must sum equal number of indices")
   check_directsum_inds(A, I, B, J)
+  I = collect(I)
+  J = collect(J)
   IJ = Vector{Base.promote_eltype(I, J)}(undef, N)
   for n in 1:N
     In = I[n]
@@ -323,6 +325,8 @@ function _directsum(
     In = dir(A, In) != dir(In) ? dag(In) : In
     Jn = dir(B, Jn) != dir(Jn) ? dag(Jn) : Jn
     IJn = directsum(In, Jn; tags=tags[n])
+    I[n] = In
+    J[n] = Jn
     IJ[n] = IJn
   end
   return _directsum(IJ, A, I, B, J)

--- a/test/base/test_fermions.jl
+++ b/test/base/test_fermions.jl
@@ -699,7 +699,7 @@ import ITensors: Out, In
       T = ITensor(s[1], dag(s[2]))
       T[2, 2] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test norm(T - U * S * V) ≈ 0
+      @test_broken norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -711,7 +711,7 @@ import ITensors: Out, In
       T = ITensor(dag(s[1]), dag(s[2]))
       T[1, 2] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test norm(T - U * S * V) ≈ 0
+      @test_broken norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)

--- a/test/base/test_fermions.jl
+++ b/test/base/test_fermions.jl
@@ -501,8 +501,8 @@ import ITensors: Out, In
 
     psi_orig = copy(psi)
     orthogonalize!(psi, 1)
-    @test inner(psi_orig, psi) ≈ 1.0
-    @test inner(psi, psi_orig) ≈ 1.0
+    @test_broken inner(psi_orig, psi) ≈ 1.0
+    @test_broken inner(psi, psi_orig) ≈ 1.0
   end
 
   @testset "MPS inner regression test" begin
@@ -629,28 +629,28 @@ import ITensors: Out, In
     for n1 in 1:4, n2 in 1:4
       (n1 == n2) && continue
       U, S, V = svd(A, (s[n1], s[n2]))
-      @test norm(U * S * V - A) < 1E-10
+      @test_broken norm(U * S * V - A) < 1E-10
     end
     for n1 in 1:4, n2 in 1:4, n3 in 1:4
       (n1 == n2) && continue
       (n1 == n3) && continue
       (n2 == n3) && continue
       U, S, V = svd(A, (s[n1], s[n2], s[n3]))
-      @test norm(U * S * V - A) < 1E-10
+      @test_broken norm(U * S * V - A) < 1E-10
     end
 
     B = randomITensor(QN("Nf", 3, -1), s[1], s[2], s[3], s[4])
     for n1 in 1:4, n2 in 1:4
       (n1 == n2) && continue
       U, S, V = svd(B, (s[n1], s[n2]))
-      @test norm(U * S * V - B) < 1E-10
+      @test_broken norm(U * S * V - B) < 1E-10
     end
     for n1 in 1:4, n2 in 1:4, n3 in 1:4
       (n1 == n2) && continue
       (n1 == n3) && continue
       (n2 == n3) && continue
       U, S, V = svd(B, (s[n1], s[n2], s[n3]))
-      @test norm(U * S * V - B) < 1E-10
+      @test_broken norm(U * S * V - B) < 1E-10
     end
   end # Fermionic SVD tests
 
@@ -675,7 +675,7 @@ import ITensors: Out, In
       T[1, 2] = 1.0
       T[2, 1] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test norm(T - U * S * V) ≈ 0
+      @test_broken norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -687,7 +687,7 @@ import ITensors: Out, In
       T = ITensor(dag(s[1]), s[2])
       T[2, 2] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test norm(T - U * S * V) ≈ 0
+      @test_broken norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -699,7 +699,7 @@ import ITensors: Out, In
       T = ITensor(s[1], dag(s[2]))
       T[2, 2] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test norm(T - U * S * V) ≈ 0
+      @test_broken norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -711,7 +711,7 @@ import ITensors: Out, In
       T = ITensor(dag(s[1]), dag(s[2]))
       T[1, 2] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test norm(T - U * S * V) ≈ 0
+      @test_broken norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -859,7 +859,7 @@ import ITensors: Out, In
 
       # Test using SVD within DMRG too:
       energy, psi = dmrg([Ht, HV], psi0, sweeps; outputlevel=0, which_decomp="svd")
-      @test abs(energy - correct_energy) < 1E-4
+      @test_broken abs(energy - correct_energy) < 1E-4
 
       # Test using only eigen decomp:
       energy, psi = dmrg([Ht, HV], psi0, sweeps; outputlevel=0, which_decomp="eigen")
@@ -932,7 +932,7 @@ import ITensors: Out, In
       # Results in -|110⟩
       ψ1 = product(Os, ψ011; cutoff=1e-15)
 
-      @test inner(ψ1, ψ110) == -1
+      @test_broken inner(ψ1, ψ110) == -1
 
       os = OpSum()
       os += "Cdag", 1, "C", 3
@@ -956,8 +956,8 @@ import ITensors: Out, In
 
       U, S, V = svd(phi, (l1, s2))
 
-      @test norm((U * S) * V - phi) < 1E-10
-      @test norm(U * (S * V) - phi) < 1E-10
+      @test_broken norm((U * S) * V - phi) < 1E-10
+      @test_broken norm(U * (S * V) - phi) < 1E-10
     end
 
     @testset "Eigen Positive Semi Def Regression Test" begin
@@ -1019,7 +1019,7 @@ import ITensors: Out, In
 
       U, S, V = svd(T, dag(l22), dag(l23), s1)
 
-      @test norm(T - U * S * V) < 1E-10
+      @test_broken norm(T - U * S * V) < 1E-10
     end
 
     @testset "OpSum Regression Test" begin

--- a/test/base/test_fermions.jl
+++ b/test/base/test_fermions.jl
@@ -501,8 +501,8 @@ import ITensors: Out, In
 
     psi_orig = copy(psi)
     orthogonalize!(psi, 1)
-    @test_broken inner(psi_orig, psi) ≈ 1.0
-    @test_broken inner(psi, psi_orig) ≈ 1.0
+    @test inner(psi_orig, psi) ≈ 1.0
+    @test inner(psi, psi_orig) ≈ 1.0
   end
 
   @testset "MPS inner regression test" begin
@@ -629,28 +629,28 @@ import ITensors: Out, In
     for n1 in 1:4, n2 in 1:4
       (n1 == n2) && continue
       U, S, V = svd(A, (s[n1], s[n2]))
-      @test_broken norm(U * S * V - A) < 1E-10
+      @test norm(U * S * V - A) < 1E-10
     end
     for n1 in 1:4, n2 in 1:4, n3 in 1:4
       (n1 == n2) && continue
       (n1 == n3) && continue
       (n2 == n3) && continue
       U, S, V = svd(A, (s[n1], s[n2], s[n3]))
-      @test_broken norm(U * S * V - A) < 1E-10
+      @test norm(U * S * V - A) < 1E-10
     end
 
     B = randomITensor(QN("Nf", 3, -1), s[1], s[2], s[3], s[4])
     for n1 in 1:4, n2 in 1:4
       (n1 == n2) && continue
       U, S, V = svd(B, (s[n1], s[n2]))
-      @test_broken norm(U * S * V - B) < 1E-10
+      @test norm(U * S * V - B) < 1E-10
     end
     for n1 in 1:4, n2 in 1:4, n3 in 1:4
       (n1 == n2) && continue
       (n1 == n3) && continue
       (n2 == n3) && continue
       U, S, V = svd(B, (s[n1], s[n2], s[n3]))
-      @test_broken norm(U * S * V - B) < 1E-10
+      @test norm(U * S * V - B) < 1E-10
     end
   end # Fermionic SVD tests
 
@@ -675,7 +675,7 @@ import ITensors: Out, In
       T[1, 2] = 1.0
       T[2, 1] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test_broken norm(T - U * S * V) ≈ 0
+      @test norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -687,7 +687,7 @@ import ITensors: Out, In
       T = ITensor(dag(s[1]), s[2])
       T[2, 2] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test_broken norm(T - U * S * V) ≈ 0
+      @test norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -699,7 +699,7 @@ import ITensors: Out, In
       T = ITensor(s[1], dag(s[2]))
       T[2, 2] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test_broken norm(T - U * S * V) ≈ 0
+      @test norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -711,7 +711,7 @@ import ITensors: Out, In
       T = ITensor(dag(s[1]), dag(s[2]))
       T[1, 2] = 1.0
       U, S, V, spec, u, v = svd(T, s[1])
-      @test_broken norm(T - U * S * V) ≈ 0
+      @test norm(T - U * S * V) ≈ 0
       UU = dag(U) * prime(U, u)
       @test norm(UU - id(u)) ≈ 0
       VV = dag(V) * prime(V, v)
@@ -859,7 +859,7 @@ import ITensors: Out, In
 
       # Test using SVD within DMRG too:
       energy, psi = dmrg([Ht, HV], psi0, sweeps; outputlevel=0, which_decomp="svd")
-      @test_broken abs(energy - correct_energy) < 1E-4
+      @test abs(energy - correct_energy) < 1E-4
 
       # Test using only eigen decomp:
       energy, psi = dmrg([Ht, HV], psi0, sweeps; outputlevel=0, which_decomp="eigen")
@@ -932,7 +932,7 @@ import ITensors: Out, In
       # Results in -|110⟩
       ψ1 = product(Os, ψ011; cutoff=1e-15)
 
-      @test_broken inner(ψ1, ψ110) == -1
+      @test inner(ψ1, ψ110) == -1
 
       os = OpSum()
       os += "Cdag", 1, "C", 3
@@ -956,8 +956,8 @@ import ITensors: Out, In
 
       U, S, V = svd(phi, (l1, s2))
 
-      @test_broken norm((U * S) * V - phi) < 1E-10
-      @test_broken norm(U * (S * V) - phi) < 1E-10
+      @test norm((U * S) * V - phi) < 1E-10
+      @test norm(U * (S * V) - phi) < 1E-10
     end
 
     @testset "Eigen Positive Semi Def Regression Test" begin
@@ -1019,7 +1019,7 @@ import ITensors: Out, In
 
       U, S, V = svd(T, dag(l22), dag(l23), s1)
 
-      @test_broken norm(T - U * S * V) < 1E-10
+      @test norm(T - U * S * V) < 1E-10
     end
 
     @testset "OpSum Regression Test" begin

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -1676,12 +1676,15 @@ end
     @test allhastags(A, "x")
   end
 
-  @testset "directsum" begin
-    x = Index(2, "x")
-    i1 = Index(3, "i1")
-    j1 = Index(4, "j1")
-    i2 = Index(5, "i2")
-    j2 = Index(6, "j2")
+  @testset "directsum" for space in (
+    identity,
+    d -> [QN(0) => d, QN(1) => d],
+  )
+    x = Index(space(2), "x")
+    i1 = Index(space(3), "i1")
+    j1 = Index(space(4), "j1")
+    i2 = Index(space(5), "i2")
+    j2 = Index(space(6), "j2")
 
     A1 = randomITensor(i1, x, j1)
     A2 = randomITensor(x, j2, i2)

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -1676,10 +1676,9 @@ end
     @test allhastags(A, "x")
   end
 
-  @testset "directsum" for space in (
-    identity,
-    d -> [QN(0) => d, QN(1) => d],
-  )
+  @testset "directsum" for space in (identity, d -> [QN(0) => d, QN(1) => d]),
+    index_op in (identity, dag)
+
     x = Index(space(2), "x")
     i1 = Index(space(3), "i1")
     j1 = Index(space(4), "j1")
@@ -1689,14 +1688,19 @@ end
     A1 = randomITensor(i1, x, j1)
     A2 = randomITensor(x, j2, i2)
 
-    # Generate indices automatically
-    S1, s1 = directsum(A1 => (i1, j1), A2 => (i2, j2); tags=["sum_i", "sum_j"])
+    # Generate indices automatically.
+    # Reverse the arrow directions in the QN case as a
+    # regression test for:
+    # https://github.com/ITensor/ITensors.jl/pull/1178.
+    S1, s1 = directsum(
+      A1 => index_op.((i1, j1)), A2 => index_op.((i2, j2)); tags=["sum_i", "sum_j"]
+    )
 
     # Provide indices
     i1i2 = directsum(i1, i2; tags="sum_i")
     j1j2 = directsum(j1, j2; tags="sum_j")
     s2 = [i1i2, j1j2]
-    S2 = directsum(s2, A1 => (i1, j1), A2 => (i2, j2))
+    S2 = directsum(s2, A1 => index_op.((i1, j1)), A2 => index_op.((i2, j2)))
     for (S, s) in zip((S1, S2), (s1, s2))
       for vx in 1:dim(x)
         proj = dag(onehot(x => vx))
@@ -1715,43 +1719,45 @@ end
       end
     end
 
-    i1, i2, j, k, l = Index.((2, 3, 4, 5, 6), ("i1", "i2", "j", "k", "l"))
+    i1, i2, j, k, l = Index.(space.((2, 3, 4, 5, 6)), ("i1", "i2", "j", "k", "l"))
 
     A = randomITensor(i1, i2, j)
     B = randomITensor(i1, i2, k)
     C = randomITensor(i1, i2, l)
 
-    S, s = directsum(A => j, B => k)
+    S, s = directsum(A => index_op(j), B => index_op(k))
     @test dim(s) == dim(j) + dim(k)
     @test hassameinds(S, (i1, i2, s))
 
-    S, s = (A => j) ⊕ (B => k)
+    S, s = (A => index_op(j)) ⊕ (B => index_op(k))
     @test dim(s) == dim(j) + dim(k)
     @test hassameinds(S, (i1, i2, s))
 
-    S, s = directsum(A => j, B => k, C => l)
+    S, s = directsum(A => index_op(j), B => index_op(k), C => index_op(l))
     @test dim(s) == dim(j) + dim(k) + dim(l)
     @test hassameinds(S, (i1, i2, s))
 
-    @test_throws ErrorException directsum(A => i2, B => i2)
+    @test_throws ErrorException directsum(A => index_op(i2), B => index_op(i2))
 
-    S, (s,) = directsum(A => (j,), B => (k,))
+    S, (s,) = directsum(A => (index_op(j),), B => (index_op(k),))
     @test s == uniqueind(S, A)
     @test dim(s) == dim(j) + dim(k)
     @test hassameinds(S, (i1, i2, s))
 
-    S, ss = directsum(A => (i2, j), B => (i2, k))
+    S, ss = directsum(A => index_op.((i2, j)), B => index_op.((i2, k)))
     @test length(ss) == 2
     @test dim(ss[1]) == dim(i2) + dim(i2)
     @test hassameinds(S, (i1, ss...))
 
-    S, ss = directsum(A => (j,), B => (k,), C => (l,))
+    S, ss = directsum(A => (index_op(j),), B => (index_op(k),), C => (index_op(l),))
     s = only(ss)
     @test s == uniqueind(S, A)
     @test dim(s) == dim(j) + dim(k) + dim(l)
     @test hassameinds(S, (i1, i2, s))
 
-    S, ss = directsum(A => (i2, i1, j), B => (i1, i2, k), C => (i1, i2, l))
+    S, ss = directsum(
+      A => index_op.((i2, i1, j)), B => index_op.((i1, i2, k)), C => index_op.((i1, i2, l))
+    )
     @test length(ss) == 3
     @test dim(ss[1]) == dim(i2) + dim(i1) + dim(i1)
     @test dim(ss[2]) == dim(i1) + dim(i2) + dim(i2)


### PR DESCRIPTION
# Description

#1176 introduced a bug in `directsum` of QN ITensors for cases when the directions of the indices that were passed to specify what indices should be direct-summed didn't match the directions of the internal indices of the tensors.

**EDIT:** Also fixes a bug introduced in #1174 when SVDing fermionic tensors with the auto fermion system disabled.