### PR TITLE
[ITensors] Improve type stability of `svdMPO` and `qn_svdMPO`

### DIFF
--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -1,6 +1,4 @@
-function svdMPO(
-  ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...
-)::MPO where {C}
+function svdMPO(ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...)::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, 10000)
   cutoff::Float64 = get(kwargs, :cutoff, 1E-15)

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -7,6 +7,8 @@ function svdMPO(ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...)::MPO wh
 
   N = length(sites)
 
+  # Specifying the element type with `Matrix{ValType}[...]` improves type inference and therefore efficiency.
+  # See https://github.com/ITensor/ITensors.jl/pull/1183.
   Vs = Matrix{ValType}[Matrix{ValType}(undef, 1, 1) for n in 1:N]
   tempMPO = [MatElem{Scaled{C,Prod{Op}}}[] for n in 1:N]
 

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -141,6 +141,6 @@ end #svdMPO
 
 function svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
   # Function barrier to improve type stability
-  ValType = ITensors.determineValType(ITensors.terms(os))
+  ValType = determineValType(terms(os))
   return svdMPO(ValType, os, sites; kwargs...)
 end

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -1,5 +1,5 @@
 function svdMPO(
-  ValType::ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...
+  ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...
 )::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, 10000)

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -117,7 +117,7 @@ function svdMPO(
     end
 
     #
-    # Special handling of starting and 
+    # Special handling of starting and
     # ending identity operators:
     #
     idM = zeros(ValType, dim(ll), dim(rl))

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -7,7 +7,7 @@ function svdMPO(
 
   N = length(sites)
 
-  Vs = [Matrix{ValType}(undef, 1, 1) for n in 1:N]
+  Vs = Matrix{ValType}[Matrix{ValType}(undef, 1, 1) for n in 1:N]
   tempMPO = [MatElem{Scaled{C,Prod{Op}}}[] for n in 1:N]
 
   function crosses_bond(t::Scaled{C,Prod{Op}}, n::Int) where {C}

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -1,3 +1,5 @@
+# `ValType::Type{<:Number}` is used instead of `ValType::Type` for efficiency, possibly due to increased method specialization.
+# See https://github.com/ITensor/ITensors.jl/pull/1183.
 function svdMPO(ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...)::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, 10000)

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -1,5 +1,5 @@
 function svdMPO(
-  ValType::Union{Type{Float64},Type{ComplexF64}}, os::OpSum{C}, sites; kwargs...
+  ValType::ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...
 )::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, 10000)

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -1,11 +1,11 @@
-function svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
+function svdMPO(
+  ValType::Union{Type{Float64},Type{ComplexF64}}, os::OpSum{C}, sites; kwargs...
+)::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, 10000)
   cutoff::Float64 = get(kwargs, :cutoff, 1E-15)
 
   N = length(sites)
-
-  ValType = determineValType(terms(os))
 
   Vs = [Matrix{ValType}(undef, 1, 1) for n in 1:N]
   tempMPO = [MatElem{Scaled{C,Prod{Op}}}[] for n in 1:N]
@@ -138,3 +138,9 @@ function svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
 
   return H
 end #svdMPO
+
+function svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
+  # Function barrier to improve type stability
+  ValType = ITensors.determineValType(ITensors.terms(os))
+  return svdMPO(ValType, os, sites; kwargs...)
+end

--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -1,3 +1,5 @@
+# `ValType::Type{<:Number}` is used instead of `ValType::Type` for efficiency, possibly due to increased method specialization.
+# See https://github.com/ITensor/ITensors.jl/pull/1183.
 function qn_svdMPO(ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...)::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, typemax(Int))

--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -254,6 +254,6 @@ end #qn_svdMPO
 
 function qn_svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
   # Function barrier to improve type stability
-  ValType = ITensors.determineValType(ITensors.terms(os))
+  ValType = determineValType(terms(os))
   return qn_svdMPO(ValType, os, sites; kwargs...)
 end

--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -7,6 +7,8 @@ function qn_svdMPO(ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...)::MPO
 
   N = length(sites)
 
