### PR TITLE
[BlockSparseArrays] Define in-place view that may instantiate blocks

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.28"
+version = "0.3.29"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -335,3 +335,24 @@ function blocked_cartesianindices(axes::Tuple, subaxes::Tuple, blocks)
     return cartesianindices(subaxes, block)
   end
 end
+
+function view!(a::BlockSparseArray{<:Any,N}, index::Block{N}) where {N}
+  return view!(a, Tuple(index)...)
+end
+function view!(a::AbstractArray{<:Any,N}, index::Vararg{Block{1},N}) where {N}
+  blocks(a)[Int.(index)...] = blocks(a)[Int.(index)...]
+  return blocks(a)[Int.(index)...]
+end
+
+function view!(a::AbstractArray{<:Any,N}, index::BlockIndexRange{N}) where {N}
+  # TODO: Is there a better code pattern for this?
+  indices = ntuple(N) do dim
+    return Tuple(Block(index))[dim][index.indices[dim]]
+  end
+  return view!(a, indices...)
+end
+function view!(a::AbstractArray{<:Any,N}, index::Vararg{BlockIndexRange{1},N}) where {N}
+  b = view!(a, Block.(index)...)
+  r = map(index -> only(index.indices), index)
+  return @view b[r...]
+end

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -356,3 +356,13 @@ function view!(a::AbstractArray{<:Any,N}, index::Vararg{BlockIndexRange{1},N}) w
   r = map(index -> only(index.indices), index)
   return @view b[r...]
 end
+
+using MacroTools: @capture
+using NDTensors.SparseArrayDOKs: is_getindex_expr
+macro view!(expr)
+  if !is_getindex_expr(expr)
+    error("@view must be used with getindex syntax (as `@view! a[i,j,...]`)")
+  end
+  @capture(expr, array_[indices__])
+  return :(view!($(esc(array)), $(esc.(indices)...)))
+end

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
@@ -186,6 +186,11 @@ function Base.setindex!(a::BlockSparseArrayLike{<:Any,1}, value, I::Block{1})
   return a
 end
 
+function Base.fill!(a::BlockSparseArrayLike, value)
+  blocksparse_fill!(a, value)
+  return a
+end
+
 # `BlockArrays` interface
 # TODO: Is this needed if `blocks` is defined?
 function BlockArrays.viewblock(a::BlockSparseArrayLike{<:Any,N}, I::Block{N,Int}) where {N}

--- a/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
@@ -9,7 +9,7 @@ using BlockArrays:
   blocklengths,
   findblockindex
 using LinearAlgebra: Adjoint, Transpose
-using ..SparseArrayInterface: perm, iperm, nstored
+using ..SparseArrayInterface: perm, iperm, nstored, sparse_zero!
 ## using MappedArrays: mappedarray
 
 blocksparse_blocks(a::AbstractArray) = error("Not implemented")
@@ -92,6 +92,18 @@ function blocksparse_setindex!(
     )
   end
   blocks(a)[i...] = value
+  return a
+end
+
+function blocksparse_fill!(a::AbstractArray, value)
+  if iszero(value)
+    # This drops all of the blocks.
+    sparse_zero!(blocks(a))
+    return a
+  end
+  for b in BlockRange(a)
+    a[b] .= value
+  end
   return a
 end
 

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -404,6 +404,34 @@ include("TestBlockSparseArraysUtils.jl")
     @test !isassigned(a, Block(2)[3], Block(2)[5])
     @test !isassigned(a, Block(1)[1], Block(0)[1])
     @test !isassigned(a, Block(3)[3], Block(2)[4])
+
+    a = BlockSparseArray{elt}([2, 3], [3, 4])
+    @test iszero(a)
+    @test iszero(block_nstored(a))
+    fill!(a, 0)
+    @test iszero(a)
+    @test iszero(block_nstored(a))
+    fill!(a, 2)
+    @test !iszero(a)
+    @test all(==(2), a)
+    @test block_nstored(a) == 4
+    fill!(a, 0)
+    @test iszero(a)
+    @test iszero(block_nstored(a))
+
+    a = BlockSparseArray{elt}([2, 3], [3, 4])
+    @test iszero(a)
+    @test iszero(block_nstored(a))
+    a .= 0
+    @test iszero(a)
+    @test iszero(block_nstored(a))
+    a .= 2
+    @test !iszero(a)
+    @test all(==(2), a)
+    @test block_nstored(a) == 4
+    a .= 0
+    @test iszero(a)
+    @test iszero(block_nstored(a))
   end
   @testset "view!" begin
     for blk in ((Block(2, 2),), (Block(2), Block(2)))
