### PR TITLE
[Docs] Add random number generator in docstring for randomITensor

### DIFF
--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -582,8 +582,8 @@ function dense(A::ITensor)
 end
 
 """
-    randomITensor([::Type{ElT <: Number} = Float64, ]inds)
-    randomITensor([::Type{ElT <: Number} = Float64, ]inds::Index...)
+    randomITensor([rng=default_rng(), ::Type{ElT <: Number} = Float64, ]inds)
+    randomITensor([rng=default_rng(), ::Type{ElT <: Number} = Float64, ]inds::Index...)
 
 Construct an ITensor with type `ElT` and indices `inds`, whose elements are
 normally distributed random numbers. If the element type is not specified,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -582,8 +582,8 @@ function dense(A::ITensor)
 end
 
 """
-    randomITensor([rng=default_rng(), ::Type{ElT <: Number} = Float64, ]inds)
-    randomITensor([rng=default_rng(), ::Type{ElT <: Number} = Float64, ]inds::Index...)
+    randomITensor([rng=Random.default_rng(), ][::Type{ElT <: Number} = Float64, ]inds)
+    randomITensor([rng=Random.default_rng(), ][::Type{ElT <: Number} = Float64, ]inds::Index...)
 
 Construct an ITensor with type `ElT` and indices `inds`, whose elements are
 normally distributed random numbers. If the element type is not specified,

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -582,8 +582,8 @@ function dense(A::ITensor)
 end
 
 """
-    randomITensor([rng=Random.default_rng(), ][::Type{ElT <: Number} = Float64, ]inds)
-    randomITensor([rng=Random.default_rng(), ][::Type{ElT <: Number} = Float64, ]inds::Index...)
+    randomITensor([rng=Random.default_rng()], [ElT=Float64], inds)
+    randomITensor([rng=Random.default_rng()], [ElT=Float64], inds::Index...)
 
 Construct an ITensor with type `ElT` and indices `inds`, whose elements are
 normally distributed random numbers. If the element type is not specified,


### PR DESCRIPTION
Motivation: calling `randomITensor` with a rng as the first argument is supported but not documented (see [here](https://itensor.github.io/ITensors.jl/dev/ITensorType.html#ITensors.randomITensor-Tuple{Type{%3C:Number},%20Union{Tuple{Vararg{IndexT}},%20Vector{IndexT}}%20where%20IndexT%3C:Index})).

(i hope the syntax with the square brackets is correct)