### PR TITLE
Define checkflux for ProjMPOSum (actually AbstractSum) and test

### DIFF
--- a/src/mps/projmposum.jl
+++ b/src/mps/projmposum.jl
@@ -111,6 +111,12 @@ function disk(sum::AbstractSum; disk_kwargs...)
   return set_terms(sum, map(t -> disk(t; disk_kwargs...), terms(sum)))
 end
 
+function checkflux(sum::AbstractSum)
+  for t in terms(sum)
+    checkflux(t)
+  end
+end
+
 #
 # Definition of concrete, generic SequentialSum type
 #

--- a/test/ITensorLegacyMPS/base/test_dmrg.jl
+++ b/test/ITensorLegacyMPS/base/test_dmrg.jl
@@ -146,16 +146,15 @@ using ITensors: nsite, set_nsite!, checkflux
     end
     HB = MPO(osB, sites)
 
-    ps = ProjMPOSum([HA,HB])
+    ps = ProjMPOSum([HA, HB])
     @test isnothing(checkflux(ps))
 
     # Test error thrown when non-qn conserving MPO included
     osC = OpSum()
-    osC += "S+",1,"S+",2
+    osC += "S+", 1, "S+", 2
     HC = MPO(osC, sites)
-    ps = ProjMPOSum([HA,HB,HC])
+    ps = ProjMPOSum([HA, HB, HC])
     @test_throws ErrorException isnothing(checkflux(ps))
-
   end
 
   @testset "ProjMPOSum DMRG with disk caching" begin


### PR DESCRIPTION
Define `checkflux` for `AbstractSum` which includes `ProjMPOSum` as a special case. Added test. Meant to address the issue raised in [this forum post](https://itensor.discourse.group/t/bug-in-factorize-qr-leading-to-very-slow-calls-to-orthogonalize/1412/11).
