### PR TITLE
[NDTensors] Fix issue where trace promotes F32 to F64

### DIFF
--- a/src/tensor_operations/matrix_algebra.jl
+++ b/src/tensor_operations/matrix_algebra.jl
@@ -6,10 +6,7 @@ function _tr(T::ITensor; plev::Pair{Int,Int}=0 => 1, tags::Pair=ts"" => ts"")
   Tᶜ = T * Cᴸ * Cᴿ
   cᴸ = uniqueind(Cᴸ, T)
   cᴿ = uniqueind(Cᴿ, T)
-  ## deafult eltype for delta is Float64 so this 
-  ## can promote eltype from F32 to F64
-  elt = eltype(T)
-  Tᶜ *= δ(elt, dag((cᴸ, cᴿ)))
+  Tᶜ *= δ(eltype(T), dag((cᴸ, cᴿ)))
   if order(Tᶜ) == 0
     return Tᶜ[]
   end

--- a/src/tensor_operations/matrix_algebra.jl
+++ b/src/tensor_operations/matrix_algebra.jl
@@ -6,7 +6,10 @@ function _tr(T::ITensor; plev::Pair{Int,Int}=0 => 1, tags::Pair=ts"" => ts"")
   Tᶜ = T * Cᴸ * Cᴿ
   cᴸ = uniqueind(Cᴸ, T)
   cᴿ = uniqueind(Cᴿ, T)
-  Tᶜ *= δ(dag((cᴸ, cᴿ)))
+  ## deafult eltype for delta is Float64 so this 
+  ## can promote eltype from F32 to F64
+  elt = eltype(T)
+  Tᶜ *= δ(elt, dag((cᴸ, cᴿ)))
   if order(Tᶜ) == 0
     return Tᶜ[]
   end

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -316,7 +316,7 @@ end
       @test ndims(A) == 0
     end
 
-    @testset "trace (tr)" for ElType in (Float32, Float64, ComplexF32, ComplexF64)
+    @testset "trace (tr) (eltype=$elt)" for elt in (Float32, Float64, Complex{Float32}, Complex{Float64})
       i, j, k, l = Index.((2, 3, 4, 5), ("i", "j", "k", "l"))
       T = random_itensor(ElType, j, k', i', k, j', i)
       trT1 = tr(T)

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -316,16 +316,16 @@ end
       @test ndims(A) == 0
     end
 
-    @testset "trace (tr)" begin
+    @testset "trace (tr)" for ElType in (Float32, Float64, ComplexF32, ComplexF64)
       i, j, k, l = Index.((2, 3, 4, 5), ("i", "j", "k", "l"))
-      T = random_itensor(j, k', i', k, j', i)
+      T = random_itensor(ElType, j, k', i', k, j', i)
       trT1 = tr(T)
-      trT2 = (T * δ(i, i') * δ(j, j') * δ(k, k'))[]
+      trT2 = (T * δ(ElType, i, i') * δ(ElType, j, j') * δ(ElType, k, k'))[]
       @test trT1 ≈ trT2
 
-      T = random_itensor(j, k', i', l, k, j', i)
+      T = random_itensor(ElType, j, k', i', l, k, j', i)
       trT1 = tr(T)
-      trT2 = T * δ(i, i') * δ(j, j') * δ(k, k')
+      trT2 = T * δ(ElType, i, i') * δ(ElType, j, j') * δ(ElType, k, k')
       @test trT1 ≈ trT2
     end
 

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -322,6 +322,7 @@ end
       i, j, k, l = Index.((2, 3, 4, 5), ("i", "j", "k", "l"))
       T = random_itensor(elt, j, k', i', k, j', i)
       trT1 = tr(T)
+      @test eltype(trT1) === elt
       trT2 = (T * δ(elt, i, i') * δ(elt, j, j') * δ(elt, k, k'))[]
       @test trT1 ≈ trT2
 

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -325,6 +325,7 @@ end
 
       T = random_itensor(ElType, j, k', i', l, k, j', i)
       trT1 = tr(T)
+      @test eltype(trT1) === elt
       trT2 = T * δ(ElType, i, i') * δ(ElType, j, j') * δ(ElType, k, k')
       @test trT1 ≈ trT2
     end

--- a/test/base/test_itensor.jl
+++ b/test/base/test_itensor.jl
@@ -316,17 +316,19 @@ end
       @test ndims(A) == 0
     end
 
-    @testset "trace (tr) (eltype=$elt)" for elt in (Float32, Float64, Complex{Float32}, Complex{Float64})
+    @testset "trace (tr) (eltype=$elt)" for elt in (
+      Float32, Float64, Complex{Float32}, Complex{Float64}
+    )
       i, j, k, l = Index.((2, 3, 4, 5), ("i", "j", "k", "l"))
-      T = random_itensor(ElType, j, k', i', k, j', i)
+      T = random_itensor(elt, j, k', i', k, j', i)
       trT1 = tr(T)
-      trT2 = (T * δ(ElType, i, i') * δ(ElType, j, j') * δ(ElType, k, k'))[]
+      trT2 = (T * δ(elt, i, i') * δ(elt, j, j') * δ(elt, k, k'))[]
       @test trT1 ≈ trT2
 
-      T = random_itensor(ElType, j, k', i', l, k, j', i)
+      T = random_itensor(elt, j, k', i', l, k, j', i)
       trT1 = tr(T)
       @test eltype(trT1) === elt
-      trT2 = T * δ(ElType, i, i') * δ(ElType, j, j') * δ(ElType, k, k')
+      trT2 = T * δ(elt, i, i') * δ(elt, j, j') * δ(elt, k, k')
       @test trT1 ≈ trT2
     end
 


### PR DESCRIPTION
# Description

The delta constructor has a default eltype of Float64
```julia
delta(is...) = delta(Float64, is...)
```
to preserve the eltype in trace feed `eltype(T)` into the constructor of `delta`. Addresses the issue [1444](https://github.com/ITensor/ITensors.jl/issues/1444)