### PR TITLE
[DOCS] Warning in `ITensors.compile()` docs about ITensors v0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.7.8"
+version = "0.7.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/packagecompile/compile.jl
+++ b/src/packagecompile/compile.jl
@@ -50,5 +50,11 @@ This will take some time, perhaps a few minutes.
 This will create a system image containing the compiled version of ITensors
 located at `dir/filename`, by default `$(default_compile_path())`.
 
+!!! compat "ITensors 0.7"
+    As of ITensors 0.7, you must now install and load the
+    [ITensorMPS.jl](https://github.com/ITensor/ITensorMPS.jl) package
+    in order to use `ITensors.compile()`, since it relies on running MPS/MPO
+    functionality as example code for Julia to compile.
+
 $(compile_note())
 """ compile


### PR DESCRIPTION
Add warning in `ITensors.compile()` docstring about requiring `ITensorMPS.jl` to be loaded in ITensors v0.7. Addresses #1605.