### PR TITLE
[BlockSparseArrays] Redesign and fix slicing with unit ranges

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.21"
+version = "0.3.22"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
@@ -68,8 +68,12 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     a = BlockSparseArray{elt}(d1, d2, d1, d2)
     blockdiagonal!(randn!, a)
     m = fusedims(a, (1, 2), (3, 4))
-    @test axes(m, 1) isa GradedUnitRange
-    @test axes(m, 2) isa GradedUnitRange
+
+    # TODO: Fix this.
+    @test_broken axes(m, 1) isa GradedUnitRange
+    # TODO: Fix this.
+    @test_broken axes(m, 2) isa GradedUnitRange
+
     @test a[1, 1, 1, 1] == m[1, 1]
     @test a[2, 2, 2, 2] == m[4, 4]
     # TODO: Current `fusedims` doesn't merge

--- a/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/ext/BlockSparseArraysGradedAxesExt/test/runtests.jl
@@ -3,7 +3,8 @@ using Compat: Returns
 using Test: @test, @testset, @test_broken
 using BlockArrays: Block, blocksize
 using NDTensors.BlockSparseArrays: BlockSparseArray, block_nstored
-using NDTensors.GradedAxes: GradedAxes, GradedUnitRange, UnitRangeDual, dual, gradedrange
+using NDTensors.GradedAxes:
+  GradedAxes, GradedUnitRange, UnitRangeDual, blocklabels, dual, gradedrange
 using NDTensors.LabelledNumbers: label
 using NDTensors.SparseArrayInterface: nstored
 using NDTensors.TensorAlgebra: fusedims, splitdims
@@ -68,17 +69,26 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     a = BlockSparseArray{elt}(d1, d2, d1, d2)
     blockdiagonal!(randn!, a)
     m = fusedims(a, (1, 2), (3, 4))
-
-    # TODO: Fix this.
-    @test_broken axes(m, 1) isa GradedUnitRange
-    # TODO: Fix this.
-    @test_broken axes(m, 2) isa GradedUnitRange
-
+    # TODO: Once block merging is implemented, this should
+    # be the real test.
+    for ax in axes(m)
+      @test ax isa GradedUnitRange
+      @test_broken blocklabels(ax) == [U1(0), U1(1), U1(2)]
+      @test blocklabels(ax) == [U1(0), U1(1), U1(1), U1(2)]
+    end
+    for I in CartesianIndices(m)
+      if I ∈ CartesianIndex.([(1, 1), (4, 4)])
+        @test !iszero(m[I])
+      else
+        @test iszero(m[I])
+      end
+    end
     @test a[1, 1, 1, 1] == m[1, 1]
     @test a[2, 2, 2, 2] == m[4, 4]
     # TODO: Current `fusedims` doesn't merge
     # common sectors, need to fix.
     @test_broken blocksize(m) == (3, 3)
+    @test blocksize(m) == (4, 4)
     @test a == splitdims(m, (d1, d2), (d1, d2))
   end
   @testset "dual axes" begin

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/map.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/map.jl
@@ -14,10 +14,9 @@ using ..SparseArrayInterface:
 
 # Returns `Vector{<:CartesianIndices}`
 function union_stored_blocked_cartesianindices(as::Vararg{AbstractArray})
+  combined_axes = combine_axes(axes.(as)...)
   stored_blocked_cartesianindices_as = map(as) do a
-    return blocked_cartesianindices(
-      axes(a), combine_axes(axes.(as)...), block_stored_indices(a)
-    )
+    return blocked_cartesianindices(axes(a), combined_axes, block_stored_indices(a))
   end
   return ∪(stored_blocked_cartesianindices_as...)
 end

--- a/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
@@ -267,7 +267,7 @@ function Base.isassigned(a::SparseSubArrayBlocks{<:Any,N}, I::Vararg{Int,N}) whe
   return true
 end
 function SparseArrayInterface.stored_indices(a::SparseSubArrayBlocks)
-  return stored_indices(view(blocks(parent(a.array)), axes(a)...))
+  return stored_indices(view(blocks(parent(a.array)), blockrange(a)...))
 end
 # TODO: Either make this the generic interface or define
 # `SparseArrayInterface.sparse_storage`, which is used

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -255,19 +255,19 @@ include("TestBlockSparseArraysUtils.jl")
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     x = randn(elt, 1, 2)
     @view(a[Block(2, 2)])[1:1, 1:2] = x
-    @test @view(a[Block(2, 2)])[1:1, 1:2] == x
     @test a[Block(2, 2)][1:1, 1:2] == x
 
     # TODO: This is broken, fix!
