### PR TITLE
[ITensorsNamedDimsArraysExt] Convert symmetric tensors

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.62"
+version = "0.3.63"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/GradedAxes/src/gradedunitrangedual.jl
+++ b/NDTensors/src/lib/GradedAxes/src/gradedunitrangedual.jl
@@ -94,6 +94,21 @@ function blockedunitrange_getindices(
   return flip_blockvector(v)
 end
 
+# Fixes ambiguity error.
+# TODO: Write this in terms of `blockedunitrange_getindices(dual(a), indices)`.
+function blockedunitrange_getindices(
+  a::GradedUnitRangeDual, indices::AbstractBlockVector{<:Block{1}}
+)
+  blks = map(bs -> mortar(map(b -> a[b], bs)), blocks(indices))
+  # We pass `length.(blks)` to `mortar` in order
+  # to pass block labels to the axes of the output,
+  # if they exist. This makes it so that
+  # `only(axes(a[indices])) isa `GradedUnitRange`
+  # if `a isa `GradedUnitRange`, for example.
+  v = mortar(blks, labelled_length.(blks))
+  return flip_blockvector(v)
+end
+
 function flip_blockvector(v::BlockVector)
   block_axes = flip.(axes(v))
   flipped = mortar(vec.(blocks(v)), block_axes)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/lib/ITensorsNamedDimsArraysExt/examples/example_dmrg.jl
+++ b/src/lib/ITensorsNamedDimsArraysExt/examples/example_dmrg.jl
@@ -1,6 +1,5 @@
 using Adapt: adapt
-using ITensors: MPO, dmrg, random_mps, siteinds
-using ITensors.Ops: OpSum
+using ITensorMPS: MPO, OpSum, dmrg, random_mps, siteinds
 using ITensors.ITensorsNamedDimsArraysExt: to_nameddimsarray
 
 function main(; n, conserve_qns=false, nsweeps=3, cutoff=1e-4, arraytype=Array)

--- a/src/lib/ITensorsNamedDimsArraysExt/src/to_nameddimsarray.jl
+++ b/src/lib/ITensorsNamedDimsArraysExt/src/to_nameddimsarray.jl
@@ -1,5 +1,5 @@
-using ..NDTensors: data, inds
 using ITensors: ITensor
+using ..NDTensors: data, inds
 
 # TODO: Delete this, it is a hack to decide
 # if an Index is blocked.
@@ -34,20 +34,34 @@ function to_nameddimsarray(x::DiagTensor)
   return named(DiagonalArray(data(x), size(x)), name.(inds(x)))
 end
 
-using ..NDTensors: BlockSparseTensor
+using ITensors: ITensors, dir, qn
+using ..NDTensors: BlockSparseTensor, array, blockdim, datatype, nblocks, nzblocks
 using ..NDTensors.BlockSparseArrays: BlockSparseArray
+using ..NDTensors.BlockSparseArrays.BlockArrays: BlockArrays, blockedrange
+using ..NDTensors.GradedAxes: dual, gradedrange
+using ..NDTensors.TypeParameterAccessors: set_ndims
 # TODO: Delete once `BlockSparse` is removed.
 function to_nameddimsarray(x::BlockSparseTensor)
-  blockinds = map(i -> [blockdim(i, b) for b in 1:nblocks(i)], inds(x))
+  blockinds = map(inds(x)) do i
+    r = gradedrange([qn(i, b) => blockdim(i, b) for b in 1:nblocks(i)])
+    if dir(i) == ITensors.In
+      return dual(r)
+    end
+    return r
+  end
   blocktype = set_ndims(datatype(x), ndims(x))
   # TODO: Make a simpler constructor:
   # BlockSparseArray(blocktype, blockinds)
-  arraystorage = BlockSparseArray{eltype(x),ndims(x),blocktype}(blockinds)
+  arraystorage = BlockSparseArray{eltype(x),ndims(x),blocktype}(undef, blockinds)
   for b in nzblocks(x)
-    arraystorage[BlockArrays.Block(Tuple(b)...)] = x[b]
+    arraystorage[BlockArrays.Block(Int.(Tuple(b))...)] = array(x[b])
   end
   return named(arraystorage, name.(inds(x)))
 end
+
+using ITensors: QN
+using ..NDTensors.GradedAxes: GradedAxes
+GradedAxes.fuse_labels(l1::QN, l2::QN) = l1 + l2
 
 ## TODO: Add this back, define `CombinerArrays` library in NDTensors!
 ## using ..NDTensors: CombinerTensor, CombinerArray, storage

--- a/src/lib/ITensorsNamedDimsArraysExt/src/to_nameddimsarray.jl
+++ b/src/lib/ITensorsNamedDimsArraysExt/src/to_nameddimsarray.jl
@@ -63,6 +63,10 @@ using ITensors: QN
 using ..NDTensors.GradedAxes: GradedAxes
 GradedAxes.fuse_labels(l1::QN, l2::QN) = l1 + l2
 
+using ITensors: QN
+using ..NDTensors.SymmetrySectors: SymmetrySectors
+SymmetrySectors.dual(l::QN) = -l
+
 ## TODO: Add this back, define `CombinerArrays` library in NDTensors!
 ## using ..NDTensors: CombinerTensor, CombinerArray, storage
 ## # TODO: Delete when we directly use `CombinerArray` as storage.

--- a/src/lib/ITensorsNamedDimsArraysExt/test/Project.toml
+++ b/src/lib/ITensorsNamedDimsArraysExt/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
+NDTensors = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"

--- a/src/lib/ITensorsNamedDimsArraysExt/test/test_basics.jl
+++ b/src/lib/ITensorsNamedDimsArraysExt/test/test_basics.jl
@@ -1,0 +1,33 @@
+@eval module $(gensym())
+using BlockArrays: blocklengths
+using ITensors: ITensor, Index, QN, dag, inds, plev, random_itensor
+using ITensors.ITensorsNamedDimsArraysExt: to_nameddimsarray
+using NDTensors: tensor
+using NDTensors.BlockSparseArrays: BlockSparseArray, block_nstored
+using NDTensors.GradedAxes: isdual
+using NDTensors.LabelledNumbers: label
+using NDTensors.NamedDimsArrays: NamedDimsArray, unname
+using Test: @test, @testset
+@testset "to_nameddimsarray" begin
+  i = Index([QN(0) => 2, QN(1) => 3])
+  a = random_itensor(i', dag(i))
+  b = to_nameddimsarray(a)
+  @test b isa ITensor
+  @test plev(inds(b)[1]) == 1
+  @test plev(inds(b)[2]) == 0
+  @test inds(b)[1] == i'
+  @test inds(b)[2] == dag(i)
+  nb = tensor(b)
+  @test nb isa NamedDimsArray{Float64}
+  bb = unname(nb)
+  @test bb isa BlockSparseArray{Float64}
+  @test !isdual(axes(bb, 1))
+  @test isdual(axes(bb, 2))
+  @test blocklengths(axes(bb, 1)) == [2, 3]
+  @test blocklengths(axes(bb, 2)) == [2, 3]
+  @test label.(blocklengths(axes(bb, 1))) == [QN(0), QN(1)]
+  @test label.(blocklengths(axes(bb, 2))) == [QN(0), QN(-1)]
+  @test block_nstored(bb) == 2
+  @test b' * b ≈ to_nameddimsarray(a' * a)
+end
+end

--- a/src/lib/ITensorsNamedDimsArraysExt/test/test_examples.jl
+++ b/src/lib/ITensorsNamedDimsArraysExt/test/test_examples.jl
@@ -1,5 +1,17 @@
+@eval module $(gensym())
+using ITensors: ITensors
+using Suppressor: @suppress
 using Test: @testset
-
 @testset "examples" begin
-  include("../examples/example_readme.jl")
+  @suppress include(
+    joinpath(
+      pkgdir(ITensors),
+      "src",
+      "lib",
+      "ITensorsNamedDimsArraysExt",
+      "examples",
+      "example_readme.jl",
+    ),
+  )
+end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/test/lib/ITensorsNamedDimsArraysExt/Project.toml
+++ b/test/lib/ITensorsNamedDimsArraysExt/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
+NDTensors = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"

--- a/test/lib/ITensorsNamedDimsArraysExt/runtests.jl
+++ b/test/lib/ITensorsNamedDimsArraysExt/runtests.jl
@@ -1,0 +1,8 @@
+@eval module $(gensym())
+using ITensors: ITensors
+include(
+  joinpath(
+    pkgdir(ITensors), "src", "lib", "ITensorsNamedDimsArraysExt", "test", "runtests.jl"
+  ),
+)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ ITensors.disable_threaded_blocksparse()
       "base",
       "threading",
       "lib/ContractionSequenceOptimization",
+      "lib/ITensorsNamedDimsArraysExt",
       "ext/ITensorsChainRulesCoreExt",
       "ext/ITensorsVectorInterfaceExt",
       "ext/NDTensorsMappedArraysExt",


### PR DESCRIPTION
With this PR, we can now use `to_nameddimsarray` to convert `ITensor`, `MPS`, and `MPO` objects that contain tensors with the current format for non-fused abelian symmetric ITensors, i.e. an `NDTensors.Tensor` with `BlockSparse` storage and `QN` blocks labels, to the new format we are developing, i.e. a `NamedDimsArray` wrapping a `BlockSparseArray` with `GradedUnitRange` axes. In the current design, the block labels of the graded unit range still use the old format for sector labels, i.e. the `ITensors.QuantumNumbers.QN` type, but it would be easy to support converting those to the new `SymmetrySectors.SectorProduct` format. Interestingly, it only required overloading `GradedAxes.fuse_labels(::QN, ::QN)` to make that work, which I think is a testament to the flexibility of the new code is design!

@ogauthe I also fixed a missing overload for `GradedUnitRangeDual` that I hit when contracting ITensors with the new data format (similar to the definitions introduced in #1571).

So to be concrete, after this PR you can do the following:
```julia
using ITensors: Index, QN, dag, random_itensor
using ITensors.ITensorsNamedDimsArraysExt: to_nameddimsarray
i = Index([QN(0) => 2, QN(1) => 3])
a = random_itensor(i', dag(i))
b = to_nameddimsarray(a)
b' * b ≈ to_nameddimsarray(a' * a)
```
which returns `true`. You can see the data format of `b` is:
```julia
julia> using NDTensors: tensor

julia> tensor(b)
5×5 NDTensors.NamedDimsArrays.NamedDimsArray{Float64, 2, NDTensors.BlockSparseArrays.BlockSparseArray{Float64, 2, Matrix{Float64}, NDTensors.SparseArrayDOKs.SparseArrayDOK{Matrix{Float64}, 2, NDTensors.BlockSparseArrays.BlockZero{Tuple{NDTensors.GradedAxes.GradedOneTo{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}, Vector{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}}}, NDTensors.GradedAxes.GradedUnitRangeDual{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}, Vector{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}}, NDTensors.GradedAxes.GradedOneTo{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}, Vector{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}}}}}}}, Tuple{NDTensors.GradedAxes.GradedOneTo{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}, Vector{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}}}, NDTensors.GradedAxes.GradedUnitRangeDual{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}, Vector{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}}, NDTensors.GradedAxes.GradedOneTo{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}, Vector{NDTensors.LabelledNumbers.LabelledInteger{Int64, QN}}}}}}, Tuple{ITensors.IndexID, ITensors.IndexID}} with indices GradedOneTo[QN(0) => 1:2, QN(1) => 3:5]×GradedUnitRangeDual[QN(0) => 1:2, QN(1) => 3:5]:
 -0.47797  -0.059555   0.0       0.0        0.0
 -1.14491  -0.121613   0.0       0.0        0.0
  0.0       0.0        1.17931  -0.128576  -0.615945
  0.0       0.0       -1.16749   0.952272  -0.210146
  0.0       0.0        1.15278  -1.20505    1.12212
```

To-do:
- [x] Add tests.