### PR TITLE
[BlockSparseArrays] Fix some bugs involving BlockSparseArrays with dual axes

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.22"
+version = "0.3.23"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -129,7 +129,7 @@ function cartesianindices(axes::Tuple, b::Block)
 end
 
 # Get the range within a block.
-function blockindexrange(axis::AbstractUnitRange, r::UnitRange)
+function blockindexrange(axis::AbstractUnitRange, r::AbstractUnitRange)
   bi1 = findblockindex(axis, first(r))
   bi2 = findblockindex(axis, last(r))
   b = block(bi1)

--- a/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
+++ b/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
@@ -68,8 +68,24 @@ end
 using NDTensors.LabelledNumbers: LabelledNumbers, label
 LabelledNumbers.label(a::UnitRangeDual) = dual(label(nondual(a)))
 
-using BlockArrays: BlockArrays, blockaxes, blocklasts, findblock
+using BlockArrays: BlockArrays, blockaxes, blocklasts, combine_blockaxes, findblock
 BlockArrays.blockaxes(a::UnitRangeDual) = blockaxes(nondual(a))
 BlockArrays.blockfirsts(a::UnitRangeDual) = label_dual.(blockfirsts(nondual(a)))
 BlockArrays.blocklasts(a::UnitRangeDual) = label_dual.(blocklasts(nondual(a)))
 BlockArrays.findblock(a::UnitRangeDual, index::Integer) = findblock(nondual(a), index)
+function BlockArrays.combine_blockaxes(a1::UnitRangeDual, a2::UnitRangeDual)
+  return dual(combine_blockaxes(dual(a1), dual(a2)))
+end
+
+# This is needed when constructing `CartesianIndices` from
+# a tuple of unit ranges that have this kind of dual unit range.
+# TODO: See if we can find some more elegant way of constructing
+# `CartesianIndices`, maybe by defining conversion of `LabelledInteger`
+# to `Int`, defining a more general `convert` function, etc.
+function Base.OrdinalRange{Int,Int}(
+  r::UnitRangeDual{<:LabelledInteger{Int},<:LabelledUnitRange{Int,UnitRange{Int}}}
+)
+  # TODO: Implement this broadcasting operation and use it here.
+  # return Int.(r)
+  return unlabel(nondual(r))
+end


### PR DESCRIPTION
This preserves whether axes are dual or not when adding, subtracting, etc. BlockSparseArrays. It also fixes a bug when printing views of blocks of BlockSparseArrays that have dual axes. Both are issues listed in #1336, first reported by @ogauthe.

To-do:
- [x] Fix tests, looks like this change broke some existing tests.