### PR TITLE
[BlockSparseArrays] Simplify and test `adjoint(::BlockSparseMatrix)`

### DIFF
--- a/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearray/blocksparsearray.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/src/blocksparsearray/blocksparsearray.jl
@@ -1,6 +1,7 @@
 using BlockArrays: BlockArrays, Block, BlockedUnitRange, blockedrange, blocklength
 using Dictionaries: Dictionary
 using ..SparseArrayDOKs: SparseArrayDOK
+using ..GradedAxes: dual
 
 # TODO: Delete this.
 ## using BlockArrays: blocks
@@ -118,3 +119,12 @@ blockstype(::Type{<:BlockSparseArray{<:Any,<:Any,<:Any,B}}) where {B} = B
 ##   # TODO: Preserve GPU data!
 ##   return BlockSparseArray{elt}(undef, axes)
 ## end
+
+# Avoid proliferating wrapper types
+function Base.adjoint(A::BlockSparseMatrix)
+  return BlockSparseMatrix(adjoint(blocks(A)), dual.(reverse(axes(A))))
+end
+
+function Base.transpose(A::BlockSparseMatrix)
+  return BlockSparseMatrix(transpose(blocks(A)), reverse(axes(A)))
+end

--- a/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
+++ b/NDTensors/src/lib/BlockSparseArrays/test/test_basics.jl
@@ -98,6 +98,28 @@ include("TestBlockSparseArraysUtils.jl")
     a[3, 3] = NaN
     @test isnan(norm(a))
   end
+  @testset "Adjoint and transpose" begin
+    a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
+    @views for b in [Block(1, 2), Block(2, 1)]
+      a[b] = randn(elt, size(a[b]))
+    end
+
+    ad = a'
+    @test ad isa BlockSparseMatrix
+    @test ad' == a
+    @test ad[Block(1, 1)] == adjoint(a[Block(1, 1)])
+    @test ad[Block(1, 2)] == adjoint(a[Block(2, 1)])
+    @test ad[1, 1] == conj(a[1, 1])
+    @test ad[1, 2] == conj(a[2, 1])
+
+    at = transpose(a)
+    @test at isa BlockSparseMatrix
+    @test traspose(at) == a
+    @test at[Block(1, 1)] == transpose(a[Block(1, 1)])
+    @test at[Block(1, 2)] == transpose(a[Block(2, 1)])
+    @test at[1, 1] == a[1, 1]
+    @test at[1, 2] == a[2, 1]
+  end
   @testset "Tensor algebra" begin
     a = BlockSparseArray{elt}(undef, ([2, 3], [3, 4]))
     @views for b in [Block(1, 2), Block(2, 1)]


### PR DESCRIPTION
This PR simplifies both `adjoint(::BlockSparseMatrix)` and `transpose(::BlockSparseMatrix)`.

This was discussed in #1572, but was already previously mentioned by @ogauthe as well:
https://github.com/ITensor/ITensors.jl/issues/1336#issuecomment-2254260306

Regarding your comment there about the vector types, keep in mind that I (for now) only intercepted the matrix case. I can investigate if we can make this work for `Vector` as well, keeping in mind that the `Adjoint` wrapper information is still there, it is just not the outer wrapper.