### PR TITLE
[NDTensors] Downgrade GPUArraysCore to v0.1

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.3.72"
+version = "0.3.73"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -68,7 +68,7 @@ EllipsisNotation = "1.8"
 FillArrays = "1"
 Folds = "0.2.8"
 Functors = "0.2, 0.3, 0.4, 0.5"
-GPUArraysCore = "0.1, 0.2"
+GPUArraysCore = "0.1"
 HDF5 = "0.14, 0.15, 0.16, 0.17"
 HalfIntegers = "1"
 InlineStrings = "1"


### PR DESCRIPTION
There are a lot of changes going on in the GPU backends recently. [GPUArrays.jl](https://github.com/JuliaGPU/GPUArrays.jl), which provides common GPU array functionality that is shared by CUDA.jl, AMDGPU.jl, Metal.jl, etc., recently transitioned to depending on [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl) for writing native Julia code that gets cross-compiled across different GPU backends. Very cool stuff! However, that change seems to have [broken a few things](https://github.com/JuliaGPU/GPUArrays.jl/issues/571) in our tests which we need to investigate, in the meantime I'll downgrade to a version before that transition and try things out again once the dust settles.