### PR TITLE
[WIP] [BlockSparseArrays] Direct sum/`cat`

### DIFF
--- a/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/indexing.jl
+++ b/NDTensors/src/lib/SparseArrayInterface/src/sparsearrayinterface/indexing.jl
@@ -143,6 +143,17 @@ function sparse_setindex!(a::AbstractArray, value, I::CartesianIndex{1})
   return a
 end
 
+# Slicing
+function sparse_setindex!(a::AbstractArray, value, I::AbstractUnitRange...)
+  inds = CartesianIndices(I)
+  for i in stored_indices(value)
+    if i in CartesianIndices(inds)
+      a[inds[i]] = value[i]
+    end
+  end
+  return a
+end
+
 # Handle trailing indices
 function sparse_setindex!(a::AbstractArray, value, I::CartesianIndex)
   t = Tuple(I)


### PR DESCRIPTION
This is work in progress towards direct summing/[concatenating](https://docs.julialang.org/en/v1/base/arrays/#Base.cat) block sparse arrays, and also sparse arrays since that will be used by block sparse array concatenation. This will address an issue listed in #1336.

To-do:
- [ ] Upload implementations of [`cat`](https://docs.julialang.org/en/v1/base/arrays/#Base.cat) for sparse and block sparse arrays.
- [ ] Add tests.