### PR TITLE
[CI] Develop NDTensors in IntegrationTest

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -27,6 +27,7 @@ jobs:
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
+      extra-dev-paths: "NDTensors"
       pkg: "${{ matrix.pkg }}"
   integration-gate:
     name: "IntegrationTest"


### PR DESCRIPTION
## Summary

- pass `extra-dev-paths: "NDTensors"` to the shared IntegrationTest workflow

## Rationale

ITensors.jl ships the root package alongside the in-repository `NDTensors/` package. When a PR updates the root package's compat entry for `NDTensors` together with the subpackage version, the integration test environment needs to develop both local package paths before resolving downstream tests.

## Checks

- `pre-commit run --files .github/workflows/IntegrationTest.yml`
- YAML parse of `.github/workflows/IntegrationTest.yml`
- `git diff --check`
