### PR TITLE
[ITensors][ENHANCEMENT] Faster QN hashing

### DIFF
--- a/src/qn/qn.jl
+++ b/src/qn/qn.jl
@@ -31,6 +31,8 @@ function -(qv::QNVal)
   return QNVal(name(qv), qn_mod(-val(qv), modulus(qv)), modulus(qv))
 end
 
+Base.zero(::Type{QNVal}) = QNVal()
+
 zero(qv::QNVal) = QNVal(name(qv), 0, modulus(qv))
 
 (dir::Arrow * qv::QNVal) = QNVal(name(qv), Int(dir) * val(qv), modulus(qv))
@@ -89,17 +91,15 @@ end
 QN(mqn::MQNStorage) = QN(QNStorage(mqn))
 QN(mqn::NTuple{N,QNVal}) where {N} = QN(QNStorage(mqn))
 
-function hash(obj::QN, h::UInt)
-  # TODO: use an MVector or SVector
-  # for performance here; put non-zero QNVals
-  # to front and slice when passing to hash
-  nzqv = QNVal[]
+function Base.hash(obj::QN, h::UInt)
+  out = h
   for qv in obj.data
     if val(qv) != 0
-      push!(nzqv, qv)
+      out = hash(qv, out)
     end
   end
-  return hash(nzqv, h)
+
+  return out
 end
 
 """

--- a/test/base/test_qn.jl
+++ b/test/base/test_qn.jl
@@ -6,6 +6,7 @@ import ITensors: nactive
   @testset "QNVal Basics" begin
     qv = ITensors.QNVal()
     @test !isactive(qv)
+    @test qv == zero(ITensors.QNVal)
 
     qv = ITensors.QNVal("Sz", 0)
     @test ITensors.name(qv) == ITensors.SmallString("Sz")
@@ -24,6 +25,12 @@ import ITensors: nactive
     @test val(qv) == 1
     @test modulus(qv) == -1
     @test isfermionic(qv)
+
+    qv = zero(ITensors.QNVal("Sz", 5))
+    @test ITensors.name(qv) == ITensors.SmallString("Sz")
+    @test val(qv) == 0
+    @test modulus(qv) == 1
+    @test isactive(qv)
   end
 
   @testset "QN Basics" begin


### PR DESCRIPTION
Speeds up the hashing of `QN`.


```julia
using ITensors, BenchmarkTools
@benchmark hash(qn) setup=(qn=QN(("a" => 1), ("b" => 2)))
```

<details><summary>Demonstration of previous behavior</summary><p>

```text
BenchmarkTools.Trial: 10000 samples with 972 evaluations.
 Range (min … max):   74.588 ns …   5.719 μs  ┊ GC (min … max):  0.00% … 97.63%
 Time  (median):      83.419 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   115.769 ns ± 371.789 ns  ┊ GC (mean ± σ):  23.48% ±  7.16%

 Memory estimate: 464 bytes, allocs estimate: 2.
```
</p></details>

<details><summary>Demonstration of new behavior</summary><p>

```text
BenchmarkTools.Trial: 10000 samples with 994 evaluations.
 Range (min … max):  31.522 ns … 54.871 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     32.402 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   32.617 ns ±  0.936 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

 Memory estimate: 0 bytes, allocs estimate: 0.
```
</p></details>

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
