### PR TITLE
[NDTensors] Better `eigen` backend in Julia v1.12

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,7 +1,7 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.4.9"
+version = "0.4.10"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/NDTensors/src/lib/Expose/src/functions/linearalgebra.jl
+++ b/NDTensors/src/lib/Expose/src/functions/linearalgebra.jl
@@ -20,6 +20,20 @@ function ql_positive(E::Exposed)
   return ql_positive(unexpose(E))
 end
 
+function LinearAlgebra.eigen(E::Exposed{<:Any,<:Union{Hermitian,Symmmetric}})
+  if VERSION ≥ v"1.12-"
+    # The default algorithm for eigenvalue decomposition in Julia 1.12 and later
+    # changed from `syevr` (`LinearAlgebra.RobustRepresentations()`) to `syevd`
+    # (`LinearAlgebra.DivideAndConquer()`) in https://github.com/JuliaLang/julia/pull/49262,
+    # https://github.com/JuliaLang/julia/pull/49355.
+    # However, there are cases where `syevd` fails, see:
+    # https://itensor.discourse.group/t/issue-with-linearalgebra-and-julia-1-12/2362,
+    # https://github.com/JuliaLang/LinearAlgebra.jl/issues/1313.
+    return eigen(unexpose(E); alg=LinearAlgebra.RobustRepresentations())
+  end
+  return eigen(unexpose(E))
+end
+
 function LinearAlgebra.eigen(E::Exposed)
   return eigen(unexpose(E))
 end


### PR DESCRIPTION
See https://itensor.discourse.group/t/issue-with-linearalgebra-and-julia-1-12/2362.

@VinceNeede

I'll wait to see what happens with https://github.com/JuliaLang/LinearAlgebra.jl/issues/1313, the default might be changed before the official Julia v1.12 release.