### PR TITLE
[NDTensorscuTENSORExt] Temporary fix for block sparse contractions 

### DIFF
--- a/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
+++ b/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
@@ -1,4 +1,4 @@
-using NDTensors: NDTensors, DenseTensor, array, data
+using NDTensors: NDTensors, DenseTensor, array
 using NDTensors.Expose: Exposed, unexpose
 using cuTENSOR: cuTENSOR, CuArray, CuTensor
 

--- a/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
+++ b/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
@@ -1,4 +1,4 @@
-using NDTensors: NDTensors, DenseTensor, array
+using NDTensors: NDTensors, DenseTensor, array, data
 using NDTensors.Expose: Exposed, unexpose
 using cuTENSOR: cuTENSOR, CuArray, CuTensor
 
@@ -12,9 +12,12 @@ function NDTensors.contract!(
   α::Number=one(Bool),
   β::Number=zero(Bool),
 )
-  cuR = CuTensor(array(unexpose(R)), collect(labelsR))
-  cuT1 = CuTensor(array(unexpose(T1)), collect(labelsT1))
-  cuT2 = CuTensor(array(unexpose(T2)), collect(labelsT2))
+  ## TODO for now a hack to get cuTENSOR working with blocksparse
+  R = unexpose(R)
+  cuR = CuTensor(copy(array(R)), collect(labelsR))
+  cuT1 = CuTensor(copy(array(unexpose(T1))), collect(labelsT1))
+  cuT2 = CuTensor(copy(array(unexpose(T2))), collect(labelsT2))
   cuTENSOR.mul!(cuR, cuT1, cuT2, α, β)
+  copyto!(data(R), cuR.data)
   return R
 end

