### PR TITLE
[Docs] Fixed links in sitetypes.jl to the new site

### DIFF
--- a/src/lib/SiteTypes/src/sitetype.jl
+++ b/src/lib/SiteTypes/src/sitetype.jl
@@ -229,7 +229,7 @@ Sz = op("Sz", s)
 ```
 
 You can see all of the operator names defined for the site types included
-with ITensor [here](https://itensor.github.io/ITensors.jl/dev/IncludedSiteTypes.html).
+with ITensor [here](https://docs.itensor.org/ITensorMPS/stable/IncludedSiteTypes.html).
 Note that some site types such as "S=1/2" and "Qubit"
 are aliases for each other and share operator definitions.
 """

--- a/src/lib/SiteTypes/src/sitetype.jl
+++ b/src/lib/SiteTypes/src/sitetype.jl
@@ -34,7 +34,7 @@ There are currently a few built-in site types
 recognized by `jl`. The system is easily extensible
 by users. To add new operators to an existing site type,
 or to create new site types, you can follow the instructions
-[here](https://itensor.github.io/ITensors.jl/stable/examples/Physics.html).
+[here](https://docs.itensor.org/ITensorMPS/stable/examples/Physics.html).
 
 The current built-in site types are:
 
@@ -107,7 +107,7 @@ Many operators are available, for example:
 - ...
 
 You can view the internal SiteType definitions and operators
-[here](https://itensor.github.io/ITensors.jl/stable/IncludedSiteTypes.html).
+[here](https://docs.itensor.org/ITensorMPS/stable/IncludedSiteTypes.html).
 """
 SiteType(s::AbstractString) = SiteType{SmallString(s)}()
 


### PR DESCRIPTION
# Description

In the last changes the links in `sitetype.jl` became again unreachable. I don't know if you were already scheduling to change them but since I noticed it I thought to change them on the fly, hoping you don't mind.

# How Has This Been Tested?
The new links correctly send to the new site

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
