### PR TITLE
[BlockSparseArrays] Towards block merging

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.36"
+version = "0.3.37"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -230,8 +230,26 @@ function blockrange(axis::AbstractUnitRange, r::AbstractVector{<:Block{1}})
   return r
 end
 
+# This handles changing the blocking, for example:
+# a = BlockSparseArray{Float64}([2, 2, 2, 2], [2, 2, 2, 2])
+# I = blockedrange([4, 4])
+# a[I, I]
+# TODO: Generalize to `AbstractBlockedUnitRange`.
+function blockrange(axis::BlockedOneTo{<:Integer}, r::BlockedOneTo{<:Integer})
+  # TODO: Probably this is incorrect and should be something like:
+  # return findblock(axis, first(r)):findblock(axis, last(r))
+  return only(blockaxes(r))
+end
+
+# This handles changing the blocking, for example:
+# a = BlockSparseArray{Float64}([2, 2, 2, 2], [2, 2, 2, 2])
+# I = BlockedVector([Block(4), Block(3), Block(2), Block(1)], [2, 2])
+# a[I, I]
+# TODO: Generalize to `AbstractBlockedUnitRange` and `AbstractBlockVector`.
 function blockrange(axis::BlockedOneTo{<:Integer}, r::BlockVector{<:Integer})
-  return error("Slicing not implemented for range of type `$(typeof(r))`.")
+  # TODO: Probably this is incorrect and should be something like:
+  # return findblock(axis, first(r)):findblock(axis, last(r))
+  return only(blockaxes(r))
 end
 
 using BlockArrays: BlockSlice

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
@@ -1,6 +1,7 @@
 using Adapt: Adapt, WrappedArray
 using BlockArrays:
   BlockArrays,
+  AbstractBlockVector,
   AbstractBlockedUnitRange,
   BlockIndexRange,
   BlockRange,
