### PR TITLE
[NDTensor] Allow general objects are storage backends for Tensor

### DIFF
--- a/NDTensors/src/NDTensors.jl
+++ b/NDTensors/src/NDTensors.jl
@@ -110,6 +110,13 @@ include("empty/tensoralgebra/contract.jl")
 include("empty/adapt.jl")
 
 #####################################
+# Array Tensor (experimental)
+# TODO: Move to `Experimental` module.
+#
+include("arraytensor/arraytensor.jl")
+include("arraytensor/array.jl")
+
+#####################################
 # Deprecations
 #
 include("deprecated.jl")

--- a/NDTensors/src/arraytensor/array.jl
+++ b/NDTensors/src/arraytensor/array.jl
@@ -1,11 +1,11 @@
 # Combiner
-promote_rule(::Type{<:Combiner}, arraytype::Type{<:MatrixOrArrayLike}) = arraytype
+promote_rule(::Type{<:Combiner}, arraytype::Type{<:MatrixOrArrayStorage}) = arraytype
 
 # Generic AbstractArray code
 function contract(
-  array1::MatrixOrArrayLike,
+  array1::MatrixOrArrayStorage,
   labels1,
-  array2::MatrixOrArrayLike,
+  array2::MatrixOrArrayStorage,
   labels2,
   labelsR=contract_labels(labels1, labels2),
 )
