### PR TITLE
[BackendSelection] Fix printing

### DIFF
--- a/NDTensors/src/lib/BackendSelection/src/backend_types.jl
+++ b/NDTensors/src/lib/BackendSelection/src/backend_types.jl
@@ -26,7 +26,7 @@ for type in (:Algorithm, :Backend)
     parameters(backend::$type) = getfield(backend, :kwargs)
 
     function Base.show(io::IO, backend::$type)
-      return print(io, "$type type ", backend_string(backend), ", ", parameters(backend))
+      return print(io, "$($type) type ", backend_string(backend), ", ", parameters(backend))
     end
     Base.print(io::IO, backend::$type) =
       print(io, backend_string(backend), ", ", parameters(backend))

--- a/NDTensors/src/lib/BackendSelection/test/runtests.jl
+++ b/NDTensors/src/lib/BackendSelection/test/runtests.jl
@@ -24,5 +24,6 @@ using NDTensors.AlgorithmSelection: AlgorithmSelection
   # Macro syntax.
   @test Algorithm"backend"(; x=2, y=3) === Algorithm("backend"; x=2, y=3)
   @test Backend"backend"(; x=2, y=3) === Backend("backend"; x=2, y=3)
+  @test isnothing(show(Algorithm("")))
 end
 end


### PR DESCRIPTION
I am investigating the internals of `TensorAlgebra`. I found an invalid macro, I think this should fix it.

```julia
using NDTensors.TensorAlgebra: TensorAlgebra
display(TensorAlgebra.default_contract_alg())
```

before
```
ERROR: UndefVarError: `type` not defined
Stacktrace:
 [1] show(io::IOContext{Base.TTY}, backend::NDTensors.BackendSelection.Algorithm{:matricize, @NamedTuple{}})
   @ NDTensors.BackendSelection ~/Documents/itensor/ITensors.jl/NDTensors/src/lib/BackendSelection/src/backend_types.jl:29
 [2] show(io::IOContext{Base.TTY}, ::MIME{Symbol("text/plain")}, x::NDTensors.BackendSelection.Algorithm{:matricize, @NamedTuple{}})
   @ Base.Multimedia ./multimedia.jl:47
 [3] (::REPL.var"#55#56"{REPL.REPLDisplay{REPL.LineEditREPL}, MIME{Symbol("text/plain")}, Base.RefValue{Any}})(io::Any)
   @ REPL ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:273
 [4] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
   @ REPL ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:569
 [5] display(d::REPL.REPLDisplay, mime::MIME{Symbol("text/plain")}, x::Any)
   @ REPL ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:259
 [6] display
   @ ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:278 [inlined]
 [7] display(x::Any)
   @ Base.Multimedia ./multimedia.jl:340
 [8] top-level scope
   @ REPL[33]:1
```
after
```
NDTensors.BackendSelection.Algorithm type matricize, NamedTuple()
```