+    @test_broken @view(a[Block(2, 2)])[1:1, 1:2] == x
     @test_broken a[3:3, 4:5] == x
 
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     x = randn(elt, 1, 2)
     @views a[Block(2, 2)][1:1, 1:2] = x
-    @test @view(a[Block(2, 2)])[1:1, 1:2] == x
     @test a[Block(2, 2)][1:1, 1:2] == x
 
     # TODO: This is broken, fix!
+    @test_broken @view(a[Block(2, 2)])[1:1, 1:2] == x
     @test_broken a[3:3, 4:5] == x
 
     a = BlockSparseArray{elt}([2, 3], [2, 3])

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -1,5 +1,6 @@
 @eval module $(gensym())
-using BlockArrays: Block, BlockRange, BlockedUnitRange, blockedrange, blocklength, blocksize
+using BlockArrays:
+  Block, BlockRange, BlockedUnitRange, BlockVector, blockedrange, blocklength, blocksize
 using LinearAlgebra: mul!
 using NDTensors.BlockSparseArrays: BlockSparseArray, block_nstored, block_reshape
 using NDTensors.SparseArrayInterface: nstored
@@ -275,12 +276,20 @@ include("TestBlockSparseArraysUtils.jl")
       # TODO: Use `blocksizes(a)[Int.(Tuple(b))...]` once available.
       a[b] = randn(elt, size(a[b]))
     end
-    b = @view a[[Block(1), Block(2)], [Block(1), Block(2)]]
-    for I in CartesianIndices(a)
-      @test b[I] == a[I]
-    end
-    for block in BlockRange(a)
-      @test b[block] == a[block]
+    for I in (
+      Block.(1:2),
+      [Block(1), Block(2)],
+      BlockVector([Block(1), Block(2)], [1, 1]),
+      # TODO: This should merge blocks.
+      BlockVector([Block(1), Block(2)], [2]),
+    )
+      b = @view a[I, I]
+      for I in CartesianIndices(a)
+        @test b[I] == a[I]
+      end
+      for block in BlockRange(a)
+        @test b[block] == a[block]
+      end
     end
 
     a = BlockSparseArray{elt}([2, 3], [2, 3])
@@ -288,15 +297,22 @@ include("TestBlockSparseArraysUtils.jl")
       # TODO: Use `blocksizes(a)[Int.(Tuple(b))...]` once available.
       a[b] = randn(elt, size(a[b]))
     end
-    b = @view a[[Block(2), Block(1)], [Block(2), Block(1)]]
-    @test b[Block(1, 1)] == a[Block(2, 2)]
-    @test b[Block(2, 1)] == a[Block(1, 2)]
-    @test b[Block(1, 2)] == a[Block(2, 1)]
-    @test b[Block(2, 2)] == a[Block(1, 1)]
-    @test b[1, 1] == a[3, 3]
-    @test b[4, 4] == a[1, 1]
-    b[4, 4] = 44
-    @test b[4, 4] == 44
+    for I in (
+      [Block(2), Block(1)],
+      BlockVector([Block(2), Block(1)], [1, 1]),
+      # TODO: This should merge blocks.
+      BlockVector([Block(2), Block(1)], [2]),
+    )
+      b = @view a[I, I]
+      @test b[Block(1, 1)] == a[Block(2, 2)]
+      @test b[Block(2, 1)] == a[Block(1, 2)]
+      @test b[Block(1, 2)] == a[Block(2, 1)]
+      @test b[Block(2, 2)] == a[Block(1, 1)]
+      @test b[1, 1] == a[3, 3]
+      @test b[4, 4] == a[1, 1]
+      b[4, 4] = 44
+      @test b[4, 4] == 44
+    end
 
     ## Broken, need to fix.
 

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -257,19 +257,15 @@ include("TestBlockSparseArraysUtils.jl")
     x = randn(elt, 1, 2)
     @view(a[Block(2, 2)])[1:1, 1:2] = x
     @test a[Block(2, 2)][1:1, 1:2] == x
-
-    # TODO: This is broken, fix!
-    @test_broken @view(a[Block(2, 2)])[1:1, 1:2] == x
-    @test_broken a[3:3, 4:5] == x
+    @test @view(a[Block(2, 2)])[1:1, 1:2] == x
+    @test a[3:3, 4:5] == x
 
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     x = randn(elt, 1, 2)
     @views a[Block(2, 2)][1:1, 1:2] = x
     @test a[Block(2, 2)][1:1, 1:2] == x
