### PR TITLE
Fixed a bug in MPS from string.

### DIFF
--- a/src/mps/mps.jl
+++ b/src/mps/mps.jl
@@ -423,7 +423,7 @@ function MPS(eltype::Type{<:Number}, sites::Vector{<:Index}, states_)
     end
     links = Vector{QNIndex}(undef, N - 1)
     for j in (N - 1):-1:1
-      links[j] = dag(Index(lflux => 1; tags="Link,l=$j"))
+      links[j] = Index(lflux => 1; tags="Link,l=$j")
       lflux -= flux(states[j])
     end
   else


### PR DESCRIPTION
Fixes what I believe to be a bug in the construction of a QN MPS from a list of strings. Specifically I think the direction of the link indices was backwards.

```julia
using ITensors

sites = siteinds("Qubit", 2; conserve_qns=true)

os = OpSum()
os .+= 1, "Z", 1
os .+= 1, "Z", 2
H = MPO(os, sites)

psi = MPS(sites, ["1", "1"])
@show linkinds(psi)

Hpsi = apply(H, psi)
@show linkinds(Hpsi)

add(psi, Hpsi; alg="directsum")
```

<details><summary>Demonstration of previous behavior</summary><p>

```text
linkinds(psi) = Index{Vector{Pair{QN, Int64}}}[(dim=1|id=823|"Link,l=1") <In>
 1: QN("Parity",1,2) => 1]
linkinds(Hpsi) = Index{Vector{Pair{QN, Int64}}}[(dim=1|id=961|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1]
ERROR: LoadError: To direct sum two indices, they must have the same direction. Trying to direct sum indices (dim=1|id=823|"Link,l=1") <In>
 1: QN("Parity",1,2) => 1 and (dim=1|id=961|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1.
```
</p></details>

<details><summary>Demonstration of new behavior</summary><p>

```text
linkinds(psi) = Index{Vector{Pair{QN, Int64}}}[(dim=1|id=124|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1]
linkinds(Hpsi) = Index{Vector{Pair{QN, Int64}}}[(dim=1|id=906|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1]
MPS
[1] ((dim=2|id=724|"Qubit,Site,n=1") <Out>
 1: QN("Parity",0,2) => 1
 2: QN("Parity",1,2) => 1, (dim=2|id=806|"Link,l=1") <Out>
 1: QN("Parity",1,2) => 1
 2: QN("Parity",1,2) => 1)
[2] ((dim=2|id=269|"Qubit,Site,n=2") <Out>
 1: QN("Parity",0,2) => 1
 2: QN("Parity",1,2) => 1, (dim=2|id=806|"Link,l=1") <In>
 1: QN("Parity",1,2) => 1
 2: QN("Parity",1,2) => 1)
```
</p></details>

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