@@ -459,9 +487,7 @@ include("TestBlockSparseArraysUtils.jl")
     a_dest = a1 * a2
     @test Array(a_dest) ≈ Array(a1) * Array(a2)
     @test a_dest isa BlockSparseArray{elt}
-
-    # TODO: Fix this.
-    @test_broken block_nstored(a_dest) == 1
+    @test block_nstored(a_dest) == 1
   end
   @testset "Matrix multiplication" begin
     a1 = BlockSparseArray{elt}([2, 3], [2, 3])

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -11,7 +11,8 @@ using BlockArrays:
   blocksize,
   mortar
 using LinearAlgebra: mul!
-using NDTensors.BlockSparseArrays: BlockSparseArray, block_nstored, block_reshape, view!
+using NDTensors.BlockSparseArrays:
+  @view!, BlockSparseArray, block_nstored, block_reshape, view!
 using NDTensors.SparseArrayInterface: nstored
 using NDTensors.TensorAlgebra: contract
 using Test: @test, @test_broken, @test_throws, @testset
@@ -414,6 +415,18 @@ include("TestBlockSparseArraysUtils.jl")
       @test a[blk...] == x
       @test @view(a[blk...]) == x
       @test view!(a, blk...) == x
+      @test @view!(a[blk...]) == x
+    end
+    for blk in ((Block(2, 2),), (Block(2), Block(2)))
+      a = BlockSparseArray{elt}([2, 3], [2, 3])
+      b = @view! a[blk...]
+      x = randn(elt, 3, 3)
+      b .= x
+      @test b == x
+      @test a[blk...] == x
+      @test @view(a[blk...]) == x
+      @test view!(a, blk...) == x
+      @test @view!(a[blk...]) == x
     end
     for blk in ((Block(2, 2)[2:3, 1:2],), (Block(2)[2:3], Block(2)[1:2]))
       a = BlockSparseArray{elt}([2, 3], [2, 3])
@@ -424,6 +437,18 @@ include("TestBlockSparseArraysUtils.jl")
       @test a[blk...] == x
       @test @view(a[blk...]) == x
       @test view!(a, blk...) == x
+      @test @view!(a[blk...]) == x
+    end
+    for blk in ((Block(2, 2)[2:3, 1:2],), (Block(2)[2:3], Block(2)[1:2]))
+      a = BlockSparseArray{elt}([2, 3], [2, 3])
+      b = @view! a[blk...]
+      x = randn(elt, 2, 2)
+      b .= x
+      @test b == x
+      @test a[blk...] == x
+      @test @view(a[blk...]) == x
+      @test view!(a, blk...) == x
+      @test @view!(a[blk...]) == x
     end
   end
   @testset "LinearAlgebra" begin

--- a/NDTensors/src/lib/SparseArrayDOKs/test/Project.toml
+++ b/NDTensors/src/lib/SparseArrayDOKs/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 NDTensors = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"

--- a/NDTensors/src/lib/SparseArrayInterface/src/abstractsparsearray/arraylayouts.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/abstractsparsearray/arraylayouts.jl
@@ -1,5 +1,13 @@
-using ArrayLayouts: ArrayLayouts
+using ArrayLayouts: ArrayLayouts, MatMulMatAdd
 
 function ArrayLayouts.MemoryLayout(arraytype::Type{<:SparseArrayLike})
   return SparseLayout()
+end
+
+function ArrayLayouts.materialize!(
+  m::MatMulMatAdd{<:AbstractSparseLayout,<:AbstractSparseLayout,<:AbstractSparseLayout}
+)
+  α, a1, a2, β, a_dest = m.α, m.A, m.B, m.β, m.C
+  sparse_mul!(a_dest, a1, a2, α, β)
+  return a_dest
 end

--- a/NDTensors/src/lib/SparseArrayInterface/src/abstractsparsearray/baseinterface.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/abstractsparsearray/baseinterface.jl
@@ -29,3 +29,7 @@ end
 function Base.setindex!(a::AbstractSparseArray, I...)
   return SparseArrayInterface.sparse_setindex!(a, I...)
 end
