### PR TITLE
[BlockSparseArrays] Fix eachindex(::BlockSparseArray) with dual axes

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.15"
+version = "0.3.16"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/src/BlockSparseArraysGradedAxesExt.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/src/BlockSparseArraysGradedAxesExt.jl
@@ -1,8 +1,14 @@
 module BlockSparseArraysGradedAxesExt
 using BlockArrays: AbstractBlockVector, Block, BlockedUnitRange
-using ..BlockSparseArrays: BlockSparseArrays, block_merge
+using ..BlockSparseArrays: BlockSparseArrays, AbstractBlockSparseArray, block_merge
 using ...GradedAxes:
-  GradedUnitRange, OneToOne, blockmergesortperm, blocksortperm, invblockperm, tensor_product
+  GradedUnitRange,
+  OneToOne,
+  blockmergesortperm,
+  blocksortperm,
+  invblockperm,
+  nondual,
+  tensor_product
 using ...TensorAlgebra:
   TensorAlgebra, FusionStyle, BlockReshapeFusion, SectorFusion, fusedims, splitdims
 
@@ -44,5 +50,13 @@ function TensorAlgebra.splitdims(
   blockperms = invblockperm.(blocksortperm.(axes_prod))
   a_blockpermed = a[blockperms...]
   return splitdims(BlockReshapeFusion(), a_blockpermed, split_axes...)
+end
+
+# This is a temporary fix for `eachindex` being broken for BlockSparseArrays
+# with mixed dual and non-dual axes. This shouldn't be needed once
+# GradedAxes is rewritten using BlockArrays v1.
+# TODO: Delete this once GradedAxes is rewritten.
+function Base.eachindex(a::AbstractBlockSparseArray)
+  return CartesianIndices(nondual.(axes(a)))
 end
 end

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/src/BlockSparseArraysGradedAxesExt.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/src/BlockSparseArraysGradedAxesExt.jl
@@ -1,6 +1,7 @@
 module BlockSparseArraysGradedAxesExt
-using BlockArrays: AbstractBlockVector, Block, BlockedUnitRange
-using ..BlockSparseArrays: BlockSparseArrays, AbstractBlockSparseArray, block_merge
+using BlockArrays: AbstractBlockVector, Block, BlockedUnitRange, blocks
+using ..BlockSparseArrays:
+  BlockSparseArrays, AbstractBlockSparseArray, BlockSparseArray, block_merge
 using ...GradedAxes:
   GradedUnitRange,
   OneToOne,
@@ -58,5 +59,21 @@ end
 # TODO: Delete this once GradedAxes is rewritten.
 function Base.eachindex(a::AbstractBlockSparseArray)
   return CartesianIndices(nondual.(axes(a)))
+end
+
+# This is a temporary fix for `show` being broken for BlockSparseArrays
+# with mixed dual and non-dual axes. This shouldn't be needed once
+# GradedAxes is rewritten using BlockArrays v1.
+# TODO: Delete this once GradedAxes is rewritten.
+function Base.show(io::IO, mime::MIME"text/plain", a::BlockSparseArray; kwargs...)
+  a_nondual = BlockSparseArray(blocks(a), nondual.(axes(a)))
+  println(io, "typeof(axes) = ", typeof(axes(a)), "\n")
+  println(
+    io,
+    "Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.\n",
+  )
+  return invoke(
+    show, Tuple{IO,MIME"text/plain",AbstractArray}, io, mime, a_nondual; kwargs...
+  )
 end
 end

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
@@ -5,7 +5,6 @@ using BlockArrays: Block, blocksize
 using NDTensors.BlockSparseArrays: BlockSparseArray, block_nstored
 using NDTensors.GradedAxes: GradedAxes, GradedUnitRange, dual, gradedrange
 using NDTensors.LabelledNumbers: label
-## using NDTensors.Sectors: U1
 using NDTensors.SparseArrayInterface: nstored
 using NDTensors.TensorAlgebra: fusedims, splitdims
 using Random: randn!

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
@@ -83,10 +83,9 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     a[Block(1, 1)] = randn(size(a[Block(1, 1)]))
     a[Block(2, 2)] = randn(size(a[Block(2, 2)]))
     a_dense = Array(a)
-    if VERSION ≥ v"1.10"
-      for I in eachindex(a)
-        @test a[I] == a_dense[I]
-      end
+    @test eachindex(a) == CartesianIndices(size(a))
+    for I in eachindex(a)
+      @test a[I] == a_dense[I]
     end
   end
 end

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
@@ -83,8 +83,10 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     a[Block(1, 1)] = randn(size(a[Block(1, 1)]))
     a[Block(2, 2)] = randn(size(a[Block(2, 2)]))
     a_dense = Array(a)
-    for I in eachindex(a)
-      @test a[I] == a_dense[I]
+    if VERSION ≥ v"1.10"
+      for I in eachindex(a)
+        @test a[I] == a_dense[I]
+      end
     end
   end
 end

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
@@ -87,6 +87,8 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     for I in eachindex(a)
       @test a[I] == a_dense[I]
     end
+
+    @test isnothing(show(devnull, MIME("text/plain"), a))
   end
 end
 end

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
@@ -3,9 +3,9 @@ using Compat: Returns
 using Test: @test, @testset, @test_broken
 using BlockArrays: Block, blocksize
 using NDTensors.BlockSparseArrays: BlockSparseArray, block_nstored
-using NDTensors.GradedAxes: GradedUnitRange, gradedrange
+using NDTensors.GradedAxes: GradedAxes, GradedUnitRange, dual, gradedrange
 using NDTensors.LabelledNumbers: label
-using NDTensors.Sectors: U1
+## using NDTensors.Sectors: U1
 using NDTensors.SparseArrayInterface: nstored
 using NDTensors.TensorAlgebra: fusedims, splitdims
 using Random: randn!
@@ -16,6 +16,14 @@ function blockdiagonal!(f, a::AbstractArray)
   end
   return a
 end
+
+struct U1
+  n::Int
+end
+GradedAxes.dual(c::U1) = U1(-c.n)
+GradedAxes.fuse_labels(c1::U1, c2::U1) = U1(c1.n + c2.n)
+Base.isless(c1::U1, c2::U1) = isless(c1.n, c2.n)
+
 const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
 @testset "BlockSparseArraysGradedAxesExt (eltype=$elt)" for elt in elts
   @testset "map" begin
@@ -69,6 +77,16 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     # common sectors, need to fix.
     @test_broken blocksize(m) == (3, 3)
     @test a == splitdims(m, (d1, d2), (d1, d2))
+  end
+  @testset "dual axes" begin
+    r = gradedrange([U1(0) => 2, U1(1) => 2])
+    a = BlockSparseArray{elt}(dual(r), r)
+    a[Block(1, 1)] = randn(size(a[Block(1, 1)]))
+    a[Block(2, 2)] = randn(size(a[Block(2, 2)]))
+    a_dense = Array(a)
+    for I in eachindex(a)
+      @test a[I] == a_dense[I]
+    end
   end
 end
 end

--- a/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
+++ b/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
@@ -48,19 +48,6 @@ end
 
 Base.axes(a::UnitRangeDual) = axes(nondual(a))
 
-if VERSION ≥ v"1.10"
-  # This fixes an issue in `eachindex(::BlockSparseArray)`
-  # when it has axes that are a mixture of non-dual
-  # and dual axes.
-  # TODO: This is a hack that won't be needed once we   rewrite
-  # GradedAxes using BlockArrays v1, delete this once it is
-  # not needed anymore.
-  Base.AbstractUnitRange{T}(a::UnitRangeDual{T}) where {T} = a
-  function Base.AbstractUnitRange{T}(a::UnitRangeDual) where {T}
-    return AbstractUnitRange{T}(nondual(a))
-  end
-end
-
 using BlockArrays: BlockArrays, Block, BlockSlice
 using NDTensors.LabelledNumbers: LabelledUnitRange
 function BlockArrays.BlockSlice(b::Block, a::LabelledUnitRange)

--- a/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
+++ b/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
@@ -48,15 +48,17 @@ end
 
 Base.axes(a::UnitRangeDual) = axes(nondual(a))
 
-# This fixes an issue in `eachindex(::BlockSparseArray)`
-# when it has axes that are a mixture of non-dual
-# and dual axes.
-# TODO: This is a hack that won't be needed once we rewrite
-# GradedAxes using BlockArrays v1, delete this once it is
-# not needed anymore.
-Base.AbstractUnitRange{T}(a::UnitRangeDual{T}) where {T} = a
-function Base.AbstractUnitRange{T}(a::UnitRangeDual) where {T}
-  return AbstractUnitRange{T}(nondual(a))
+if VERSION ≥ v"1.10"
+  # This fixes an issue in `eachindex(::BlockSparseArray)`
+  # when it has axes that are a mixture of non-dual
+  # and dual axes.
+  # TODO: This is a hack that won't be needed once we   rewrite
+  # GradedAxes using BlockArrays v1, delete this once it is
+  # not needed anymore.
+  Base.AbstractUnitRange{T}(a::UnitRangeDual{T}) where {T} = a
+  function Base.AbstractUnitRange{T}(a::UnitRangeDual) where {T}
+    return AbstractUnitRange{T}(nondual(a))
+  end
 end
 
 using BlockArrays: BlockArrays, Block, BlockSlice

--- a/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
+++ b/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
@@ -48,6 +48,17 @@ end
 
 Base.axes(a::UnitRangeDual) = axes(nondual(a))
 
+# This fixes an issue in `eachindex(::BlockSparseArray)`
+# when it has axes that are a mixture of non-dual
+# and dual axes.
+# TODO: This is a hack that won't be needed once we rewrite
+# GradedAxes using BlockArrays v1, delete this once it is
+# not needed anymore.
+Base.AbstractUnitRange{T}(a::UnitRangeDual{T}) where {T} = a
+function Base.AbstractUnitRange{T}(a::UnitRangeDual) where {T}
+  return AbstractUnitRange{T}(nondual(a))
+end
+
 using BlockArrays: BlockArrays, Block, BlockSlice
 using NDTensors.LabelledNumbers: LabelledUnitRange
 function BlockArrays.BlockSlice(b::Block, a::LabelledUnitRange)


### PR DESCRIPTION
This is a temporary hack to fix `eachindex(a::BlockSparseArray)` when `a` has a mixture of dual and non-dual axes.

This will be fixed in a better way once GradedAxes is rewritten using BlockArrays v1 but for now I'm implementing some temporary fixes for issues like this and other ones being tracked in #1336.

@ogauthe