### PR TITLE
[ITensors] Add missing kwargs to `replacebond!` and downstream functions

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -540,6 +540,7 @@ function replacebond!(
   maxdim=nothing,
   cutoff=nothing,
   eigen_perturbation=nothing,
+  # svd kwargs
   svd_alg=nothing,
   use_absolute_cutoff=nothing,
   use_relative_cutoff=nothing,

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -543,7 +543,7 @@ function replacebond!(
   svd_alg=nothing,
   use_absolute_cutoff=nothing,
   use_relative_cutoff=nothing,
-  min_blockdim=nothing
+  min_blockdim=nothing,
 )
   normalize = NDTensors.replace_nothing(normalize, false)
   swapsites = NDTensors.replace_nothing(swapsites, false)
@@ -568,7 +568,7 @@ function replacebond!(
     tags=tags(linkind(M, b)),
     use_absolute_cutoff,
     use_relative_cutoff,
-    min_blockdim
+    min_blockdim,
   )
   M[b] = L
   M[b + 1] = R

--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -541,6 +541,9 @@ function replacebond!(
   cutoff=nothing,
   eigen_perturbation=nothing,
   svd_alg=nothing,
+  use_absolute_cutoff=nothing,
+  use_relative_cutoff=nothing,
+  min_blockdim=nothing
 )
   normalize = NDTensors.replace_nothing(normalize, false)
   swapsites = NDTensors.replace_nothing(swapsites, false)
@@ -563,6 +566,9 @@ function replacebond!(
     eigen_perturbation,
     svd_alg,
     tags=tags(linkind(M, b)),
+    use_absolute_cutoff,
+    use_relative_cutoff,
+    min_blockdim
   )
   M[b] = L
   M[b + 1] = R

--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -602,7 +602,7 @@ function factorize_svd(
   tags=nothing,
   use_absolute_cutoff=nothing,
   use_relative_cutoff=nothing,
-  min_blockdim=nothing
+  min_blockdim=nothing,
 )
   leftdir, rightdir = dir, dir
   if !isnothing(leftdir)
@@ -624,7 +624,7 @@ function factorize_svd(
     righttags=tags,
     use_absolute_cutoff,
     use_relative_cutoff,
-    min_blockdim
+    min_blockdim,
   )
   if isnothing(USV)
     return nothing
@@ -658,7 +658,7 @@ function factorize_eigen(
   cutoff=nothing,
   tags=nothing,
   use_absolute_cutoff=nothing,
-  use_relative_cutoff=nothing
+  use_relative_cutoff=nothing,
 )
   if ortho == "left"
     Lis = commoninds(A, indices(Linds...))
@@ -677,7 +677,18 @@ function factorize_eigen(
     delta_A2 = noprime(delta_A2)
     A2 += delta_A2
   end
-  F = eigen(A2, Lis, simLis; ishermitian=true, mindim, maxdim, cutoff, tags, use_absolute_cutoff, use_relative_cutoff)
+  F = eigen(
+    A2,
+    Lis,
+    simLis;
+    ishermitian=true,
+    mindim,
+    maxdim,
+    cutoff,
+    tags,
+    use_absolute_cutoff,
+    use_relative_cutoff,
+  )
   D, _, spec = F
   L = F.Vt
   R = dag(L) * A
@@ -788,7 +799,19 @@ function factorize(
   end
   if which_decomp == "svd"
     LR = factorize_svd(
-      A, Linds...; mindim, maxdim, cutoff, tags, ortho, alg=svd_alg, dir, singular_values!, use_absolute_cutoff, use_relative_cutoff, min_blockdim
+      A,
+      Linds...;
+      mindim,
+      maxdim,
+      cutoff,
+      tags,
+      ortho,
+      alg=svd_alg,
+      dir,
+      singular_values!,
+      use_absolute_cutoff,
+      use_relative_cutoff,
+      min_blockdim,
     )
     if isnothing(LR)
       return nothing
@@ -796,7 +819,16 @@ function factorize(
     L, R, spec = LR
   elseif which_decomp == "eigen"
     L, R, spec = factorize_eigen(
-      A, Linds...; mindim, maxdim, cutoff, tags, ortho, eigen_perturbation, use_absolute_cutoff, use_relative_cutoff
+      A,
+      Linds...;
+      mindim,
+      maxdim,
+      cutoff,
+      tags,
+      ortho,
+      eigen_perturbation,
+      use_absolute_cutoff,
+      use_relative_cutoff,
     )
   elseif which_decomp == "qr"
     L, R = factorize_qr(A, Linds...; ortho, tags)

--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -600,6 +600,9 @@ function factorize_svd(
   maxdim=nothing,
   cutoff=nothing,
   tags=nothing,
+  use_absolute_cutoff=nothing,
+  use_relative_cutoff=nothing,
+  min_blockdim=nothing
 )
   leftdir, rightdir = dir, dir
   if !isnothing(leftdir)
@@ -619,6 +622,9 @@ function factorize_svd(
     cutoff,
     lefttags=tags,
     righttags=tags,
+    use_absolute_cutoff,
+    use_relative_cutoff,
+    min_blockdim
   )
   if isnothing(USV)
     return nothing
@@ -651,6 +657,8 @@ function factorize_eigen(
   maxdim=nothing,
   cutoff=nothing,
   tags=nothing,
+  use_absolute_cutoff=nothing,
+  use_relative_cutoff=nothing
 )
   if ortho == "left"
     Lis = commoninds(A, indices(Linds...))
@@ -669,7 +677,7 @@ function factorize_eigen(
     delta_A2 = noprime(delta_A2)
     A2 += delta_A2
   end
-  F = eigen(A2, Lis, simLis; ishermitian=true, mindim, maxdim, cutoff, tags)
+  F = eigen(A2, Lis, simLis; ishermitian=true, mindim, maxdim, cutoff, tags, use_absolute_cutoff, use_relative_cutoff)
   D, _, spec = F
   L = F.Vt
   R = dag(L) * A
@@ -780,7 +788,7 @@ function factorize(
   end
   if which_decomp == "svd"
     LR = factorize_svd(
-      A, Linds...; mindim, maxdim, cutoff, tags, ortho, alg=svd_alg, dir, singular_values!
+      A, Linds...; mindim, maxdim, cutoff, tags, ortho, alg=svd_alg, dir, singular_values!, use_absolute_cutoff, use_relative_cutoff, min_blockdim
     )
     if isnothing(LR)
       return nothing
@@ -788,7 +796,7 @@ function factorize(
     L, R, spec = LR
   elseif which_decomp == "eigen"
     L, R, spec = factorize_eigen(
-      A, Linds...; mindim, maxdim, cutoff, tags, ortho, eigen_perturbation
+      A, Linds...; mindim, maxdim, cutoff, tags, ortho, eigen_perturbation, use_absolute_cutoff, use_relative_cutoff
     )
   elseif which_decomp == "qr"
     L, R = factorize_qr(A, Linds...; ortho, tags)

--- a/test/ITensorLegacyMPS/base/test_mps.jl
+++ b/test/ITensorLegacyMPS/base/test_mps.jl
@@ -627,7 +627,15 @@ include(joinpath(@__DIR__, "utils", "util.jl"))
     phi = psi[1] * psi[2]
     replacebond!(psi, 1, phi; ortho="left", which_decomp="svd", use_relative_cutoff=true)
     phi = psi[5] * psi[6]
-    replacebond!(psi, 5, phi; ortho="right", which_decomp="svd", use_absolute_cutoff=true)
+    replacebond!(
+      psi,
+      5,
+      phi;
+      ortho="right",
+      which_decomp="svd",
+      use_absolute_cutoff=true,
+      min_blockdim=2,
+    )
   end
 end
 

--- a/test/ITensorLegacyMPS/base/test_mps.jl
+++ b/test/ITensorLegacyMPS/base/test_mps.jl
@@ -603,7 +603,7 @@ include(joinpath(@__DIR__, "utils", "util.jl"))
     replacebond!(psi, 1, phi)
     @test tags(linkind(psi, 1)) == bondindtags
 
-    # check that replacebond! updates llim and rlim properly
+    # check that replacebond! updates llim and rlim properly and works with use_absolute_cutoff
     orthogonalize!(psi, 5)
     phi = psi[5] * psi[6]
     replacebond!(psi, 5, phi; ortho="left", which_decomp="svd", use_absolute_cutoff=true)
@@ -615,6 +615,7 @@ include(joinpath(@__DIR__, "utils", "util.jl"))
     @test ITensors.leftlim(psi) == 4
     @test ITensors.rightlim(psi) == 6
 
+    # check that replacebond! works with use_absolute_cutoff
     ITensors.setleftlim!(psi, 3)
     ITensors.setrightlim!(psi, 7)
     phi = psi[5] * psi[6]

--- a/test/ITensorLegacyMPS/base/test_mps.jl
+++ b/test/ITensorLegacyMPS/base/test_mps.jl
@@ -603,10 +603,10 @@ include(joinpath(@__DIR__, "utils", "util.jl"))
     replacebond!(psi, 1, phi)
     @test tags(linkind(psi, 1)) == bondindtags
 
-    # check that replacebond! updates llim and rlim properly and works with use_absolute_cutoff
+    # check that replacebond! updates llim and rlim properly
     orthogonalize!(psi, 5)
     phi = psi[5] * psi[6]
-    replacebond!(psi, 5, phi; ortho="left", which_decomp="svd", use_absolute_cutoff=true)
+    replacebond!(psi, 5, phi; ortho="left")
     @test ITensors.leftlim(psi) == 5
     @test ITensors.rightlim(psi) == 7
 
@@ -615,13 +615,19 @@ include(joinpath(@__DIR__, "utils", "util.jl"))
     @test ITensors.leftlim(psi) == 4
     @test ITensors.rightlim(psi) == 6
 
-    # check that replacebond! works with use_absolute_cutoff
     ITensors.setleftlim!(psi, 3)
     ITensors.setrightlim!(psi, 7)
     phi = psi[5] * psi[6]
-    replacebond!(psi, 5, phi; ortho="left", which_decomp="svd", use_relative_cutoff=true)
+    replacebond!(psi, 5, phi; ortho="left")
     @test ITensors.leftlim(psi) == 3
     @test ITensors.rightlim(psi) == 7
+
+    # check that replacebond! runs with svd kwargs
+    psi = randomMPS(sites)
+    phi = psi[1] * psi[2]
+    replacebond!(psi, 1, phi; ortho="left", which_decomp="svd", use_relative_cutoff=true)
+    phi = psi[5] * psi[6]
+    replacebond!(psi, 5, phi; ortho="right", which_decomp="svd", use_absolute_cutoff=true)
   end
 end
 

--- a/test/ITensorLegacyMPS/base/test_mps.jl
+++ b/test/ITensorLegacyMPS/base/test_mps.jl
@@ -606,7 +606,7 @@ include(joinpath(@__DIR__, "utils", "util.jl"))
     # check that replacebond! updates llim and rlim properly
     orthogonalize!(psi, 5)
     phi = psi[5] * psi[6]
-    replacebond!(psi, 5, phi; ortho="left")
+    replacebond!(psi, 5, phi; ortho="left", which_decomp="svd", use_absolute_cutoff=true)
     @test ITensors.leftlim(psi) == 5
     @test ITensors.rightlim(psi) == 7
 
@@ -618,7 +618,7 @@ include(joinpath(@__DIR__, "utils", "util.jl"))
     ITensors.setleftlim!(psi, 3)
     ITensors.setrightlim!(psi, 7)
     phi = psi[5] * psi[6]
-    replacebond!(psi, 5, phi; ortho="left")
+    replacebond!(psi, 5, phi; ortho="left", which_decomp="svd", use_relative_cutoff=true)
     @test ITensors.leftlim(psi) == 3
     @test ITensors.rightlim(psi) == 7
   end


### PR DESCRIPTION
# Description

A previous PR to ITensors.jl (https://github.com/ITensor/ITensors.jl/pull/1226) refactored away from `kwargs...` in function calls to replacebond!, factorize, and some downstream calls, but missed a few kwargs `use_relative_cutoff`, `use_absolute_cutoff`, and `min_blockdim`. This fix adds those back to the high level function and ensures they are passed down correctly into the eigen and svd decomposition routines.


Fixes #1297  (see issue for previous behavior)

# How Has This Been Tested?

I updated the tests in `test_mps.jl` to include some of these keyword arguments in the `replacebond!` testset. We can add more to increase code coverage, but I wanted to get your thoughts on what I've modified so far before going any further.

- [x] `test/ITensorLegacyMPS/base/test_mps.jl` testset `replacebond!`

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [] I have made corresponding changes to the documentation. (no changes needed, just fixing a regression.)
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
