### PR TITLE
Modify delta to have Bool storage

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -531,8 +531,8 @@ end
 diagITensor(x::Number, is...) = diagITensor(NeverAlias(), x, is...)
 
 """
-    delta([::Type{ElT} = Float64, ]inds)
-    delta([::Type{ElT} = Float64, ]inds::Index...)
+    delta([::Type{ElT} = Bool, ]inds)
+    delta([::Type{ElT} = Bool, ]inds::Index...)
 
 Make a uniform diagonal ITensor with all diagonal elements
 `one(ElT)`. Only a single diagonal element is stored.

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -547,7 +547,7 @@ function delta(eltype::Type{<:Number}, is...)
   return delta(eltype, indices(is...))
 end
 
-delta(is...) = delta(Float64, is...)
+delta(is...) = delta(Bool, is...)
 
 const δ = delta
 

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -500,8 +500,8 @@ function diagITensor(inds::QNIndices)
 end
 
 """
-    delta([::Type{ElT} = Float64, ][flux::QN = QN(), ]is)
-    delta([::Type{ElT} = Float64, ][flux::QN = QN(), ]is::Index...)
+    delta([::Type{ElT} = Bool, ][flux::QN = QN(), ]is)
+    delta([::Type{ElT} = Bool, ][flux::QN = QN(), ]is::Index...)
 
 Make an ITensor with storage type `NDTensors.DiagBlockSparse` with uniform
 elements `one(ElT)`. The ITensor only has diagonal blocks consistent with the
@@ -544,7 +544,7 @@ function dropzeros(T::ITensor; tol=0)
 end
 
 function δ_split(i1::Index, i2::Index)
-  d = emptyITensor(Bool,i1, i2)
+  d = emptyITensor(Bool, i1, i2)
   for n in 1:min(dim(i1), dim(i2))
     d[n, n] = 1
   end

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -521,15 +521,15 @@ function delta(::Type{ElT}, flux::QN, is...) where {ElT<:Number}
   return delta(ElT, flux, indices(is...))
 end
 
-delta(flux::QN, inds::Indices) = delta(Float64, flux, is)
+delta(flux::QN, inds::Indices) = delta(Bool, flux, is)
 
-delta(flux::QN, is...) = delta(Float64, flux, indices(is...))
+delta(flux::QN, is...) = delta(Bool, flux, indices(is...))
 
 function delta(::Type{ElT}, inds::QNIndices) where {ElT<:Number}
   return delta(ElT, QN(), inds)
 end
 
-delta(inds::QNIndices) = delta(Float64, QN(), inds)
+delta(inds::QNIndices) = delta(Bool, QN(), inds)
 
 function dropzeros(T::ITensor; tol=0)
   # XXX: replace with empty(T)
@@ -544,7 +544,7 @@ function dropzeros(T::ITensor; tol=0)
 end
 
 function δ_split(i1::Index, i2::Index)
-  d = emptyITensor(i1, i2)
+  d = emptyITensor(Bool,i1, i2)
   for n in 1:min(dim(i1), dim(i2))
     d[n, n] = 1
   end

--- a/test/base/test_diagitensor.jl
+++ b/test/base/test_diagitensor.jl
@@ -263,8 +263,8 @@ using Test
     end
 
     @testset "Add (Diag uniform + Diag uniform)" begin
-      D1 = δ(i, j, k)
-      D2 = δ(k, i, j)
+      D1 = δ(i, j, k) * 1.0 # hack, for Float64
+      D2 = δ(k, i, j) * 1.0
 
       D3 = D1 + D2
 
@@ -391,12 +391,12 @@ using Test
     @testset "delta constructor (order 2)" begin
       D = δ(i, j)
 
-      @test eltype(D) == Float64
+      @test eltype(D) == Bool
       for ii in 1:d, jj in 1:d
         if ii == jj
-          @test D[i => ii, j => jj] == 1.0
+          @test D[i => ii, j => jj] == 1
         else
