### PR TITLE
[DOCS] Fix typo in state names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/IncludedSiteTypes.md
+++ b/docs/src/IncludedSiteTypes.md
@@ -149,7 +149,7 @@ sites = siteinds("S=1",N; conserve_sz=true, qnname_sz="TotalSz")
 The available state names for "S=1" sites are:
 - `"Up"` (aliases: `"Z+"`, `"↑"`) spin in the up state
 - `"Z0"` (aliases: `"0"`) spin in the Sz=0 state
-- `"Dn"` (aliases: `"Z-"`, `"↓"`) spin in the Sz=0 state
+- `"Dn"` (aliases: `"Z-"`, `"↓"`) spin in the down state
 
 #### "S=1" Operators
 


### PR DESCRIPTION
This PR fixes a small typo in the docs reported by forum user Zhen_H in the following post:
https://itensor.discourse.group/t/small-typo-in-the-itensor-documentation/2274
