### PR TITLE
[ITensors] Make sure `polar` preserves the input element type

### DIFF
--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -555,7 +555,7 @@ function polar(A::ITensor, Linds...)
   U, S, V = svd(A, Linds...)
   u = commoninds(S, U)
   v = commoninds(S, V)
-  δᵤᵥ′ = δ(u..., v'...)
+  δᵤᵥ′ = δ(eltype(A), u..., v'...)
   Q = U * δᵤᵥ′ * V'
   P = dag(V') * dag(δᵤᵥ′) * S * V
   return Q, P, commoninds(Q, P)

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -1528,6 +1528,11 @@ end
           end
         end
       end
+      @testset "Test polar type safety" begin
+        U, P, u = polar(A, (k, l))
+        @test eltype(U) == eltype(A)
+        @test eltype(P) == eltype(A)
+      end
 
       @testset "Test Hermitian eigendecomposition of an ITensor" begin
         is = IndexSet(i, j)

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -1512,7 +1512,12 @@ end
 
       @testset "Test polar decomposition of an ITensor" begin
         U, P, u = polar(A, (k, l))
+
+        @test eltype(U) == eltype(A)
+        @test eltype(P) == eltype(A)
+
         @test A ≈ U * P atol = atol
+
         #Note: this is only satisfied when left dimensions
         #are greater than right dimensions
         UUᵀ = U * dag(prime(U, u))
@@ -1527,11 +1532,6 @@ end
             @test val ≈ zero(SType) atol = atol
           end
         end
-      end
-      @testset "Test polar type safety" begin
-        U, P, u = polar(A, (k, l))
-        @test eltype(U) == eltype(A)
-        @test eltype(P) == eltype(A)
       end
 
       @testset "Test Hermitian eigendecomposition of an ITensor" begin


### PR DESCRIPTION
# Description

Suggested change from Matt (thanks!) to fix the type safety in polar

Fixes #1374 

```julia
julia> i,j = Index.([3,3]); T = randomITensor(Float32,i,j)
ITensor ord=2 (dim=3|id=725) (dim=3|id=755)
NDTensors.Dense{Float32, Vector{Float32}}
julia> eltype(polar(T,i)[2])
Float32
```