### PR TITLE
[BlockSparseArrays] Sub-slices of multiple blocks

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.23"
+version = "0.3.24"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -159,8 +159,8 @@ function blockrange(axis::AbstractUnitRange, r::UnitRange)
 end
 
 function blockrange(axis::AbstractUnitRange, r::Int)
-  error("Slicing with integer values isn't supported.")
-  return findblock(axis, r)
+  ## return findblock(axis, r)
+  return error("Slicing with integer values isn't supported.")
 end
 
 function blockrange(axis::AbstractUnitRange, r::AbstractVector{<:Block{1}})
@@ -185,6 +185,17 @@ end
 
 function blockrange(axis::AbstractUnitRange, r::BlockIndexRange)
   return Block(r):Block(r)
+end
+
+function blockrange(axis::AbstractUnitRange, r::AbstractVector{<:BlockIndexRange{1}})
+  return error("Slicing not implemented for range of type `$(typeof(r))`.")
+end
+
+function blockrange(
+  axis::AbstractUnitRange,
+  r::BlockVector{BlockIndex{1},<:AbstractVector{<:BlockIndexRange{1}}},
+)
+  return map(b -> Block(b), blocks(r))
 end
 
 function blockrange(axis::AbstractUnitRange, r)
@@ -226,6 +237,22 @@ end
 
 function blockindices(a::AbstractUnitRange, b::Block, r::BlockIndices)
   return blockindices(a, b, r.blocks)
