### PR TITLE
[NDTensors][Bug] Fix CPU performance issue

### DIFF
--- a/NDTensors/src/abstractarray/iswrappedarray.jl
+++ b/NDTensors/src/abstractarray/iswrappedarray.jl
@@ -33,6 +33,7 @@ parenttype(::Type{<:UnitUpperTriangular{<:Any,P}}) where {P} = P
 parenttype(::Type{<:UnitLowerTriangular{<:Any,P}}) where {P} = P
 parenttype(::Type{<:Diagonal{<:Any,P}}) where {P} = P
 parenttype(::Type{<:SubArray{<:Any,<:Any,P}}) where {P} = P
+parenttype(::Type{<:StridedView{<:Any,<:Any,P}}) where {P} = P
 
 # For working with instances, not used by
 # `SimpleTraits.jl` traits dispatch.

--- a/NDTensors/src/array/permutedims.jl
+++ b/NDTensors/src/array/permutedims.jl
@@ -1,6 +1,6 @@
 # NDTensors.permutedims
 function permutedims(::Type{<:Array}, M, perm)
-  return @strided Base.permutedims(M, perm)
+  return @strided A = Base.permutedims(M, perm)
 end
 
 # NDTensors.permutedims!


### PR DESCRIPTION
# Description

Joey found that contractions slowed down by roughly a factor of 5-10. It turned out that a permutedim was being evaluated lazily resulting in a complicated type that wasn't being parsed properly and as a result generic `mul!` was begin called. Here I create a function to unwrap a strided array to properly show its parenttype and I force evaluate of a permutation to ensure the strided version of mul is called.

# Checklist:

- [ ] Fix Joeys CPU `mul!` slowdown
