### PR TITLE
Fix incorrect one-arg Base.hash for Block in NDTensors

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,6 +1,6 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
-version = "0.4.22"
+version = "0.4.23"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
 
 [workspace]

--- a/NDTensors/src/blocksparse/block.jl
+++ b/NDTensors/src/blocksparse/block.jl
@@ -140,8 +140,7 @@ else
     end
 end
 
-hash(b::Block) = UInt(b.hash)
-hash(b::Block, h::UInt) = h + hash(b)
+hash(b::Block, h::UInt) = hash(b.hash, h)
 
 #
 # Custom NTuple{N, Int} hashes


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

## Summary

`hash(b::Block)` in `NDTensors/src/blocksparse/block.jl` defines a one-arg `Base.hash` (via `import Base: hash` in `imports.jl`). This means the two-arg fallback `hash(x, h::UInt)` uses `objectid`-based hashing, which can cause:

- **Correctness bugs**: equal `Block`s may hash differently when used as compound keys in `Dict` or `Set`
- **Performance issues**: excessive method invalidation across the ecosystem
- **Julia 1.13+ breakage**: the default hash seed is changing from `zero(UInt)` to a random value

The existing two-arg method also used addition (`h + hash(b)`) instead of proper hash chaining.

## Fix

Replace both methods with a single proper two-arg `hash(b::Block, h::UInt) = hash(b.hash, h)` that chains the cached hash value through the seed.

## Test plan

- No custom `==` for `Block`; default struct equality compares `data` and `hash` fields, which is consistent with the new hash method
- `Block` is used as Dict key (`Dict{Block{NR}, Bool}`), so correct `Base.hash` is important

---
This PR was generated with the assistance of generative AI.

Co-Authored-By: Claude <noreply@anthropic.com>