### PR TITLE
Add parity warnings to Fermion and Electron site types

### DIFF
--- a/src/lib/SiteTypes/src/sitetypes/electron.jl
+++ b/src/lib/SiteTypes/src/sitetypes/electron.jl
@@ -27,6 +27,9 @@ function space(
   if !isnothing(conserve_parity)
     conserve_nfparity = conserve_parity
   end
+  if conserve_nf && conserve_nfparity
+    @warn "Setting conserve_nfparity=true when conserve_nf=true for \"Electron\" SiteType will have no effect, and only the \"Nf\" quantum number will be explicitly conserved."
+  end
   if conserve_sz && conserve_nf
     return [
       QN((qnname_nf, 0, -1), (qnname_sz, 0)) => 1

--- a/src/lib/SiteTypes/src/sitetypes/fermion.jl
+++ b/src/lib/SiteTypes/src/sitetypes/fermion.jl
@@ -28,6 +28,9 @@ function space(
   if !isnothing(conserve_parity)
     conserve_nfparity = conserve_parity
   end
+  if conserve_nf && conserve_nfparity
+    @warn "Setting conserve_nfparity=true when conserve_nf=true for \"Fermion\" SiteType will have no effect, and only the \"Nf\" quantum number will be explicitly conserved."
+  end
   if conserve_sz == true
     conserve_sz = "Up"
   end


### PR DESCRIPTION
Based on the forum discussion [here](https://itensor.discourse.group/t/unexpected-qns-for-fermionic-siteind/2456/3), this PR adds warning messages to both the Fermion and Electron `space` functions that explains how setting `conserve_nfparity=true` when `conserve_nf=true` will have no effect beyond conserving `Nf`.
