### PR TITLE
[BlockSparseArrays] Redesign block views again

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.37"
+version = "0.3.38"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -396,6 +396,23 @@ function blocked_cartesianindices(axes::Tuple, subaxes::Tuple, blocks)
   end
 end
 
+# Represents a view of a block of a blocked array.
+struct BlockView{T,N,Array<:AbstractArray{T,N}} <: AbstractArray{T,N}
+  array::Array
+  block::Tuple{Vararg{Block{1,Int},N}}
+end
+function Base.size(a::BlockView)
+  return ntuple(dim -> length(axes(a.array, dim)[a.block[dim]]), ndims(a))
+end
+function Base.getindex(a::BlockView{<:Any,N}, index::Vararg{Int,N}) where {N}
+  return blocks(a.array)[Int.(a.block)...][index...]
+end
+function Base.setindex!(a::BlockView{<:Any,N}, value, index::Vararg{Int,N}) where {N}
+  blocks(a.array)[Int.(a.block)...] = blocks(a.array)[Int.(a.block)...]
+  blocks(a.array)[Int.(a.block)...][index...] = value
+  return a
+end
+
 function view!(a::BlockSparseArray{<:Any,N}, index::Block{N}) where {N}
   return view!(a, Tuple(index)...)
 end

--- a/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -401,8 +401,18 @@ struct BlockView{T,N,Array<:AbstractArray{T,N}} <: AbstractArray{T,N}
   array::Array
   block::Tuple{Vararg{Block{1,Int},N}}
 end
+function Base.axes(a::BlockView)
+  # TODO: Try to avoid conversion to `Base.OneTo{Int}`, or just convert
+  # the element type to `Int` with `Int.(...)`.
+  # When the axes of `a.array` are `GradedOneTo`, the block is `LabelledUnitRange`,
+  # which has element type `LabelledInteger`. That causes conversion problems
+  # in some generic Base Julia code, for example when printing `BlockView`.
+  return ntuple(ndims(a)) do dim
+    return Base.OneTo{Int}(only(axes(axes(a.array, dim)[a.block[dim]])))
+  end
+end
 function Base.size(a::BlockView)