--- a/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
+++ b/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
@@ -22,9 +22,7 @@ function NDTensors.contract!(
   cuT2 = CuTensor(arrayT2, collect(labelsT2))
   cuTENSOR.mul!(cuR, cuT1, cuT2, α, β)
   if !zoffR
-    ## use vec to flatten cuR.data which could be multidimensional but
-    ## tensor data is currently a vector
-    data(R) .= vec(cuR.data)
+    array(R) .= cuR.data
   end
   return R
 end

--- a/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
+++ b/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
@@ -2,69 +2,29 @@ using NDTensors: NDTensors, DenseTensor, array, data
 using NDTensors.Expose: Exposed, unexpose
 using cuTENSOR: cuTENSOR, CuArray, CuTensor
 
-struct CuArrayOffset{N} end
-function CuArrayOffset(V)
-  return CuArrayOffset{V}()
-end
-
 function NDTensors.contract!(
-  R::Exposed{<:CuArray,<:DenseTensor},
+  exposedR::Exposed{<:CuArray,<:DenseTensor},
   labelsR,
-  T1::Exposed{<:CuArray,<:DenseTensor},
+  exposedT1::Exposed{<:CuArray,<:DenseTensor},
   labelsT1,
-  T2::Exposed{<:CuArray,<:DenseTensor},
+  exposedT2::Exposed{<:CuArray,<:DenseTensor},
   labelsT2,
   α::Number=one(Bool),
   β::Number=zero(Bool),
 )
-  R, T1, T2 = unexpose.((R, T1, T2))
-  ## Instance the contract! function off the 
-  ## offset on the CuArrays
-  offR = CuArrayOffset(data(R).offset)
-  offT1 = CuArrayOffset(data(T1).offset)
-  offT2 = CuArrayOffset(data(T2).offset)
-  return contract!(offR, R, labelsR, offT1, T1, labelsT1, offT2, T2, labelsT2, α, β)
-end
-
-function contract!(
-  ::CuArrayOffset{0},
-  R,
-  labelsR,
-  ::CuArrayOffset{0},
-  T1,
-  labelsT1,
-  ::CuArrayOffset{0},
-  T2,
-  labelsT2,
-  α,
-  β,
-)
-  cuR = CuTensor(array(R), collect(labelsR))
-  cuT1 = CuTensor(array(T1), collect(labelsT1))
-  cuT2 = CuTensor(array(T2), collect(labelsT2))
+  R, T1, T2 = unexpose.((exposedR, exposedT1, exposedT2))
+  zoffR = iszero(array(R).offset)
+  arrayR = zoffR ? array(R) : copy(array(R))
+  arrayT1 = iszero(array(T1).offset) ? array(T1) : copy(array(T1))
+  arrayT2 = iszero(array(T2).offset) ? array(T2) : copy(array(T2))
+  cuR = CuTensor(arrayR, collect(labelsR))
+  cuT1 = CuTensor(arrayT1, collect(labelsT1))
+  cuT2 = CuTensor(arrayT2, collect(labelsT2))
   cuTENSOR.mul!(cuR, cuT1, cuT2, α, β)
-  return R
-end
-
-## TODO Should I always copy all of them if any are non-zero
-## Or should I create a function for every possible non-zero case?
-function contract!(
-  ::CuArrayOffset,
-  R,
-  labelsR,
-  ::CuArrayOffset,
-  T1,
-  labelsT1,
-  ::CuArrayOffset,
-  T2,
-  labelsT2,
-  α,
-  β,
-)
-  cuR = CuTensor(copy(array(R)), collect(labelsR))
-  cuT1 = CuTensor(copy(array(T1)), collect(labelsT1))
-  cuT2 = CuTensor(copy(array(T2)), collect(labelsT2))
-  cuTENSOR.mul!(cuR, cuT1, cuT2, α, β)
-  array(R) .= cuR.data
+  if !zoffR
+    ## use vec to flatten cuR.data which could be multidimensional but
+    ## tensor data is currently a vector
+    data(R) .= vec(cuR.data)
+  end
   return R
 end

--- a/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
+++ b/NDTensors/ext/NDTensorscuTENSORExt/contract.jl
@@ -2,6 +2,11 @@ using NDTensors: NDTensors, DenseTensor, array, data
 using NDTensors.Expose: Exposed, unexpose
 using cuTENSOR: cuTENSOR, CuArray, CuTensor
 
+struct CuArrayOffset{N} end
+function CuArrayOffset(V)
+  return CuArrayOffset{V}()
+end
+
 function NDTensors.contract!(
   R::Exposed{<:CuArray,<:DenseTensor},
   labelsR,
@@ -12,12 +17,54 @@ function NDTensors.contract!(
   α::Number=one(Bool),
   β::Number=zero(Bool),
 )
-  ## TODO for now a hack to get cuTENSOR working with blocksparse
-  R = unexpose(R)
-  cuR = CuTensor(copy(array(R)), collect(labelsR))
-  cuT1 = CuTensor(copy(array(unexpose(T1))), collect(labelsT1))
-  cuT2 = CuTensor(copy(array(unexpose(T2))), collect(labelsT2))
+  R, T1, T2 = unexpose.((R, T1, T2))
+  ## Instance the contract! function off the 
+  ## offset on the CuArrays
+  offR = CuArrayOffset(data(R).offset)
+  offT1 = CuArrayOffset(data(T1).offset)
+  offT2 = CuArrayOffset(data(T2).offset)
+  return contract!(offR, R, labelsR, offT1, T1, labelsT1, offT2, T2, labelsT2, α, β)
+end
+
+function contract!(
+  ::CuArrayOffset{0},
+  R,
+  labelsR,
+  ::CuArrayOffset{0},
+  T1,
+  labelsT1,
+  ::CuArrayOffset{0},
+  T2,
+  labelsT2,
+  α,
+  β,
+)
+  cuR = CuTensor(array(R), collect(labelsR))
+  cuT1 = CuTensor(array(T1), collect(labelsT1))
+  cuT2 = CuTensor(array(T2), collect(labelsT2))
   cuTENSOR.mul!(cuR, cuT1, cuT2, α, β)
-  copyto!(data(R), cuR.data)
+  return R
+end
+
+## TODO Should I always copy all of them if any are non-zero
+## Or should I create a function for every possible non-zero case?
+function contract!(
+  ::CuArrayOffset,
+  R,
+  labelsR,
+  ::CuArrayOffset,
+  T1,
+  labelsT1,
+  ::CuArrayOffset,
+  T2,
+  labelsT2,
+  α,
+  β,
+)
+  cuR = CuTensor(copy(array(R)), collect(labelsR))
+  cuT1 = CuTensor(copy(array(T1)), collect(labelsT1))
+  cuT2 = CuTensor(copy(array(T2)), collect(labelsT2))
+  cuTENSOR.mul!(cuR, cuT1, cuT2, α, β)
+  array(R) .= cuR.data
   return R
 end

--- a/NDTensors/test/ITensors/TestITensorDMRG/TestITensorDMRG.jl
+++ b/NDTensors/test/ITensors/TestITensorDMRG/TestITensorDMRG.jl
@@ -14,11 +14,6 @@ reference_energies = Dict([
 ])
 
 is_broken(dev, elt::Type, conserve_qns::Val) = false
-## Currently there is an issue in blocksparse cutensor, seems to be related to using @view, I am still working to fix this issue.
-## For some reason ComplexF64 works and throws an error in `test_broken`
-function is_broken(dev::typeof(cu), elt::Type, conserve_qns::Val{true})
-  return ("cutensor" ∈ ARGS && elt != ComplexF64)
-end
 
 include("dmrg.jl")
 


### PR DESCRIPTION
# Description

Quick fix by copying all the viewed blocks and rewriting the block back to fix cuTENSOR problem.
# Checklist:

- [x] BlockSparse cutensor contractions work.
- [x] Check that the performance isn't too slow compared to cuBLAS implementation.
- [x] Avoid copying when it isn't needed, for example when the offset field of the CuArray is 0 (https://github.com/JuliaGPU/CUDA.jl/blob/v5.4.2/src/array.jl#L61).