### PR TITLE
Remove unnecessary pull-requests write permission from IntegrationTest

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -11,8 +11,6 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
-permissions:
-  pull-requests: "write"
 jobs:
   integration-test:
     name: "IntegrationTest"


### PR DESCRIPTION
## Summary

- Remove `permissions: pull-requests: write` from `IntegrationTest.yml`
- This was added for comment-posting in the fork-PR skip logic, but fork PRs get read-only tokens so it never worked
- Comment-posting was removed from ITensorActions in https://github.com/ITensor/ITensorActions/pull/49, so this permission is no longer needed

## Test plan

- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)