### PR TITLE
[ITensors] Qualify overloading `NDTensors.Tensor`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/itensor.jl
+++ b/src/itensor.jl
@@ -148,8 +148,8 @@ ITensor(::AliasStyle, args...; kwargs...)::ITensor = error(
 Create a `Tensor` that stores a copy of the storage and
 indices of the input `ITensor`.
 """
-Tensor(T::ITensor)::Tensor = Tensor(NeverAlias(), T)
-Tensor(as::NeverAlias, T::ITensor)::Tensor = Tensor(AllowAlias(), copy(T))
+NDTensors.Tensor(T::ITensor)::Tensor = Tensor(NeverAlias(), T)
+NDTensors.Tensor(as::NeverAlias, T::ITensor)::Tensor = Tensor(AllowAlias(), copy(T))
 
 """
     tensor(::ITensor)
@@ -157,7 +157,7 @@ Tensor(as::NeverAlias, T::ITensor)::Tensor = Tensor(AllowAlias(), copy(T))
 Convert the `ITensor` to a `Tensor` that shares the same
 storage and indices as the `ITensor`.
 """
-Tensor(::AllowAlias, A::ITensor) = A.tensor
+NDTensors.Tensor(::AllowAlias, A::ITensor) = A.tensor
 
 """
     ITensor([::Type{ElT} = Float64, ]inds)

--- a/test/threading/test_threading.jl
+++ b/test/threading/test_threading.jl
@@ -1,4 +1,3 @@
-using Compat
 using ITensors
 using Test
 using LinearAlgebra
@@ -8,7 +7,7 @@ if isone(Threads.nthreads())
 end
 
 @testset "Threading" begin
-  blas_num_threads = Compat.get_num_threads()
+  blas_num_threads = BLAS.get_num_threads()
   strided_num_threads = ITensors.NDTensors.Strided.get_num_threads()
 
   BLAS.set_num_threads(1)


### PR DESCRIPTION
# Description

Fixing a warning and an error revealed for `julia 1.12-beta1`. In particular:
1. Warning: Explicitly reference `NDTensors` for `Tensor` constructor from `ITensors`
2. Warning: Change `Compat.get_num_threads` to `BLAS.get_num_threads` since first one is deprecated.
3. Error in `contract_threads`: `threadid` goes from `nthreads(:interactive) .+ 1:nthreads(:default)` as reported in [`nthreads`](https://docs.julialang.org/en/v1/base/multi-threading/#Base.Threads.nthreads). The error was not spotted previously case the number of interactive threads was defaulted to `0`, but now the default value is `1` as reported in the [News](https://github.com/JuliaLang/julia/blob/v1.12.0-beta1/NEWS.md#language-changes). Note that this fixes the error, but [`threadid`](https://docs.julialang.org/en/v1/base/multi-threading/#Base.Threads.threadid) documentation suggest to don't use it for indexing arrays.

All the modifications should be still compatible with `julia 1.11.5`.

Fixes #1647 

# How Has This Been Tested?

Please add tests that verify your changes to a file in the `test` directory.

Please give a summary of the tests that you added to verify your changes.

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
