### PR TITLE
[NDTensors] Fix issue in `Tensor` constructor when storage involves wrapper types

### DIFF
--- a/.github/workflows/comment_trigger_example.yml
+++ b/.github/workflows/comment_trigger_example.yml
@@ -27,7 +27,7 @@ jobs:
           # https://github.com/actions/checkout/issues/331#issuecomment-1438220926
           ref: refs/pull/${{ github.event.issue.number }}/head
       - name: Setup Node.js 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Deploy

--- a/NDTensors/test/test_dense.jl
+++ b/NDTensors/test/test_dense.jl
@@ -40,9 +40,9 @@ NDTensors.dim(i::MyInd) = i.dim
       @test dims(Aview) == (2, 2)
       ## Added for issue 1431 create a tensor from 
       ## a sliced view of another tensor
-      Acopy = Tensor(NDTensors.storage(Aview), (1,4))
+      Acopy = Tensor(NDTensors.storage(Aview), (1, 4))
       @test @allowscalar data(Acopy) == data(Aview)
-      @test dims(Acopy) == (1,4)
+      @test dims(Acopy) == (1, 4)
 
       B = dev(Tensor(elt, undef, (3, 4)))
       randn!(B)

--- a/NDTensors/test/test_dense.jl
+++ b/NDTensors/test/test_dense.jl
@@ -41,7 +41,7 @@ NDTensors.dim(i::MyInd) = i.dim
       ## Added for issue 1431 create a tensor from 
       ## a sliced view of another tensor
       Acopy = Tensor(NDTensors.storage(Aview), (1, 4))
-      @test @allowscalar data(Acopy) == data(Aview)
+      @test NDTensors.cpu(data(Acopy)) == NDTensors.cpu(data(Aview))
       @test dims(Acopy) == (1, 4)
 
       B = dev(Tensor(elt, undef, (3, 4)))

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+ITensorMPS = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 
 [compat]
 Documenter = "0.27"


### PR DESCRIPTION
This is the proposed solution from issue 1438 and should make it possible now to create a copy `Tensor/ITensor` from a view of another `Tensor/ITensor`.  I also fixed an additional constructor in UnallocatedArrays that should say `UnallocatedX` instead of `new` I am adding a test for that in the unittests now

Fixes #1438.