### PR TITLE
[GradedAxes] Simplify tests

### DIFF
--- a/NDTensors/src/lib/GradedAxes/test/runtests.jl
+++ b/NDTensors/src/lib/GradedAxes/test/runtests.jl
@@ -17,7 +17,6 @@ struct U1
   dim::Int
 end
 Base.isless(l1::U1, l2::U1) = isless(l1.dim, l2.dim)
-Base.:*(c::Int, l::U1) = U1(c * l.dim)
 GradedAxes.fuse(l1::U1, l2::U1) = U1(l1.dim + l2.dim)
 GradedAxes.dual(l::U1) = U1(-l.dim)
 


### PR DESCRIPTION
Remove the overload of `Base.:*` for the example sector in the tests, since it's not needed based on the changes in #1274.