### PR TITLE
[ITensors] Remove `sort` from `sites(a::Union{Sum,Prod})`.

### DIFF
--- a/src/Ops/Ops.jl
+++ b/src/Ops/Ops.jl
@@ -142,7 +142,7 @@ function sites(a::Union{Sum,Prod})
   for n in 1:length(a)
     s = s ∪ sites(a[n])
   end
-  return sort(map(identity, s))
+  return map(identity, s)
 end
 sites(a::Scaled{C,<:Sum}) where {C} = sites(argument(a))
 sites(a::Scaled{C,<:Prod}) where {C} = sites(argument(a))


### PR DESCRIPTION
# Description
This removes a (hopefully) unnecessary call to `sort` on the output of `sites(a::Union{Sum,Prod}` in `src/Ops/Ops.jl`, related to `OpSum` and `MPO` construction. 
Since ITensorNetworks.jl allows arbitrary vertex (i.e. `site`) names, a comparison `isless` of different `sites` may not be well defined and leads to errors due to that call.

Tests are passing except for one related to QN, which seems to be unrelated (and also occurs without the change), see below:
```
Running /mnt/home/bkloss/.julia/v1.9/dev/ITensors/test/base/test_qn.jl
QNVal Basics: Error During Test at /mnt/home/bkloss/.julia/v1.9/dev/ITensors/test/base/test_qn.jl:9
  Test threw exception
  Expression: qv == zero(ITensors.QNVal)
  MethodError: no method matching zero(::Type{ITensors.QNVal})
  
  Closest candidates are:
    zero(::Union{Type{P}, P}) where P<:Dates.Period
     @ Dates /mnt/sw/nix/store/fms6zspq4gnq3x8bps8i9wx4lhd6j8s3-julia-1.9.0/share/julia/stdlib/v1.9/Dates/src/periods.jl:51
    zero(::Union{VectorInterface.One, VectorInterface.Zero})
     @ VectorInterface ~/.julia/v1.9/packages/VectorInterface/TAlcJ/src/onezero.jl:65
    zero(::Union{Zeros.One, Zeros.Zero})
     @ Zeros ~/.julia/v1.9/packages/Zeros/eEqdd/src/Zeros.jl:48
    ...
  
  Stacktrace:
   [1] macro expansion
     @ /mnt/sw/nix/store/fms6zspq4gnq3x8bps8i9wx4lhd6j8s3-julia-1.9.0/share/julia/stdlib/v1.9/Test/src/Test.jl:478 [inlined]
   [2] macro expansion
     @ ~/.julia/v1.9/dev/ITensors/test/base/test_qn.jl:9 [inlined]
   [3] macro expansion
     @ /mnt/sw/nix/store/fms6zspq4gnq3x8bps8i9wx4lhd6j8s3-julia-1.9.0/share/julia/stdlib/v1.9/Test/src/Test.jl:1498 [inlined]
   [4] macro expansion
     @ ~/.julia/v1.9/dev/ITensors/test/base/test_qn.jl:7 [inlined]
   [5] macro expansion
     @ /mnt/sw/nix/store/fms6zspq4gnq3x8bps8i9wx4lhd6j8s3-julia-1.9.0/share/julia/stdlib/v1.9/Test/src/Test.jl:1498 [inlined]
   [6] top-level scope
     @ ~/.julia/v1.9/dev/ITensors/test/base/test_qn.jl:6
  1.610808 seconds (1.37 M allocations: 98.077 MiB, 81.36% compilation time)
```