### PR TITLE
Switch IntegrationTest to pull_request_target, add fail-fast false

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - "main"
     tags: "*"
-  pull_request:
+  pull_request_target:
     types:
       - "opened"
       - "synchronize"
@@ -15,6 +15,7 @@ jobs:
   integration-test:
     name: "IntegrationTest"
     strategy:
+      fail-fast: false
       matrix:
         pkg:
           - "ITensorGaussianMPS"
@@ -28,7 +29,6 @@ jobs:
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
       pkg: "${{ matrix.pkg }}"
-      is-fork-pr: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
   integration-gate:
     name: "IntegrationTest"
     needs: "integration-test"

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -8,7 +8,7 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
+
     uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@main"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-    secrets: "inherit"


### PR DESCRIPTION
## Summary

- Switch from `pull_request` to `pull_request_target` so fork PRs get secrets and can run private downstream tests (Tennis.jl)
- Add `fail-fast: false` so a single matrix failure does not cancel other tests
- Remove `is-fork-pr` input (no longer needed)

Depends on https://github.com/ITensor/ITensorActions/pull/54

## Test plan

- [ ] Merge ITensorActions PR first
- [ ] Merge this PR
- [ ] Rebase https://github.com/ITensor/ITensors.jl/pull/1716 and verify all integration tests including Tennis.jl run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)