### PR TITLE
Fix doc: use `θ` as parameter name in `Rz` and `CRz` gates rather than `ϕ`

### DIFF
--- a/docs/src/IncludedSiteTypes.md
+++ b/docs/src/IncludedSiteTypes.md
@@ -84,7 +84,7 @@ Single-qubit operators:
 - `"π/8"` (aliases: `"T"`)
 - `"Rx"` (takes argument: θ) Rotation around x axis
 - `"Ry"` (takes argument: θ) Rotation around y axis
-- `"Rz"` (takes argument: ϕ) Rotation around z axis
+- `"Rz"` (takes argument: θ) Rotation around z axis
 - `"Rn"` (takes arguments: θ, ϕ, λ) (aliases: `"Rn̂"`) Rotation about axis n=(θ, ϕ, λ)
 - `"Proj0"` (aliases: `"ProjUp"`, `"projUp"`) Operator $|0\rangle\langle 0|$
 - `"Proj1"` (aliases: `"ProjDn"`, `"projDn"`) Operator $|1\rangle\langle 1|$
@@ -107,7 +107,7 @@ Two-qubit gates:
 - `"CPHASE"` (aliases: `"Cphase"`) Controlled Phase gate
 - `"CRx"` (aliases: `"CRX"`) (takes arguments: θ)
 - `"CRy"` (aliases: `"CRY"`) (takes arguments: θ)
-- `"CRz"` (aliases: `"CRZ"`) (takes arguments: ϕ)
+- `"CRz"` (aliases: `"CRZ"`) (takes arguments: θ)
 - `"CRn"` (aliases: `"CRn̂"`) (takes arguments: θ, ϕ, λ)
 - `"SWAP"` (aliases: `"Swap"`) 
 - `"√SWAP"` (aliases: `"√Swap"`) 


### PR DESCRIPTION
# Description

When I read code in [qubit.jl](https://github.com/ITensor/ITensors.jl/blob/main/src/physics/site_types/qudit.jl) I found we are supposed to specify keyword arugment `θ` when creating a Rz (similarly CRz).

The current [documentation](https://itensor.github.io/ITensors.jl/dev/IncludedSiteTypes.html#%22Qubit%22-SiteType) says `"Rz" (takes argument: ϕ)`, which is not consistent with code in [here](https://github.com/ITensor/ITensors.jl/blob/2d2a81f776db409d54004c4c52b9eb52e256b14d/src/physics/site_types/qubit.jl#L178-L181) (similarly CRz).

# How Has This Been Tested?

Generate docs locally with the following commands:

```console
$ cd /path/to/ITensors.jl
$ julia --project=docs -e 'using Pkg; Pkg.instantiate()'
$ julia --project=docs -e 'include("docs/make.jl")' 
```

It is followed by

```console
$ using LiveServer; serve(dir="docs/build")
```

<img width="600" alt="image" src="https://github.com/ITensor/ITensors.jl/assets/16760547/7a4025b0-ccc5-4175-987f-50c40b6c8d63">

<img width="600" alt="image" src="https://github.com/ITensor/ITensors.jl/assets/16760547/ea4e6b28-df79-45d9-9ada-abc28f5afad0">


# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