+  # Specifying the element type with `Dict{QN,Matrix{ValType}}[...]` improves type inference and therefore efficiency.
+  # See https://github.com/ITensor/ITensors.jl/pull/1183.
   Vs = Dict{QN,Matrix{ValType}}[Dict{QN,Matrix{ValType}}() for n in 1:(N + 1)]
   sparse_MPO = [QNMatElem{Scaled{C,Prod{Op}}}[] for n in 1:N]
 

--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -7,7 +7,7 @@ function qn_svdMPO(
 
   N = length(sites)
 
-  Vs = [Dict{QN,Matrix{ValType}}() for n in 1:(N + 1)]
+  Vs = Dict{QN,Matrix{ValType}}[Dict{QN,Matrix{ValType}}() for n in 1:(N + 1)]
   sparse_MPO = [QNMatElem{Scaled{C,Prod{Op}}}[] for n in 1:N]
 
   function crosses_bond(t::Scaled{C,Prod{Op}}, n::Int)

--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -1,6 +1,4 @@
-function qn_svdMPO(
-  ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...
-)::MPO where {C}
+function qn_svdMPO(ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...)::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, typemax(Int))
   cutoff::Float64 = get(kwargs, :cutoff, 1E-15)

--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -1,11 +1,11 @@
-function qn_svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
+function qn_svdMPO(
+  ValType::Union{Type{Float64},Type{ComplexF64}}, os::OpSum{C}, sites; kwargs...
+)::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, typemax(Int))
   cutoff::Float64 = get(kwargs, :cutoff, 1E-15)
 
   N = length(sites)
-
-  ValType = determineValType(terms(os))
 
   Vs = [Dict{QN,Matrix{ValType}}() for n in 1:(N + 1)]
   sparse_MPO = [QNMatElem{Scaled{C,Prod{Op}}}[] for n in 1:N]
@@ -251,3 +251,9 @@ function qn_svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
 
   return H
 end #qn_svdMPO
+
+function qn_svdMPO(os::OpSum{C}, sites; kwargs...)::MPO where {C}
+  # Function barrier to improve type stability
+  ValType = ITensors.determineValType(ITensors.terms(os))
+  return qn_svdMPO(ValType, os, sites; kwargs...)
+end

--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -1,5 +1,5 @@
 function qn_svdMPO(
-  ValType::Union{Type{Float64},Type{ComplexF64}}, os::OpSum{C}, sites; kwargs...
+  ValType::ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...
 )::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, typemax(Int))

--- a/src/physics/autompo/opsum_to_mpo_qn.jl
+++ b/src/physics/autompo/opsum_to_mpo_qn.jl
@@ -1,5 +1,5 @@
 function qn_svdMPO(
-  ValType::ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...
+  ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...
 )::MPO where {C}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, typemax(Int))


### PR DESCRIPTION
# Description

