### PR TITLE
[NDTensors] Scalar diag calls `expose` to skip scalar indexing

### DIFF
--- a/NDTensors/src/diag/diagtensor.jl
+++ b/NDTensors/src/diag/diagtensor.jl
@@ -82,7 +82,8 @@ setdiag(T::UniformDiagTensor, val) = tensor(Diag(val), inds(T))
   end
 end
 @propagate_inbounds getindex(T::DiagTensor{<:Number,1}, ind::Int) = storage(T)[ind]
-@propagate_inbounds getindex(T::DiagTensor{<:Number,0}) = storage(T)[1]
+using NDTensors.Expose: expose
+@propagate_inbounds getindex(T::DiagTensor{<:Number,0}) = getindex(expose(storage(T)))
 
 # Set diagonal elements
 # Throw error for off-diagonal

--- a/NDTensors/test/test_diag.jl
+++ b/NDTensors/test/test_diag.jl
@@ -63,7 +63,7 @@ using .NDTensorsTestUtils: devices_list, is_supported_eltype
       @test x == dev(diagm(0 => vr))
       @test x == D
     end
-    @test sqrt(contract(D, (-1,-2), D, (-1,-2))[]) ≈ norm(D)
+    @test sqrt(contract(D, (-1, -2), D, (-1, -2))[]) ≈ norm(D)
     # This if statement corresponds to the reported bug:
     # https://github.com/JuliaGPU/Metal.jl/issues/364
     if !(dev == NDTensors.mtl && elt === ComplexF32)

--- a/NDTensors/test/test_diag.jl
+++ b/NDTensors/test/test_diag.jl
@@ -63,7 +63,7 @@ using .NDTensorsTestUtils: devices_list, is_supported_eltype
       @test x == dev(diagm(0 => vr))
       @test x == D
     end
-
+    @test sqrt(contract(D, (-1,-2), D, (-1,-2))[]) ≈ norm(D)
     # This if statement corresponds to the reported bug:
     # https://github.com/JuliaGPU/Metal.jl/issues/364
     if !(dev == NDTensors.mtl && elt === ComplexF32)

--- a/NDTensors/test/test_diag.jl
+++ b/NDTensors/test/test_diag.jl
@@ -63,7 +63,7 @@ using .NDTensorsTestUtils: devices_list, is_supported_eltype
       @test x == dev(diagm(0 => vr))
       @test x == D
     end
-    @test sqrt(contract(D, (-1, -2), D, (-1, -2))[]) ≈ norm(D)
+    @test sqrt(contract(D, (-1, -2), conj(D), (-1, -2))[]) ≈ norm(D)
     # This if statement corresponds to the reported bug:
     # https://github.com/JuliaGPU/Metal.jl/issues/364
     if !(dev == NDTensors.mtl && elt === ComplexF32)


### PR DESCRIPTION
# Description

When Diag is a scalar we should call the `expose` version of getindex to allow this to work on CPU and GPU without scalar indexing issue. Related to this issue on discourse https://itensor.discourse.group/t/scalar-on-a-zero-rank-tensor-on-gpu/1863/2