### PR TITLE
[ITensors] Add `checkflux` debug check to `factorize`

### DIFF
--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -763,6 +763,9 @@ function factorize(
   (singular_values!)=nothing,
   dir=nothing,
 )
+  @debug_check begin
+    checkflux(A)
+  end
   if !isnothing(eigen_perturbation)
     if !(isnothing(which_decomp) || which_decomp == "eigen")
       error("""when passing a non-trivial eigen_perturbation to `factorize`,

--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -763,9 +763,7 @@ function factorize(
   (singular_values!)=nothing,
   dir=nothing,
 )
-  @debug_check begin
-    checkflux(A)
-  end
+  @debug_check checkflux(A)
   if !isnothing(eigen_perturbation)
     if !(isnothing(which_decomp) || which_decomp == "eigen")
       error("""when passing a non-trivial eigen_perturbation to `factorize`,


### PR DESCRIPTION
Adds a call to `checkflux` at the beginning of `factorize` when debug checks are enabled.

Related to [this forum discussion](https://itensor.discourse.group/t/bug-in-factorize-qr-leading-to-very-slow-calls-to-orthogonalize/1412/9).
