### PR TITLE
[ITensors] Add option to ignore space error in replaceind

### DIFF
--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -614,7 +614,9 @@ function replaceinds(is::Indices, inds1, inds2; ignoreSpaceError::Bool=false)
   return (is_tuple)
 end
 
-replaceind(is::Indices, i1::Index, i2::Index; ignoreSpaceError::Bool=false) = replaceinds(is, (i1,), (i2,); ignoreSpaceError)
+function replaceind(is::Indices, i1::Index, i2::Index; ignoreSpaceError::Bool=false)
+  return replaceinds(is, (i1,), (i2,); ignoreSpaceError)
+end
 
 function replaceind(is::Indices, i1::Index, i2::Indices)
   length(i2) != 1 &&

--- a/src/indexset.jl
+++ b/src/indexset.jl
@@ -597,7 +597,7 @@ function replaceinds_space_error(is, inds1, inds2, i1, i2)
                """)
 end
 
-function replaceinds(is::Indices, inds1, inds2)
+function replaceinds(is::Indices, inds1, inds2; ignoreSpaceError::Bool=false)
   is1 = inds1
   poss = indexin(is1, is)
   is_tuple = Tuple(is)
@@ -606,7 +606,7 @@ function replaceinds(is::Indices, inds1, inds2)
     i1 = is_tuple[pos]
     i2 = inds2[j]
     i2 = setdir(i2, dir(i1))
-    if space(i1) ≠ space(i2)
+    if !ignoreSpaceError && space(i1) ≠ space(i2)
       replaceinds_space_error(is, inds1, inds2, i1, i2)
     end
     is_tuple = setindex(is_tuple, i2, pos)
@@ -614,7 +614,7 @@ function replaceinds(is::Indices, inds1, inds2)
   return (is_tuple)
 end
 
-replaceind(is::Indices, i1::Index, i2::Index) = replaceinds(is, (i1,), (i2,))
+replaceind(is::Indices, i1::Index, i2::Index; ignoreSpaceError::Bool=false) = replaceinds(is, (i1,), (i2,); ignoreSpaceError)
 
 function replaceind(is::Indices, i1::Index, i2::Indices)
   length(i2) != 1 &&


### PR DESCRIPTION
# Description

Added a keyword to ignore changes in the QN space when calling `replaceind`.

# Fixes: Trying to change the space of a QNIndex 

I use this to create a MPO with a certain set of QNs and then modify the QNs after construction. Specifically I use this to create the Fermi-Hubbard Hamiltonian on $N$ sites with full momentum conservation $\mod N$, then change this to be $\mod N/2$ after construction. Using full conservation during construction ensures maximum MPO sparsity, but the MPS seems to converge to the ground state faster when momentum is only conserved $\mod N/2$.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
