### PR TITLE
Fix sqrt decomp

### DIFF
--- a/src/tensor_operations/matrix_decomposition.jl
+++ b/src/tensor_operations/matrix_decomposition.jl
@@ -581,8 +581,8 @@ using NDTensors: map_diag!
 function sqrt_decomp(D::ITensor, u::Index, v::Index)
   (storage(D) isa Union{Diag,DiagBlockSparse}) ||
     error("Must be a diagonal matrix ITensor.")
-  sqrtDL = diag_itensor(u, dag(u)')
-  sqrtDR = diag_itensor(v, dag(v)')
+  sqrtDL = adapt(datatype(D))(diag_itensor(u, dag(u)'))
+  sqrtDR = adapt(datatype(D))(diag_itensor(v, dag(v)'))
   map_diag!(sqrt ∘ abs, sqrtDL, D)
   map_diag!(sqrt ∘ abs, sqrtDR, D)
   δᵤᵥ = copy(D)


### PR DESCRIPTION
A quick fix is implemented to preserve the ITensor type in the `sqrt_decomp` function and allow it to work on GPUs.