### PR TITLE
Add check for zero norm to expect

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -989,6 +989,7 @@ function expect(psi::MPS, ops; sites=1:length(psi), site_range=nothing)
 
   orthogonalize!(psi, start_site)
   norm2_psi = norm(psi)^2
+  iszero(norm2_psi) && error("MPS has zero norm in function `expect`")
 
   ex = map((o, el_t) -> zeros(el_t, Ns), ops, el_types)
   for (entry, j) in enumerate(site_range)


### PR DESCRIPTION
# Description

Currently if you pass an MPS to `expect` whose norm is zero, the code will compute the norm and later divide by it, siletly producing NaN's in the output. A [user recently ran into this issue](https://itensor.discourse.group/t/applying-down-projection-operator-to-up-spin-site-gives-psi-with-sz-nan-instead-of-0/1284). This PR adds a simple error check of the norm.

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
using ITensors

function ITensors.op!(Op::ITensor,
                      ::OpName"Pdn",
                      ::SiteType"S=1/2",
                      s::Index)
  Op[s'=>2,s=>2] = 1.0
end

let
  N = 10
  s = siteinds("S=1/2",N)

  psi0 = MPS(s,"Up")
  psi1 = apply(op("Pdn",s[5]),psi0)

  @show expect(psi1,"Sz")

  return
end
```
</p></details>

