### PR TITLE
Add private downstream CI trigger and fork-aware skip

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -11,6 +11,8 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
+permissions:
+  pull-requests: "write"
 jobs:
   integration-test:
     name: "IntegrationTest"
@@ -28,6 +30,7 @@ jobs:
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
       pkg: "${{ matrix.pkg }}"
+      is-fork-pr: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
   integration-gate:
     name: "IntegrationTest"
     needs: "integration-test"

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -1,0 +1,14 @@
+name: "Integration Test Request"
+on:
+  issue_comment:
+    types:
+      - "created"
+jobs:
+  integrationrequest:
+    if: |
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@main"
+    with:
+      localregistry: "https://github.com/ITensor/ITensorRegistry.git"
+    secrets: "inherit"


### PR DESCRIPTION
Add IntegrationTestRequest.yml caller workflow (standard skeleton pattern) so maintainers can comment `/integrationtest <package-url>` on PRs to run private downstream tests.

Update IntegrationTest.yml to pass `is-fork-pr` and add `pull-requests: write` permission for skip notification comments.