### PR TITLE
[BlockSparseArrays] Update to BlockArrays v1.1, fix some issues with nested views

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.30"
+version = "0.3.31"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -56,7 +56,7 @@ AMDGPU = "0.9"
 Accessors = "0.1.33"
 Adapt = "3.7, 4"
 ArrayLayouts = "1.4"
-BlockArrays = "1"
+BlockArrays = "1.1"
 CUDA = "5"
 Compat = "4.9"
 Dictionaries = "0.4"

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -215,7 +215,7 @@ end
 
 function blockrange(
   axis::AbstractUnitRange,
-  r::BlockVector{BlockIndex{1},<:AbstractVector{<:BlockIndexRange{1}}},
+  r::BlockVector{<:BlockIndex{1},<:AbstractVector{<:BlockIndexRange{1}}},
 )
   return map(b -> Block(b), blocks(r))
 end
@@ -271,7 +271,7 @@ end
 function blockindices(
   a::AbstractUnitRange,
   b::Block,
-  r::BlockVector{BlockIndex{1},<:AbstractVector{<:BlockIndexRange{1}}},
+  r::BlockVector{<:BlockIndex{1},<:AbstractVector{<:BlockIndexRange{1}}},
 )
   # TODO: Change to iterate over `BlockRange(r)`
   # once https://github.com/JuliaArrays/BlockArrays.jl/issues/404

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/view.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/view.jl
@@ -27,7 +27,3 @@ end
 function Base.view(a::BlockSparseArrayLike{<:Any,1}, index::Block{1})
   return blocksparse_view(a, index)
 end
-
-function Base.view(a::BlockSparseArrayLike, indices::BlockIndexRange)
-  return view(view(a, block(indices)), indices.indices...)
-end


### PR DESCRIPTION
Fixes some issues with nested views, for example this now works:
```julia
julia> using BlockArrays: Block

julia> using NDTensors.BlockSparseArrays: BlockSparseArray

julia> a = BlockSparseArray{Float64}([2, 3], [2, 3])
typeof(axes) = Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 5×5 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}:
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0
 ──────────┼───────────────
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0

julia> b = @view a[[Block(2), Block(1)], [Block(2), Block(1)]]
5×5 view(::BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}, [3, 4, 5, 1, 2], [3, 4, 5, 1, 2]) with eltype Float64 with indices BlockArrays.BlockedOneTo([3, 5])×BlockArrays.BlockedOneTo([3, 5]):
 0.0  0.0  0.0  │  0.0  0.0
 0.0  0.0  0.0  │  0.0  0.0
 0.0  0.0  0.0  │  0.0  0.0
 ───────────────┼──────────
 0.0  0.0  0.0  │  0.0  0.0
 0.0  0.0  0.0  │  0.0  0.0

julia> b[Block(1, 1)] .= randn(3, 3)
3×3 view(view(::BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}, [3, 4, 5, 1, 2], [3, 4, 5, 1, 2]), BlockSlice(Block(1),1:3), BlockSlice(Block(1),1:3)) with eltype Float64:
  0.994707   0.611011    0.110323
 -1.42947    0.0876526   0.808757
  0.887843  -0.267044   -0.909812

julia> a
typeof(axes) = Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 5×5 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}:
 0.0  0.0  │   0.0        0.0         0.0     
 0.0  0.0  │   0.0        0.0         0.0     
 ──────────┼──────────────────────────────────
 0.0  0.0  │   0.994707   0.611011    0.110323
 0.0  0.0  │  -1.42947    0.0876526   0.808757
 0.0  0.0  │   0.887843  -0.267044   -0.909812

julia> b
5×5 view(::BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}, [3, 4, 5, 1, 2], [3, 4, 5, 1, 2]) with eltype Float64 with indices BlockArrays.BlockedOneTo([3, 5])×BlockArrays.BlockedOneTo([3, 5]):
  0.994707   0.611011    0.110323  │  0.0  0.0
 -1.42947    0.0876526   0.808757  │  0.0  0.0
  0.887843  -0.267044   -0.909812  │  0.0  0.0
 ──────────────────────────────────┼──────────
  0.0        0.0         0.0       │  0.0  0.0
  0.0        0.0         0.0       │  0.0  0.0
```