### PR TITLE
Fix exp check for fermionic ITensors

### DIFF
--- a/src/tensor_operations/matrix_algebra.jl
+++ b/src/tensor_operations/matrix_algebra.jl
@@ -65,8 +65,8 @@ function exp(A::ITensor, Linds, Rinds; ishermitian=false)
   end
 
   # <fermions>
-  auto_fermion_enabled = using_auto_fermion()
-  if auto_fermion_enabled
+  fermionic_itensor = using_auto_fermion() && has_fermionic_subspaces(inds(A))
+  if fermionic_itensor
     # If fermionic, bring indices into i',j',..,dag(j),dag(i)
     # ordering with Out indices coming before In indices
     # Resulting tensor acts like a normal matrix (no extra signs
@@ -95,7 +95,7 @@ function exp(A::ITensor, Linds, Rinds; ishermitian=false)
   expA = (itensor(expAT) * dag(CR)) * dag(CL)
 
   # <fermions>
-  if auto_fermion_enabled
+  if fermionic_itensor
     # Ensure expA indices in "matrix" form before re-enabling fermion system
     expA = permute(expA, ordered_inds)
     enable_auto_fermion()

--- a/test/base/test_fermions.jl
+++ b/test/base/test_fermions.jl
@@ -1,3 +1,4 @@
+@eval module $(gensym())
 using ITensors, Test
 import ITensors: Out, In
 using ITensors.SiteTypes: op, siteind, siteinds
@@ -805,3 +806,5 @@ using ITensors.SiteTypes: op, siteind, siteinds
 
   ITensors.disable_auto_fermion()
 end
+
+end # module

--- a/test/base/test_qnitensor.jl
+++ b/test/base/test_qnitensor.jl
@@ -1,9 +1,11 @@
+@eval module $(gensym())
 using ITensors
 using ITensors.NDTensors
 using ITensors.SiteTypes: siteind, siteinds
 using LinearAlgebra
 using Random
 using Test
+using ITensors.SiteTypes: op
 
 Random.seed!(1234)
 
@@ -1915,3 +1917,5 @@ Random.seed!(1234)
     @test !ITensors.have_same_qns([QN(0) => 1, QN(0) => 2, QN(("Sz", 2)) => 1])
   end
 end
+
+end # module


### PR DESCRIPTION
This PR fixes the check inside the `exp` function so it is restricted to fermionic ITensors (and when the fermion system is on) only. 

Choosing `Linds` and `Rinds` to all have the same arrows within each set may be advisable for most cases, but we decided to allow mixed-arrow `exp` for now.

This PR also wraps selected tests in generated modules. Previously the `test_qnitensors.jl` file would error if run standalone, due to a missing import.