-  return ntuple(dim -> length(axes(a.array, dim)[a.block[dim]]), ndims(a))
+  return length.(axes(a))
 end
 function Base.getindex(a::BlockView{<:Any,N}, index::Vararg{Int,N}) where {N}
   return blocks(a.array)[Int.(a.block)...][index...]

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/abstractblocksparsearray.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/abstractblocksparsearray.jl
@@ -42,3 +42,18 @@ function Base.setindex!(
   blocksparse_setindex!(a, value, I...)
   return a
 end
+
+function Base.setindex!(
+  a::AbstractBlockSparseArray{<:Any,N}, value, I::Vararg{Block{1},N}
+) where {N}
+  blocksize = ntuple(dim -> length(axes(a, dim)[I[dim]]), N)
+  if size(value) ≠ blocksize
+    throw(
+      DimensionMismatch(
+        "Trying to set block $(Block(Int.(I)...)), which has a size $blocksize, with data of size $(size(value)).",
+      ),
+    )
+  end
+  blocks(a)[Int.(I)...] = value
+  return a
+end

--- a/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/views.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/abstractblocksparsearray/views.jl
@@ -1,4 +1,4 @@
-using BlockArrays: Block, BlockSlices
+using BlockArrays: BlockArrays, Block, BlockSlices, viewblock
 
 function blocksparse_view(a, I...)
   return Base.invoke(view, Tuple{AbstractArray,Vararg{Any}}, a, I...)
@@ -21,4 +21,20 @@ function Base.view(
   V::SubArray{<:Any,1,<:BlockSparseArrayLike,<:Tuple{BlockSlices}}, I::Block{1}
 )
   return blocksparse_view(a, I)
+end
+
+# Specialized code for getting the view of a block.
+function BlockArrays.viewblock(
+  a::AbstractBlockSparseArray{<:Any,N}, block::Block{N}
+) where {N}
+  return viewblock(a, Tuple(block)...)
+end
+function BlockArrays.viewblock(
+  a::AbstractBlockSparseArray{<:Any,N}, block::Vararg{Block{1},N}
+) where {N}
+  I = CartesianIndex(Int.(block))
+  if I ∈ stored_indices(blocks(a))
+    return blocks(a)[I]
+  end
+  return BlockView(a, block)
 end

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -17,7 +17,7 @@ using BlockArrays:
 using Compat: @compat
 using LinearAlgebra: mul!
 using NDTensors.BlockSparseArrays:
-  @view!, BlockSparseArray, block_nstored, block_reshape, view!
+  @view!, BlockSparseArray, BlockView, block_nstored, block_reshape, view!
 using NDTensors.SparseArrayInterface: nstored
 using NDTensors.TensorAlgebra: contract
 using Test: @test, @test_broken, @test_throws, @testset
@@ -362,10 +362,10 @@ include("TestBlockSparseArraysUtils.jl")
     b = @view a[Block(2, 2)]
     @test size(b) == (3, 4)
     for i in parentindices(b)
-      @test i isa BlockSlice{<:Block{1}}
+      @test i isa Base.OneTo{Int}
     end
-    @test parentindices(b)[1] == BlockSlice(Block(2), 3:5)
-    @test parentindices(b)[2] == BlockSlice(Block(2), 4:7)
+    @test parentindices(b)[1] == 1:3
+    @test parentindices(b)[2] == 1:4
 
     a = BlockSparseArray{elt}([2, 3], [3, 4])
     b = @view a[Block(2, 2)[1:2, 2:2]]
@@ -392,9 +392,9 @@ include("TestBlockSparseArraysUtils.jl")
 
     a = BlockSparseArray{elt}([2, 3], [3, 4])
     b = @views a[Block(2, 2)][1:2, 2:3]
-    @test b isa SubArray{<:Any,<:Any,<:BlockSparseArray}
+    @test b isa SubArray{<:Any,<:Any,<:BlockView}
     for i in parentindices(b)
-      @test i isa BlockSlice{<:BlockIndexRange{1}}
+      @test i isa UnitRange{Int}
     end
     x = randn(elt, 2, 2)
     b .= x

--- a/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
+++ b/NDTensors/src/lib/GradedAxes/src/unitrangedual.jl
@@ -68,6 +68,21 @@ end
 using NDTensors.LabelledNumbers: LabelledNumbers, label
 LabelledNumbers.label(a::UnitRangeDual) = dual(label(nondual(a)))
 
+using NDTensors.LabelledNumbers: LabelledUnitRange
+# The Base version of `length(::AbstractUnitRange)` drops the label.
+function Base.length(a::UnitRangeDual{<:Any,<:LabelledUnitRange})
+  return dual(length(nondual(a)))
+end
+function Base.iterate(a::UnitRangeDual, i)
+  i == last(a) && return nothing
+  return dual.(iterate(nondual(a), i))
+end
+# TODO: Is this a good definition?
+Base.unitrange(a::UnitRangeDual{<:Any,<:AbstractUnitRange}) = a
+
+using NDTensors.LabelledNumbers: LabelledInteger, label, labelled, unlabel
+dual(i::LabelledInteger) = labelled(unlabel(i), dual(label(i)))
+
 using BlockArrays: BlockArrays, blockaxes, blocklasts, combine_blockaxes, findblock
 BlockArrays.blockaxes(a::UnitRangeDual) = blockaxes(nondual(a))
 BlockArrays.blockfirsts(a::UnitRangeDual) = label_dual.(blockfirsts(nondual(a)))

--- a/NDTensors/src/lib/LabelledNumbers/src/labelledunitrange.jl
+++ b/NDTensors/src/lib/LabelledNumbers/src/labelledunitrange.jl
@@ -28,6 +28,9 @@ function Base.OrdinalRange{T,T}(a::LabelledUnitRange) where {T<:Integer}
   return OrdinalRange{T,T}(unlabel(a))
 end
 
+# TODO: Is this a good definition?
+Base.unitrange(a::LabelledUnitRange) = a
+
 for f in [:first, :getindex, :last, :length, :step]
   @eval Base.$f(a::LabelledUnitRange, args...) = labelled($f(unlabel(a), args...), label(a))
 end


### PR DESCRIPTION
This PR is an iteration on the redesign of block views that was implemented in #1481, which implemented block views (i.e. `@view a[Block(1, 1)]`) as a `SubArray` wrapping the block sparse array and storing the location of the desired block. It is also related to #1498, which introduced `view!`/`@view!` that may instantiate blocks if they don't exist.

This PR defines a devoted type `BlockView`, and now `@view a[Block(1, 1)]` either directly outputs the data of the block if it exists, or a `BlockView` wrapping the block sparse array and the location of the desired block if the block doesn't exist.

So for example:
```julia
julia> using BlockArrays: Block

julia> using NDTensors.BlockSparseArrays: BlockSparseArray

julia> a = BlockSparseArray{Float64}([2, 3], [2, 3])
typeof(axes) = Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}

Warning: To temporarily circumvent a bug in printing BlockSparseArrays with mixtures of dual and non-dual axes, the types of the dual axes printed below might not be accurate. The types printed above this message are the correct ones.

2×2-blocked 5×5 BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}:
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0
 ──────────┼───────────────
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0
 0.0  0.0  │  0.0  0.0  0.0

julia> a[Block(1, 1)] = randn(2, 2)
2×2 Matrix{Float64}:
  0.114978   3.56484
 -0.508884  -0.323752

julia> @view a[Block(1, 1)]
2×2 Matrix{Float64}:
  0.114978   3.56484
 -0.508884  -0.323752

julia> @view a[Block(2, 2)]
3×3 NDTensors.BlockSparseArrays.BlockView{Float64, 2, BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockArrays.BlockedOneTo{Int64, Vector{Int64}}, BlockArrays.BlockedOneTo{Int64, Vector{Int64}}}}}:
 0.0  0.0  0.0
 0.0  0.0  0.0
 0.0  0.0  0.0
```

I think this will make some operations with block views easier to implement, and also help to simplify some code internally.

I'm not totally settled on the design that views of existing blocks directly returns the block data, an alternative would be that it also outputs a `BlockView` which is more comparable to the current behavior that it outputs a `SubArray` no matter what. However, I think it is worth trying out this design and seeing how it goes, it would be easy to change that later.

@ogauthe this is related to our discussion in #1336. I think this new design will make it a bit easier to fix some issues with block views you brought up, like using them in `TensorAlgebra.contract` and in `Strided.@strided`.