### PR TITLE
fix typo in `error_contract` docs

### DIFF
--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -561,7 +561,7 @@ end
 """
     error_contract(y::MPS, A::MPO, x::MPS;
                    make_inds_match::Bool = true)
-    error_contract(y::MPS, x::MPS, x::MPO;
+    error_contract(y::MPS, x::MPS, A::MPO;
                    make_inds_match::Bool = true)
 
 Compute the distance between A|x> and an approximation MPS y:


### PR DESCRIPTION
# Description

Fixed a typo in the docs of `error_contract`. 

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
