### PR TITLE
TagBot: opt into subdir tagging for NDTensors

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -10,4 +10,6 @@ jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
     uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@main"
+    with:
+      subdirs: '["NDTensors"]'
     secrets: "inherit"


### PR DESCRIPTION
## Summary

NDTensors releases registered in the General registry have not been producing corresponding `NDTensors-v*` tags or GitHub releases on this repository. As a result, `JuliaTagBot` keeps re-posting `expected a tag to exist by now` notifications on the trigger issue indefinitely after each NDTensors registration.

The root cause was in the reusable TagBot workflow this repo calls (`ITensor/ITensorActions/.github/workflows/TagBot.yml`), which invoked `JuliaRegistries/TagBot@v1` without a `subdir` parameter. That has now been fixed: the reusable workflow accepts an opt-in `subdirs` input ([ITensor/ITensorActions#86](https://github.com/ITensor/ITensorActions/pull/86)) that runs an additional matrix job, passing each name as the `subdir` parameter to TagBot.

This PR opts this repo in by passing `subdirs: '["NDTensors"]'`.

After this lands, a manual `workflow_dispatch` of `TagBot.yml` will pick up the queued NDTensors versions (`v0.4.23` through `v0.4.27`) and create the missing tags. From then on, the standard `issue_comment` trigger will tag NDTensors releases automatically alongside top-level ITensors releases.

Closes #1731.