-
-    # TODO: This is broken, fix!
-    @test_broken @view(a[Block(2, 2)])[1:1, 1:2] == x
-    @test_broken a[3:3, 4:5] == x
+    @test @view(a[Block(2, 2)])[1:1, 1:2] == x
+    @test a[3:3, 4:5] == x
 
     a = BlockSparseArray{elt}([2, 3], [2, 3])
     @views for b in [Block(1, 1), Block(2, 2)]
@@ -314,15 +310,13 @@ include("TestBlockSparseArraysUtils.jl")
       @test b[4, 4] == 44
     end
 
-    ## Broken, need to fix.
-
     # This is outputting only zero blocks.
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     a[Block(1, 2)] = randn(elt, size(@view(a[Block(1, 2)])))
     a[Block(2, 1)] = randn(elt, size(@view(a[Block(2, 1)])))
     b = a[Block(2):Block(2), Block(1):Block(2)]
-    @test_broken block_nstored(b) == 1
-    @test_broken b == Array(a)[3:5, 1:end]
+    @test block_nstored(b) == 1
+    @test b == Array(a)[3:5, 1:end]
   end
   @testset "LinearAlgebra" begin
     a1 = BlockSparseArray{elt}([2, 3], [2, 3])

--- a/NDTensors/src/lib/GradedAxes/src/blockedunitrange.jl
+++ b/NDTensors/src/lib/GradedAxes/src/blockedunitrange.jl
@@ -42,6 +42,9 @@ end
 
 # TODO: Move this to a `BlockArraysExtensions` library.
 # Like `a[indices]` but preserves block structure.
+# TODO: Consider calling this something else, for example
+# `blocked_getindex`. See the discussion here:
+# https://github.com/JuliaArrays/BlockArrays.jl/issues/347
 function blockedunitrange_getindices(
   a::BlockedUnitRange, indices::AbstractUnitRange{<:Integer}
 )
@@ -81,7 +84,16 @@ end
 function blockedunitrange_getindices(
   a::BlockedUnitRange, indices::AbstractVector{<:Union{Block{1},BlockIndexRange{1}}}
 )
-  return mortar(map(index -> a[index], indices))
+  # Without converting `indices` to `Vector`,
+  # mapping `indices` outputs a `BlockVector`
+  # which is harder to reason about.
+  blocks = map(index -> a[index], Vector(indices))
+  # We pass `length.(blocks)` to `mortar` in order
+  # to pass block labels to the axes of the output,
+  # if they exist. This makes it so that
+  # `only(axes(a[indices])) isa `GradedUnitRange`
+  # if `a isa `GradedUnitRange`, for example.
+  return mortar(blocks, length.(blocks))
 end
 
 # TODO: Move this to a `BlockArraysExtensions` library.

