### PR TITLE
[DOCS] Update links for operator definitions

### DIFF
--- a/src/lib/SiteTypes/src/sitetype.jl
+++ b/src/lib/SiteTypes/src/sitetype.jl
@@ -34,7 +34,7 @@ There are currently a few built-in site types
 recognized by `jl`. The system is easily extensible
 by users. To add new operators to an existing site type,
 or to create new site types, you can follow the instructions
-[here](https://itensor.github.io/jl/stable/examples/Physics.html).
+[here](https://itensor.github.io/ITensors.jl/stable/examples/Physics.html).
 
 The current built-in site types are:
 
@@ -106,8 +106,8 @@ Many operators are available, for example:
    `"Cdagup"`, `"Cdn"`, `"Cdagdn"`, `"Sz"`, `"Sx"`, `"Sy"`, `"S+"`, `"S-"`, ...
 - ...
 
-You can view the source code for the internal SiteType definitions
-and operators that are defined [here](https://github.com/ITensor/jl/tree/main/src/physics/site_types).
+You can view the internal SiteType definitions and operators
+[here](https://itensor.github.io/ITensors.jl/stable/IncludedSiteTypes.html).
 """
 SiteType(s::AbstractString) = SiteType{SmallString(s)}()
 
@@ -228,9 +228,9 @@ s = Index(2, "Site,S=1/2")
 Sz = op("Sz", s)
 ```
 
-To see all of the operator names defined for the site types included with
-ITensor, please view the [source code](https://github.com/ITensor/jl/tree/main/src/physics/site_types)
-for each site type. Note that some site types such as "S=1/2" and "Qubit"
+You can see all of the operator names defined for the site types included
+with ITensor [here](https://itensor.github.io/ITensors.jl/dev/IncludedSiteTypes.html).
+Note that some site types such as "S=1/2" and "Qubit"
 are aliases for each other and share operator definitions.
 """
 function op(name::AbstractString, s::Index...; adjoint::Bool=false, kwargs...)


### PR DESCRIPTION
# Description

Updated link refs in documentation of `SiteType`

Fixes #1626

# How Has This Been Tested?

I've run `make_local_notest.jl` and checked that the new links worked.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
