### PR TITLE
[ITensors] Fix `ITensorsPackageCompilerExt` precompile issue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.6.21"
+version = "0.6.22"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -39,7 +39,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 [extensions]
 ITensorsHDF5Ext = "HDF5"
 ITensorsObserversExt = "Observers"
-ITensorsPackageCompilerExt = "PackageCompiler"
+ITensorsPackageCompilerExt = ["PackageCompiler", "VectorInterface"]
 ITensorsVectorInterfaceExt = "VectorInterface"
 ITensorsZygoteRulesExt = "ZygoteRules"
 

--- a/ext/ITensorsPackageCompilerExt/precompile_itensors.jl
+++ b/ext/ITensorsPackageCompilerExt/precompile_itensors.jl
@@ -1,4 +1,6 @@
 using ITensors.ITensorMPS: MPO, OpSum, dmrg, random_mps, siteinds
+using VectorInterface: VectorInterface
+include("$(@__DIR__)/../ITensorsVectorInterfaceExt/ITensorsVectorInterfaceExt.jl")
 
 # TODO: This uses all of the tests to make
 # precompile statements, but takes a long time

--- a/ext/ITensorsPackageCompilerExt/precompile_itensors.jl
+++ b/ext/ITensorsPackageCompilerExt/precompile_itensors.jl
@@ -1,5 +1,4 @@
 using ITensors.ITensorMPS: MPO, OpSum, dmrg, random_mps, siteinds
-using VectorInterface: VectorInterface
 include("$(@__DIR__)/../ITensorsVectorInterfaceExt/ITensorsVectorInterfaceExt.jl")
 
 # TODO: This uses all of the tests to make


### PR DESCRIPTION
# Description
Fixing the issue #1548 .
The issue is related to the `precomile_itensor.jl` file's dependency on `VectorInterface`. During precompile, `ITensorsVectorIntefaceExt` is not being added which throws an error due to a missing function.