### PR TITLE
Fixed typo in 'delta' constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensors"
 uuid = "9136182c-28ba-11e9-034c-db9fb085ebd5"
-version = "0.9.26"
+version = "0.9.27"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
 
 [workspace]

--- a/src/qn/qnitensor.jl
+++ b/src/qn/qnitensor.jl
@@ -543,7 +543,7 @@ function delta(::Type{ElT}, flux::QN, is...) where {ElT <: Number}
     return delta(ElT, flux, indices(is...))
 end
 
-delta(flux::QN, inds::Indices) = delta(Float64, flux, is)
+delta(flux::QN, inds::Indices) = delta(Float64, flux, inds)
 
 delta(flux::QN, is...) = delta(Float64, flux, indices(is...))
 

--- a/test/base/test_qndiagitensor.jl
+++ b/test/base/test_qndiagitensor.jl
@@ -55,14 +55,24 @@ using Test
         @test norm(dense(NDTensors.tensor(A)) - dense(NDTensors.tensor(B))) ≈ 0
     end
 
-    @testset "delta Tuple constructor" begin
+    @testset "delta constructors" begin
         i = Index(QN(0) => 2, QN(1) => 3; tags = "i")
         ĩ = sim(i; tags = "i_sim")
 
-        δiĩ = δ((dag(i), ĩ))
+        @testset "$label" for (label, args, expected_inds) in (
+                ("varargs", (dag(i), ĩ), (dag(i), ĩ)),
+                ("Tuple", ((dag(i), ĩ),), (dag(i), ĩ)),
+                ("flux and QNIndices", (QN(), [i, dag(i)]), (i, dag(i))),
+            )
+            δiĩ = delta(args...)
 
-        for b in eachnzblock(δiĩ)
-            @test flux(δiĩ, b) == QN()
+            @test hassameinds(δiĩ, expected_inds)
+            @test storage(δiĩ) isa
+                NDTensors.DiagBlockSparse{ElT, ElT} where {ElT <: Number}
+            @test δiĩ[1, 1] == 1
+            for b in eachnzblock(δiĩ)
+                @test flux(δiĩ, b) == QN()
+            end
         end
     end
 


### PR DESCRIPTION
# Description

This fixes a bug where constructing a `delta` ITensor with only `QN` and `inds` crashes.

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
julia> using ITensors; ind = Index(QN() => 1); delta(QN(), [ind, dag(ind)])
ERROR: UndefVarError: `is` not defined in `ITensors`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] delta(flux::QN, inds::Vector{Index{Vector{Pair{QN, Int64}}}})
   @ ITensors ~/.julia/packages/ITensors/GrLgo/src/qn/qnitensor.jl:546
 [2] top-level scope
   @ REPL[1]:1
```

</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```julia
julia> using ITensors; ind = Index(QN() => 1); delta(QN(), [ind, dag(ind)])
ITensor ord=2
(dim=1|id=883) <Out>
 1: QN() => 1
(dim=1|id=883) <In>
 1: QN() => 1
NDTensors.DiagBlockSparse{Float64, Float64, 2}
```

</p></details>