### PR TITLE
[NestedPermutedDimsArrays] Fix `setindex!`

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.71"
+version = "0.3.72"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/NestedPermutedDimsArrays/test/runtests.jl
+++ b/NDTensors/src/lib/NestedPermutedDimsArrays/test/runtests.jl
@@ -5,19 +5,19 @@ using Test: @test, @testset
   Float32, Float64, Complex{Float32}, Complex{Float64}
 )
   a = map(_ -> randn(elt, 2, 3, 4), CartesianIndices((2, 3, 4)))
-  perm = (3, 2, 1)
+  perm = (3, 1, 2)
   p = NestedPermutedDimsArray(a, perm)
   T = PermutedDimsArray{elt,3,perm,invperm(perm),eltype(a)}
   @test typeof(p) === NestedPermutedDimsArray{T,3,perm,invperm(perm),typeof(a)}
-  @test size(p) == (4, 3, 2)
+  @test size(p) == (4, 2, 3)
   @test eltype(p) === T
   for I in eachindex(p)
-    @test size(p[I]) == (4, 3, 2)
-    @test p[I] == permutedims(a[CartesianIndex(reverse(Tuple(I)))], perm)
+    @test size(p[I]) == (4, 2, 3)
+    @test p[I] == permutedims(a[CartesianIndex(map(i -> Tuple(I)[i], invperm(perm)))], perm)
   end
-  x = randn(elt, 4, 3, 2)
-  p[3, 2, 1] = x
-  @test p[3, 2, 1] == x
-  @test a[1, 2, 3] == permutedims(x, perm)
+  x = randn(elt, 4, 2, 3)
+  p[3, 1, 2] = x
+  @test p[3, 1, 2] == x
+  @test a[1, 2, 3] == permutedims(x, invperm(perm))
 end
 end


### PR DESCRIPTION
The previous version of `setindex!` wasn't inverting the permutation, this fixes that issue. I also changed the tests to catch that issue, the previous version didn't catch it since the permutation was its own inverse.

Additionally, I added some comments about how the `NestedPermutedDimsArrays` module could be rewritten using a `PermutedDimsArray` wrapping a `MappedArrays.MappedArray`, as mentioned in #1336. I tried it out and it mostly works but there would be a few issues to work through with that approach, probably best to keep it on the back burner for now and reassess later.