### PR TITLE
[ITensors] Faster QN addition and filling

### DIFF
--- a/src/qn/qn.jl
+++ b/src/qn/qn.jl
@@ -238,7 +238,7 @@ function (a::QN + b::QN)
   !isactive(b[1]) && return a
 
   ma = MQNStorage(data(a))
-  for nb in 1:maxQNs
+  @inbounds for nb in 1:maxQNs
     !isactive(b[nb]) && break
     bname = name(b[nb])
     for na in 1:maxQNs
@@ -293,6 +293,7 @@ function fillqns_from(qn1::QN, qn2::QN)
   # If qn1 has no non-trivial qns, fill
   # with qn2
   !isactive(qn1) && return zero(qn2)
+  !isactive(qn2) && return qn1
   for qv2 in qn2
     if !hasname(qn1, qv2)
       qn1 = addqnval(qn1, zero(qv2))


### PR DESCRIPTION
# Description

The main benefit of the `@inbounds` is that it lets Julia allocate `ma` on the stack instead of the heap.

A performance comparison:

```julia
using ITensors, BenchmarkTools
@benchmark qn + qn setup=(qn=QN("a" =>  1))
```

Performance before:
```
BenchmarkTools.Trial: 10000 samples with 996 evaluations.
 Range (min … max):  28.614 ns … 269.277 ns  ┊ GC (min … max): 0.00% … 72.18%
 Time  (median):     30.924 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   34.880 ns ±  15.130 ns  ┊ GC (mean ± σ):  2.09% ±  4.88%

 Memory estimate: 208 bytes, allocs estimate: 1.
```

Performance after:
```
BenchmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  23.370 ns … 80.040 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     23.571 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   24.034 ns ±  2.391 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

 Memory estimate: 0 bytes, allocs estimate: 0.
```

This along with the other change have real impact on the runtime of my MPO construction algorithm.


# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
