### PR TITLE
[ITensors] Optimize `directsum` again

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -269,6 +269,14 @@ ITensor(x::RealOrComplex{Int}, is...) = ITensor(float(x), is...)
 # EmptyStorage ITensor constructors
 #
 
+# TODO: Replace with a simpler and more generic `zeros` constructor
+# when the new `UnallocatedZeros` type lands.
+# This is only used internally inside the implementation of `directsum`
+# right now.
+function zeros_itensor(elt::Type{<:Number}, inds::Index...)
+  return ITensor(elt, inds...)
+end
+
 # TODO: Deprecated!
 """
     emptyITensor([::Type{ElT} = NDTensors.EmptyNumber, ]inds)

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -274,7 +274,7 @@ ITensor(x::RealOrComplex{Int}, is...) = ITensor(float(x), is...)
 # This is only used internally inside the implementation of `directsum`
 # right now.
 function zeros_itensor(elt::Type{<:Number}, inds::Index...)
-  return ITensor(elt, inds...)
+  return ITensor(elt, zero(elt), inds...)
 end
 
 # TODO: Deprecated!

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -11,6 +11,18 @@
   return setindex!!(T, x, I...)
 end
 
+# TODO: Replace with a simpler and more generic `zeros` constructor
+# when the new `UnallocatedZeros` type lands.
+# This is needed for now since there is some issue with calling
+# `setindex!` on `EmptyTensor`, it's not really worth investigating
+# right now since that type will be removed soon anyway in
+# https://github.com/ITensor/ITensors.jl/pull/1213.
+# This is only used internally inside the implementation of `directsum`
+# right now.
+function zeros_itensor(elt::Type{<:Number}, inds::QNIndex...)
+  return itensor(tensor(BlockSparse(elt, undef, NDTensors.Dictionary{Block{length(inds)},Int}(), 0), inds))
+end
+
 """
     ITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds)
     ITensor([::Type{ElT} = Float64, ][flux::QN = QN(), ]inds::Index...)

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -287,7 +287,7 @@ end
 # `setindex!` on `EmptyTensor`, it's not really worth investigating
 # right now since that type will be removed soon anyway in
 # https://github.com/ITensor/ITensors.jl/pull/1213.
-function zero_itensor(elt::Type{<:Number}, inds::QNIndex...)
+function zeros_itensor(elt::Type{<:Number}, inds::QNIndex...)
   return itensor(tensor(BlockSparse(elt, undef, NDTensors.Dictionary{Block{length(inds)},Int}(), 0), inds))
 end
 
@@ -302,8 +302,8 @@ function directsum_projectors(
   # Or with new notation:
   # D1 = zeros(elt1, dag(i), ij)
   # D2 = zeros(elt1, dag(j), ij)
-  D1 = zero_itensor(elt1, dag(i), ij)
-  D2 = zero_itensor(elt1, dag(j), ij)
+  D1 = zeros_itensor(elt1, dag(i), ij)
+  D2 = zeros_itensor(elt1, dag(j), ij)
   directsum_projectors!(tensor(D1), tensor(D2))
   return D1, D2
 end

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -275,22 +275,6 @@ function directsum_projectors!(D1::Tensor, D2::Tensor)
   return D1, D2
 end
 
-# TODO: Replace with a simpler and more generic `zeros` constructor
-# when the new `UnallocatedZeros` type lands.
-function zeros_itensor(elt::Type{<:Number}, inds::Index...)
-  return ITensor(elt, inds...)
-end
-
-# TODO: Replace with a simpler and more generic `zeros` constructor
-# when the new `UnallocatedZeros` type lands.
-# This is needed for now since there is some issue with calling
-# `setindex!` on `EmptyTensor`, it's not really worth investigating
-# right now since that type will be removed soon anyway in
-# https://github.com/ITensor/ITensors.jl/pull/1213.
-function zeros_itensor(elt::Type{<:Number}, inds::QNIndex...)
-  return itensor(tensor(BlockSparse(elt, undef, NDTensors.Dictionary{Block{length(inds)},Int}(), 0), inds))
-end
-
 # Helper tensors for performing a partial direct sum
 function directsum_projectors(
   elt1::Type{<:Number}, elt2::Type{<:Number}, i::Index, j::Index, ij::Index


### PR DESCRIPTION
This should fix a performance issue in `directsum` that was raised in https://itensor.discourse.group/t/directsum-with-qn-seems-very-inefficient-compared-to-the-c-version/1106/8.

In `directsum`, we are constructing projectors to project the tensors being direct summed into the correct subspace. The previous code introduced in #1185 was constructing those in an inefficient way, by creating zero flux tensors by first filling in all blocks consistent with that flux and then setting appropriate elements to 1 to make the projectors. In this PR, in the block sparse case I'm making tensors that initially have no blocks, then those blocks are allocated as needed to make the projectors.

I hacked together some specialized constructors for making QN ITensors without any blocks for this purpose (or in the case where there aren't QNs, it makes a zero tensor). There is probably a simpler way to do that, but @kmp5VT is working on a number of improvements to the ITensor storage types, constructors, and operations on unallocated tensors so I think it is ok to leave it for now and replace that code with better constructors that will be introduced soon.