### PR TITLE
[NDTensorsCUDAExt][Debug]  QR based SVD fails for some rectangular matrices

### DIFF
--- a/NDTensors/ext/NDTensorsCUDAExt/linearalgebra.jl
+++ b/NDTensors/ext/NDTensorsCUDAExt/linearalgebra.jl
@@ -1,13 +1,39 @@
-function NDTensors.svd_catch_error(A::CuMatrix; alg="JacobiAlgorithm")
+function NDTensors.svd_catch_error(A::CuMatrix; alg::String="JacobiAlgorithm")
   if alg == "JacobiAlgorithm"
     alg = CUDA.CUSOLVER.JacobiAlgorithm()
   else
     alg = CUDA.CUSOLVER.QRAlgorithm()
   end
+  return NDTensors.svd_catch_error(A, alg)
+end
+
+function NDTensors.svd_catch_error(A::CuMatrix, ::CUDA.CUSOLVER.JacobiAlgorithm)
   USV = try
-    svd(expose(A); alg=alg)
+    svd(A; alg=CUDA.CUSOLVER.JacobiAlgorithm())
   catch
     return nothing
+  end
+  return USV
+end
+
+function NDTensors.svd_catch_error(A::CuMatrix, ::CUDA.CUSOLVER.QRAlgorithm)
+  s = size(A)
+  if s[1] < s[2]
+    At = copy(Adjoint(A))
+    
+    USV = try 
+      svd(At; alg=CUDA.CUSOLVER.QRAlgorithm())
+    catch
+      return nothing
+    end
+    MV ,MS, MU = USV;
+    USV = SVD(copy(MU), MS, Adjoint(MV))
+  else
+    USV = try 
+      svd(A; alg=CUDA.CUSOLVER.QRAlgorithm())
+    catch
+      return nothing
+    end
   end
   return USV
 end


### PR DESCRIPTION
# Description

CUDA's QRAlgorithm fails when an `(N x M)` matrix has `N < M`. Here I fix this issue by catching the problem in the SVD dispatch and transposing the matrices and the resulting SVD.

# TODO
- [ ] Fix the QR SVD algorithm
- [ ] Make sure all the unit tests still pass