+
+function Base.fill!(a::AbstractSparseArray, value)
+  return SparseArrayInterface.sparse_fill!(a, value)
+end

--- a/NDTensors/src/lib/SparseArrayInterface/src/abstractsparsearray/sparsearrayinterface.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/abstractsparsearray/sparsearrayinterface.jl
@@ -13,5 +13,6 @@ end
 function SparseArrayInterface.setindex_notstored!(
   a::AbstractSparseArray{<:Any,N}, value, I::CartesianIndex{N}
 ) where {N}
+  iszero(value) && return a
   return error("Setting the specified unstored index is not supported.")
 end

--- a/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/base.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/base.jl
@@ -44,12 +44,13 @@ end
 # but we don't use that here since `sparse_fill!`
 # is used inside of `sparse_map!`.
 function sparse_fill!(a::AbstractArray, x)
-  ## TODO: Add this back?
-  ## if iszero(x)
-  ##   # TODO: Check that `typeof(x)` is compatible
-  ##   # with `eltype(a)`.
-  ##   dropall!(a)
-  ## end
+  if iszero(x)
+    # This checks that `x` is compatible
+    # with `eltype(a)`.
+    x = convert(eltype(a), x)
+    sparse_zero!(a)
+    return a
+  end
   fill!(sparse_storage(a), x)
   return a
 end

--- a/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/base.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/base.jl
@@ -51,7 +51,9 @@ function sparse_fill!(a::AbstractArray, x)
     sparse_zero!(a)
     return a
   end
-  fill!(sparse_storage(a), x)
+  for I in eachindex(a)
+    a[I] = x
+  end
   return a
 end
 

--- a/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/indexing.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/indexing.jl
@@ -153,9 +153,7 @@ function sparse_setindex!(a::AbstractArray, value, I::StoredIndex)
 end
 
 function sparse_setindex!(a::AbstractArray, value, I::NotStoredIndex)
-  if !iszero(value)
-    setindex_notstored!(a, value, index(I))
-  end
+  setindex_notstored!(a, value, index(I))
   return a
 end
 

--- a/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/interface_optional.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/interface_optional.jl
@@ -15,6 +15,7 @@ end
 # where there is not a stored value.
 # Some types (like `Diagonal`) may not support this.
 function setindex_notstored!(a::AbstractArray, value, I)
+  iszero(value) && return a
   return throw(ArgumentError("Can't set nonzero values of $(typeof(a))."))
 end
 

--- a/NDTensors/src/lib/SparseArrayInterface/test/SparseArrayInterfaceTestUtils/AbstractSparseArrays.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/test/SparseArrayInterfaceTestUtils/AbstractSparseArrays.jl
@@ -1,6 +1,6 @@
 module AbstractSparseArrays
+using ArrayLayouts: ArrayLayouts, MatMulMatAdd, MemoryLayout, MulAdd
 using NDTensors.SparseArrayInterface: SparseArrayInterface, AbstractSparseArray
-using ArrayLayouts: ArrayLayouts, MemoryLayout, MulAdd
 
 struct SparseArray{T,N} <: AbstractSparseArray{T,N}
   data::Vector{T}
@@ -25,6 +25,13 @@ struct SparseLayout <: MemoryLayout end
 ArrayLayouts.MemoryLayout(::Type{<:SparseArray}) = SparseLayout()
 function Base.similar(::MulAdd{<:SparseLayout,<:SparseLayout}, elt::Type, axes)
   return similar(SparseArray{elt}, axes)
+end
+function ArrayLayouts.materialize!(
+  m::MatMulMatAdd{<:SparseLayout,<:SparseLayout,<:SparseLayout}
+)
+  α, a1, a2, β, a_dest = m.α, m.A, m.B, m.β, m.C
+  SparseArrayInterface.sparse_mul!(a_dest, a1, a2, α, β)
+  return a_dest
 end
 
 # AbstractArray interface

--- a/NDTensors/src/lib/SparseArrayInterface/test/SparseArrayInterfaceTestUtils/SparseArrays.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/test/SparseArrayInterfaceTestUtils/SparseArrays.jl
@@ -1,4 +1,5 @@
 module SparseArrays
+using LinearAlgebra: LinearAlgebra
 using NDTensors.SparseArrayInterface: SparseArrayInterface
 
 struct SparseArray{T,N} <: AbstractArray{T,N}