-          @test D[i => ii, j => jj] == 0.0
+          @test D[i => ii, j => jj] == 0
         end
       end
     end
@@ -404,12 +404,12 @@ using Test
     @testset "delta constructor (order 3)" begin
       D = δ(i, j, k)
 
-      @test eltype(D) == Float64
+      @test eltype(D) == Bool
       for ii in 1:dim(i), jj in 1:dim(j), kk in 1:dim(k)
         if ii == jj == kk
-          @test D[i => ii, j => jj, k => kk] == 1.0
+          @test D[i => ii, j => jj, k => kk] == 1
         else
-          @test D[i => ii, j => jj, k => kk] == 0.0
+          @test D[i => ii, j => jj, k => kk] == 0
         end
       end
     end
@@ -417,7 +417,7 @@ using Test
     @testset "Set elements" begin
       D = δ(i, j, k)
 
-      @test eltype(D) == Float64
+      @test eltype(D) == Bool
 
       # Can't set elements of uniform diag tensor
       # TODO: should we make a function that converts
@@ -431,18 +431,18 @@ using Test
       D = δ(i, j, k)
       T = dense(D)
 
-      @test storage(T) isa NDTensors.Dense{Float64}
+      @test storage(T) isa NDTensors.Dense{Bool}
       for ii in 1:d, jj in 1:d, kk in 1:d
         if ii == jj == kk
-          @test T[ii, ii, ii] == 1.0
+          @test T[ii, ii, ii] == 1
         else
-          @test T[i => ii, j => jj, k => kk] == 0.0
+          @test T[i => ii, j => jj, k => kk] == 0
         end
       end
     end
 
     @testset "Add (Diag uniform + Dense)" begin
-      D = δ(i, j, k)
+      D = δ(i, j, k) * 1.0 # hack, Float64
       A = randomITensor(k, j, i)
 
       R = D + A
@@ -508,16 +508,16 @@ using Test
     end
 
     @testset "Contraction (Diag uniform * Diag uniform, all contracted)" begin
-      D1 = δ(l, i, k, j)
-      D2 = δ(j, l, i, k)
+      D1 = δ(l, i, k, j) * 1.0 # hack, convert to Float64
+      D2 = δ(j, l, i, k) * 1.0
 
       @test D1 * D2 ≈ dense(D1) * dense(D2)
       @test D2 * D1 ≈ dense(D1) * dense(D2)
     end
 
     @testset "Contraction (Diag uniform * Diag uniform, general)" begin
-      D1 = δ(l, i, k, j)
-      D2 = δ(m, k, n, l)
+      D1 = δ(l, i, k, j) * 1.0 # hack convert to Float64
+      D2 = δ(m, k, n, l) * 1.0
 
       @test D1 * D2 ≈ dense(D1) * dense(D2)
       @test D2 * D1 ≈ dense(D1) * dense(D2)


### PR DESCRIPTION
# Description

Generically, having `delta` default to Float64 storage is causing problems with GPU (see #1143  and comment from @kmp5VT ) as well as converting previous codes to different types Float32/etc. One bandaid is to swap `delta` to have Bool storage so it can select the correct type when multiplying something later. However, there are some questionable uses of `delta` in the tests that now break, but I expect these won't be in many production codes.

However, this doesn't address the separate problem of matching an ITensor eltype, notably when GPU vs not GPU, so delta should probably be converted to something that only creates storage once a contraction is called

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
ITensor ord=2 (dim=3|id=99) (dim=3|id=712)
NDTensors.Diag{Float64, Float64}
```
</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
julia> i,j = Index.([3,3]); D1 = δ(i,j)
ITensor ord=2 (dim=3|id=427) (dim=3|id=721)
NDTensors.Diag{Bool, Bool}
```
</p></details>

# How Has This Been Tested?

- [x] Tests in `test_diagitensor`

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
