### PR TITLE
Drop redundant tag triggers from CI; restrict docs to v* tags

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-    tags: "*"
   pull_request_target:
     types:
       - "opened"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,15 +3,15 @@ on:
   push:
     branches:
       - "main"
-    tags: "*"
+    tags: ["v*"]
   pull_request:
     branches:
       - "main"
-    tags: "*"
+    tags: ["v*"]
   workflow_dispatch:
     branches:
       - "main"
-    tags: "*"
+    tags: ["v*"]
 jobs:
   build:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/test_itensors_base_ubuntu.yml
+++ b/.github/workflows/test_itensors_base_ubuntu.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-    tags: "*"
   pull_request: ~
 jobs:
   test:

--- a/.github/workflows/test_ndtensors.yml
+++ b/.github/workflows/test_ndtensors.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-    tags: "*"
   pull_request: ~
 jobs:
   test:


### PR DESCRIPTION
## Summary

Test and integration-test workflows currently re-run on every tag push. The same commit was already tested on merge to `main`, and tags fire after registration — re-running adds no signal. Documentation keeps tag triggering for Documenter.jl's versioned-docs flow but restricts to `v*` so subdir-package tags (e.g. `NDTensors-v0.4.27`) don't pollute the docs build.

## Background

The original PkgTemplates.jl design ships a single combined CI workflow where `tags: '*'` was needed so Documenter.jl's versioned-docs deploy job would fire on tag pushes. Splitting tests and docs into separate workflow files in this repo's custom CI inherited the trigger block on both sides, so the test workflows have been firing on every tag push as a side-effect rather than for any active reason.

A recent failure mode that surfaced this: TagBot retroactively created subdir-prefixed tags (`NDTensors-v0.4.x`) pointing at old historical commits. Those retroactive tags fire modern CI against ancient commits that fail noisily because dependencies and the test harness have moved on. The same wildcard would also let subdir-prefixed tags trigger the docs workflow, where they would either no-op (Documenter ignores non-`v*` tags by default) or pollute the versioned-docs tree.

This mirrors the corresponding skeleton change in [ITensorPkgSkeleton.jl#132](https://github.com/ITensor/ITensorPkgSkeleton.jl/pull/132).

## Changes

| File | Change |
|---|---|
| `test_itensors_base_ubuntu.yml` | Drop `tags: "*"` |
| `test_ndtensors.yml` | Drop `tags: "*"` |
| `IntegrationTest.yml` | Drop `tags: "*"` |
| `documentation.yml` | `tags: "*"` → `tags: ["v*"]` (3 occurrences) |