### PR TITLE
[ITensors] Fix issue with directsum involving EmptyStorage

### DIFF
--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -261,10 +261,14 @@ function directsum_projectors(
   return D1, D2
 end
 
-function directsum_projectors(::Type{<:EmptyNumber}, ::Type{<:EmptyNumber}, ::Index, ::Index, ::Index)
-  error("It is not possible to call directsum on two tensors with element type EmptyNumber.
-  If you are inputting ITensors constructor like ITensor(i, j), try specifying the element type, 
-  e.g. ITensor(Float64, i, j), or filling them with zero value, e.g. ITensor(0.0, i, j).")
+function directsum_projectors(
+  ::Type{<:EmptyNumber}, ::Type{<:EmptyNumber}, ::Index, ::Index, ::Index
+)
+  return error(
+    "It is not possible to call directsum on two tensors with element type EmptyNumber.
+If you are inputting ITensors constructor like ITensor(i, j), try specifying the element type, 
+e.g. ITensor(Float64, i, j), or filling them with zero value, e.g. ITensor(0.0, i, j).",
+  )
 end
 
 function check_directsum_inds(A::ITensor, I, B::ITensor, J)

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -254,16 +254,11 @@ function directsum_projectors(
   # Or with new notation:
   # D1 = zeros(elt1, dag(i), ij)
   # D2 = zeros(elt1, dag(j), ij)
-  D1 = zeros_itensor(elt1, dag(i), ij)
-  D2 = zeros_itensor(elt1, dag(j), ij)
+  elt = promote_type(elt1, elt2)
+  D1 = zeros_itensor(elt, dag(i), ij)
+  D2 = zeros_itensor(elt, dag(j), ij)
   directsum_projectors!(tensor(D1), tensor(D2))
   return D1, D2
-end
-
-function directsum_projectors(
-  elt1::Type{<:EmptyNumber}, elt2::Type{<:Number}, i::Index, j::Index, ij::Index
-)
-  return directsum_projectors(elt2, elt1, i, j, ij)
 end
 
 function check_directsum_inds(A::ITensor, I, B::ITensor, J)

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -254,8 +254,9 @@ function directsum_projectors(
   # Or with new notation:
   # D1 = zeros(elt1, dag(i), ij)
   # D2 = zeros(elt1, dag(j), ij)
-  D1 = zeros_itensor(elt1, dag(i), ij)
-  D2 = zeros_itensor(elt1, dag(j), ij)
+  elt = promote_type(elt1, elt2)
+  D1 = zeros_itensor(elt, dag(i), ij)
+  D2 = zeros_itensor(elt, dag(j), ij)
   directsum_projectors!(tensor(D1), tensor(D2))
   return D1, D2
 end

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -266,8 +266,8 @@ function directsum_projectors(
 )
   return error(
     "It is not possible to call directsum on two tensors with element type EmptyNumber.
-If you are inputting ITensors constructor like ITensor(i, j), try specifying the element type, 
-e.g. ITensor(Float64, i, j), or filling them with zero value, e.g. ITensor(0.0, i, j).",
+If you are inputting ITensors constructed like `ITensor(i, j)`, try specifying the element type, 
+e.g. `ITensor(Float64, i, j)`, or fill them with zero values, e.g. `ITensor(zero(Float64), i, j)`.",
   )
 end
 

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -261,6 +261,12 @@ function directsum_projectors(
   return D1, D2
 end
 
+function directsum_projectors(::Type{<:EmptyNumber}, ::Type{<:EmptyNumber}, ::Index, ::Index, ::Index)
+  error("It is not possible to call directsum on two tensors with element type EmptyNumber.
+  If you are inputting ITensors constructor like ITensor(i, j), try specifying the element type, 
+  e.g. ITensor(Float64, i, j), or filling them with zero value, e.g. ITensor(0.0, i, j).")
+end
+
 function check_directsum_inds(A::ITensor, I, B::ITensor, J)
   a = uniqueinds(A, I)
   b = uniqueinds(B, J)

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -254,11 +254,16 @@ function directsum_projectors(
   # Or with new notation:
   # D1 = zeros(elt1, dag(i), ij)
   # D2 = zeros(elt1, dag(j), ij)
-  elt = promote_type(elt1, elt2)
-  D1 = zeros_itensor(elt, dag(i), ij)
-  D2 = zeros_itensor(elt, dag(j), ij)
+  D1 = zeros_itensor(elt1, dag(i), ij)
+  D2 = zeros_itensor(elt1, dag(j), ij)
   directsum_projectors!(tensor(D1), tensor(D2))
   return D1, D2
+end
+
+function directsum_projectors(
+  elt1::Type{<:EmptyNumber}, elt2::Type{<:Number}, i::Index, j::Index, ij::Index
+)
+  return directsum_projectors(elt2, elt1, i, j, ij)
 end
 
 function check_directsum_inds(A::ITensor, I, B::ITensor, J)

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -1805,12 +1805,21 @@ end
     A = randomITensor(i1, i2, j)
     B = randomITensor(i1, i2, k)
     C = randomITensor(i1, i2, l)
+    D = ITensor(i1, i2, k)
 
     S, s = directsum(A => index_op(j), B => index_op(k))
     @test dim(s) == dim(j) + dim(k)
     @test hassameinds(S, (i1, i2, s))
 
     S, s = (A => index_op(j)) ⊕ (B => index_op(k))
+    @test dim(s) == dim(j) + dim(k)
+    @test hassameinds(S, (i1, i2, s))
+
+    S, s = (A => index_op(j)) ⊕ (D => index_op(k))
+    @test dim(s) == dim(j) + dim(k)
+    @test hassameinds(S, (i1, i2, s))
+
+    S, s = (D => index_op(k)) ⊕ (A => index_op(j))
     @test dim(s) == dim(j) + dim(k)
     @test hassameinds(S, (i1, i2, s))
 

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -1806,6 +1806,7 @@ end
     B = randomITensor(i1, i2, k)
     C = randomITensor(i1, i2, l)
     D = ITensor(i1, i2, k)
+    F = ITensor(i1, i2, j)
 
     S, s = directsum(A => index_op(j), B => index_op(k))
     @test dim(s) == dim(j) + dim(k)
@@ -1818,6 +1819,8 @@ end
     S, s = (A => index_op(j)) ⊕ (D => index_op(k))
     @test dim(s) == dim(j) + dim(k)
     @test hassameinds(S, (i1, i2, s))
+
+    @test_throws ErrorException (F => index_op(j)) ⊕ (D => index_op(k))
 
     S, s = (D => index_op(k)) ⊕ (A => index_op(j))
     @test dim(s) == dim(j) + dim(k)


### PR DESCRIPTION
# Description

In this I attempt to fix [issue 1430](https://github.com/ITensor/ITensors.jl/issues/1430) where there is an issue in directsum when an `EmptyTensor` is fed in as the first argument instead of the second. In `tensor_algebra.jl` the directsum code attempts to call `one(EmptyNumber)`.  

To fix this code I am modifying this function 
```julia
function directsum_projectors(
  elt1::Type{<:Number}, elt2::Type{<:Number}, i::Index, j::Index, ij::Index
)
  D1 = zeros_itensor(elt1, dag(i), ij)
  D2 = zeros_itensor(elt1, dag(j), ij)
  directsum_projectors!(tensor(D1), tensor(D2))
  return D1, D2
end
```
I have 2 fix ideas, the first is slightly intrusive `elt = promote_type(elt1, elt2)` and use `elt` instead of `elt1` in both `D1` and `D2`. The second is less intrusive, it is 
```julia 
directsum_projectors(
  elt1::Type{<:EmptyNumber}, elt2::Type{<:Number}, i::Index, j::Index, ij::Index) = directsum_projector(elt2, elt1, i, j, ij) 
```
which is what I have implemented. 

# How Has This Been Tested?

I added some tests in the `test_itensors.jl` I test an empty tensor in front and in back.

