### PR TITLE
[SparseArrayDOKs] Fix escaping in @maybe_grow

### DIFF
--- a/NDTensors/src/lib/SparseArrayDOKs/src/sparsearraydok.jl
+++ b/NDTensors/src/lib/SparseArrayDOKs/src/sparsearraydok.jl
@@ -144,5 +144,5 @@ macro maybe_grow(expr)
     )
   end
   @capture(expr, array_[indices__] = value_)
-  return :(setindex_maybe_grow!($(esc(array)), $value, $indices...))
+  return :(setindex_maybe_grow!($(esc(array)), $(esc(value)), $(esc.(indices)...)))
 end

--- a/NDTensors/src/lib/SparseArrayDOKs/test/runtests.jl
+++ b/NDTensors/src/lib/SparseArrayDOKs/test/runtests.jl
@@ -119,6 +119,15 @@ using SparseArrays: SparseMatrixCSC, nnz
     @maybe_grow v[5] = 50
     @test size(v) == (5,)
     @test v[5] == 50
+    # Test setting from a variable (to test macro escaping)
+    i = 6
+    val = 60
+    @maybe_grow v[i] = val
+    @test v[i] == val
+    i, j = 1, 2
+    val = 120
+    @maybe_grow a[i, j] = val
+    @test a[i, j] == val
   end
   @testset "Test Lower Level Constructor" begin
     d = Dictionary{CartesianIndex{2},elt}()


### PR DESCRIPTION
I didn't make strong enough tests for `@maybe_grow` and some escaping issues slipped through. This PR fixes those issues and adds a stronger test.