@@ -14,21 +14,23 @@ function contract(
   return output_array
 end
 
-function contraction_output(array1::MatrixOrArrayLike, array2::MatrixOrArrayLike, indsR)
+function contraction_output(
+  array1::MatrixOrArrayStorage, array2::MatrixOrArrayStorage, indsR
+)
   arraytypeR = contraction_output_type(typeof(array1), typeof(array2), indsR)
   return NDTensors.similar(arraytypeR, indsR)
 end
 
 function contraction_output_type(
-  arraytype1::Type{<:MatrixOrArrayLike}, arraytype2::Type{<:MatrixOrArrayLike}, inds
+  arraytype1::Type{<:MatrixOrArrayStorage}, arraytype2::Type{<:MatrixOrArrayStorage}, inds
 )
   return similartype(promote_type(arraytype1, arraytype2), inds)
 end
 
 function contraction_output(
-  array1::MatrixOrArrayLike,
+  array1::MatrixOrArrayStorage,
   labelsarray1,
-  array2::MatrixOrArrayLike,
+  array2::MatrixOrArrayStorage,
   labelsarray2,
   labelsoutput_array,
 )
@@ -42,11 +44,11 @@ end
 
 # Required interface for specific AbstractArray types
 function contract!(
-  arrayR::MatrixOrArrayLike,
+  arrayR::MatrixOrArrayStorage,
   labelsR,
-  array1::MatrixOrArrayLike,
+  array1::MatrixOrArrayStorage,
   labels1,
-  array2::MatrixOrArrayLike,
+  array2::MatrixOrArrayStorage,
   labels2,
 )
   props = ContractionProperties(labels1, labels2, labelsR)
@@ -57,7 +59,7 @@ function contract!(
 end
 
 function permutedims!(
-  output_array::MatrixOrArrayLike, array::MatrixOrArrayLike, perm, f::Function
+  output_array::MatrixOrArrayStorage, array::MatrixOrArrayStorage, perm, f::Function
 )
   @strided output_array .= f.(output_array, permutedims(array, perm))
   return output_array

--- a/NDTensors/src/arraytensor/array.jl
+++ b/NDTensors/src/arraytensor/array.jl
@@ -1,0 +1,64 @@
+# Combiner
+promote_rule(::Type{<:Combiner}, arraytype::Type{<:MatrixOrArrayLike}) = arraytype
+
+# Generic AbstractArray code
+function contract(
+  array1::MatrixOrArrayLike,
+  labels1,
+  array2::MatrixOrArrayLike,
+  labels2,
+  labelsR=contract_labels(labels1, labels2),
+)
+  output_array = contraction_output(array1, labels1, array2, labels2, labelsR)
+  contract!(output_array, labelsR, array1, labels1, array2, labels2)
+  return output_array
+end
+
+function contraction_output(array1::MatrixOrArrayLike, array2::MatrixOrArrayLike, indsR)
+  arraytypeR = contraction_output_type(typeof(array1), typeof(array2), indsR)
+  return NDTensors.similar(arraytypeR, indsR)
+end
+
+function contraction_output_type(
+  arraytype1::Type{<:MatrixOrArrayLike}, arraytype2::Type{<:MatrixOrArrayLike}, inds
+)
+  return similartype(promote_type(arraytype1, arraytype2), inds)
+end
+
+function contraction_output(
+  array1::MatrixOrArrayLike,
+  labelsarray1,
+  array2::MatrixOrArrayLike,
+  labelsarray2,
+  labelsoutput_array,
+)
+  # TODO: Maybe use `axes` here to be more generic, for example for BlockArrays?
+  indsoutput_array = contract_inds(
+    size(array1), labelsarray1, size(array2), labelsarray2, labelsoutput_array
+  )
+  output_array = contraction_output(array1, array2, indsoutput_array)
+  return output_array
+end
+
+# Required interface for specific AbstractArray types
+function contract!(
+  arrayR::MatrixOrArrayLike,
+  labelsR,
+  array1::MatrixOrArrayLike,
+  labels1,
+  array2::MatrixOrArrayLike,
+  labels2,
+)
+  props = ContractionProperties(labels1, labels2, labelsR)
+  compute_contraction_properties!(props, array1, array2, arrayR)
+  # TODO: Change this to just `contract!`, or maybe `contract_ttgt!`?
+  _contract!(arrayR, array1, array2, props)
+  return arrayR
+end
+
+function permutedims!(
+  output_array::MatrixOrArrayLike, array::MatrixOrArrayLike, perm, f::Function
+)
+  @strided output_array .= f.(output_array, permutedims(array, perm))
+  return output_array
+end

--- a/NDTensors/src/arraytensor/arraytensor.jl
+++ b/NDTensors/src/arraytensor/arraytensor.jl
@@ -22,7 +22,9 @@ const MatrixStorageTensor{T,S,I} = Tensor{T,2,S,I} where {S<:MatrixStorage{T}}
 const MatrixOrArrayStorageTensor{T,S,I} =
   Tensor{T,N,S,I} where {N,S<:MatrixOrArrayStorage{T}}
 
-Tensor(storage::MatrixOrArrayStorageTensor, inds::Tuple) = Tensor(NeverAlias(), storage, inds)
+function Tensor(storage::MatrixOrArrayStorageTensor, inds::Tuple)
+  return Tensor(NeverAlias(), storage, inds)
+end
 
 function Tensor(as::AliasStyle, storage::MatrixOrArrayStorage, inds::Tuple)
   return Tensor{eltype(storage),length(inds),typeof(storage),typeof(inds)}(

--- a/NDTensors/src/arraytensor/arraytensor.jl
+++ b/NDTensors/src/arraytensor/arraytensor.jl
@@ -1,0 +1,90 @@
+# Used for dispatch to distinguish from Tensors wrapping TensorStorage.
+# Remove once TensorStorage is removed.
+const ArrayLike{T,N} = Union{Array{T,N},ReshapedArray{T,N},SubArray{T,N}}
+const MatrixLike{T} = Union{
+  Matrix{T},
+  Transpose{T},
+  Adjoint{T},
+  Symmetric{T},
+  Hermitian{T},
+  UpperTriangular{T},
+  LowerTriangular{T},
+  UnitUpperTriangular{T},
+  UnitLowerTriangular{T},
+  Diagonal{T},
+}
+const MatrixOrArrayLike{T} = Union{MatrixLike{T},ArrayLike{T}}
+
+const ArrayLikeTensor{T,N,S,I} = Tensor{T,N,S,I} where {S<:ArrayLike{T,N}}
+const MatrixLikeTensor{T,S,I} = Tensor{T,2,S,I} where {S<:MatrixLike{T}}
+const MatrixOrArrayLikeTensor{T,S,I} = Tensor{T,N,S,I} where {N,S<:MatrixOrArrayLike{T}}
+
+function getindex(tensor::MatrixOrArrayLikeTensor, I::Integer...)
+  return storage(tensor)[I...]
+end
+
+function setindex!(tensor::MatrixOrArrayLikeTensor, v, I::Integer...)
+  storage(tensor)[I...] = v
+  return tensor
+end
+
+function contraction_output(
+  tensor1::MatrixOrArrayLikeTensor, tensor2::MatrixOrArrayLikeTensor, indsR
+)
+  tensortypeR = contraction_output_type(typeof(tensor1), typeof(tensor2), indsR)
+  return NDTensors.similar(tensortypeR, indsR)
+end
+
+function contract!(
+  tensorR::MatrixOrArrayLikeTensor,
+  labelsR,
+  tensor1::MatrixOrArrayLikeTensor,
+  labels1,
+  tensor2::MatrixOrArrayLikeTensor,
+  labels2,
+)
+  contract!(storage(tensorR), labelsR, storage(tensor1), labels1, storage(tensor2), labels2)
+  return tensorR
+end
+
+function permutedims!(
+  output_tensor::MatrixOrArrayLikeTensor, tensor::MatrixOrArrayLikeTensor, perm, f::Function
+)
+  permutedims!(storage(output_tensor), storage(tensor), perm, f)
+  return output_tensor
+end
+
+# Linear algebra (matrix algebra)
+Base.adjoint(tens::MatrixLikeTensor) = tensor(adjoint(storage(tens)), reverse(inds(tens)))
+
+function LinearAlgebra.mul!(C::MatrixLikeTensor, A::MatrixLikeTensor, B::MatrixLikeTensor)
+  mul!(storage(C), storage(A), storage(B))
+  return C
+end
+
+function LinearAlgebra.svd(tens::MatrixLikeTensor)
+  F = svd(storage(tens))
+  U, S, V = F.U, F.S, F.Vt
+  i, j = inds(tens)
+  # TODO: Make this more general with a `similar_ind` function,
+  # so the dimension can be determined from the length of `S`.
+  min_ij = dim(i) ≤ dim(j) ? i : j
+  α = sim(min_ij) # similar_ind(i, space(S))
+  β = sim(min_ij) # similar_ind(i, space(S))
+  Utensor = tensor(U, (i, α))
+  # TODO: Remove conversion to `Matrix` to make more general.
+  # Used for now to avoid introducing wrapper types.
+  Stensor = tensor(Diagonal(S), (α, β))
+  Vtensor = tensor(V, (β, j))
+  return Utensor, Stensor, Vtensor, Spectrum(nothing, 0.0)
+end
+
+array(tensor::MatrixOrArrayLikeTensor) = storage(tensor)
+
+# Combiner
+function contraction_output(
+  tensor1::MatrixOrArrayLikeTensor, tensor2::CombinerTensor, indsR
+)
+  tensortypeR = contraction_output_type(typeof(tensor1), typeof(tensor2), indsR)
+  return NDTensors.similar(tensortypeR, indsR)
+end

--- a/NDTensors/src/arraytensor/arraytensor.jl
+++ b/NDTensors/src/arraytensor/arraytensor.jl
@@ -22,6 +22,14 @@ const MatrixStorageTensor{T,S,I} = Tensor{T,2,S,I} where {S<:MatrixStorage{T}}
 const MatrixOrArrayStorageTensor{T,S,I} =
   Tensor{T,N,S,I} where {N,S<:MatrixOrArrayStorage{T}}
 
+Tensor(storage::MatrixOrArrayStorageTensor, inds::Tuple) = Tensor(NeverAlias(), storage, inds)
+
+function Tensor(as::AliasStyle, storage::MatrixOrArrayStorage, inds::Tuple)
+  return Tensor{eltype(storage),length(inds),typeof(storage),typeof(inds)}(
+    as, storage, inds
+  )
+end
+
 function getindex(tensor::MatrixOrArrayStorageTensor, I::Integer...)
   return storage(tensor)[I...]
 end

--- a/NDTensors/src/tensor/tensor.jl
+++ b/NDTensors/src/tensor/tensor.jl
@@ -1,11 +1,10 @@
-
 """
 Tensor{StoreT,IndsT}
 
 A plain old tensor (with order independent
 interface and no assumption of labels)
 """
-struct Tensor{ElT,N,StoreT<:TensorStorage,IndsT} <: AbstractArray{ElT,N}
+struct Tensor{ElT,N,StoreT,IndsT} <: AbstractArray{ElT,N}
   storage::StoreT
   inds::IndsT
 
@@ -21,8 +20,8 @@ struct Tensor{ElT,N,StoreT<:TensorStorage,IndsT} <: AbstractArray{ElT,N}
   and tensor(store::TensorStorage, inds) constructors.
   """
   function Tensor{ElT,N,StoreT,IndsT}(
-    ::AllowAlias, storage::TensorStorage, inds::Tuple
-  ) where {ElT,N,StoreT<:TensorStorage,IndsT}
+    ::AllowAlias, storage, inds::Tuple
+  ) where {ElT,N,StoreT,IndsT}
     @assert ElT == eltype(StoreT)
     @assert length(inds) == N
     return new{ElT,N,StoreT,IndsT}(storage, inds)
@@ -64,7 +63,7 @@ The Tensor holds a copy of the storage data.
 
 The indices `inds` will be converted to a `Tuple`.
 """
-function Tensor(as::AliasStyle, storage::TensorStorage, inds::Tuple)
+function Tensor(as::AliasStyle, storage, inds::Tuple)
   return Tensor{eltype(storage),length(inds),typeof(storage),typeof(inds)}(
     as, storage, inds
   )
@@ -74,12 +73,12 @@ end
 # already (like a Vector). In the future this may be lifted
 # to allow for very large tensor orders in which case Tuple
 # operations may become too slow.
-function Tensor(as::AliasStyle, storage::TensorStorage, inds)
+function Tensor(as::AliasStyle, storage, inds)
   return Tensor(as, storage, Tuple(inds))
 end
 
 tensor(args...; kwargs...) = Tensor(AllowAlias(), args...; kwargs...)
-Tensor(storage::TensorStorage, inds::Tuple) = Tensor(NeverAlias(), storage, inds)
+Tensor(storage, inds::Tuple) = Tensor(NeverAlias(), storage, inds)
 
 function Tensor(eltype::Type, inds::Tuple)
   return Tensor(AllowAlias(), default_storagetype(eltype, inds)(dim(inds)), inds)

--- a/NDTensors/src/tensor/tensor.jl
+++ b/NDTensors/src/tensor/tensor.jl
@@ -63,7 +63,7 @@ The Tensor holds a copy of the storage data.
 
 The indices `inds` will be converted to a `Tuple`.
 """
-function Tensor(as::AliasStyle, storage, inds::Tuple)
+function Tensor(as::AliasStyle, storage::TensorStorage, inds::Tuple)
   return Tensor{eltype(storage),length(inds),typeof(storage),typeof(inds)}(
     as, storage, inds
   )
@@ -78,7 +78,7 @@ function Tensor(as::AliasStyle, storage, inds)
 end
 
 tensor(args...; kwargs...) = Tensor(AllowAlias(), args...; kwargs...)
-Tensor(storage, inds::Tuple) = Tensor(NeverAlias(), storage, inds)
+Tensor(storage::TensorStorage, inds::Tuple) = Tensor(NeverAlias(), storage, inds)
 
 function Tensor(eltype::Type, inds::Tuple)
   return Tensor(AllowAlias(), default_storagetype(eltype, inds)(dim(inds)), inds)

--- a/NDTensors/src/tensoralgebra/generic_tensor_operations.jl
+++ b/NDTensors/src/tensoralgebra/generic_tensor_operations.jl
@@ -18,7 +18,7 @@ end
 function permutedims!(output_tensor::Tensor, tensor::Tensor, perm, f::Function=(r, t) -> t)
   Base.checkdims_perm(output_tensor, tensor, perm)
   error(
-    "`perutedims!(output_tensor::Tensor, tensor::Tensor, perm, f::Function=(r, t) -> t)` not implemented for `typeof(output_tensor) = $(typeof(output_tensor))`, `typeof(tensor) = $(typeof(tensor))`, `perm = $perm`, and `f = $f`.",
+    "`permutedims!(output_tensor::Tensor, tensor::Tensor, perm, f::Function=(r, t) -> t)` not implemented for `typeof(output_tensor) = $(typeof(output_tensor))`, `typeof(tensor) = $(typeof(tensor))`, `perm = $perm`, and `f = $f`.",
   )
   return output_tensor
 end

--- a/NDTensors/test/arraytensor/arraytensor.jl
+++ b/NDTensors/test/arraytensor/arraytensor.jl
@@ -1,0 +1,53 @@
+using NDTensors
+using LinearAlgebra
+using Test
+
+using NDTensors: storage, storagetype
+
+@testset "Tensor wrapping Array" begin
+  is1 = (2, 3)
+  D1 = randn(is1)
+
+  is2 = (3, 4)
+  D2 = randn(is2)
+
+  T1 = tensor(D1, is1)
+  T2 = tensor(D2, is2)
+
+  @test T1[1, 1] == D1[1, 1]
+
+  x = rand()
+  T1[1, 1] = x
+
+  @test T1[1, 1] == x
+  @test array(T1) == D1
+  @test storagetype(T1) <: Matrix{Float64}
+  @test storage(T1) == D1
+  @test eltype(T1) == eltype(D1)
+  @test inds(T1) == is1
+
+  R = T1 * T2
+  @test storagetype(R) <: Matrix{Float64}
+  @test Array(R) ≈ Array(T1) * Array(T2)
+
+  T1r = randn!(similar(T1))
+  @test Array(T1r + T1) ≈ Array(T1r) + Array(T1)
+  @test Array(permutedims(T1, (2, 1))) ≈ permutedims(Array(T1), (2, 1))
+
+  U, S, V = svd(T1)
+  @test U * S * V ≈ T1
+
+  T12 = contract(T1, (1, -1), T2, (-1, 2))
+  @test T12 ≈ T1 * T2
+
+  D12 = contract(D1, (1, -1), D2, (-1, 2))
+  @test D12 ≈ Array(T12)
+
+  ## IT1 = itensor(T1)
+  ## IT2 = itensor(T2)
+  ## IR = IT1 * IT2
+  ## IX = IT1 + IT1
+
+  ## IU, IS, IV = svd(IT1, i)
+  ## @test IU * IS * IV ≈ IT1
+end

--- a/NDTensors/test/arraytensor/arraytensor.jl
+++ b/NDTensors/test/arraytensor/arraytensor.jl
@@ -42,12 +42,4 @@ using NDTensors: storage, storagetype
 
   D12 = contract(D1, (1, -1), D2, (-1, 2))
   @test D12 ≈ Array(T12)
-
-  ## IT1 = itensor(T1)
-  ## IT2 = itensor(T2)
-  ## IR = IT1 * IT2
-  ## IX = IT1 + IT1
-
-  ## IU, IS, IV = svd(IT1, i)
-  ## @test IU * IS * IV ≈ IT1
 end

--- a/NDTensors/test/runtests.jl
+++ b/NDTensors/test/runtests.jl
@@ -28,6 +28,7 @@ end
     "emptynumber.jl",
     "emptystorage.jl",
     "combiner.jl",
+    "arraytensor/arraytensor.jl",
   ]
     println("Running $filename")
     include(filename)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -82,7 +82,7 @@ NDTensors.Dense{Float64,Array{Float64,1}}
 ## Accessor Functions, Index Functions and Operations
 mutable struct ITensor
   tensor::Tensor
-  function ITensor(::AllowAlias, T::Tensor{<:Any,<:Any,<:TensorStorage,<:Tuple})
+  function ITensor(::AllowAlias, T::Tensor{<:Any,<:Any,<:Any,<:Tuple})
     @debug_check begin
       is = inds(T)
       if !allunique(is)
@@ -761,7 +761,7 @@ end
 
 Return a view of the TensorStorage of the ITensor.
 """
-storage(T::ITensor)::TensorStorage = storage(tensor(T))
+storage(T::ITensor) = storage(tensor(T))
 
 storagetype(x::ITensor) = storagetype(tensor(x))
 


### PR DESCRIPTION
# Description

This relaxes the type constraint on the `storage` field of `Tensor` to allow any objects as storage backends.

The idea would be that the `storage` should adhere to a minimal interface requirement, for example in general that it is an `AbstractArray` (though that isn't required) and defines some contraction and permutation functionality (though if we provide a general TTGT backend, we could in general only require permutations and matrix multiplications) as well as factorizations like SVD or QR.

You can see the interface requirements demonstrated in `arraytensor/array.jl`. Some of that can be made more generic, and therefore won't need to be defined for every storage backend.

For now, the design is that non-TensorStorage storage backends are "registered" in the type union `ArrayStorage`, only for the purpose of ensuring that dispatch doesn't get confused between new functionality we write for generic storage backends as opposed to the current `TensorStorage` type which has particular requirements, so that we don't have to change current `TensorStorage` code. Once we replace the current `TensorStorage` types in favor of `AbstractArray` backends (`Array`, `BlockSparseArray`, `DiagonalArray`, etc.) we can just remove the `ArrayStorage` type union (and maybe replace it with `AbstractArray` where appropriate).

@kmp5VT your PR #1161 aligns with this new design since you are getting rid of the `EmptyStorage` type (already in the right direction of removing s`TensorStorage` types) and also the `UnallocatedZeros` type will still be relevant here since it will either be used directly as a `Tensor` storage or used as a data backend for one of the other storage types like `BlockSparseArray` or `DiagonalArray`. Additionally, I don't anticipate getting rid of our `contract` or `permutedims` code, just making sure they both work for the new storage types, so the optimizations you are doing in #1194 are definitely still important.

A strategy for how to proceed with the goal of removing `TensorStorage` types is to "peel off" the storage types one by one. For example, we can start by making sure that using an `Array` as a storage backend for `Tensor` has all of the same functionality as `Dense` (which I already started to do in this PR, as you can see it already works for a number of operations like addition, permutation, contraction, etc.). Then we can just change the default `ITensor` constructor to use `Array` (or `UnallocatedZeros`) storage instead of `Dense` storage when there are dense indices. Then, once we develop external `BlockSparseArray` and `DiagonalArray` AbstractArrays (`BlockSparseArray` already started in #1205), once we make them feature-complete with `BlockSparse` and `Diag` we can use them as defaults as well, and then just remove `BlockSparse` and `Diag`.

The `Combiner` is a slightly awkward corner case, but I think we can basically just leave it as-is for now and hopefully it get replaced by a more principle fusion tree type in the future.