### PR TITLE
[NDTensorsMetalExt] Update for `Unwrap` module

### DIFF
--- a/NDTensors/ext/NDTensorsMetalExt/NDTensorsMetalExt.jl
+++ b/NDTensors/ext/NDTensorsMetalExt/NDTensorsMetalExt.jl
@@ -2,7 +2,7 @@ module NDTensorsMetalExt
 
 using Adapt
 using Functors
-using LinearAlgebra: LinearAlgebra, Transpose, mul!, qr, eigen, svd
+using LinearAlgebra: LinearAlgebra, Adjoint, Transpose, mul!, qr, eigen, svd
 using NDTensors
 using NDTensors.SetParameters
 using NDTensors.Unwrap: qr_positive, ql_positive, ql
@@ -22,4 +22,5 @@ include("copyto.jl")
 include("append.jl")
 include("permutedims.jl")
 include("mul.jl")
+
 end

--- a/NDTensors/ext/NDTensorsMetalExt/adapt.jl
+++ b/NDTensors/ext/NDTensorsMetalExt/adapt.jl
@@ -1,3 +1,5 @@
+NDTensors.cpu(e::Exposed{<:MtlArray}) = adapt(Array, e)
+
 function mtl(xs; storage=DefaultStorageMode)
   return adapt(set_storagemode(MtlArray, storage), xs)
 end

