### PR TITLE
[ITensorMPS] Make ITensorTDVP functions into compatibility layer

### DIFF
--- a/src/ITensorMPS/contract_mpo_mps.jl
+++ b/src/ITensorMPS/contract_mpo_mps.jl
@@ -12,8 +12,8 @@ function contractmpo_solver(; kwargs...)
   return solver
 end
 
-function ITensors.contract(
-  ::Algorithm"fit", A::MPO, psi0::MPS; init_mps=psi0, nsweeps=1, kwargs...
+function itensortdvp_contract(
+  alg::Algorithm"fit", A::MPO, psi0::MPS; init_mps=psi0, nsweeps=1, kwargs...
 )::MPS
   n = length(A)
   n != length(psi0) &&

--- a/src/ITensorMPS/dmrg.jl
+++ b/src/ITensorMPS/dmrg.jl
@@ -419,7 +419,7 @@ function dmrg_solver(
   return solver
 end
 
-function alternating_update_dmrg(
+function itensortdvp_dmrg(
   H,
   psi0::MPS;
   ishermitian=default_ishermitian(),

--- a/src/ITensorMPS/dmrg_x.jl
+++ b/src/ITensorMPS/dmrg_x.jl
@@ -10,7 +10,7 @@ function dmrg_x_solver(PH, t, psi0; current_time, outputlevel)
   return U_max, nothing
 end
 
-function dmrg_x(PH, psi0::MPS; reverse_step=false, kwargs...)
+function itensortdvp_dmrg_x(PH, psi0::MPS; reverse_step=false, kwargs...)
   psi = alternating_update(dmrg_x_solver, PH, psi0; reverse_step, kwargs...)
   return psi
 end

--- a/src/ITensorMPS/linsolve.jl
+++ b/src/ITensorMPS/linsolve.jl
@@ -22,7 +22,7 @@ Keyword arguments:
     ```
     See `KrylovKit.jl` documentation for more details on available keyword arguments.
 """
-function KrylovKit.linsolve(
+function itensortdvp_linsolve(
   A::MPO,
   b::MPS,
   x₀::MPS,

--- a/src/ITensorMPS/sweep_update.jl
+++ b/src/ITensorMPS/sweep_update.jl
@@ -2,7 +2,6 @@ using ITensors: uniqueinds
 using ITensors.ITensorMPS:
   ITensorMPS, MPS, isortho, orthocenter, orthogonalize!, position!, replacebond!, set_nsite!
 using LinearAlgebra: norm, normalize!, svd
-using Observers: update!
 using Printf: @printf
 
 function sweep_update(
@@ -132,7 +131,7 @@ function sub_sweep_update(
       end
       flush(stdout)
     end
-    update!(
+    update_observer!(
       observer!;
       psi,
       bond=b,

--- a/src/ITensorMPS/tdvp.jl
+++ b/src/ITensorMPS/tdvp.jl
@@ -44,7 +44,7 @@ function tdvp_solver(
   return solver
 end
 
-function tdvp(
+function itensortdvp_tdvp(
   H,
   t::Number,
   psi0::MPS;
@@ -58,7 +58,7 @@ function tdvp(
   solver_outputlevel=default_solver_outputlevel(solver_function),
   kwargs...,
 )
-  return tdvp(
+  return itensortdvp_tdvp(
     tdvp_solver(
       solver_function;
       ishermitian,
@@ -75,12 +75,12 @@ function tdvp(
   )
 end
 
-function tdvp(t::Number, H, psi0::MPS; kwargs...)
-  return tdvp(H, t, psi0; kwargs...)
+function itensortdvp_tdvp(t::Number, H, psi0::MPS; kwargs...)
+  return itensortdvp_tdvp(H, t, psi0; kwargs...)
 end
 
-function tdvp(H, psi0::MPS, t::Number; kwargs...)
-  return tdvp(H, t, psi0; kwargs...)
+function itensortdvp_tdvp(H, psi0::MPS, t::Number; kwargs...)
+  return itensortdvp_tdvp(H, t, psi0; kwargs...)
 end
 
 """
@@ -100,16 +100,16 @@ Optional keyword arguments:
 * `observer` - object implementing the [Observer](@ref observer) interface which can perform measurements and stop early
 * `write_when_maxdim_exceeds::Int` - when the allowed maxdim exceeds this value, begin saving tensors to disk to free memory in large calculations
 """
-function tdvp(solver, H::MPO, t::Number, psi0::MPS; kwargs...)
+function itensortdvp_tdvp(solver, H::MPO, t::Number, psi0::MPS; kwargs...)
   return alternating_update(solver, H, t, psi0; kwargs...)
 end
 
-function tdvp(solver, t::Number, H, psi0::MPS; kwargs...)
-  return tdvp(solver, H, t, psi0; kwargs...)
+function itensortdvp_tdvp(solver, t::Number, H, psi0::MPS; kwargs...)
+  return itensortdvp_tdvp(solver, H, t, psi0; kwargs...)
 end
 
-function tdvp(solver, H, psi0::MPS, t::Number; kwargs...)
-  return tdvp(solver, H, t, psi0; kwargs...)
+function itensortdvp_tdvp(solver, H, psi0::MPS, t::Number; kwargs...)
+  return itensortdvp_tdvp(solver, H, t, psi0; kwargs...)
 end
 
 """
@@ -131,6 +131,6 @@ each step of the algorithm when optimizing the MPS.
 Returns:
 * `psi::MPS` - time-evolved MPS
 """
-function tdvp(solver, Hs::Vector{MPO}, t::Number, psi0::MPS; kwargs...)
+function itensortdvp_tdvp(solver, Hs::Vector{MPO}, t::Number, psi0::MPS; kwargs...)
   return alternating_update(solver, Hs, t, psi0; kwargs...)
 end

--- a/src/ITensorMPS/update_observer.jl
+++ b/src/ITensorMPS/update_observer.jl
@@ -1,5 +1,7 @@
-using Observers: Observers
+function update_observer!(observer; kwargs...)
+  return error("Not implemented")
+end
 
-function Observers.update!(observer::AbstractObserver; kwargs...)
+function update_observer!(observer::AbstractObserver; kwargs...)
   return measure!(observer; kwargs...)
 end


### PR DESCRIPTION
This PR changes the names of the interface functions moved from ITensorTDVP. Now they are prepended with itensortdvp_ so as to be a compatibility layer behind which we can translate arguments to be able to work on the ITensorMPS.alternating_update code however we want without breaking ITensorTDVP.
