### PR TITLE
Bugfix of MPS from strings and faster QN hashing.

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -423,7 +423,7 @@ function MPS(eltype::Type{<:Number}, sites::Vector{<:Index}, states_)
     end
     links = Vector{QNIndex}(undef, N - 1)
     for j in (N - 1):-1:1
-      links[j] = dag(Index(lflux => 1; tags="Link,l=$j"))
+      links[j] = Index(lflux => 1; tags="Link,l=$j")
       lflux -= flux(states[j])
     end
   else

--- a/src/qn/qn.jl
+++ b/src/qn/qn.jl
@@ -31,6 +31,8 @@ function -(qv::QNVal)
   return QNVal(name(qv), qn_mod(-val(qv), modulus(qv)), modulus(qv))
 end
 
+Base.zero(::Type{QNVal}) = QNVal()
+
 zero(qv::QNVal) = QNVal(name(qv), 0, modulus(qv))
 
 (dir::Arrow * qv::QNVal) = QNVal(name(qv), Int(dir) * val(qv), modulus(qv))
@@ -89,17 +91,15 @@ end
 QN(mqn::MQNStorage) = QN(QNStorage(mqn))
 QN(mqn::NTuple{N,QNVal}) where {N} = QN(QNStorage(mqn))
 
-function hash(obj::QN, h::UInt)
-  # TODO: use an MVector or SVector
-  # for performance here; put non-zero QNVals
-  # to front and slice when passing to hash
-  nzqv = QNVal[]
+function Base.hash(obj::QN, h::UInt)
+  out = h
   for qv in obj.data
     if val(qv) != 0
-      push!(nzqv, qv)
+      out = hash(qv, out)
     end
   end
-  return hash(nzqv, h)
+
+  return out
 end
 
 """


### PR DESCRIPTION
This is two different changes and I'm happy to split this into two PR's if requested.

# MPS construction bug fix

The first change fixes what I believe to be a bug in the construction of a QN MPS from a list of strings. Specifically I think the direction of the link indices was backwards.

```julia
using ITensors

sites = siteinds("Qubit", 2; conserve_qns=true)

os = OpSum()
os .+= 1, "Z", 1
os .+= 1, "Z", 2
H = MPO(os, sites)

psi = MPS(sites, ["1", "1"])
@show linkinds(psi)

Hpsi = apply(H, psi)
@show linkinds(Hpsi)

add(psi, Hpsi; alg="directsum")
```

<details><summary>Demonstration of previous behavior</summary><p>

```text
linkinds(psi) = Index{Vector{Pair{QN, Int64}}}[(dim=1|id=823|"Link,l=1") <In>
 1: QN("Parity",1,2) => 1]
linkinds(Hpsi) = Index{Vector{Pair{QN, Int64}}}[(dim=1|id=961|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1]
ERROR: LoadError: To direct sum two indices, they must have the same direction. Trying to direct sum indices (dim=1|id=823|"Link,l=1") <In>
 1: QN("Parity",1,2) => 1 and (dim=1|id=961|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1.
```
</p></details>

<details><summary>Demonstration of new behavior</summary><p>

```text
linkinds(psi) = Index{Vector{Pair{QN, Int64}}}[(dim=1|id=124|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1]
linkinds(Hpsi) = Index{Vector{Pair{QN, Int64}}}[(dim=1|id=906|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1]
MPS
[1] ((dim=2|id=724|"Qubit,Site,n=1") <Out>
 1: QN("Parity",0,2) => 1
 2: QN("Parity",1,2) => 1, (dim=2|id=806|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1
 2: QN("Parity",1,2) => 1)
[2] ((dim=2|id=269|"Qubit,Site,n=2") <Out>
 1: QN("Parity",0,2) => 1
 2: QN("Parity",1,2) => 1, (dim=2|id=806|"Link,l=1") <In>
 1: QN("Parity",1,2) => 1
 2: QN("Parity",1,2) => 1)
```
</p></details>

# Faster QN hashing

The second change majorly speeds up the hashing of `QN`.


```julia
using ITensors, BenchmarkTools
@benchmark hash(qn) setup=(qn=QN(("a" => 1), ("b" => 2)))
```

<details><summary>Demonstration of previous behavior</summary><p>

```text
BenchmarkTools.Trial: 10000 samples with 972 evaluations.
 Range (min … max):   74.588 ns …   5.719 μs  ┊ GC (min … max):  0.00% … 97.63%
 Time  (median):      83.419 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   115.769 ns ± 371.789 ns  ┊ GC (mean ± σ):  23.48% ±  7.16%

 Memory estimate: 464 bytes, allocs estimate: 2.
```
</p></details>

<details><summary>Demonstration of new behavior</summary><p>

```text
BenchmarkTools.Trial: 10000 samples with 994 evaluations.
 Range (min … max):  31.522 ns … 54.871 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     32.402 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   32.617 ns ±  0.936 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

 Memory estimate: 0 bytes, allocs estimate: 0.
```
</p></details>

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
