### PR TITLE
[WIP] [BlockSparseArrays] Change behavior of non-blocked slicing

### DIFF
--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
@@ -1,7 +1,7 @@
 @eval module $(gensym())
 using Compat: Returns
 using Test: @test, @testset, @test_broken
-using BlockArrays: Block, blocksize
+using BlockArrays: Block, blocklength, blocksize
 using NDTensors.BlockSparseArrays: BlockSparseArray, block_nstored
 using NDTensors.GradedAxes: GradedAxes, GradedUnitRange, UnitRangeDual, dual, gradedrange
 using NDTensors.LabelledNumbers: label
@@ -50,14 +50,12 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
 
     b = a[2:3, 2:3, 2:3, 2:3]
     @test size(b) == (2, 2, 2, 2)
-    @test blocksize(b) == (2, 2, 2, 2)
-    @test nstored(b) == 2
-    @test block_nstored(b) == 2
+    @test blocksize(b) == (1, 1, 1, 1)
+    @test nstored(b) == length(b)
+    @test block_nstored(b) == blocklength(b)
     for i in 1:ndims(a)
-      @test axes(b, i) isa GradedUnitRange
+      @test axes(b, i) isa Base.OneTo{Int}
     end
-    @test label(axes(b, 1)[Block(1)]) == U1(0)
-    @test label(axes(b, 1)[Block(2)]) == U1(1)
     @test Array(a) isa Array{elt}
     @test Array(a) == a
   end

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/map.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/map.jl
@@ -28,14 +28,15 @@ end
 ## Base.promote_shape(a1::Tuple{Vararg{BlockedUnitRange}}, a2::Tuple{Vararg{BlockedUnitRange}}) = combine_axes(a1, a2)
 
 # Work around issue that:
-#
+# ```julia
 # julia> using BlockArrays: blocks
 #
 # julia> blocks(randn(2, 2))[1, 1]
 # 2×2 view(::Matrix{Float64}, BlockSlice(Block(1),Base.OneTo(2)), BlockSlice(Block(1),Base.OneTo(2))) with eltype Float64:
 #   0.0534014  -1.1738
 #  -0.649799    0.128661
-#
+# ```
+# TODO: Raise an issue with BlockArrays.jl.
 function blocks_getindex(a::AbstractArray{<:Any,N}, index::Vararg{Integer,N}) where {N}
   return a[index...]
 end

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
@@ -3,8 +3,9 @@ using SplitApplyCombine: groupcount
 
 using Adapt: Adapt, WrappedArray
 
