### PR TITLE
[CI] Inline IntegrationTest workflow for subdir compat coupling

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -12,7 +12,9 @@ on:
       - "converted_to_draft"
 jobs:
   integration-test:
-    name: "IntegrationTest"
+    name: "${{ matrix.pkg }}"
+    if: "!github.event.pull_request.draft"
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
@@ -23,11 +25,62 @@ jobs:
           - "ITensorUnicodePlots"
           - "ITensorVisualizationBase"
           - "https://github.com/ITensor/Tennis.jl"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
-    secrets: "inherit"
-    with:
-      localregistry: "https://github.com/ITensor/ITensorRegistry.git"
-      pkg: "${{ matrix.pkg }}"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          ref: "${{ github.event.pull_request.head.sha || github.sha }}"
+      - uses: "julia-actions/setup-julia@v2"
+        with:
+          version: "1"
+          arch: "x64"
+      - name: "Configure git authentication for private repository"
+        env:
+          TOKEN: "${{ secrets.INTEGRATIONTEST_PAT }}"
+        run: |
+          pkg="${{ matrix.pkg }}"
+          if [[ "$pkg" == https://* ]] || [[ "$pkg" == git@* ]]; then
+            if [ -n "$TOKEN" ]; then
+              git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+            fi
+          fi
+          
+      - name: "Run the downstream tests"
+        shell: "julia --color=yes --project=downstream {0}"
+        run: |
+          using Pkg
+          Pkg.Registry.add(
+              Pkg.RegistrySpec(; url = "https://github.com/ITensor/ITensorRegistry.git")
+          )
+          pkg = "${{ matrix.pkg }}"
+          try
+              # `develop` the PR's parent package and its in-tree `NDTensors/`
+              # subdirectory together so the downstream resolves against the
+              # PR's sources for both, even when the parent's `[compat]` for
+              # `NDTensors` has been bumped to a version of `NDTensors` that
+              # has not yet been registered.
+              Pkg.develop([
+                  PackageSpec(; path = "."),
+                  PackageSpec(; path = "NDTensors"),
+              ])
+              if startswith(pkg, "https://") || startswith(pkg, "git@")
+                  pkg_name = replace(basename(pkg), r"\.jl$" => "")
+                  Pkg.add(PackageSpec(; url = pkg))
+                  Pkg.update()
+                  Pkg.test(PackageSpec(; name = pkg_name))
+              else
+                  Pkg.add(PackageSpec(; name = pkg))
+                  Pkg.update()
+                  Pkg.test(PackageSpec(; name = pkg))
+              end
+          catch err
+              err isa Pkg.Resolve.ResolverError || rethrow()
+              # An unsatisfiable resolve here means this PR is intentionally
+              # SemVer-breaking against the downstream's registered compat,
+              # so report a non-failure outcome.
+              @info "Not compatible with this release. No problem." exception = err
+              exit(0)
+          end
+          
   integration-gate:
     name: "IntegrationTest"
     needs: "integration-test"


### PR DESCRIPTION
## Summary
- Replace the thin caller of `ITensor/ITensorActions/.github/workflows/IntegrationTest.yml` with an inlined workflow.
- Skip `julia-actions/julia-buildpkg` and `Pkg.develop` both this repo's parent package and its in-tree `NDTensors/` subdirectory from the PR checkout before resolving the downstream.
- Preserve the existing matrix of downstreams (`ITensorGaussianMPS`, `ITensorMPS`, `ITensorNetworks`, `ITensorUnicodePlots`, `ITensorVisualizationBase`, and the URL-form `Tennis.jl`) and keep the `IntegrationTest` integration-gate required-check name unchanged.

## Why
This repo ships a parent package (root `Project.toml`) alongside the in-tree `NDTensors/` subdirectory package, and the parent's `[compat]` for `NDTensors` is bumped at the same time `NDTensors/Project.toml` is bumped to a new version. While that new `NDTensors` version has not yet been registered, the shared reusable's `julia-actions/julia-buildpkg` step (which calls `Pkg.instantiate` on the parent project) fails with `Unsatisfiable requirements detected for package NDTensors` — and the failure happens outside the test script's `try`/`catch`, so the integration job fails even though the script was designed to treat a `Pkg.Resolve.ResolverError` as an intentional SemVer break.

Inlining lets the test script `Pkg.develop` both the parent and the `NDTensors/` subdirectory from the PR checkout in a single resolver pass, so the downstream resolves against the PR's actual sources. A genuinely breaking compat bump still surfaces as a `Pkg.Resolve.ResolverError` in the same script, which is caught and reported as a non-failure (matching the reverse-dependency integration testing pattern from JuliaDiff/ChainRules and similar projects).

This chicken-and-egg only manifests for parent packages that share a repo with a subdirectory package and bump compat against the subdirectory before the subdirectory tag is registered. Other ecosystem repos using the shared reusable are unaffected.

## Test plan
- [ ] Verify on #1734 (NDTensors 0.4 → 0.5 breaking bump): each `IntegrationTest (<pkg>)` matrix job either runs the downstream tests successfully or reports the resolver error and exits zero, and the `IntegrationTest` gate job goes green.
- [ ] Verify on a non-breaking PR that all matrix jobs run their downstream test suites end-to-end.