@@ -40,8 +41,9 @@ function Base.to_indices(
 end
 
 # a[BlockVector([Block(2), Block(1)], [2]), BlockVector([Block(2), Block(1)], [2])]
+# a[BlockedVector([Block(2), Block(1)], [2]), BlockedVector([Block(2), Block(1)], [2])]
 function Base.to_indices(
-  a::BlockSparseArrayLike, inds, I::Tuple{BlockVector{<:Block{1}},Vararg{Any}}
+  a::BlockSparseArrayLike, inds, I::Tuple{AbstractBlockVector{<:Block{1}},Vararg{Any}}
 )
   return blocksparse_to_indices(a, inds, I)
 end

--- a/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
@@ -4,6 +4,7 @@ using BlockArrays:
   BlockIndex,
   BlockVector,
   BlockedUnitRange,
+  BlockedVector,
   block,
   blockcheckbounds,
   blocklengths,
@@ -43,6 +44,12 @@ end
 # TODO: This isn't merging blocks yet, that needs to be implemented that.
 function blocksparse_to_indices(a, inds, I::Tuple{BlockVector{<:Block{1}},Vararg{Any}})
   I1 = BlockIndices(I[1], blockedunitrange_getindices(inds[1], I[1]))
+  return (I1, to_indices(a, Base.tail(inds), Base.tail(I))...)
+end
+
+# TODO: Should this be combined with the version above?
+function blocksparse_to_indices(a, inds, I::Tuple{BlockedVector{<:Block{1}},Vararg{Any}})
+  I1 = blockedunitrange_getindices(inds[1], I[1])
   return (I1, to_indices(a, Base.tail(inds), Base.tail(I))...)
 end
 
@@ -223,6 +230,9 @@ function Base.size(a::SparseSubArrayBlocks)
   return length.(axes(a))
 end
 function Base.getindex(a::SparseSubArrayBlocks{<:Any,N}, I::Vararg{Int,N}) where {N}
+  # TODO: Should this be defined as `@view a.array[Block(I)]` instead?
+  ## return @view a.array[Block(I)]
+
   parent_blocks = @view blocks(parent(a.array))[blockrange(a)...]
   parent_block = parent_blocks[I...]
   # TODO: Define this using `blockrange(a::AbstractArray, indices::Tuple{Vararg{AbstractUnitRange}})`.

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -7,6 +7,7 @@ using BlockArrays:
   BlockVector,
   BlockedOneTo,
   BlockedUnitRange,
+  BlockedVector,
   blockedrange,
   blocklength,
   blocklengths,
@@ -23,6 +24,24 @@ using Test: @test, @test_broken, @test_throws, @testset
 include("TestBlockSparseArraysUtils.jl")
 @testset "BlockSparseArrays (eltype=$elt)" for elt in
                                                (Float32, Float64, ComplexF32, ComplexF64)
+  @testset "Broken" begin
+    a = BlockSparseArray{elt}([2, 2, 2, 2], [2, 2, 2, 2])
+    @views for I in [Block(1, 1), Block(2, 2), Block(3, 3), Block(4, 4)]
+      a[I] = randn(elt, size(a[I]))
+    end
+
+    I = blockedrange([4, 4])
+    b = @view a[I, I]
+    @test_broken copy(b)
+
+    I = BlockedVector(Block.(1:4), [2, 2])
+    b = @view a[I, I]
+    @test_broken copy(b)
+
+    I = BlockedVector([Block(4), Block(3), Block(2), Block(1)], [2, 2])
+    b = @view a[I, I]
+    @test_broken copy(b)
+  end
   @testset "Basics" begin
     a = BlockSparseArray{elt}([2, 3], [2, 3])
     @test a == BlockSparseArray{elt}(blockedrange([2, 3]), blockedrange([2, 3]))

--- a/NDTensors/src/lib/GradedAxes/src/blockedunitrange.jl
+++ b/NDTensors/src/lib/GradedAxes/src/blockedunitrange.jl
@@ -6,6 +6,7 @@ using BlockArrays:
   BlockRange,
   BlockSlice,
   BlockedUnitRange,
+  BlockedVector,
   block,
   blockindex,
   findblock,
@@ -68,6 +69,21 @@ function blockedunitrange_getindices(
     end
   end
   return blockedunitrange(indices .+ (first(a) - 1), blocklengths)
+end
+
+# TODO: Make sure this handles block labels (AbstractGradedUnitRange) correctly.
+function blockedunitrange_getindices(
+  a::AbstractBlockedUnitRange, indices::BlockedVector{<:Block{1},<:BlockRange{1}}
+)
+  blocklengths = map(bs -> sum(b -> length(a[b]), bs), blocks(indices))
+  return blockedrange(blocklengths)
+end
+
+# TODO: Make sure this handles block labels (AbstractGradedUnitRange) correctly.
+function blockedunitrange_getindices(
+  a::AbstractBlockedUnitRange, indices::BlockedVector{<:Block{1}}
+)
+  return mortar(map(bs -> mortar(map(b -> a[b], bs)), blocks(indices)))
 end
 
 # TODO: Move this to a `BlockArraysExtensions` library.


### PR DESCRIPTION
This adds some functionality that will be needed for slicing operations that merge blocks, one of the feature requests listed in #1336. These operations will be useful for fusion operations of symmetric tensors, removing symmetries from symmetric tensors, among other operations.

Given this block sparse array:
```julia
using BlockArrays: Block, BlockedVector, blockedrange
using NDTensors.BlockSparseArrays: BlockSparseArray
a = BlockSparseArray{Float64}([2, 2, 2, 2], [2, 2, 2, 2])
@views for I in [
  Block(1, 1),
  Block(2, 2),
  Block(3, 3),
  Block(4, 4),
]
  a[I] = randn(size(a[I]))
end
```
this PR enables the following operations:
```julia
julia> a
typeof(axes) = Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

4×4-blocked 8×8 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}:
 0.765348  -1.15712    │   0.0        0.0       │   0.0       0.0       │   0.0        0.0     
 0.176078  -0.0421353  │   0.0        0.0       │   0.0       0.0       │   0.0        0.0     
 ──────────────────────┼────────────────────────┼───────────────────────┼──────────────────────
 0.0        0.0        │  -1.48538   -1.40037   │   0.0       0.0       │   0.0        0.0     
 0.0        0.0        │  -0.718883  -0.086352  │   0.0       0.0       │   0.0        0.0     
 ──────────────────────┼────────────────────────┼───────────────────────┼──────────────────────
 0.0        0.0        │   0.0        0.0       │  -0.671303  0.773009  │   0.0        0.0     
 0.0        0.0        │   0.0        0.0       │   0.367588  0.379923  │   0.0        0.0     
 ──────────────────────┼────────────────────────┼───────────────────────┼──────────────────────
 0.0        0.0        │   0.0        0.0       │   0.0       0.0       │  -0.610198  -0.397977
 0.0        0.0        │   0.0        0.0       │   0.0       0.0       │   0.887972  -0.850992

julia> I = blockedrange([4, 4])
2-blocked 8-element BlockArrays.BlockedOneTo{Int64, Vector{Int64}}:
 1
 2
 3
 4
 ─
 5
 6
 7
 8

julia> @view a[I, I]
8×8 view(::BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}, BlockArrays.BlockedOneTo([4, 8]), BlockArrays.BlockedOneTo([4, 8])) with eltype Float64 with indices BlockArrays.BlockedOneTo([4, 8])×BlockArrays.BlockedOneTo([4, 8]):
 0.765348  -1.15712     0.0        0.0       │   0.0       0.0        0.0        0.0     
 0.176078  -0.0421353   0.0        0.0       │   0.0       0.0        0.0        0.0     
 0.0        0.0        -1.48538   -1.40037   │   0.0       0.0        0.0        0.0     
 0.0        0.0        -0.718883  -0.086352  │   0.0       0.0        0.0        0.0     
 ────────────────────────────────────────────┼───────────────────────────────────────────
 0.0        0.0         0.0        0.0       │  -0.671303  0.773009   0.0        0.0     
 0.0        0.0         0.0        0.0       │   0.367588  0.379923   0.0        0.0     
 0.0        0.0         0.0        0.0       │   0.0       0.0       -0.610198  -0.397977
 0.0        0.0         0.0        0.0       │   0.0       0.0        0.887972  -0.850992

julia> I = BlockedVector(Block.(1:4), [2, 2])
2-blocked 4-element BlockedVector{Block{1, Int64}, BlockArrays.BlockRange{1, Tuple{UnitRange{Int64}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}:
 Block(1)
 Block(2)
 ────────
 Block(3)
 Block(4)

julia> @view a[I, I]
8×8 view(::BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}, BlockArrays.BlockedOneTo([4, 8]), BlockArrays.BlockedOneTo([4, 8])) with eltype Float64 with indices BlockArrays.BlockedOneTo([4, 8])×BlockArrays.BlockedOneTo([4, 8]):
 0.765348  -1.15712     0.0        0.0       │   0.0       0.0        0.0        0.0     
 0.176078  -0.0421353   0.0        0.0       │   0.0       0.0        0.0        0.0     
 0.0        0.0        -1.48538   -1.40037   │   0.0       0.0        0.0        0.0     
 0.0        0.0        -0.718883  -0.086352  │   0.0       0.0        0.0        0.0     
 ────────────────────────────────────────────┼───────────────────────────────────────────
 0.0        0.0         0.0        0.0       │  -0.671303  0.773009   0.0        0.0     
 0.0        0.0         0.0        0.0       │   0.367588  0.379923   0.0        0.0     
 0.0        0.0         0.0        0.0       │   0.0       0.0       -0.610198  -0.397977
 0.0        0.0         0.0        0.0       │   0.0       0.0        0.887972  -0.850992

julia> I = BlockedVector([Block(4), Block(3), Block(2), Block(1)], [2, 2])
2-blocked 4-element BlockedVector{Block{1, Int64}}:
 Block(4)
 Block(3)
 ────────
 Block(2)
 Block(1)

julia> @view a[I, I]
8×8 view(::BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}, [7, 8, 5, 6, 3, 4, 1, 2], [7, 8, 5, 6, 3, 4, 1, 2]) with eltype Float64 with indices BlockArrays.BlockedOneTo([4, 8])×BlockArrays.BlockedOneTo([4, 8]):
 -0.610198  -0.397977   0.0       0.0       │   0.0        0.0       0.0        0.0      
  0.887972  -0.850992   0.0       0.0       │   0.0        0.0       0.0        0.0      
  0.0        0.0       -0.671303  0.773009  │   0.0        0.0       0.0        0.0      
  0.0        0.0        0.367588  0.379923  │   0.0        0.0       0.0        0.0      
 ───────────────────────────────────────────┼────────────────────────────────────────────
  0.0        0.0        0.0       0.0       │  -1.48538   -1.40037   0.0        0.0      
  0.0        0.0        0.0       0.0       │  -0.718883  -0.086352  0.0        0.0      
  0.0        0.0        0.0       0.0       │   0.0        0.0       0.765348  -1.15712  
  0.0        0.0        0.0       0.0       │   0.0        0.0       0.176078  -0.0421353
```
However, the implementation isn't complete yet, and basic operations like `copy(b)` and `b[Block(1, 1)]` don't work right now. I'll leave that for future PRs.