+end
+
+function blockindices(
+  a::AbstractUnitRange,
+  b::Block,
+  r::BlockVector{BlockIndex{1},<:AbstractVector{<:BlockIndexRange{1}}},
+)
+  # TODO: Change to iterate over `BlockRange(r)`
+  # once https://github.com/JuliaArrays/BlockArrays.jl/issues/404
+  # is fixed.
+  for bl in blocks(r)
+    if b == Block(bl)
+      return only(bl.indices)
+    end
+  end
+  return error("Block not found.")
 end
 
 function cartesianindices(a::AbstractArray, b::Block)

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -198,6 +198,13 @@ function blockrange(
   return map(b -> Block(b), blocks(r))
 end
 
+# This handles slicing with `:`/`Colon()`.
+function blockrange(axis::AbstractUnitRange, r::Base.Slice)
+  # TODO: Maybe use `BlockRange`, but that doesn't output
+  # the same thing.
+  return only(blockaxes(axis))
+end
+
 function blockrange(axis::AbstractUnitRange, r)
   return error("Slicing not implemented for range of type `$(typeof(r))`.")
 end

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
@@ -1,5 +1,6 @@
 using Adapt: Adapt, WrappedArray
-using BlockArrays: BlockArrays, BlockedUnitRange, BlockRange, blockedrange, mortar, unblock
+using BlockArrays:
+  BlockArrays, BlockedUnitRange, BlockIndexRange, BlockRange, blockedrange, mortar, unblock
 using SplitApplyCombine: groupcount
 
 const WrappedAbstractBlockSparseArray{T,N} = WrappedArray{

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
@@ -1,5 +1,5 @@
 using Adapt: Adapt, WrappedArray
-using BlockArrays: BlockArrays, BlockedUnitRange, BlockRange, blockedrange, unblock
+using BlockArrays: BlockArrays, BlockedUnitRange, BlockRange, blockedrange, mortar, unblock
 using SplitApplyCombine: groupcount
 
 const WrappedAbstractBlockSparseArray{T,N} = WrappedArray{
@@ -44,6 +44,15 @@ function Base.to_indices(
   a::BlockSparseArrayLike, I::Tuple{AbstractVector{<:Block{1}},Vararg{Any}}
 )
   return blocksparse_to_indices(a, I)
+end
+
+# Handle case of indexing with `[Block(1)[1:2], Block(2)[1:2]]`
+# by converting it to a `BlockVector` with
+# `mortar([Block(1)[1:2], Block(2)[1:2]])`.
+function Base.to_indices(
+  a::BlockSparseArrayLike, inds, I::Tuple{AbstractVector{<:BlockIndexRange{1}},Vararg{Any}}
+)
+  return to_indices(a, inds, (mortar(I[1]), Base.tail(I)...))
 end
 
 # Fixes ambiguity error with BlockArrays.

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
@@ -126,12 +126,23 @@ function Base.getindex(
   return blocksparse_getindex(a, block...)
 end
 
-# TODO: Define `issasigned(a, ::Block{N})`.
+# TODO: Define `blocksparse_isassigned`.
 function Base.isassigned(
   a::BlockSparseArrayLike{<:Any,N}, index::Vararg{Block{1},N}
 ) where {N}
-  # TODO: Define `blocksparse_isassigned`.
   return isassigned(blocks(a), Int.(index)...)
+end
+
+function Base.isassigned(a::BlockSparseArrayLike{<:Any,N}, index::Block{N}) where {N}
+  return isassigned(a, Tuple(index)...)
+end
+
+# TODO: Define `blocksparse_isassigned`.
+function Base.isassigned(
+  a::BlockSparseArrayLike{<:Any,N}, index::Vararg{BlockIndex{1},N}
+) where {N}
+  b = block.(index)
+  return isassigned(a, b...) && isassigned(@view(a[b...]), blockindex.(index)...)
 end
 
 function Base.setindex!(a::BlockSparseArrayLike{<:Any,N}, value, I::BlockIndex{N}) where {N}

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -352,13 +352,16 @@ include("TestBlockSparseArraysUtils.jl")
     @views for b in [Block(1, 1), Block(2, 2), Block(3, 3)]
       a[b] = randn(elt, size(a[b]))
     end
-    I1 = mortar([Block(2)[2:3], Block(3)[1:3]])
-    I2 = mortar([Block(2)[2:3], Block(3)[2:3]])
-    for b in (a[I1, I2], @view(a[I1, I2]))
-      # TODO: Rename `block_stored_length`.
-      @test block_nstored(b) == 2
-      @test b[Block(1, 1)] == a[Block(2, 2)[2:3, 2:3]]
-      @test b[Block(2, 2)] == a[Block(3, 3)[1:3, 2:3]]
+    for (I1, I2) in (
+      (mortar([Block(2)[2:3], Block(3)[1:3]]), mortar([Block(2)[2:3], Block(3)[2:3]])),
+      ([Block(2)[2:3], Block(3)[1:3]], [Block(2)[2:3], Block(3)[2:3]]),
+    )
+      for b in (a[I1, I2], @view(a[I1, I2]))
+        # TODO: Rename `block_stored_length`.
+        @test block_nstored(b) == 2
+        @test b[Block(1, 1)] == a[Block(2, 2)[2:3, 2:3]]
+        @test b[Block(2, 2)] == a[Block(3, 3)[1:3, 2:3]]
+      end
     end
 
     a = BlockSparseArray{elt}(undef, ([3, 3], [3, 3]))

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -6,6 +6,7 @@ using BlockArrays:
   BlockVector,
   blockedrange,
   blocklength,
+  blocklengths,
   blocksize,
   mortar
 using LinearAlgebra: mul!
@@ -359,6 +360,22 @@ include("TestBlockSparseArraysUtils.jl")
       @test b[Block(1, 1)] == a[Block(2, 2)[2:3, 2:3]]
       @test b[Block(2, 2)] == a[Block(3, 3)[1:3, 2:3]]
     end
+
+    a = BlockSparseArray{elt}(undef, ([3, 3], [3, 3]))
+    # TODO: Define `block_diagindices`.
+    @views for b in [Block(1, 1), Block(2, 2)]
+      a[b] = randn(elt, size(a[b]))
+    end
+    I = mortar([Block(1)[1:2], Block(2)[1:2]])
+    b = a[:, I]
+    @test b[Block(1, 1)] == a[Block(1, 1)][:, 1:2]
+    @test b[Block(2, 1)] == a[Block(2, 1)][:, 1:2]
+    @test b[Block(1, 2)] == a[Block(1, 2)][:, 1:2]
+    @test b[Block(2, 2)] == a[Block(2, 2)][:, 1:2]
+    @test blocklengths.(axes(b)) == ([3, 3], [2, 2])
+    # TODO: Rename `block_stored_length`.
+    @test blocksize(b) == (2, 2)
+    @test block_nstored(b) == 2
 
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     @views for b in [Block(1, 2), Block(2, 1)]

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -1,6 +1,13 @@
 @eval module $(gensym())
 using BlockArrays:
-  Block, BlockRange, BlockedUnitRange, BlockVector, blockedrange, blocklength, blocksize
+  Block,
+  BlockRange,
+  BlockedUnitRange,
+  BlockVector,
+  blockedrange,
+  blocklength,
+  blocksize,
+  mortar
 using LinearAlgebra: mul!
 using NDTensors.BlockSparseArrays: BlockSparseArray, block_nstored, block_reshape
 using NDTensors.SparseArrayInterface: nstored
@@ -331,13 +338,50 @@ include("TestBlockSparseArraysUtils.jl")
       @test b[4, 4] == 44
     end
 
-    # This is outputting only zero blocks.
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
-    a[Block(1, 2)] = randn(elt, size(@view(a[Block(1, 2)])))
-    a[Block(2, 1)] = randn(elt, size(@view(a[Block(2, 1)])))
+    @views for b in [Block(1, 2), Block(2, 1)]
+      a[b] = randn(elt, size(a[b]))
+    end
     b = a[Block(2):Block(2), Block(1):Block(2)]
     @test block_nstored(b) == 1
     @test b == Array(a)[3:5, 1:end]
+
+    a = BlockSparseArray{elt}(undef, ([2, 3, 4], [2, 3, 4]))
+    # TODO: Define `block_diagindices`.
+    @views for b in [Block(1, 1), Block(2, 2), Block(3, 3)]
+      a[b] = randn(elt, size(a[b]))
+    end
+    I1 = mortar([Block(2)[2:3], Block(3)[1:3]])
+    I2 = mortar([Block(2)[2:3], Block(3)[2:3]])
+    for b in (a[I1, I2], @view(a[I1, I2]))
+      # TODO: Rename `block_stored_length`.
+      @test block_nstored(b) == 2
+      @test b[Block(1, 1)] == a[Block(2, 2)[2:3, 2:3]]
+      @test b[Block(2, 2)] == a[Block(3, 3)[1:3, 2:3]]
+    end
+
+    a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
+    @views for b in [Block(1, 2), Block(2, 1)]
+      a[b] = randn(elt, size(a[b]))
+    end
+    @test isassigned(a, 1, 1)
+    @test isassigned(a, 5, 7)
+    @test !isassigned(a, 0, 1)
+    @test !isassigned(a, 5, 8)
+    @test isassigned(a, Block(1), Block(1))
+    @test isassigned(a, Block(2), Block(2))
+    @test !isassigned(a, Block(1), Block(0))
+    @test !isassigned(a, Block(3), Block(2))
+    @test isassigned(a, Block(1, 1))
+    @test isassigned(a, Block(2, 2))
+    @test !isassigned(a, Block(1, 0))
+    @test !isassigned(a, Block(3, 2))
+    @test isassigned(a, Block(1)[1], Block(1)[1])
+    @test isassigned(a, Block(2)[3], Block(2)[4])
+    @test !isassigned(a, Block(1)[0], Block(1)[1])
+    @test !isassigned(a, Block(2)[3], Block(2)[5])
+    @test !isassigned(a, Block(1)[1], Block(0)[1])
+    @test !isassigned(a, Block(3)[3], Block(2)[4])
   end
   @testset "LinearAlgebra" begin
     a1 = BlockSparseArray{elt}([2, 3], [2, 3])

--- a/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/indexing.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/indexing.jl
@@ -160,16 +160,11 @@ function sparse_setindex!(a::AbstractArray, value, I::NotStoredIndex)
 end
 
 # isassigned
-function sparse_isassigned(a::AbstractArray, I::Integer...)
-  return sparse_isassigned(a, CartesianIndex(I))
+function sparse_isassigned(a::AbstractArray{<:Any,N}, I::CartesianIndex{N}) where {N}
+  return sparse_isassigned(a, Tuple(I)...)
 end
-sparse_isassigned(a::AbstractArray, I::NotStoredIndex) = true
-sparse_isassigned(a::AbstractArray, I::StoredIndex) = sparse_isassigned(a, StorageIndex(I))
-function sparse_isassigned(a::AbstractArray, I::StorageIndex)
-  return isassigned(sparse_storage(a), index(I))
-end
-function sparse_isassigned(a::AbstractArray, I::CartesianIndex)
-  return sparse_isassigned(a, storage_index(a, I))
+function sparse_isassigned(a::AbstractArray{<:Any,N}, I::Vararg{Integer,N}) where {N}
+  return all(dim -> I[dim] ∈ axes(a, dim), 1:ndims(a))
 end
 
 # A set of indices into the storage of the sparse array.

--- a/NDTensors/src/lib/SparseArrayInterface/test/test_abstractsparsearray.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/test/test_abstractsparsearray.jl
@@ -22,8 +22,8 @@ using Test: @test, @testset
     @test iszero(a)
   end
   for I in CartesianIndices(a)
-    @test iassigned(a, Tuple(I)...)
-    @test iassigned(a, I)
+    @test isassigned(a, Tuple(I)...)
+    @test isassigned(a, I)
   end
   @test !isassigned(a, 0, 1)
   @test !isassigned(a, CartesianIndex(0, 1))
@@ -69,8 +69,8 @@ using Test: @test, @testset
     end
   end
   for I in CartesianIndices(a)
-    @test iassigned(a, Tuple(I)...)
-    @test iassigned(a, I)
+    @test isassigned(a, Tuple(I)...)
+    @test isassigned(a, I)
   end
   @test !isassigned(a, 0, 1)
   @test !isassigned(a, CartesianIndex(0, 1))

--- a/NDTensors/src/lib/SparseArrayInterface/test/test_abstractsparsearray.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/test/test_abstractsparsearray.jl
@@ -21,6 +21,14 @@ using Test: @test, @testset
   for I in eachindex(a)
     @test iszero(a)
   end
+  for I in CartesianIndices(a)
+    @test iassigned(a, Tuple(I)...)
+    @test iassigned(a, I)
+  end
+  @test !isassigned(a, 0, 1)
+  @test !isassigned(a, CartesianIndex(0, 1))
+  @test !isassigned(a, 1, 4)
+  @test !isassigned(a, CartesianIndex(1, 4))
 
   a = SparseArray{elt}(2, 3)
   fill!(a, 0)
@@ -60,6 +68,14 @@ using Test: @test, @testset
       @test iszero(a[I])
     end
   end
+  for I in CartesianIndices(a)
+    @test iassigned(a, Tuple(I)...)
+    @test iassigned(a, I)
+  end
+  @test !isassigned(a, 0, 1)
+  @test !isassigned(a, CartesianIndex(0, 1))
+  @test !isassigned(a, 1, 4)
+  @test !isassigned(a, CartesianIndex(1, 4))
 
   a = SparseArray{elt}(2, 3)
   a[1, 2] = 12


### PR DESCRIPTION
This adds support for taking slices of multiple blocks at once, for example for a block sparse array:
```julia
using BlockArrays: Block
using NDTensors.BlockSparseArrays: BlockSparseArray
a = BlockSparseArray{Float64}([3, 3], [3, 3])
a[Block(1, 1)] = randn(3, 3)
a[Block(2, 2)] = randn(3, 3)
```
we can now do this:
```julia
julia> a
typeof(axes) = Tuple{BlockArrays.BlockedUnitRange{Vector{Int64}}, BlockArrays.BlockedUnitRange{Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 6×6 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedUnitRange{Vector{Int64}}, BlockArrays.BlockedUnitRange{Vector{Int64}}}}}, Tuple{BlockArrays.BlockedUnitRange{Vector{Int64}}, BlockArrays.BlockedUnitRange{Vector{Int64}}}}:
 -0.945395   -0.116158  -0.470018  │   0.0        0.0        0.0     
  0.0648115   1.33954   -0.53128   │   0.0        0.0        0.0     
  2.21892     1.07313   -1.39657   │   0.0        0.0        0.0     
 ──────────────────────────────────┼─────────────────────────────────
  0.0         0.0        0.0       │   0.961448   0.667434   0.490545
  0.0         0.0        0.0       │  -0.282894  -0.614402  -1.1862  
  0.0         0.0        0.0       │   1.12401    0.924081   0.397953

julia> I = [Block(1)[2:3], Block(2)[1:2]];

julia> a[I, I]
typeof(axes) = Tuple{BlockArrays.BlockedUnitRange{Vector{Int64}}, BlockArrays.BlockedUnitRange{Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 4×4 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedUnitRange{Vector{Int64}}, BlockArrays.BlockedUnitRange{Vector{Int64}}}}}, Tuple{BlockArrays.BlockedUnitRange{Vector{Int64}}, BlockArrays.BlockedUnitRange{Vector{Int64}}}}:
 1.33954  -0.53128  │   0.0        0.0     
 1.07313  -1.39657  │   0.0        0.0     
 ───────────────────┼──────────────────────
 0.0       0.0      │   0.961448   0.667434
 0.0       0.0      │  -0.282894  -0.614402
```
One thing you can see is that the implementation is pretty minimal, because it can make use of the infrastructure built for other slicing operations in BlockSparseArrays and the BlockArrays.jl package.

Additionally, I think this kind of slicing operation will be very useful for implementing low-rank block-wise matrix factorizations. For example, we could reduce the rank of an SVD like this:
```julia
# Made up output from a non-truncated block-wise
# SVD of a block diagonal matrix.
using LinearAlgebra: qr

u = BlockSparseArray{Float64}([3, 3], [3, 3])
u[Block(1, 1)] = Matrix(qr(randn(3, 3)).Q)
u[Block(2, 2)] = Matrix(qr(randn(3, 3)).Q)

s = BlockSparseArray{Float64}([3, 3], [3, 3])
s[Block(1, 1)] = Diagonal(normalize([0.9, 0.3, 0.005]))
s[Block(2, 2)] = Diagonal(normalize([0.8, 0.6, 0.001]))

v = BlockSparseArray{Float64}([3, 3], [3, 3])
v[Block(1, 1)] = Matrix(qr(randn(3, 3)).Q)
v[Block(2, 2)] = Matrix(qr(randn(3, 3)).Q)

block_ranks = [2, 2]
I = [Block(1)[1:block_ranks[1]], Block(2)[1:block_ranks[2]]]
u_truncated = u[:, I]
s_truncated = s[I, I]
v_truncated = v[I, :]
```
which truncates the singular values and associated singular vectors of each block down to the specified block ranks:
```julia
julia> u
typeof(axes) = Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 6×6 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 -0.201584   0.975938  0.0831202  │   0.0        0.0       0.0      
 -0.137013  -0.112125  0.984203   │   0.0        0.0       0.0      
  0.969841   0.187011  0.156319   │   0.0        0.0       0.0      
 ─────────────────────────────────┼─────────────────────────────────
  0.0        0.0       0.0        │  -0.79183    0.607681  0.0610696
  0.0        0.0       0.0        │  -0.155642  -0.29747   0.941959 
  0.0        0.0       0.0        │   0.590577   0.736366  0.330126 

julia> u_truncated
typeof(axes) = Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 6×4 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 -0.201584   0.975938  │   0.0        0.0     
 -0.137013  -0.112125  │   0.0        0.0     
  0.969841   0.187011  │   0.0        0.0     
 ──────────────────────┼──────────────────────
  0.0        0.0       │  -0.79183    0.607681
  0.0        0.0       │  -0.155642  -0.29747 
  0.0        0.0       │   0.590577   0.736366

julia> s
typeof(axes) = Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 6×6 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 0.94867  0.0       0.0         │  0.0  0.0  0.0  
 0.0      0.316223  0.0         │  0.0  0.0  0.0  
 0.0      0.0       0.00527039  │  0.0  0.0  0.0  
 ───────────────────────────────┼─────────────────
 0.0      0.0       0.0         │  0.8  0.0  0.0  
 0.0      0.0       0.0         │  0.0  0.6  0.0  
 0.0      0.0       0.0         │  0.0  0.0  0.001

julia> s_truncated
typeof(axes) = Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 4×4 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 0.94867  0.0       │  0.0  0.0
 0.0      0.316223  │  0.0  0.0
 ───────────────────┼──────────
 0.0      0.0       │  0.8  0.0
 0.0      0.0       │  0.0  0.6

julia> norm(u_truncated * s_truncated * v_truncated - u * s * v)
0.005364420303655687
```

This kind of slicing can be performed either with the syntax `I = [Block(1)[1:2], Block(2)[1:2]]` to define the slice of the blocks in each dimension as shown above or using the syntax `I = mortar([Block(1)[1:2], Block(2)[1:2]])`. [`mortar`](https://juliaarrays.github.io/BlockArrays.jl/stable/lib/public/#BlockArrays.mortar) is one of the BlockArrays.jl interfaces for making a `BlockVector`, so it acts like a vector over `[Block(1)[1], Block(1)[2], Block(2)[1], Block(2)[2]]` but keeps track of the block structure as well.

To-do:
- [x] Add support for slicing with `I = [Block(1)[1:2], Block(2)[1:2]]`, in addition to the current implementation which is based around `I = mortar([Block(1)[1:2], Block(2)[1:2]])`.

@ogauthe, @emstoudenmire