@@ -19,6 +20,18 @@ function SparseArray{T}(::UndefInitializer, dims::Tuple{Vararg{Int}}) where {T}
 end
 SparseArray{T}(dims::Vararg{Int}) where {T} = SparseArray{T}(dims)
 
+# LinearAlgebra interface
+function LinearAlgebra.mul!(
+  a_dest::AbstractMatrix,
+  a1::SparseArray{<:Any,2},
+  a2::SparseArray{<:Any,2},
+  α::Number,
+  β::Number,
+)
+  SparseArrayInterface.sparse_mul!(a_dest, a1, a2, α, β)
+  return a_dest
+end
+
 # AbstractArray interface
 Base.size(a::SparseArray) = a.dims
 function Base.similar(a::SparseArray, elt::Type, dims::Tuple{Vararg{Int}})
@@ -28,8 +41,11 @@ end
 function Base.getindex(a::SparseArray, I...)
   return SparseArrayInterface.sparse_getindex(a, I...)
 end
-function Base.setindex!(a::SparseArray, I...)
-  return SparseArrayInterface.sparse_setindex!(a, I...)
+function Base.setindex!(a::SparseArray, value, I...)
+  return SparseArrayInterface.sparse_setindex!(a, value, I...)
+end
+function Base.fill!(a::SparseArray, value)
+  return SparseArrayInterface.sparse_fill!(a, value)
 end
 
 # Minimal interface

--- a/NDTensors/src/lib/SparseArrayInterface/test/test_abstractsparsearray.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/test/test_abstractsparsearray.jl
@@ -280,7 +280,12 @@ using Test: @test, @testset
   a′ = copy(a)
   a′ .+= b
   @test a′ == a + b
-  @test SparseArrayInterface.nstored(a′) == 2
+  # TODO: Should this be:
+  # ```julia
+  # @test SparseArrayInterface.nstored(a′) == 2
+  # ```
+  # ? I.e. should it only store the nonzero values?
+  @test SparseArrayInterface.nstored(a′) == 6
 
   # Matrix multiplication
   a1 = SparseArray{elt}(2, 3)


### PR DESCRIPTION
To-do:
- [x] Investigate issue with too many blocks being allocated when performing block sparse matrix multiplication.

As discussed in #1336. For example:
```julia
julia> using BlockArrays: Block

julia> using NDTensors.BlockSparseArrays: BlockSparseArray, @view!

julia> a = BlockSparseArray{Float64}([2, 3], [2, 3])
typeof(axes) = Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 5×5 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}:
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0
 ──────────┼───────────────
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0

julia> b = @view! a[Block(2, 2)] # or: `b = view!(a, Block(2, 2))`
3×3 Matrix{Float64}:
 0.0  0.0  0.0
 0.0  0.0  0.0
 0.0  0.0  0.0

julia> b[2, 2] = 2
2

julia> a
typeof(axes) = Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 5×5 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}:
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0
 ──────────┼───────────────
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  2.0  0.0
 0.0  0.0  │  0.0  0.0  0.0

julia> b
3×3 Matrix{Float64}:
 0.0  0.0  0.0
 0.0  2.0  0.0
 0.0  0.0  0.0
```

This can be better to work with than `view(a, Block(2, 2))`/`@view a[Block(2, 2)]` since as of #1481, `view(::BlockSparseArray, ...)` creates a `SubArray` wrapper around the entire `BlockSparseArray` instead of returning the block data directly, in order to uniformly handle stored and unstored blocks:
```julia
julia> @view a[Block(2, 2)]
3×3 view(::BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}, BlockSlice(Block(2),3:5), BlockSlice(Block(2),3:5)) with eltype Float64:
 0.0  0.0  0.0
 0.0  2.0  0.0
 0.0  0.0  0.0
```

Also note that sub-slicing of blocks is also supported with the syntax `@view! a[Block(2, 2)[1:2, 1:2]]` or `view!(a, Block(2, 2)[1:2, 1:2])`, in which case it outputs a view of the block data (either the existing block data or the newly allocated block data):
```julia
julia> @view! a[Block(2, 2)[1:2, 1:2]]
2×2 view(::Matrix{Float64}, 1:2, 1:2) with eltype Float64:
 0.0  0.0
 0.0  2.0
```

@ogauthe @emstoudenmire