### PR TITLE
[ITensors] [BUG] svdMPO generates unnecessarily large intermediate weight matrices 

### DIFF
--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -17,6 +17,7 @@ function svdMPO(ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...)::MPO wh
   end
 
   rightmaps = [Dict{Vector{Op},Int}() for _ in 1:N]
+
   for n in 1:N
     leftbond_coefs = MatElem{ValType}[]
 

--- a/src/physics/autompo/opsum_to_mpo.jl
+++ b/src/physics/autompo/opsum_to_mpo.jl
@@ -16,8 +16,7 @@ function svdMPO(ValType::Type{<:Number}, os::OpSum{C}, sites; kwargs...)::MPO wh
     return (only(site(t[1])) <= n <= only(site(t[end])))
   end
 
-  rightmaps = fill(Dict{Vector{Op},Int}(), N)
-
+  rightmaps = [Dict{Vector{Op},Int}() for _ in 1:N]
   for n in 1:N
     leftbond_coefs = MatElem{ValType}[]
 


### PR DESCRIPTION
# Description
Replaces `Vector` filled with references to the same `Dict` with a `Vector` of references to independent `Dict`s. This reduces the dimensions of intermediate weight matrices, on which compression via SVD is performed.

# How Has This Been Tested?
Passes tests in test/ITensorLegacyMPS/base. (One broken, not sure why?)

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
