### PR TITLE
Patch sectors

### DIFF
--- a/NDTensors/src/lib/Sectors/src/abstractcategory.jl
+++ b/NDTensors/src/lib/Sectors/src/abstractcategory.jl
@@ -38,6 +38,8 @@ end
 
 istrivial(c::AbstractCategory) = (c == trivial(typeof(c)))
 
-dual(c::AbstractCategory) = typeof(c)(-label(c))
+function dual(category_type::Type{<:AbstractCategory})
+    return error("`dual` not defined for type $(category_type).")
+end
 
 Base.isless(c1::AbstractCategory, c2::AbstractCategory) = isless(label(c1), label(c2))

--- a/NDTensors/src/lib/Sectors/src/abstractcategory.jl
+++ b/NDTensors/src/lib/Sectors/src/abstractcategory.jl
@@ -39,7 +39,7 @@ end
 istrivial(c::AbstractCategory) = (c == trivial(typeof(c)))
 
 function dual(category_type::Type{<:AbstractCategory})
-    return error("`dual` not defined for type $(category_type).")
+  return error("`dual` not defined for type $(category_type).")
 end
 
 Base.isless(c1::AbstractCategory, c2::AbstractCategory) = isless(label(c1), label(c2))

--- a/NDTensors/src/lib/Sectors/src/category_definitions/su.jl
+++ b/NDTensors/src/lib/Sectors/src/category_definitions/su.jl
@@ -35,6 +35,8 @@ dimension(s::SU{2}) = 1 + label(s)[1]
 
 SU{2}(d::Integer) = SU{2}((d - 1, 0))
 
+dual(s::SU{2}) = s
+
 function fusion_rule(s1::SU{2}, s2::SU{2})
   d1, d2 = dimension(s1), dimension(s2)
   return [SU{2}(d) for d in (abs(d1 - d2) + 1):2:(d1 + d2 - 1)]

--- a/NDTensors/src/lib/Sectors/src/category_definitions/su2.jl
+++ b/NDTensors/src/lib/Sectors/src/category_definitions/su2.jl
@@ -1,4 +1,4 @@
-using HalfIntegers: Half
+using HalfIntegers: Half, twice
 
 #
 # Conventional SU2 group
@@ -9,10 +9,12 @@ struct SU2 <: AbstractCategory
   j::Half{Int}
 end
 
+dual(s::SU2) = s
+
 label(s::SU2) = s.j
 
 trivial(::Type{SU2}) = SU2(0)
 
-dimension(s::SU2) = 2 * label(s) + 1
+dimension(s::SU2) = twice(label(s)) + 1
 
 label_fusion_rule(::Type{SU2}, j1, j2) = abs(j1 - j2):(j1 + j2)

--- a/NDTensors/src/lib/Sectors/src/category_definitions/u1.jl
+++ b/NDTensors/src/lib/Sectors/src/category_definitions/u1.jl
@@ -8,6 +8,8 @@ struct U1 <: AbstractCategory
   n::Half{Int}
 end
 
+dual(u::U1) = U1(-u.n)
+
 label(u::U1) = u.n
 
 dimension(::U1) = 1


### PR DESCRIPTION
# Description

Patch sectors.

- `dual` is no more defined for `AbstractCategory`.
- `dimension(::SU2)` returns an integer


<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
dual(SU2(1))
```
```
SU2(1)
```
</p></details>


# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.