### PR TITLE
[ITensors] Fix some MPO ChainRules bugs

### DIFF
--- a/src/ITensorChainRules/mps/abstractmps.jl
+++ b/src/ITensorChainRules/mps/abstractmps.jl
@@ -61,9 +61,22 @@ function _contract(::Type{MPO}, ψ::MPS, ϕ::MPS; kwargs...)
   return contract(ψmat, ϕmat; kwargs...)
 end
 
+function _is_mps_or_hermitian_mpo(x::MPO; kwargs...)
+  s = siteinds(x)
+  return all(eachindex(x)) do i
+    isapprox(x[i], swapprime(x[i], 0 => 1; inds=s[i]); kwargs...)
+  end
+end
+_is_mps_or_hermitian_mpo(x::MPS; kwargs...) = true
+
 function rrule(
   ::typeof(apply), x1::Vector{ITensor}, x2::Union{MPS,MPO}; apply_dag=false, kwargs...
 )
+  if apply_dag && !_is_mps_or_hermitian_mpo(x2)
+    error(
+      "For now, we only support taking derivatives of MPO gate application with `apply_dag=true` for Hermitian MPOs. As an alternative, you can manually apply the gate once on each side of the MPO.",
+    )
+  end
   N = length(x1) + 1
 
   # Apply circuit and store intermediates in the forward direction
@@ -102,6 +115,7 @@ function rrule(
             ϕ̃ = apply(x1[n], ϕ̃; move_sites_back=true, apply_dag=false, kwargs...)
             ϕ̃ = mapprime(ϕ̃, 1 => 2, 0 => 1)
             ϕ̃ = replaceprime(ϕ̃, 1 => 0; inds=gateinds')
+
             ξ̃ = 2 * dag(x1dag_ȳ[n + 1])'
           else
             ϕ̃ = mapprime(x1x2dag[n], 0 => 2)

--- a/src/ITensorChainRules/mps/mpo.jl
+++ b/src/ITensorChainRules/mps/mpo.jl
@@ -31,7 +31,11 @@ function rrule(::typeof(+), x1::MPO, x2::MPO; kwargs...)
 end
 
 function rrule(::typeof(-), x1::MPO, x2::MPO; kwargs...)
-  return rrule(+, x1, -x2; kwargs...)
+  y = -(x1, x2; kwargs...)
+  function subtract_pullback(ȳ)
+    return (NoTangent(), ȳ, -ȳ)
+  end
+  return y, subtract_pullback
 end
 
 function rrule(::typeof(tr), x::MPO; plev=(0 => 1), kwargs...)

--- a/test/ITensorLegacyMPS/ITensorChainRules/Project.toml
+++ b/test/ITensorLegacyMPS/ITensorChainRules/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"

--- a/test/ITensorLegacyMPS/ITensorChainRules/test_chainrules.jl
+++ b/test/ITensorLegacyMPS/ITensorChainRules/test_chainrules.jl
@@ -207,6 +207,28 @@ Random.seed!(1234)
     ∇f = f'(θ)
     ∇num = (f(θ + ϵ) - f(θ)) / ϵ
     @test ∇f ≈ ∇num atol = 1e-5
+
+    # add(MPO, MPO)
+    f = function (x, y)
+      z = x + y
+      return inner(z, z)
+    end
+    V1 = randomMPO(s)
+    V2 = randomMPO(s)
+    g1, g2 = gradient(f, V1, V2)
+    @test g1 ≈ 2 * (V1 + V2)
+    @test g2 ≈ 2 * (V1 + V2)
+
+    # subtract(MPO, MPO)
+    f = function (x, y)
+      z = x - y
+      return inner(z, z)
+    end
+    V1 = randomMPO(s)
+    V2 = randomMPO(s)
+    g1, g2 = gradient(f, V1, V2)
+    @test g1 ≈ 2 * (V1 - V2)
+    @test g2 ≈ -2 * (V1 - V2)
   end
 
   @testset "contract/apply MPOs" begin

--- a/test/ITensorLegacyMPS/ITensorChainRules/test_chainrules.jl
+++ b/test/ITensorLegacyMPS/ITensorChainRules/test_chainrules.jl
@@ -155,9 +155,10 @@ Random.seed!(1234)
       return os
     end
     H = MPO(ising(n, 1.0), s)
-
-    # apply on MPO with apply_dag=true
+    A = randomMPO(s)
     ϕ = randomMPS(ComplexF64, s; linkdims=10)
+
+    # apply on mpo with apply_dag=true
     f = function (x)
       U = [op("Ry", s[2]; θ=x), op("CX", s[1], s[2]), op("Rx", s[3]; θ=x)]
       Hθ = apply(U, H; apply_dag=true)
@@ -168,11 +169,33 @@ Random.seed!(1234)
     ∇num = (f(θ + ϵ) - f(θ)) / ϵ
     @test ∇f ≈ ∇num atol = 1e-5
 
-    # apply on MPO with apply_dag=false
+    # test that apply on non-Hermitian mpo with apply_dag=true
+    # throws an error.
+    # TODO: Fix the `rrule` so this works.
+    f = function (x)
+      U = [op("Ry", s[2]; θ=x), op("CX", s[1], s[2]), op("Rx", s[3]; θ=x)]
+      Aθ = apply(U, A; apply_dag=true)
+      return real(inner(ϕ', Aθ, ϕ))
+    end
+    θ = 0.5
+    @test_throws ErrorException f'(θ)
+
+    # apply on Hermitian MPO with apply_dag=false
     f = function (x)
       U = [op("Ry", s[2]; θ=x), op("CX", s[1], s[2]), op("Rx", s[3]; θ=x)]
       Hθ = apply(U, H; apply_dag=false)
       return real(inner(ϕ', Hθ, ϕ))
+    end
+    θ = 0.5
+    ∇f = f'(θ)
+    ∇num = (f(θ + ϵ) - f(θ)) / ϵ
+    @test ∇f ≈ ∇num atol = 1e-5
+
+    # apply on non-Hermitian MPO with apply_dag=false
+    f = function (x)
+      U = [op("Ry", s[2]; θ=x), op("CX", s[1], s[2]), op("Rx", s[3]; θ=x)]
+      Aθ = apply(U, A; apply_dag=false)
+      return real(inner(ϕ', Aθ, ϕ))
     end
     θ = 0.5
     ∇f = f'(θ)


### PR DESCRIPTION
Fixes #1313.

This also provides a partial fix for #1314, where we throw an error when trying to take derivatives through gate application of non-Hermitian MPOs with `apply_dag=true`, which is broken right now but was silently returning incorrect results.