--- a/NDTensors/ext/NDTensorsMetalExt/copyto.jl
+++ b/NDTensors/ext/NDTensorsMetalExt/copyto.jl
@@ -1,13 +1,23 @@
-# Catches a bug in `copyto!` in Metal backend.
-function NDTensors.copyto!(
-  ::Type{<:MtlArray}, dest::AbstractArray, ::Type{<:MtlArray}, src::SubArray
+function Base.copy(src::Exposed{<:MtlArray,<:Base.ReshapedArray})
+  return reshape(copy(parent(src)), size(unexpose(src)))
+end
+
+function Base.copy(
+  src::Exposed{
+    <:MtlArray,<:SubArray{<:Any,<:Any,<:Base.ReshapedArray{<:Any,<:Any,<:Adjoint}}
+  },
 )
-  return Base.copyto!(dest, copy(src))
+  return copy(@view copy(expose(parent(src)))[parentindices(unexpose(src))...])
 end
 
 # Catches a bug in `copyto!` in Metal backend.
-function NDTensors.copyto!(
-  ::Type{<:MtlArray}, dest::AbstractArray, ::Type{<:MtlArray}, src::Base.ReshapedArray
+function Base.copyto!(dest::Exposed{<:MtlArray}, src::Exposed{<:MtlArray,<:SubArray})
+  return copyto!(dest, expose(copy(src)))
+end
+
+# Catches a bug in `copyto!` in Metal backend.
+function Base.copyto!(
+  dest::Exposed{<:MtlArray}, src::Exposed{<:MtlArray,<:Base.ReshapedArray}
 )
-  return NDTensors.copyto!(dest, parent(src))
+  return copyto!(dest, expose(parent(src)))
 end

--- a/NDTensors/ext/NDTensorsMetalExt/indexing.jl
+++ b/NDTensors/ext/NDTensorsMetalExt/indexing.jl
@@ -6,3 +6,8 @@ function Base.setindex!(E::Exposed{<:MtlArray}, x::Number)
   Metal.@allowscalar unexpose(E)[] = x
   return unexpose(E)
 end
+
+# Shared with `CuArray`. Move to `NDTensorsGPUArraysCoreExt`?
+function Base.getindex(E::Exposed{<:MtlArray,<:Adjoint}, i, j)
+  return (expose(parent(E))[j, i])'
+end

--- a/NDTensors/ext/NDTensorsMetalExt/linearalgebra.jl
+++ b/NDTensors/ext/NDTensorsMetalExt/linearalgebra.jl
@@ -23,8 +23,9 @@ function LinearAlgebra.eigen(A::Exposed{<:MtlMatrix})
 end
 
 function LinearAlgebra.svd(A::Exposed{<:MtlMatrix}; kwargs...)
-  U, S, V = svd(expose(NDTensors.cpu(A)); kwargs...)
-  return adapt(unwrap_type(A), U),
-  adapt(set_ndims(unwrap_type(A), ndims(S)), S),
-  adapt(unwrap_type(A), V)
+  Ucpu, Scpu, Vcpu = svd(expose(NDTensors.cpu(A)); kwargs...)
+  U = adapt(unwrap_type(A), Ucpu)
+  S = adapt(set_ndims(unwrap_type(A), ndims(Scpu)), Scpu)
+  V = adapt(unwrap_type(A), Vcpu)
+  return U, S, V
 end

--- a/NDTensors/ext/NDTensorsMetalExt/permutedims.jl
+++ b/NDTensors/ext/NDTensorsMetalExt/permutedims.jl
@@ -1,4 +1,4 @@
-function permutedims!(
+function Base.permutedims!(
   Edest::Exposed{<:MtlArray,<:Base.ReshapedArray}, Esrc::Exposed{<:MtlArray}, perm
 )
   Aperm = permutedims(Esrc, perm)

--- a/NDTensors/src/Unwrap/src/Unwrap.jl
+++ b/NDTensors/src/Unwrap/src/Unwrap.jl
@@ -3,6 +3,7 @@ using SimpleTraits
 using LinearAlgebra
 using Base: ReshapedArray
 using StridedViews
+using Adapt: Adapt, adapt, adapt_structure
 
 include("expose.jl")
 include("iswrappedarray.jl")
@@ -16,6 +17,7 @@ include("functions/copyto.jl")
 include("functions/linearalgebra.jl")
 include("functions/mul.jl")
 include("functions/permutedims.jl")
+include("functions/adapt.jl")
 
 export IsWrappedArray,
   is_wrapped_array, parenttype, unwrap_type, expose, Exposed, unexpose, cpu

--- a/NDTensors/src/Unwrap/src/functions/adapt.jl
+++ b/NDTensors/src/Unwrap/src/functions/adapt.jl
@@ -1,0 +1,8 @@
+Adapt.adapt(to, x::Exposed) = adapt_structure(to, x)
+Adapt.adapt_structure(to, x::Exposed) = adapt_structure(to, unexpose(x))
+
+# https://github.com/JuliaGPU/Adapt.jl/pull/51
+# TODO: Remove once https://github.com/JuliaGPU/Adapt.jl/issues/71 is addressed.
+function Adapt.adapt_structure(to, A::Exposed{<:Any,<:Hermitian})
+  return Hermitian(adapt(to, parent(unexpose(A))), Symbol(unexpose(A).uplo))
+end

--- a/NDTensors/src/abstractarray/append.jl
+++ b/NDTensors/src/abstractarray/append.jl
@@ -1,6 +1,7 @@
 # NDTensors.append!
 # Used to circumvent issues with some GPU backends like Metal
 # not supporting `resize!`.
+# TODO: Change this over to use `expose`.
 function append!!(collection, collections...)
   return append!!(unwrap_type(collection), collection, collections...)
 end

--- a/NDTensors/src/blocksparse/linearalgebra.jl
+++ b/NDTensors/src/blocksparse/linearalgebra.jl
@@ -181,7 +181,7 @@ function svd(
     if sU == -1
       Ub *= -1
     end
-    copyto!(blockview(U, blockU), Ub)
+    copyto!(expose(blockview(U, blockU)), expose(Ub))
 
     blockviewS = blockview(S, blockS)
     # TODO: Replace `data` with `diagview`.
@@ -200,7 +200,7 @@ function svd(
     if (sV * sVP) == -1
       Vb *= -1
     end
-    copyto!(blockview(V, blockV), Vb)
+    copyto!(expose(blockview(V, blockV)), expose(Vb))
   end
   return U, S, V, Spectrum(d, truncerr)
 end


### PR DESCRIPTION
This updates the `NDTensorsMetalExt` using the latest `Unwrap` functionality introduced in #1220, and also circumvents an issue caused by https://github.com/JuliaGPU/Adapt.jl/pull/70.

With this PR, DMRG with dense and block sparse tensors works on Metal GPU without any errors related to scalar indexing, though block sparse DMRG is very slow.