### PR TITLE
[NDTensors] [ITensors] Revert upgrading to Functors v0.5

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.51"
+version = "0.3.52"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -67,7 +67,7 @@ Dictionaries = "0.4"
 EllipsisNotation = "1.8"
 FillArrays = "1"
 Folds = "0.2.8"
-Functors = "0.2, 0.3, 0.4, 0.5"
+Functors = "0.2, 0.3, 0.4"
 GPUArraysCore = "0.1, 0.2"
 HDF5 = "0.14, 0.15, 0.16, 0.17"
 HalfIntegers = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -43,7 +43,7 @@ ChainRulesCore = "1.10"
 Compat = "2.1, 3, 4"
 Dictionaries = "0.4"
 DocStringExtensions = "0.9.3"
-Functors = "0.2, 0.3, 0.4, 0.5"
+Functors = "0.2, 0.3, 0.4"
 HDF5 = "0.14, 0.15, 0.16, 0.17"
 IsApprox = "0.1, 1, 2"
 LinearAlgebra = "1.6"


### PR DESCRIPTION
Updating to Functors v0.5 (#1562, #1563) broke some tests in NDTensors so I'll have to investigate that before upgrading.