### PR TITLE
feat (timeit_debug)

### DIFF
--- a/docs/src/CodeTiming.md
+++ b/docs/src/CodeTiming.md
@@ -8,3 +8,21 @@ If you are concerned about the performance of your code, a good place to start i
 ## Timing and benchmarking
 
 Julia has many nice timing tools available. Tools like [@time](https://docs.julialang.org/en/v1/base/base/#Base.@time) and [TimerOutputs](https://github.com/KristofferC/TimerOutputs.jl) can be used to measure the time of specific lines of code. For microbenchmarking, we recommend the [BenchmarkTools](https://github.com/JuliaCI/BenchmarkTools.jl) package. For profiling your code, see the Julia documentation on [profiling](https://docs.julialang.org/en/v1/manual/profile/).
+
+## Using TimerOutputs
+```julia
+using TimerOutputs
+using ITensors
+using NDTensors: timer
+...
+
+TimerOutputs.enable_debug_timings(ITensors)
+@timeit timer "dmrg" energy, _ = dmrg(mpo, mps;
+                                      nsweeps=nsweeps,
+                                      maxdim=maxdim,
+                                      mindim=maxdim,
+                                      cutoff=cutoff,
+                                      outputlevel=0)
+println("Energy = $energy")
+println(timer)
+```

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -35,6 +35,7 @@ export
   contract,
   # global_variables.jl
   # Methods
+  timeit_debug_enabled,
   # Macros
   @disable_warn_order,
   @reset_warn_order,

--- a/src/global_variables.jl
+++ b/src/global_variables.jl
@@ -209,3 +209,11 @@ function disable_contraction_sequence_optimization()
   _using_contraction_sequence_optimization[] = false
   return nothing
 end
+
+#
+# Turn debug timer for TimerOutputs on and off
+#
+
+function timeit_debug_enabled()
+  return false
+end


### PR DESCRIPTION
- add timeit_debug_enabled for TimerOutputs
- update CodeTiming.md

# Description

This would fix the issue with `TimerOutputs` `timeit_debug`.
The output of profilers is too verbose and a pain to interpret, I found this more useful (see also screenshot).

Fixes #1526

![Screenshot 2024-09-11 at 12 03 19](https://github.com/user-attachments/assets/9e717aef-db5d-44a7-a887-5c582712bbaa)
