### PR TITLE
Exp for fermionic tensors 1188

### DIFF
--- a/src/tensor_operations/matrix_algebra.jl
+++ b/src/tensor_operations/matrix_algebra.jl
@@ -43,24 +43,23 @@ function exp(A::ITensor, Linds, Rinds; ishermitian=false)
     end
   end
 
-  N = ndims(A)
   NL = length(Linds)
   NR = length(Rinds)
   NL != NR && error("Must have equal number of left and right indices")
-  N != NL + NR &&
+  ndims(A) != NL + NR &&
     error("Number of left and right indices must add up to total number of indices")
 
   # Permute Lis, Ris to be in same order as on A
   Lis = permute(commoninds(A, Linds), Linds)
   Ris = permute(commoninds(A, Rinds), Rinds)
 
-  # Ensure the indices have the correct directions,
-  # QNs, etc.
+  # Ensure indices have correct directions, QNs, etc.
   for (l, r) in zip(Lis, Ris)
-    dir_check = hasqns(A) ? dir(l) == dir(dag(r)) : true
-    if !(dir_check && noprime(l) == noprime(r))
-      dir_msg = hasqns(A) ? " and opposite directions" : ""
-      error("In exp, indices must come in pairs with equal spaces$dir_msg.")
+    if space(l) != space(r)
+      error("In exp, indices must come in pairs with equal spaces.")
+    end
+    if hasqns(A) && dir(l) == dir(r)
+      error("In exp, indices must come in pairs with opposite directions")
     end
   end
 

--- a/src/tensor_operations/matrix_algebra.jl
+++ b/src/tensor_operations/matrix_algebra.jl
@@ -50,18 +50,12 @@ function exp(A::ITensor, Linds, Rinds; ishermitian=false)
   N != NL + NR &&
     error("Number of left and right indices must add up to total number of indices")
 
-  # Linds, Rinds may not have the correct directions
-  # TODO: does the need a conversion?
-  Lis = Linds
-  Ris = Rinds
+  # Permute Lis, Ris to be in same order as on A
+  Lis = permute(commoninds(A, Linds), Linds)
+  Ris = permute(commoninds(A, Rinds), Rinds)
 
   # Ensure the indices have the correct directions,
   # QNs, etc.
-
-  # Permute Lis, Ris to be in same order as on A
-  Lis = permute(commoninds(A, Lis), Lis)
-  Ris = permute(commoninds(A, Ris), Ris)
-
   for (l, r) in zip(Lis, Ris)
     dir_check = hasqns(A) ? dir(l) == dir(dag(r)) : true
     if !(dir_check && noprime(l) == noprime(r))

--- a/test/base/test_fermions.jl
+++ b/test/base/test_fermions.jl
@@ -792,6 +792,15 @@ using ITensors.SiteTypes: op, siteind, siteinds
     # Permute and test again
     id_tensor = permute(id_tensor, s[2], s[1], s[2]', s[1]')
     @test id_tensor ≈ exp(0.0 * id_tensor)
+
+    # Explicitly passing indices in different, valid orders
+    @test id_tensor ≈ exp(0.0 * id_tensor, (s[1]', s[2]'), (dag(s[1]), dag(s[2])))
+    @test id_tensor ≈ exp(0.0 * id_tensor, (s[2]', s[1]'), (dag(s[2]), dag(s[1])))
+    @test id_tensor ≈ exp(0.0 * id_tensor, (dag(s[1]), dag(s[2])), (s[1]', s[2]'))
+    @test id_tensor ≈ exp(0.0 * id_tensor, (dag(s[2]), dag(s[1])), (s[2]', s[1]'))
+
+    # Check wrong index ordering fails (i.e. we are actually paying attention to it)
+    @test norm(id_tensor - exp(0.0 * id_tensor, (dag(s[1]), dag(s[2])), (s[2]', s[1]'))) > 1
   end
 
   ITensors.disable_auto_fermion()

--- a/test/base/test_fermions.jl
+++ b/test/base/test_fermions.jl
@@ -1,6 +1,6 @@
 using ITensors, Test
 import ITensors: Out, In
-using ITensors.SiteTypes: op, siteinds
+using ITensors.SiteTypes: op, siteind, siteinds
 
 @testset "Fermions" begin
   ITensors.enable_auto_fermion()
@@ -776,6 +776,22 @@ using ITensors.SiteTypes: op, siteinds
     a = random_itensor(i', i)
     d, u = eigen(a)
     @test norm(a * u - u' * d) ≈ 0 atol = √(eps(real(eltype(a))))
+  end
+
+  @testset "Fermion exp Tests" begin
+    s = siteinds("Fermion", 2; conserve_qns=true)
+
+    # Matrix test
+    id_tensor = op("I", s[1])
+    @test id_tensor ≈ exp(0.0 * id_tensor)
+
+    # Tensor test
+    id_tensor = op("I", s[1]) * op("I", s[2])
+    @test id_tensor ≈ exp(0.0 * id_tensor)
+
+    # Permute and test again
+    id_tensor = permute(id_tensor, s[2], s[1], s[2]', s[1]')
+    @test id_tensor ≈ exp(0.0 * id_tensor)
   end
 
   ITensors.disable_auto_fermion()


### PR DESCRIPTION

# Description

Fix the `exp` function for fermionic ITensors, by bringing the indices into a canonical ordering `(i',j',k', dag(k), dag(j), dag(i))` with the `Out` indices ordered first, and then temporarily turning off the fermion system for the remainder of the `exp` operation. 

Fixes #1188

Issue #1188 and the included unit test give a good demonstration of the previous behavior and new behavior.

# Checklist:

- [X] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that verify the behavior of the changes I made.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
