### PR TITLE
[ITensors] Use `task_local_storage` for Index ID RNG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -155,8 +155,4 @@ include("deprecated.jl")
 include("argsdict/argsdict.jl")
 include("packagecompile/compile.jl")
 include("developer_tools.jl")
-
-function __init__()
-  return resize!(empty!(INDEX_ID_RNGs), Threads.nthreads()) # ensures that we didn't save a bad object
-end
 end

--- a/src/index.jl
+++ b/src/index.jl
@@ -1,6 +1,6 @@
 using NDTensors: NDTensors, sim
 using .QuantumNumbers: QuantumNumbers, Arrow, In, Neither, Out
-using Random: Random
+using Random: Xoshiro
 using .TagSets:
   TagSets, TagSet, @ts_str, addtags, commontags, hastags, removetags, replacetags
 

--- a/src/index.jl
+++ b/src/index.jl
@@ -8,7 +8,7 @@ using .TagSets:
 const IDType = UInt64
 
 const _INDEX_ID_RNG_KEY = :ITensors_index_id_rng_bLeTZeEsme4bG3vD
-index_id_rng() = get!(task_local_storage(), _INDEX_ID_RNG_KEY, Xoshiro())
+index_id_rng() = get!(task_local_storage(), _INDEX_ID_RNG_KEY, Xoshiro())::Xoshiro
 
 """
 An `Index` represents a single tensor index with fixed dimension `dim`. Copies of an Index compare equal unless their

--- a/src/index.jl
+++ b/src/index.jl
@@ -1,26 +1,14 @@
 using NDTensors: NDTensors, sim
 using .QuantumNumbers: QuantumNumbers, Arrow, In, Neither, Out
+using Random: Random
 using .TagSets:
   TagSets, TagSet, @ts_str, addtags, commontags, hastags, removetags, replacetags
 
 #const IDType = UInt128
 const IDType = UInt64
 
-# Custom RNG for Index id
-# Vector of RNGs, one for each thread
-const INDEX_ID_RNGs = MersenneTwister[]
-@inline index_id_rng() = index_id_rng(Threads.threadid())
-@noinline function index_id_rng(tid::Int)
-  0 < tid <= length(INDEX_ID_RNGs) || _index_id_rng_length_assert()
-  if @inbounds isassigned(INDEX_ID_RNGs, tid)
-    @inbounds MT = INDEX_ID_RNGs[tid]
-  else
-    MT = MersenneTwister()
-    @inbounds INDEX_ID_RNGs[tid] = MT
-  end
-  return MT
-end
-@noinline _index_id_rng_length_assert() = @assert false "0 < tid <= length(INDEX_ID_RNGs)"
+const _INDEX_ID_RNG_KEY = :ITensors_index_id_rng_bLeTZeEsme4bG3vD
+index_id_rng() = get!(task_local_storage(), _INDEX_ID_RNG_KEY, Xoshiro())
 
 """
 An `Index` represents a single tensor index with fixed dimension `dim`. Copies of an Index compare equal unless their

--- a/test/ext/ITensorsTensorOperationsExt/runtests.jl
+++ b/test/ext/ITensorsTensorOperationsExt/runtests.jl
@@ -150,10 +150,10 @@ end
     tmp * As[n]
     allocations_right_associative_pairwise += @allocated tmp = tmp * As[n]
   end
-  @test allocations_right_associative_pairwise ≈ allocations_right_associative_1 rtol = 0.1
-  @test allocations_right_associative_pairwise ≈ allocations_right_associative_2 rtol = 0.1
+  @test allocations_right_associative_pairwise ≈ allocations_right_associative_1 rtol = 0.2
+  @test allocations_right_associative_pairwise ≈ allocations_right_associative_2 rtol = 0.2
   @test allocations_right_associative_pairwise ≈ allocations_right_associative_3 rtol = 0.2
-  @test allocations_right_associative_pairwise ≈ allocations_right_associative_4 rtol = 0.1
+  @test allocations_right_associative_pairwise ≈ allocations_right_associative_4 rtol = 0.2
 
   @test allocations_right_associative_1 < allocations_left_associative
   @test allocations_right_associative_2 < allocations_left_associative


### PR DESCRIPTION
This uses [`task_local_storage`](https://docs.julialang.org/en/v1/base/parallel/#Base.task_local_storage-Tuple{Any}) in the Index ID RNG to avoid thread-local states as recommended in https://julialang.org/blog/2023/07/PSA-dont-use-threadid.

Issues with the previous design were pointed out by @amilsted.