### PR TITLE
[ITensorMPS] Added option for MPO-MPS zipup

### DIFF
--- a/src/lib/ITensorMPS/src/abstractmps.jl
+++ b/src/lib/ITensorMPS/src/abstractmps.jl
@@ -1082,7 +1082,7 @@ function deprecate_make_inds_match!(
             inds(ψ[$n]) = $(inds(M2[n]))
 
         Make sure the site indices of your MPO/MPS match. You may need to prime
-        one of the MPS, such as `dot(ϕ', ψ)`."""
+        one of the MPS, such as `dot(ϕ', ψ)`.""",
       )
     end
     make_inds_match = false

--- a/src/lib/ITensorMPS/src/abstractmps.jl
+++ b/src/lib/ITensorMPS/src/abstractmps.jl
@@ -1082,7 +1082,7 @@ function deprecate_make_inds_match!(
             inds(ψ[$n]) = $(inds(M2[n]))
 
         Make sure the site indices of your MPO/MPS match. You may need to prime
-        one of the MPS, such as `dot(ϕ', ψ)`.""",
+        one of the MPS, such as `dot(ϕ', ψ)`."""
       )
     end
     make_inds_match = false

--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -836,15 +836,14 @@ function ITensors.contract(
   N = length(A)
   N != length(B) &&
     throw(DimensionMismatch("lengths of MPOs A ($N) and B ($(length(B))) do not match"))
-  ResultType = typeof(B)
   # Special case for a single site
-  N == 1 && return ResultType([A[1] * B[1]])
+  N == 1 && return typeof(B)([A[1] * B[1]])
   A = orthogonalize(A, 1)
   B = orthogonalize(B, 1)
   A = sim(linkinds, A)
   sA = siteinds(uniqueinds, A, B)
   sB = siteinds(uniqueinds, B, A)
-  C = ResultType(N)
+  C = typeof(B)(N)
   lCᵢ = Index[]
   R = ITensor(true)
   for i in 1:(N - 2)

--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -971,10 +971,7 @@ C = apply(A, B; alg="naive", truncate=false)
    for the `"naive"` version, if you just want to contract the tensors pairwise
    exactly. This can be useful if you are contracting MPOs that have diverging
    norms, such as MPOs originating from sums of local operators.
-- `alg="zipup"`: the algorithm to use for the contraction. Supported algorithms are
-    - "naive": The MPO tensors are contracted exactly at each site and then a truncation 
-    of the resulting MPO is performed.
-    $(zipup_docstring(false))
+  $(zipup_docstring(true))
 
 See also [`apply`](@ref) for details about the arguments available.
 

--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -826,7 +826,7 @@ function ITensors.contract(
   cutoff=1e-14,
   maxdim=maxlinkdim(A) * maxlinkdim(B),
   mindim=1,
-  truncate_kwargs=(;),
+  truncate_kwargs=(; cutoff, maxdim, mindim),
   kwargs...,
 )
   if hassameinds(siteinds, A, B)

--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -875,7 +875,7 @@ function ITensors.contract(
     mindim,
     kwargs...,
   )
-  truncate!(C, truncate_kwargs...)
+  truncate!(C; truncate_kwargs...)
   return C
 end
 

--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -826,6 +826,7 @@ function ITensors.contract(
   cutoff=1e-14,
   maxdim=maxlinkdim(A) * maxlinkdim(B),
   mindim=1,
+  truncate_kwargs=(;),
   kwargs...,
 )
   if hassameinds(siteinds, A, B)
@@ -874,6 +875,7 @@ function ITensors.contract(
     mindim,
     kwargs...,
   )
+  truncate!(C, truncate_kwargs...)
   return C
 end
 

--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -662,11 +662,16 @@ Choose the method with the `method` keyword, for example
 - `mindim::Int=1`: the minimal bond dimension of the resulting MPS.
 - `normalize::Bool=false`: whether or not to normalize the resulting MPS.
 - `method::String="densitymatrix"`: the algorithm to use for the contraction.
-   Currently the options are "densitymatrix", where the network formed by the
-   MPO and MPS is squared and contracted down to a density matrix which is
-   diagonalized iteratively at each site, and "naive", where the MPO and MPS
-   tensor are contracted exactly at each site and then a truncation of the
-   resulting MPS is performed.
+    - "densitymatrix": The network formed by the MPO and MPS is squared and contracted down to
+    a density matrix which is diagonalized iteratively at each site.
+    - "naive": The MPO and MPS tensor are contracted exactly at each site and then a truncation 
+    of the resulting MPS is performed.
+    - "zipup": The MPO and MPS tensors are contracted then truncated at each site without enforcing
+    the appropriate orthogonal gauge. Once this sweep is complete a call to `truncate!` occurs.
+    Because the initial truncation is not locally optimal it is recommended to use a loose
+    `cutoff` and `maxdim` and then pass the desired truncation parameters to the locally optimal
+    `truncate!` sweep via the additional keyword argument `truncate_kwargs`.
+    Suggested use is `contract(A, ψ; method="zipup", cutoff=cutoff / 10, maxdim=2 * maxdim, truncate_kwargs=(; cutoff, maxdim))`.
 
 See also [`apply`](@ref).
 """
@@ -946,14 +951,20 @@ C = apply(A, B; alg="naive", truncate=false)
    in general you should set a `cutoff` value.
 - `maxdim::Int=maxlinkdim(A) * maxlinkdim(B))`: the maximal bond dimension of the results MPS.
 - `mindim::Int=1`: the minimal bond dimension of the resulting MPS.
-- `alg="zipup"`: Either `"zipup"` or `"naive"`. `"zipup"` contracts pairs of
-   site tensors and truncates with SVDs in a sweep across the sites, while `"naive"`
-   first contracts pairs of tensor exactly and then truncates at the end if `truncate=true`.
 - `truncate=true`: Enable or disable truncation. If `truncate=false`, ignore
    other truncation parameters like `cutoff` and `maxdim`. This is most relevant
    for the `"naive"` version, if you just want to contract the tensors pairwise
    exactly. This can be useful if you are contracting MPOs that have diverging
    norms, such as MPOs originating from sums of local operators.
+- `alg="zipup"`: the algorithm to use for the contraction. Supported algorithms are
+    - "naive": The MPO tensors are contracted exactly at each site and then a truncation 
+    of the resulting MPO is performed.
+    - "zipup": The MPO and MPS tensors are contracted then truncated at each site without enforcing
+    the appropriate orthogonal gauge. Once this sweep is complete a call to `truncate!` occurs.
+    Because the initial truncation is not locally optimal it is recommended to use a loose
+    `cutoff` and `maxdim` and then pass the desired truncation parameters to the locally optimal
+    `truncate!` sweep via the additional keyword argument `truncate_kwargs`.
+    Suggested use is `contract(A, ψ; method="zipup", cutoff=cutoff / 10, maxdim=2 * maxdim, truncate_kwargs=(; cutoff, maxdim))`.
 
 See also [`apply`](@ref) for details about the arguments available.
 """

--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -822,7 +822,7 @@ end
 function ITensors.contract(
   ::Algorithm"zipup",
   A::MPO,
-  B::MPO;
+  B::AbstractMPS;
   cutoff=1e-14,
   maxdim=maxlinkdim(A) * maxlinkdim(B),
   mindim=1,
@@ -836,14 +836,15 @@ function ITensors.contract(
   N = length(A)
   N != length(B) &&
     throw(DimensionMismatch("lengths of MPOs A ($N) and B ($(length(B))) do not match"))
+  ResultType = typeof(B)
   # Special case for a single site
-  N == 1 && return MPO([A[1] * B[1]])
+  N == 1 && return ResultType([A[1] * B[1]])
   A = orthogonalize(A, 1)
   B = orthogonalize(B, 1)
   A = sim(linkinds, A)
   sA = siteinds(uniqueinds, A, B)
   sB = siteinds(uniqueinds, B, A)
-  C = MPO(N)
+  C = ResultType(N)
   lCᵢ = Index[]
   R = ITensor(true)
   for i in 1:(N - 2)
@@ -874,7 +875,6 @@ function ITensors.contract(
     mindim,
     kwargs...,
   )
-  truncate!(C; kwargs...)
   return C
 end
 

--- a/src/lib/ITensorMPS/src/mpo.jl
+++ b/src/lib/ITensorMPS/src/mpo.jl
@@ -629,6 +629,24 @@ function ITensors.contract(A::MPO, ψ::MPS; alg=nothing, method=alg, kwargs...)
   return contract(Algorithm(alg), A, ψ; kwargs...)
 end
 
+function zipup_docstring(isMPOMPO::Bool)::String
+  rhsTypeString = isMPOMPO ? "MPO" : "MPS"
+  rhsString = isMPOMPO ? "B" : "ψ"
+  return """    - "zipup": The MPO and $rhsTypeString tensors are contracted then truncated at each site without enforcing
+  the appropriate orthogonal gauge. Once this sweep is complete a call to `truncate!` occurs.
+  Because the initial truncation is not locally optimal it is recommended to use a loose
+  `cutoff` and `maxdim` and then pass the desired truncation parameters to the locally optimal
+  `truncate!` sweep via the additional keyword argument `truncate_kwargs`.
+  A set of parameters suggested in [^Paeckel2019] is
+  `contract(A, $rhsString; method="zipup", cutoff=cutoff / 10, maxdim=2 * maxdim, truncate_kwargs=(; cutoff, maxdim))`."""
+end
+
+function Paeckel2019_citation_docstring()::String
+  return """
+  [^Paeckel2019]: Time-evolution methods for matrix-product states. Sebastian Paeckel et al. [arXiv:1901.05824](https://arxiv.org/abs/1901.05824)
+  """
+end
+
 contract_mpo_mps_doc = """
     contract(ψ::MPS, A::MPO; kwargs...) -> MPS
     *(::MPS, ::MPO; kwargs...) -> MPS
@@ -666,14 +684,11 @@ Choose the method with the `method` keyword, for example
     a density matrix which is diagonalized iteratively at each site.
     - "naive": The MPO and MPS tensor are contracted exactly at each site and then a truncation 
     of the resulting MPS is performed.
-    - "zipup": The MPO and MPS tensors are contracted then truncated at each site without enforcing
-    the appropriate orthogonal gauge. Once this sweep is complete a call to `truncate!` occurs.
-    Because the initial truncation is not locally optimal it is recommended to use a loose
-    `cutoff` and `maxdim` and then pass the desired truncation parameters to the locally optimal
-    `truncate!` sweep via the additional keyword argument `truncate_kwargs`.
-    Suggested use is `contract(A, ψ; method="zipup", cutoff=cutoff / 10, maxdim=2 * maxdim, truncate_kwargs=(; cutoff, maxdim))`.
+    $(zipup_docstring(false))
 
 See also [`apply`](@ref).
+
+$(Paeckel2019_citation_docstring())
 """
 
 @doc """
@@ -959,14 +974,11 @@ C = apply(A, B; alg="naive", truncate=false)
 - `alg="zipup"`: the algorithm to use for the contraction. Supported algorithms are
     - "naive": The MPO tensors are contracted exactly at each site and then a truncation 
     of the resulting MPO is performed.
-    - "zipup": The MPO and MPS tensors are contracted then truncated at each site without enforcing
-    the appropriate orthogonal gauge. Once this sweep is complete a call to `truncate!` occurs.
-    Because the initial truncation is not locally optimal it is recommended to use a loose
-    `cutoff` and `maxdim` and then pass the desired truncation parameters to the locally optimal
-    `truncate!` sweep via the additional keyword argument `truncate_kwargs`.
-    Suggested use is `contract(A, ψ; method="zipup", cutoff=cutoff / 10, maxdim=2 * maxdim, truncate_kwargs=(; cutoff, maxdim))`.
+    $(zipup_docstring(false))
 
 See also [`apply`](@ref) for details about the arguments available.
+
+$(Paeckel2019_citation_docstring())
 """
 
 @doc """

--- a/src/lib/ITensorMPS/test/base/test_mpo.jl
+++ b/src/lib/ITensorMPS/test/base/test_mpo.jl
@@ -287,7 +287,9 @@ end
       orthogonalize!(psi, 1; maxdim=link_dim)
       orthogonalize!(K, 1; maxdim=link_dim)
       orthogonalize!(phi, 1; normalize=true, maxdim=link_dim)
-      psi_out = contract(deepcopy(K), deepcopy(psi); method, maxdim=10 * link_dim, cutoff=0.0)
+      psi_out = contract(
+        deepcopy(K), deepcopy(psi); method, maxdim=10 * link_dim, cutoff=0.0
+      )
       @test inner(phi', psi_out) ≈ inner(phi', K, psi)
     end
   end


### PR DESCRIPTION
# Description

Minimal changes necessary to extend the "zipup" algorithm for MPO-MPO products to MPO-MPS products. The main request I foresee is to bring it inline with the "naive" algorithm which also has a single implementation for MPO-MPO(S) products. Once those details are worked out I'll add docs and tests.

# How Has This Been Tested?

It has not.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
