### PR TITLE
 Fix `VectorInterface.scalartype` for arrays of ITensors 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.7.12"
+version = "0.7.13"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/ITensorsVectorInterfaceExt/ITensorsVectorInterfaceExt.jl
+++ b/ext/ITensorsVectorInterfaceExt/ITensorsVectorInterfaceExt.jl
@@ -58,6 +58,15 @@ function VectorInterface.scalartype(a::ITensor)
   return ITensors.scalartype(a)
 end
 
+# Circumvent issue that `VectorInterface.jl` computes
+# the scalartype in the type domain, which isn't known
+# for ITensors.
+function VectorInterface.scalartype(a::AbstractArray{ITensor})
+  # Like the implementation of `LinearAlgebra.promote_leaf_eltypes`:
+  # https://github.com/JuliaLang/LinearAlgebra.jl/blob/e7da19f2764ba36bd0a9eb8ec67dddce19d87114/src/generic.jl#L1933
+  return mapreduce(VectorInterface.scalartype, promote_type, a; init=Bool)
+end
+
 function VectorInterface.scale(a::ITensor, α::Number)
   return a * α
 end

--- a/test/ext/ITensorsVectorInterfaceExt/runtests.jl
+++ b/test/ext/ITensorsVectorInterfaceExt/runtests.jl
@@ -1,5 +1,5 @@
 @eval module $(gensym())
-using ITensors: Index, dag, inds, random_itensor
+using ITensors: ITensor, Index, dag, inds, random_itensor
 using Test: @test, @testset
 using VectorInterface:
   add,
@@ -68,6 +68,9 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
   # scalartype
   @test scalartype(a) === elt
   @test scalartype(b) === elt
+  @test scalartype([a, b]) === elt
+  @test scalartype([a, random_itensor(Float32, i, j)]) === elt
+  @test scalartype(ITensor[]) === Bool
 
   # scale
   @test scale(a, α) ≈ α * a


### PR DESCRIPTION
This fixes an issue exposed in https://github.com/ITensor/ITensorMPS.jl/pull/109.