--- a/NDTensors/src/lib/GradedAxes/src/blockedunitrange.jl
+++ b/NDTensors/src/lib/GradedAxes/src/blockedunitrange.jl
@@ -76,8 +76,10 @@ function blockedunitrange_getindices(a::BlockedUnitRange, indices::Vector{<:Inte
 end
 
 # TODO: Move this to a `BlockArraysExtensions` library.
+# TODO: Make a special definition for `BlockedVector{<:Block{1}}` in order
+# to merge blocks.
 function blockedunitrange_getindices(
-  a::BlockedUnitRange, indices::Vector{<:Union{Block{1},BlockIndexRange{1}}}
+  a::BlockedUnitRange, indices::AbstractVector{<:Union{Block{1},BlockIndexRange{1}}}
 )
   return mortar(map(index -> a[index], indices))
 end

--- a/NDTensors/src/lib/GradedAxes/src/blockedunitrange.jl
+++ b/NDTensors/src/lib/GradedAxes/src/blockedunitrange.jl
@@ -36,6 +36,10 @@ function blockedunitrange_findblockindex(a::BlockedUnitRange, index::Integer)
   return @inbounds findblockindex(a, index + first(a) - 1)
 end
 
+function blockedunitrange_getindices(a::AbstractUnitRange, indices)
+  return a[indices]
+end
+
 # TODO: Move this to a `BlockArraysExtensions` library.
 # Like `a[indices]` but preserves block structure.
 function blockedunitrange_getindices(

--- a/NDTensors/src/lib/GradedAxes/test/test_basics.jl
+++ b/NDTensors/src/lib/GradedAxes/test/test_basics.jl
@@ -81,9 +81,11 @@ using Test: @test, @test_broken, @testset
   @test label(a[Block(1)]) == "x"
   @test a[Block(2)] == 3:4
   @test label(a[Block(2)]) == "y"
-  @test isone(first(only(axes(a))))
-  @test length(only(axes(a))) == length(a)
-  @test blocklengths(only(axes(a))) == blocklengths(a)
+  ax = only(axes(a))
+  @test ax == 1:length(a)
+  @test length(ax) == length(a)
+  @test blocklengths(ax) == blocklengths(a)
+  @test blocklabels(ax) == blocklabels(a)
 
   x = gradedrange(["x" => 2, "y" => 3])
   a = x[3:4]
@@ -92,6 +94,11 @@ using Test: @test, @test_broken, @testset
   @test blocklength(a) == 1
   @test a[Block(1)] == 3:4
   @test label(a[Block(1)]) == "y"
+  ax = only(axes(a))
+  @test ax == 1:length(a)
+  @test length(ax) == length(a)
+  @test blocklengths(ax) == blocklengths(a)
+  @test blocklabels(ax) == blocklabels(a)
 
   x = gradedrange(["x" => 2, "y" => 3])
   a = x[2:4][1:2]
@@ -102,6 +109,11 @@ using Test: @test, @test_broken, @testset
   @test label(a[Block(1)]) == "x"
   @test a[Block(2)] == 3:3
   @test label(a[Block(2)]) == "y"
+  ax = only(axes(a))
+  @test ax == 1:length(a)
+  @test length(ax) == length(a)
+  @test blocklengths(ax) == blocklengths(a)
+  @test blocklabels(ax) == blocklabels(a)
 
   x = gradedrange(["x" => 2, "y" => 3])
   a = x[Block(2)[2:3]]
@@ -109,6 +121,10 @@ using Test: @test, @test_broken, @testset
   @test length(a) == 2
   @test a == 4:5
   @test label(a) == "y"
+  ax = only(axes(a))
+  @test ax == 1:length(a)
+  @test length(ax) == length(a)
+  @test label(ax) == label(a)
 
   x = gradedrange(["x" => 2, "y" => 3, "z" => 4])
   a = x[Block(2):Block(3)]
@@ -119,6 +135,11 @@ using Test: @test, @test_broken, @testset
   @test blocklabels(a) == ["y", "z"]
   @test a[Block(1)] == 3:5
   @test a[Block(2)] == 6:9
+  ax = only(axes(a))
+  @test ax == 1:length(a)
+  @test length(ax) == length(a)
+  @test blocklengths(ax) == blocklengths(a)
+  @test blocklabels(ax) == blocklabels(a)
 
   x = gradedrange(["x" => 2, "y" => 3, "z" => 4])
   a = x[[Block(3), Block(2)]]
@@ -126,11 +147,20 @@ using Test: @test, @test_broken, @testset
   @test length(a) == 7
   @test blocklength(a) == 2
   # TODO: `BlockArrays` doesn't define `blocklengths`
-  # for `BlockVector`, should it?
+  # `blocklengths(::BlockVector)`, unbrake this test
+  # once it does.
   @test_broken blocklengths(a) == [4, 3]
   @test blocklabels(a) == ["z", "y"]
   @test a[Block(1)] == 6:9
   @test a[Block(2)] == 3:5
+  ax = only(axes(a))
+  @test ax == 1:length(a)
+  @test length(ax) == length(a)
+  # TODO: Change to:
+  # @test blocklengths(ax) == blocklengths(a)
+  # once `blocklengths(::BlockVector)` is defined.
+  @test blocklengths(ax) == [4, 3]
+  @test blocklabels(ax) == blocklabels(a)
 
   x = gradedrange(["x" => 2, "y" => 3, "z" => 4])
   a = x[[Block(3)[2:3], Block(2)[2:3]]]
@@ -143,5 +173,13 @@ using Test: @test, @test_broken, @testset
   @test blocklabels(a) == ["z", "y"]
   @test a[Block(1)] == 7:8
   @test a[Block(2)] == 4:5
+  ax = only(axes(a))
+  @test ax == 1:length(a)
+  @test length(ax) == length(a)
+  # TODO: Change to:
+  # @test blocklengths(ax) == blocklengths(a)
+  # once `blocklengths(::BlockVector)` is defined.
+  @test blocklengths(ax) == [2, 2]
+  @test blocklabels(ax) == blocklabels(a)
 end
 end


### PR DESCRIPTION
This redesigns slicing of BlockSparseArrays with unit ranges to use `BlockArrays.BlockSlice`. I've also fixed some tests that are marked as broken in https://github.com/ITensor/ITensors.jl/blob/82cfd7687696e12bb45ea1f8d9f13a1152e3b3d8/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl, addressing some open issues listed in #1336.