### PR TITLE
[GradedAxes] Fix labelled_isequal namespace

### DIFF
--- a/NDTensors/src/lib/GradedAxes/src/gradedunitrange.jl
+++ b/NDTensors/src/lib/GradedAxes/src/gradedunitrange.jl
@@ -21,7 +21,13 @@ using BlockArrays:
 using Compat: allequal
 using FillArrays: Fill
 using ..LabelledNumbers:
-  LabelledNumbers, LabelledInteger, LabelledUnitRange, label, labelled, unlabel
+  LabelledNumbers,
+  LabelledInteger,
+  LabelledUnitRange,
+  label,
+  labelled,
+  labelled_isequal,
+  unlabel
 
 const AbstractGradedUnitRange{T<:LabelledInteger} = AbstractBlockedUnitRange{T}
 
@@ -42,7 +48,7 @@ end
 struct NoLabel end
 blocklabels(r::AbstractUnitRange) = Fill(NoLabel(), blocklength(r))
 
-function labelled_isequal(a1::AbstractUnitRange, a2::AbstractUnitRange)
+function LabelledNumbers.labelled_isequal(a1::AbstractUnitRange, a2::AbstractUnitRange)
   return blockisequal(a1, a2) && (blocklabels(a1) == blocklabels(a2))
 end
 

--- a/NDTensors/src/lib/GradedAxes/test/test_basics.jl
+++ b/NDTensors/src/lib/GradedAxes/test/test_basics.jl
@@ -9,9 +9,9 @@ using BlockArrays:
   blocklength,
   blocklengths,
   blocks
-using NDTensors.GradedAxes:
-  GradedOneTo, GradedUnitRange, blocklabels, labelled_isequal, gradedrange
-using NDTensors.LabelledNumbers: LabelledUnitRange, islabelled, label, labelled, unlabel
+using NDTensors.GradedAxes: GradedOneTo, GradedUnitRange, blocklabels, gradedrange
+using NDTensors.LabelledNumbers:
+  LabelledUnitRange, islabelled, label, labelled, labelled_isequal, unlabel
 using Test: @test, @test_broken, @testset
 @testset "GradedAxes basics" begin
   for a in (


### PR DESCRIPTION
I realized there was a conflict with `labelled_isequal`, which was not defined as a `LabelledNumbers` inside `GradedAxes`. We could also use a different function name for this method in `GradedAxes`.