### PR TITLE
[NDTensors] Generalize insertat and deleteat

### DIFF
--- a/NDTensors/src/tupletools.jl
+++ b/NDTensors/src/tupletools.jl
@@ -145,8 +145,8 @@ function _deleteat(t, pos, i)
   return t[i + 1]
 end
 
-function deleteat(t::NTuple{N}, pos::Integer) where {N}
-  return ntuple(i -> _deleteat(t, pos, i), Val(N - 1))
+function deleteat(t::Tuple, pos::Integer) #where {N}
+  return ntuple(i -> _deleteat(t, pos, i), Val(length(t) - 1))
 end
 
 deleteat(t::Tuple, I::Tuple{Int}) = deleteat(t, I[1])
@@ -180,13 +180,13 @@ end
 
 Remove the value at pos and insert the elements in val
 """
-function insertat(t::NTuple{N}, val::NTuple{M}, pos::Integer) where {N,M}
+function insertat(t::Tuple, val::Tuple, pos::Integer)
+  N, M = length(t), length(val)
+  @assert pos <= N
   return ntuple(i -> _insertat(t, pos, M, val, i), Val(N + M - 1))
 end
 
-function insertat(t::NTuple{N}, val, pos::Integer) where {N}
-  return insertat(t, tuple(val), pos)
-end
+insertat(t::Tuple, val, pos::Integer) = insertat(t, tuple(val), pos)
 
 function _insertafter(t, pos, n_insert, val, i)
   if i <= pos

--- a/NDTensors/src/tupletools.jl
+++ b/NDTensors/src/tupletools.jl
@@ -182,7 +182,7 @@ Remove the value at pos and insert the elements in val
 """
 function insertat(t::Tuple, val::Tuple, pos::Integer)
   N, M = length(t), length(val)
-  @boundscheck checkbounds(Base.OneTo(length(t)), pos)
+  @boundscheck checkbounds(Base.OneTo(N), pos)
   return ntuple(i -> _insertat(t, pos, M, val, i), Val(N + M - 1))
 end
 

--- a/NDTensors/src/tupletools.jl
+++ b/NDTensors/src/tupletools.jl
@@ -145,7 +145,7 @@ function _deleteat(t, pos, i)
   return t[i + 1]
 end
 
-function deleteat(t::Tuple, pos::Integer) #where {N}
+function deleteat(t::Tuple, pos::Integer)
   return ntuple(i -> _deleteat(t, pos, i), Val(length(t) - 1))
 end
 

--- a/NDTensors/src/tupletools.jl
+++ b/NDTensors/src/tupletools.jl
@@ -182,7 +182,7 @@ Remove the value at pos and insert the elements in val
 """
 function insertat(t::Tuple, val::Tuple, pos::Integer)
   N, M = length(t), length(val)
-  @assert pos <= N
+  @boundscheck checkbounds(Base.OneTo(length(t)), pos)
   return ntuple(i -> _insertat(t, pos, M, val, i), Val(N + M - 1))
 end
 

--- a/NDTensors/test/test_tupletools.jl
+++ b/NDTensors/test/test_tupletools.jl
@@ -7,5 +7,28 @@ using NDTensors: NDTensors
   @test NDTensors.diff((1, 2, 3)) == (1, 1)
 end
 
-nothing
+@testset "Test deleteat" begin
+  t = (1, 2, 3, 4)
+  t = NDTensors.deleteat(t, 2)
+  @test t == (1, 3, 4)
+
+  # deleteat with mixed-type Tuple
+  t = ('a', 2, 'c', 4)
+  t = NDTensors.deleteat(t, 2)
+  @test t == ('a', 'c', 4)
+  t = NDTensors.deleteat(t, 2)
+  @test t == ('a', 4)
+end
+
+@testset "Test insertat" begin
+  t = (1, 2)
+  t = NDTensors.insertat(t, (3, 4), 2)
+  @test t == (1, 3, 4)
+
+  # insertat with mixed-type Tuple
+  t = (1, 'b')
+  t = NDTensors.insertat(t, ('c'), 2)
+  @test t == (1, 'c')
+end
+
 end


### PR DESCRIPTION
# Description

This PR generalizes the `insertat` and `deleteat` functions in tupletools.jl. The need for this fix is an experimental TCI code I am working on which uses tensors with "spaces" that carry arrays of pivot information. As a result, the combiner code calls `insertat` and `deleteat` on index tuples that contain mixed types. Currently these functions only allow tuples with a uniform type and fail to compile if mixed-type tuples are passed.

Though this could be a slight performance regression, it may also be that Julia can perform the constant propagation for the tuple sizes.

If practical and applicable, please include a minimal demonstration of the previous behavior and new behavior below.

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
t = (1,'a')
t = insertat(t,2,'c') # this currently fails to compile since t contains mixed types
```
</p></details>

# How Has This Been Tested?

Added two new tests to `test_tupletools.jl`.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
