### PR TITLE
Fix behavior of factorize mindim

### DIFF
--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -662,7 +662,9 @@ function factorize(A::ITensor, Linds...; kwargs...)
   # so eigen should only be used if a larger cutoff is requested)
   automatic_cutoff = 1e-12
   Lis = indices(Linds...)
-  dL, dR = dim(commoninds(inds(A), Lis)), dim(indices(setdiff(inds(A), Lis)))
+  Lis = commoninds(A, indices(Linds...))
+  Ris = uniqueinds(A, Lis)
+  dL, dR = dim(Lis), dim(Ris)
   # maxdim is forced to be at most the max given SVD
   maxdim = min(get(kwargs, :maxdim, min(dL, dR)), min(dL, dR))
   might_truncate = !isnothing(cutoff) || maxdim < min(dL, dR)

--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -630,7 +630,7 @@ Perform a factorization of `A` into ITensors `L` and `R` such that `A ≈ L * R`
 
 For truncation arguments, see: [`svd`](@ref)
 """
-function factorize(A::ITensor, Linds...; kwargs...)
+function factorize(A::ITensor, Linds...; maxdim=nothing, kwargs...)
   ortho::String = get(kwargs, :ortho, "left")
   tags::TagSet = get(kwargs, :tags, "Link,fact")
   plev::Int = get(kwargs, :plev, 0)
@@ -666,7 +666,10 @@ function factorize(A::ITensor, Linds...; kwargs...)
   Ris = uniqueinds(A, Lis)
   dL, dR = dim(Lis), dim(Ris)
   # maxdim is forced to be at most the max given SVD
-  maxdim = min(get(kwargs, :maxdim, min(dL, dR)), min(dL, dR))
+  if isnothing(maxdim)
+    maxdim = min(dL, dR)
+  end
+  maxdim = min(maxdim, min(dL, dR))
   might_truncate = !isnothing(cutoff) || maxdim < min(dL, dR)
 
   if isnothing(which_decomp)
@@ -680,7 +683,7 @@ function factorize(A::ITensor, Linds...; kwargs...)
   end
 
   if which_decomp == "svd"
-    LR = factorize_svd(A, Linds...; kwargs...)
+    LR = factorize_svd(A, Linds...; kwargs..., maxdim=maxdim)
     if isnothing(LR)
       return nothing
     end

--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -661,7 +661,6 @@ function factorize(A::ITensor, Linds...; maxdim=nothing, kwargs...)
   # Determines when to use eigen vs. svd (eigen is less precise,
   # so eigen should only be used if a larger cutoff is requested)
   automatic_cutoff = 1e-12
-  Lis = indices(Linds...)
   Lis = commoninds(A, indices(Linds...))
   Ris = uniqueinds(A, Lis)
   dL, dR = dim(Lis), dim(Ris)

--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -662,8 +662,9 @@ function factorize(A::ITensor, Linds...; kwargs...)
   # so eigen should only be used if a larger cutoff is requested)
   automatic_cutoff = 1e-12
   Lis = indices(Linds...)
-  dL, dR = dim(Lis), dim(indices(setdiff(inds(A), Lis)))
-  maxdim = get(kwargs, :maxdim, min(dL, dR))
+  dL, dR = dim(commoninds(inds(A), Lis)), dim(indices(setdiff(inds(A), Lis)))
+  # maxdim is forced to be at most the max given SVD
+  maxdim = min(get(kwargs, :maxdim, min(dL, dR)), min(dL, dR))
   might_truncate = !isnothing(cutoff) || maxdim < min(dL, dR)
 
   if isnothing(which_decomp)
@@ -683,7 +684,7 @@ function factorize(A::ITensor, Linds...; kwargs...)
     end
     L, R, spec = LR
   elseif which_decomp == "eigen"
-    L, R, spec = factorize_eigen(A, Linds...; kwargs...)
+    L, R, spec = factorize_eigen(A, Linds...; kwargs..., maxdim=maxdim)
   elseif which_decomp == "qr"
     L, R = factorize_qr(A, Linds...; kwargs...)
     spec = Spectrum(nothing, 0.0)

--- a/test/base/test_decomp.jl
+++ b/test/base/test_decomp.jl
@@ -465,6 +465,20 @@ end
       @test blockdim(u, b) == blockdim(i, b) || blockdim(u, b) >= min_blockdim
     end
   end
+
+  @testset "factorize with mindim" begin
+    l = Index(8, "l")
+    s1 = Index(2, "s1")
+    s2 = Index(2, "s2")
+    r = Index(2, "r")
+
+    phi = randomITensor(l, s1, s2, r)
+
+    U, B = factorize(phi, (l, s1); ortho="left", mindim=8, which_decomp="eigen")
+
+    @test norm(U * B - phi) < 1E-5
+    @test dim(commonind(U, B)) <= 4
+  end
 end
 
 nothing


### PR DESCRIPTION
# Description

Fixes #1207 



<details><summary>Minimal demonstration of previous behavior</summary><p>

> Quick update, a more minimal example. Say we have a two-site tensor that we want to factorize
> 
> ```julia
> s  = Index(2)
> s′ = Index(2)
> l = Index(64)
> r = Index(16)
> T = randomITensor(l,s,s′,r)
> ```
> 
> The inconsistent behavior manifests as
> 
> ```julia
> > L,R,spec = factorize(T,l,s; cutoff=0,mindim=64)
> > @show inds(L)
> inds(L) = ((dim=64|id=719), (dim=2|id=499), (dim=32|id=847|"Link,fact"))
> ```
> 
> where we get the 64->32->16 stepdown. Or with cutoff
> 
> ```julia
> > L,R,spec = factorize(T,l,s; cutoff=1e-10,mindim=64)
> > @show inds(L)
> inds(L) = ((dim=64|id=444), (dim=2|id=941), (dim=64|id=961|"Link,fact"))
> ```
> 
> Where the factorize respects the mindim by padding the link dimension. I think the `cutoff=0` behavior is best here.


</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
using ITensors

s  = Index(2)
s′ = Index(2)
l = Index(64)
r = Index(16)
T = randomITensor(l,s,s′,r)

L,R,spec = factorize(T,l,s; cutoff=1e-10,maxdim=64,mindim=64)
@show inds(L)
@show inds(R)
```

```julia
> inds(L) = ((dim=64|id=96), (dim=2|id=968), (dim=32|id=502|"Link,fact"))
> inds(R) = ((dim=32|id=502|"Link,fact"), (dim=2|id=814), (dim=16|id=189))

```
</p></details>

# How Has This Been Tested?

No new tests

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