This PR improves the performance of `svdMPO` and `qn_svdMPO` which are called from [`MPO(os::OpSum, sites::Vector{<:Index})::MPO`](https://github.com/ITensor/ITensors.jl/blob/b54e8d74d528f2dac481f1115ed7b7117296352d/src/physics/autompo/opsum_to_mpo_generic.jl#L292-L307).

My research has revealed the following:

Getting `ValType = determineValType(terms(os))` inside the method `svdMPO` and defining `Vs = [Matrix{ValType}(undef, 1, 1) for n in 1:N]` without type annotation causes type instability.

Type instability causes the following code sections to run slowly.

https://github.com/ITensor/ITensors.jl/blob/b54e8d74d528f2dac481f1115ed7b7117296352d/src/physics/autompo/opsum_to_mpo.jl#L96-L113

If practical and applicable, please include a minimal demonstration of the previous behavior and new behavior below.

<details><summary>Minimal demonstration of previous behavior</summary><p>

- Step1: Prepare the following Python script to generate the test data:

```python
# qph.py
from openfermion import MolecularData
from openfermionpyscf import run_pyscf

# pip3 install quri-parts-openfermion
from quri_parts.openfermion.transforms import jordan_wigner

basis = "6-31g"
multiplicity = 1
charge = 0
distance = 1.6
geometry = [("Li", (0, 0, 0)), ("H", (0, 0, distance))]

pyscf_molecule = MolecularData(geometry, basis, multiplicity, charge)
molecule = run_pyscf(pyscf_molecule)
n_orbs = molecule.n_orbitals
n_elecs = molecule.n_electrons


op_mapper = jordan_wigner.get_of_operator_mapper()

n_active_orbs = 8

qubit_count = 2 * n_active_orbs
hamiltonian = molecule.get_molecular_hamiltonian(
    range(n_elecs // 2), range(n_active_orbs)
)
qp_h = op_mapper(hamiltonian)

li = []

for pauli, c in qp_h.items():
    ps = []
    for i, p in pauli:
        ps.append((i, p))
    li.append(pauli)

print(f"N={qubit_count}")
print("paulis = [")
for e in sorted(li, key=lambda g: len(g)):
    if len(e) == 0:
        continue
    sorted_list = sorted(list(e), key=lambda e: e[0])
    sorted_list = [(1 + s[0], s[1].name) for s in sorted_list]
    out = "    ["
    seqs = []
    for s1, s2 in sorted_list:
        seqs.append('"' + s2 + '"')
        seqs.append(str(s1))
    out += ",".join(seqs)
    out += "],"
    print(out)
print("]")
```

- Step2: Run the following command:

```console
python qph.py > paulis.jl
```

It will create a file `paulis.jl`.

You can also find `paulis.jl` from [my gist](https://gist.github.com/terasakisatoshi/cdea50225b327d1b9641832c72dfe1bd).


- Step3: Prepare the following Julia script `mpo_bench.jl` to show our Pull Request improves performance for creating `MPO`.

```julia
# mpo_bench.jl 
using ITensors

include("paulis.jl") # export paulis, N

for conserve_qns in [true, false]
  sites = siteinds("Qubit", N; conserve_qns)
  os = ITensors.OpSum()

  for p in paulis
    coeff = rand()
    os += ITensors.Ops.op_term((coeff, p...))
  end

  @time MPO(os, sites)
  @time MPO(os, sites)
  @time MPO(os, sites)
end
```

On `main` branch we have:

```console
$ julia mpo_bench.jl 
 26.777017 seconds (84.34 M allocations: 4.188 GiB, 5.44% gc time, 90.48% compilation time)
  2.426720 seconds (44.33 M allocations: 1.601 GiB, 14.37% gc time)
  2.540036 seconds (44.33 M allocations: 1.601 GiB, 13.92% gc time)
 29.800494 seconds (263.40 M allocations: 10.456 GiB, 8.58% gc time, 36.43% compilation time)
 20.952781 seconds (246.38 M allocations: 9.343 GiB, 9.42% gc time)
 16.334621 seconds (246.38 M allocations: 9.343 GiB, 9.50% gc time)
```
</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

Our new pull request reduces the number of allocations and improves the performance of getting `MPO(os, site)`.

```console
julia mpo_bench.jl 
 26.626078 seconds (44.08 M allocations: 3.383 GiB, 5.20% gc time, 95.01% compilation time)
  1.958892 seconds (6.27 M allocations: 968.143 MiB, 17.07% gc time)
  1.869094 seconds (6.27 M allocations: 968.143 MiB, 16.23% gc time)
 20.243849 seconds (21.06 M allocations: 6.434 GiB, 5.73% gc time, 46.55% compilation time)
 11.731973 seconds (3.96 M allocations: 5.315 GiB, 6.59% gc time)
  9.871340 seconds (3.96 M allocations: 5.315 GiB, 5.76% gc time)
```
</p></details>

# How Has This Been Tested?

```julia
$ julia -q
julia> ]
] activate
] instantiate
] test
```

# Checklist:

- [ x ] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [  ] I have added tests that verify the behavior of the changes I made.
  - This PR does not break user interface.
- [  ] I have made corresponding changes to the documentation.
- [ x ] My changes generate no new warnings.
- [  ] Any dependent changes have been merged and published in downstream modules.
  - No additional dependencies are required for this PR.