### PR TITLE
[NDTensors] Fix UndefVarError on CUDA.jl v6.0 in vendored extension

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,6 +1,6 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
-version = "0.4.25"
+version = "0.4.26"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
 
 [workspace]

--- a/NDTensors/src/vendored/TypeParameterAccessors/ext/TypeParameterAccessorsCUDAExt.jl
+++ b/NDTensors/src/vendored/TypeParameterAccessors/ext/TypeParameterAccessorsCUDAExt.jl
@@ -3,10 +3,17 @@ module TypeParameterAccessorsCUDAExt
 using CUDA: CUDA, CuArray
 using NDTensors.Vendored.TypeParameterAccessors: Position, TypeParameterAccessors
 
+# CUDA.jl v6.0 moved `default_memory` from `CUDA` to `CUDA.CUDACore`.
+const default_memory = if isdefined(CUDA, :default_memory)
+    CUDA.default_memory
+else
+    CUDA.CUDACore.default_memory
+end
+
 TypeParameterAccessors.position(::Type{<:CuArray}, ::typeof(eltype)) = Position(1)
 TypeParameterAccessors.position(::Type{<:CuArray}, ::typeof(ndims)) = Position(2)
 function TypeParameterAccessors.default_type_parameters(::Type{<:CuArray})
-    return (Float64, 1, CUDA.default_memory)
+    return (Float64, 1, default_memory)
 end
 
 end

--- a/NDTensors/test/Project.toml
+++ b/NDTensors/test/Project.toml
@@ -45,11 +45,11 @@ Random = "1.10"
 SafeTestsets = "0.1"
 SparseArrays = "1.10"
 StableRNGs = "1"
-StridedViews = "0.4"
+StridedViews = "0.4, 0.5"
 TensorOperations = "5.5"
 Test = "1.10"
 Zygote = "0.7"
-cuTENSOR = "2"
+cuTENSOR = "2, 6"
 
 [extras]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"


### PR DESCRIPTION
CUDA.jl v6.0 refactored its module structure: `default_memory` moved from `CUDA` to `CUDA.CUDACore`. The vendored TypeParameterAccessors CUDA extension's reference to `CUDA.default_memory` therefore raises `UndefVarError` on every downstream that pairs NDTensors with CUDA v6.0.

This applies the same back-compat shim as the upstream TypeParameterAccessors fix (ITensor/TypeParameterAccessors.jl#125): resolve `default_memory` once at extension load via `isdefined(CUDA, :default_memory)`, falling back to `CUDA.CUDACore.default_memory` on CUDA.jl v6+.

Patch bump: NDTensors 0.4.25 → 0.4.26.

### Why GPU CI did not catch this

The Jenkins GPU stage runs `Pkg.test("NDTensors"; test_args=["cuda"])` on a V100, which adds CUDA into the test sandbox. The earlier CompatHelper bump for `[compat] CUDA = "5, 6"` (#1724) merged green because the test sandbox inherits its compat from `NDTensors/test/Project.toml`, which had `StridedViews = "0.4"` (and `cuTENSOR = "2"`). CUDA v6 transitively requires `StridedViews >= 0.5` via the StridedViews CUDA extension, so the resolver had no choice but to install CUDA v5.x — every CompatHelper bump for CUDA / cuTENSOR has merged without GPU CI ever actually exercising the new declared range.

This PR therefore also bumps the corresponding `test/Project.toml [compat]` entries (`StridedViews = "0.4, 0.5"`, `cuTENSOR = "2, 6"`) so the Jenkins sandbox can resolve to CUDA v6.0 and actually verify the back-compat shim above.

Locally reproduced: develop NDTensors at this branch into a fresh env, mirror the test sandbox compat caps, `Pkg.add("CUDA")` resolves to v6.0.0; without the StridedViews bump, the resolver falls back to v5.11.x.