-const WrappedAbstractBlockSparseArray{T,N} = WrappedArray{
-  T,N,AbstractBlockSparseArray,AbstractBlockSparseArray{T,N}
+const WrappedAbstractBlockSparseArray{T,N} = Union{
+  WrappedArray{T,N,AbstractBlockSparseArray,AbstractBlockSparseArray{T,N}},
+  BlockedSubArray{T,N,<:AbstractBlockSparseArray{T,N}},
 }
 
 # TODO: Rename `AnyBlockSparseArray`.

--- a/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
@@ -345,12 +345,25 @@ function blocked_view(
   return BlockedSubArray(a, indices)
 end
 
+function blocked_view(a::AbstractArray{<:Any,N}, indices::Vararg{Any,N}) where {N}
+  return view(a, indices...)
+end
+
 function blocksparse_blocks(a::BlockedSubArray)
   return SparseSubArrayBlocks(a)
 end
 
+# TODO: Restrict to:
+# SubArray{<:Any,<:Any,<:Any,<:Tuple{Vararg{AbstractVector{<:Integer}}}}
+# and consider making a trait, like `is_blocked_slice`.
 function blocksparse_blocks(a::SubArray)
   return BlocksView(a)
+end
+
+function blocksparse_blocks(
+  a::SubArray{<:Any,<:Any,<:Any,<:Tuple{Vararg{AbstractVector{<:Block}}}}
+)
+  return SparseSubArrayBlocks(a)
 end
 
 using BlockArrays: BlocksView

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -153,6 +153,10 @@ include("TestBlockSparseArraysUtils.jl")
     @test blocksize(b) == (2, 2)
     @test nstored(b) == nstored(a)
     @test block_nstored(b) == 2
+    b_view = @view a[[Block(2), Block(1)], [Block(2), Block(1)]]
+
+    # TODO: Fix this!
+    @test_broken show(devnull, MIME("text/plain"), b_view)
 
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     a[Block(1, 2)] = randn(elt, size(@view(a[Block(1, 2)])))
@@ -182,9 +186,9 @@ include("TestBlockSparseArraysUtils.jl")
     b = a[2:4, 2:4]
     @test b == Array(a)[2:4, 2:4]
     @test size(b) == (3, 3)
-    @test blocksize(b) == (2, 2)
-    @test nstored(b) == 1 * 1 + 2 * 2
-    @test block_nstored(b) == 2
+    @test blocksize(b) == (1, 1)
+    @test nstored(b) == length(b)
+    @test block_nstored(b) == blocklength(b)
 
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     a[Block(1, 2)] = randn(elt, size(@view(a[Block(1, 2)])))
@@ -257,18 +261,14 @@ include("TestBlockSparseArraysUtils.jl")
     @view(a[Block(2, 2)])[1:1, 1:2] = x
     @test @view(a[Block(2, 2)])[1:1, 1:2] == x
     @test a[Block(2, 2)][1:1, 1:2] == x
-
-    # TODO: This is broken, fix!
-    @test_broken a[3:3, 4:5] == x
+    @test a[3:3, 4:5] == x
 
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     x = randn(elt, 1, 2)
     @views a[Block(2, 2)][1:1, 1:2] = x
     @test @view(a[Block(2, 2)])[1:1, 1:2] == x
     @test a[Block(2, 2)][1:1, 1:2] == x
-
-    # TODO: This is broken, fix!
-    @test_broken a[3:3, 4:5] == x
+    @test a[3:3, 4:5] == x
 
     ## Broken, need to fix.
 

--- a/NDTensors/src/lib/GradedAxes/src/gradedunitrange.jl
+++ b/NDTensors/src/lib/GradedAxes/src/gradedunitrange.jl
@@ -261,13 +261,6 @@ function blocklabels(a::AbstractUnitRange, indices)
   end
 end
 
-function blockedunitrange_getindices(
-  ga::GradedUnitRange, indices::AbstractUnitRange{<:Integer}
-)
-  a_indices = blockedunitrange_getindices(unlabel_blocks(ga), indices)
-  return labelled_blocks(a_indices, blocklabels(ga, indices))
-end
-
 function blockedunitrange_getindices(ga::GradedUnitRange, indices::BlockRange)
   return labelled_blocks(unlabel_blocks(ga)[indices], blocklabels(ga, indices))
 end

--- a/NDTensors/src/lib/GradedAxes/src/gradedunitrange.jl
+++ b/NDTensors/src/lib/GradedAxes/src/gradedunitrange.jl
@@ -184,6 +184,20 @@ using BlockArrays: block, blockindex
 function blockedunitrange_getindices(
   a::BlockedUnitRange, indices::AbstractUnitRange{<:Integer}
 )
+  return indices
+end
+
+# TODO: Move this to a `BlockArraysExtensions` library.
+# Slice a BlockedUnitRange, preserving the blocking.
+# See https://github.com/JuliaArrays/BlockArrays.jl/issues/347.
+function blocked_getindex(a::AbstractUnitRange, indices)
+  return a[indices]
+end
+
+# TODO: Move this to a `BlockArraysExtensions` library.
+# Slice a BlockedUnitRange, preserving the blocking.
+# See https://github.com/JuliaArrays/BlockArrays.jl/issues/347.
+function blocked_getindex(a::BlockedUnitRange, indices::AbstractUnitRange{<:Integer})
   first_blockindex = blockedunitrange_findblockindex(a, first(indices))
   last_blockindex = blockedunitrange_findblockindex(a, last(indices))
   first_block = block(first_blockindex)

--- a/NDTensors/src/lib/GradedAxes/test/test_basics.jl
+++ b/NDTensors/src/lib/GradedAxes/test/test_basics.jl
@@ -87,21 +87,9 @@ using Test: @test, @test_broken, @testset
 
   x = gradedrange(["x" => 2, "y" => 3])
   a = x[3:4]
-  @test a isa GradedUnitRange
+  @test a isa AbstractUnitRange
   @test length(a) == 2
-  @test blocklength(a) == 1
-  @test a[Block(1)] == 3:4
-  @test label(a[Block(1)]) == "y"
-
-  x = gradedrange(["x" => 2, "y" => 3])
-  a = x[2:4][1:2]
-  @test a isa GradedUnitRange
-  @test length(a) == 2
-  @test blocklength(a) == 2
-  @test a[Block(1)] == 2:2
-  @test label(a[Block(1)]) == "x"
-  @test a[Block(2)] == 3:3
-  @test label(a[Block(2)]) == "y"
+  @test a == 3:4
 
   x = gradedrange(["x" => 2, "y" => 3])
   a = x[Block(2)[2:3]]

--- a/NDTensors/src/lib/GradedAxes/test/test_basics.jl
+++ b/NDTensors/src/lib/GradedAxes/test/test_basics.jl
@@ -74,16 +74,9 @@ using Test: @test, @test_broken, @testset
   # Slicing operations
   x = gradedrange(["x" => 2, "y" => 3])
   a = x[2:4]
-  @test a isa GradedUnitRange
+  @test a isa AbstractUnitRange
   @test length(a) == 3
-  @test blocklength(a) == 2
-  @test a[Block(1)] == 2:2
-  @test label(a[Block(1)]) == "x"
-  @test a[Block(2)] == 3:4
-  @test label(a[Block(2)]) == "y"
-  @test isone(first(only(axes(a))))
-  @test length(only(axes(a))) == length(a)
-  @test blocklengths(only(axes(a))) == blocklengths(a)
+  @test a == 2:4
 
   x = gradedrange(["x" => 2, "y" => 3])
   a = x[3:4]

--- a/NDTensors/src/lib/GradedAxes/test/test_dual.jl
+++ b/NDTensors/src/lib/GradedAxes/test/test_dual.jl
@@ -22,8 +22,7 @@ GradedAxes.dual(c::U1) = U1(-c.n)
   @test ad[4] == 4
   @test label(ad[4]) == U1(-1)
   @test ad[2:4] == 2:4
-  @test ad[2:4] isa UnitRangeDual
-  @test label(ad[2:4][Block(2)]) == U1(-1)
+  @test ad[2:4] isa AbstractUnitRange
   @test ad[[2, 4]] == [2, 4]
   @test label(ad[[2, 4]][2]) == U1(-1)
   @test ad[Block(2)] == 3:5


### PR DESCRIPTION
Addresses one of the issues being tracked in #1336, based on a design discussed in https://github.com/JuliaArrays/BlockArrays.jl/issues/347.

To-do:
- [ ] Fix printing blocked views, for example `show(stdout, MIME("text/plain"), @view(a[[Block(2), Block(1)], [Block(2), Block(1)]]))`, and add a test.
- [x] Raise an issue in `BlockArrays` about `x = randn(2, 2); blocks(x)[1, 1]` not returning `x`, but instead returning a view object which is more challenging to work with (https://github.com/JuliaArrays/BlockArrays.jl/issues/403).
- [x] Get tests passing.
- [x] Add new tests.