### PR TITLE
Make checkflux pass for dense ITensors

### DIFF
--- a/src/qn/flux.jl
+++ b/src/qn/flux.jl
@@ -68,10 +68,11 @@ allfluxequal(T::Tensor) = allequal(flux(T, b) for b in nzblocks(T))
 
 Check that fluxes of all non-zero blocks of a blocked or symmetric Tensor
 are equal. Throws an error if one or more blocks have a different flux.
+If the tensor is dense (is not blocked) then `checkflux` returns `nothing`.
 """
-function checkflux(T::Tensor) 
+function checkflux(T::Tensor)
   (!hasqns(T) || isempty(T)) && return nothing
-  allfluxequal(T) ? nothing : error("Fluxes not all equal")
+  return allfluxequal(T) ? nothing : error("Fluxes not all equal")
 end
 
 """

--- a/src/qn/flux.jl
+++ b/src/qn/flux.jl
@@ -69,7 +69,10 @@ allfluxequal(T::Tensor) = allequal(flux(T, b) for b in nzblocks(T))
 Check that fluxes of all non-zero blocks of a blocked or symmetric Tensor
 are equal. Throws an error if one or more blocks have a different flux.
 """
-checkflux(T::Tensor) = allfluxequal(T) ? nothing : error("Fluxes not all equal")
+function checkflux(T::Tensor) 
+  (!hasqns(T) || isempty(T)) && return nothing
+  allfluxequal(T) ? nothing : error("Fluxes not all equal")
+end
 
 """
     checkflux(T::Tensor, flux)

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -1838,6 +1838,11 @@ end
     n = uniqueindex(N, A)
     @test dim(n) == dim(j) - dim(i)
   end
+
+  @testset "checkflux test" begin
+    # Calling checkflux should not error (issue #1283)
+    @test ITensors.checkflux(randomITensor(Index(2))) == nothing
+  end
 end # End Dense ITensor basic functionality
 
 # Disable debug checking once tests are completed


### PR DESCRIPTION
# Description

The `checkflux` function currently tries to run some inapplicable logic when called on dense ITensors. It is called in a generic test within the `dmrg` routine when debug checks are enabled. This small change checks `hasqns` or `isempty` on an ITensor, and if `false` just returns `nothing` rather than running any more checks.

I considered changing `nzblocks` instead to just return something like `[Block(1,1,1,1,...)]` instead for a dense tensor, but concluded that might not be what we want right now and regardless even the flux of that single block is not well-defined, so it might not make sense to say that `allfluxequal` even on that single block. So probably better to just have the logic be that `checkflux` always just passes or does nothing in the dense case.

Fixes #1283

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
i = Index(2)
T = randomITensor(i) # make a dense ITensor
ITensors.checkflux(T) # this would error
```
</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
i = Index(2)
T = randomITensor(i) # make a dense ITensor
@assert ITensors.checkflux(T) == nothing # no longer errors
```
</p></details>

# How Has This Been Tested?

Added a test to base/test_itensors.jl that calling `checkflux` does not error and that it does return `nothing`.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
