### PR TITLE
[UnallocatedArrays] Fix UnallocatedArrays constructor

### DIFF
--- a/NDTensors/src/lib/UnallocatedArrays/src/unallocatedfill.jl
+++ b/NDTensors/src/lib/UnallocatedArrays/src/unallocatedfill.jl
@@ -7,7 +7,7 @@ struct UnallocatedFill{ElT,N,Axes,Alloc} <: AbstractFill{ElT,N,Axes}
 end
 
 function UnallocatedFill{ElT,N,Axes}(f::Fill, alloc::Type) where {ElT,N,Axes}
-  return new{ElT,N,Axes,Type{alloc}}(f, alloc)
+  return UnallocatedFill{ElT,N,Axes,Type{alloc}}(f, alloc)
 end
 
 function UnallocatedFill{ElT,N}(f::Fill, alloc) where {ElT,N}

--- a/NDTensors/src/lib/UnallocatedArrays/src/unallocatedzeros.jl
+++ b/NDTensors/src/lib/UnallocatedArrays/src/unallocatedzeros.jl
@@ -17,7 +17,7 @@ struct UnallocatedZeros{ElT,N,Axes,Alloc} <: AbstractZeros{ElT,N,Axes}
 end
 
 function UnallocatedZeros{ElT,N,Axes}(z::Zeros, alloc::Type) where {ElT,N,Axes}
-  return new{ElT,N,Axes,Type{alloc}}(z, alloc)
+  return UnallocatedZeros{ElT,N,Axes,Type{alloc}}(z, alloc)
 end
 
 function UnallocatedZeros{ElT,N}(z::Zeros, alloc) where {ElT,N}

--- a/NDTensors/src/lib/UnallocatedArrays/test/runtests.jl
+++ b/NDTensors/src/lib/UnallocatedArrays/test/runtests.jl
@@ -14,6 +14,7 @@ using .NDTensorsTestUtils: devices_list
   @testset "Basic funcitonality" begin
     z = Zeros{elt}((2, 3))
     Z = UnallocatedZeros(z, dev(Matrix{elt}))
+    Z = UnallocatedZeros{elt}(z, dev(Matrix{elt}))
 
     @test Z isa AbstractFill
     @test size(Z) == (2, 3)
@@ -44,6 +45,8 @@ using .NDTensorsTestUtils: devices_list
     # UnallocatedFill
     f = Fill{elt}(3, (2, 3, 4))
     F = UnallocatedFill(f, Array{elt,ndims(f)})
+    F = UnallocatedFill{elt}(f, Array{elt,ndims(f)})
+
     @test F isa AbstractFill
     @test size(F) == (2, 3, 4)
     @test length(F) == 24

--- a/NDTensors/src/lib/UnallocatedArrays/test/runtests.jl
+++ b/NDTensors/src/lib/UnallocatedArrays/test/runtests.jl
@@ -14,7 +14,6 @@ using .NDTensorsTestUtils: devices_list
   @testset "Basic funcitonality" begin
     z = Zeros{elt}((2, 3))
     Z = UnallocatedZeros(z, dev(Matrix{elt}))
-    Z = UnallocatedZeros{elt}(z, dev(Matrix{elt}))
 
     @test Z isa AbstractFill
     @test size(Z) == (2, 3)
@@ -23,6 +22,8 @@ using .NDTensorsTestUtils: devices_list
     @test iszero(norm(Z))
     @test iszero(Z[2, 3])
     @test allocate(Z) isa dev(Matrix{elt})
+    Zp = UnallocatedZeros{elt}(Zeros(2, 3), dev(Matrix{elt}))
+    @test Zp == Z
     Zp = set_alloctype(z, dev(Matrix{elt}))
     @test Zp == Z
     Zc = copy(Z)
@@ -45,7 +46,6 @@ using .NDTensorsTestUtils: devices_list
     # UnallocatedFill
     f = Fill{elt}(3, (2, 3, 4))
     F = UnallocatedFill(f, Array{elt,ndims(f)})
-    F = UnallocatedFill{elt}(f, Array{elt,ndims(f)})
 
     @test F isa AbstractFill
     @test size(F) == (2, 3, 4)
@@ -54,6 +54,8 @@ using .NDTensorsTestUtils: devices_list
     @test norm(F) ≈ sqrt(elt(3)^2 * 24)
     @test F[2, 3, 1] == elt(3)
     @test allocate(F) isa Array{elt,3}
+    Fp = UnallocatedFill{elt}(Fill(3, (2, 3, 4)), Array{elt,ndims(f)})
+    @test Fp == F
     Fp = allocate(F)
     @test norm(Fp) ≈ norm(F)
     Fs = similar(F)


### PR DESCRIPTION
# Description

Theres an issue with a constructor line in UnallocatedArrays which can only be seen if the parameters are partially provided to construct the type. I added a test for these constructors and fixed the issue.