### PR TITLE
Fix performance issue for fermion system

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
-version = "0.9.24"
+version = "0.9.25"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
 
 [workspace]

--- a/src/fermions/fermions.jl
+++ b/src/fermions/fermions.jl
@@ -15,7 +15,7 @@ function parity_sign(P)::Int
     L = length(P)
     s = +1
     for i in 1:L, j in (i + 1):L
-        s *= sign(P[j] - P[i])
+        @inbounds s *= sign(P[j] - P[i])
     end
     return s
 end
@@ -70,32 +70,37 @@ Base.isodd(q::QN) = isodd(fparity(q))
 Base.isodd(iv::Pair{<:Index}) = isodd(fparity(iv))
 
 """
-    compute_permfactor(p,iv_or_qn::Vararg{T,N})
+    compute_permfactor(p,iv_or_qn::NTuple{N,T})
 
 Given a permutation p and a set "s" of QNIndexVals or QNs,
 if the subset of index vals which are fermion-parity
 odd undergo an odd permutation (odd number of swaps)
 according to p, then return -1. Otherwise return +1.
 """
-function compute_permfactor(p, iv_or_qn...; range = 1:length(iv_or_qn))::Int
+function compute_permfactor(
+        p,
+        iv_or_qn::NTuple{N, T};
+        range = 1:length(iv_or_qn)
+    )::Int where {N, T}
     !using_auto_fermion() && return 1
-    N = length(iv_or_qn)
-    # XXX: Bug https://github.com/ITensor/ITensors.jl/issues/931
-    # oddp = @MVector zeros(Int, N)
-    oddp = MVector((ntuple(Returns(0), Val(N))))
+    oddp = MVector(ntuple(Returns(0), Val(N)))
     n = 0
-    @inbounds for j in range
-        if fparity(iv_or_qn[p[j]]) == 1
+    for j in range
+        if (@inbounds fparity(iv_or_qn[p[j]]) == 1)
             n += 1
-            oddp[n] = p[j]
+            @inbounds oddp[n] = p[j]
         end
     end
     return parity_sign(oddp[1:n])
 end
 
+# This version of compute_permfactor
+# is for backwards compatibility with ITensorNetworks
+compute_permfactor(p, iv_or_qn...; kws...) = compute_permfactor(p, iv_or_qn; kws...)
+
 function NDTensors.permfactor(p, ivs::Vararg{Pair{QNIndex}, N}; kwargs...) where {N}
     !using_auto_fermion() && return 1
-    return compute_permfactor(p, ivs...; kwargs...)
+    return compute_permfactor(p, ivs; kwargs...)
 end
 
 function NDTensors.permfactor(
@@ -103,7 +108,7 @@ function NDTensors.permfactor(
     ) where {N}
     !using_auto_fermion() && return 1
     qns = ntuple(n -> qn(inds[n], block[n]), N)
-    return compute_permfactor(perm, qns...; kwargs...)
+    return compute_permfactor(perm, qns; kwargs...)
 end
 
 NDTensors.block_parity(i::QNIndex, block::Integer) = fparity(qn(i, block))


### PR DESCRIPTION
This PR fixes a performance issue in the auto-fermion system, in a simpler way than the previous PR https://github.com/ITensor/ITensors.jl/pull/1709.

The fix is as @mtfishman suggested, with the `compute_permfactor` function having a static inference is
sue that was making the construction of an MVector very slow. 

The main changes here are:
1. restrict second argument to `compute_permfactor` to be an `NTuple` so static inference succeeds
2. modify `permfactor` functions to pass a tuple instead of splatting 
3. keep vararg wrapper to `compute_permfactor` as backwards compatibility to code in ITensorNetworks/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl (https://github.com/ITensor/ITensorNetworks.jl/blob/4e59ab208d67f7f9bbc64bdc213b70278bbc6fe0/src/treetensornetworks/opsum_to_ttn/opsum_to_ttn.jl#L390) 
