### PR TITLE
[CI] Harden ITensors workflow security configuration

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,16 +1,12 @@
 name: "Format Check"
 on:
-  pull_request_target:
+  pull_request:
     types:
       - "opened"
       - "synchronize"
       - "reopened"
       - "ready_for_review"
-permissions:
-  contents: "read"
-  actions: "write"
-  pull-requests: "write"
 jobs:
   format-check:
     name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -1,0 +1,16 @@
+name: "Format Check Comment"
+on:
+  workflow_run:
+    workflows:
+      - "Format Check"
+    types:
+      - "completed"
+jobs:
+  comment:
+    name: "Format Check Comment"
+    if: "github.event.workflow_run.event == 'pull_request'"
+    permissions:
+      pull-requests: "write"
+      actions: "read"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -12,5 +12,5 @@ permissions:
 jobs:
   format-pull-request:
     name: "Format Pull Request"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v1"
     secrets: "inherit"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - "main"
-  pull_request_target:
+    tags: "*"
+  pull_request:
     types:
       - "opened"
       - "synchronize"
@@ -13,30 +14,11 @@ on:
 jobs:
   integration-test:
     name: "IntegrationTest"
-    strategy:
-      fail-fast: false
-      matrix:
-        pkg:
-          - "ITensorGaussianMPS"
-          - "ITensorMPS"
-          - "ITensorNetworks"
-          - "ITensorUnicodePlots"
-          - "ITensorVisualizationBase"
-          - "https://github.com/ITensor/Tennis.jl"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
       extra-dev-paths: "NDTensors"
-      pkg: "${{ matrix.pkg }}"
-  integration-gate:
-    name: "IntegrationTest"
-    needs: "integration-test"
-    if: "${{ always() && needs.integration-test.result != 'skipped' }}"
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Fail if any downstream integration test failed"
-        run: |
-          echo "integration-test.result = ${{ needs.integration-test.result }}"
-          test "${{ needs.integration-test.result }}" = "success"
+      pkgs: |
+        ["ITensorGaussianMPS", "ITensorMPS", "ITensorNetworks", "ITensorUnicodePlots", "ITensorVisualizationBase", "https://github.com/ITensor/Tennis.jl"]
           

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -20,5 +20,12 @@ jobs:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
       extra-dev-paths: "NDTensors"
       pkgs: |
-        ["ITensorGaussianMPS", "ITensorMPS", "ITensorNetworks", "ITensorUnicodePlots", "ITensorVisualizationBase", "https://github.com/ITensor/Tennis.jl"]
+        [
+          "ITensorGaussianMPS",
+          "ITensorMPS",
+          "ITensorNetworks",
+          "ITensorUnicodePlots",
+          "ITensorVisualizationBase",
+          "https://github.com/ITensor/Tennis.jl"
+        ]
           

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -3,12 +3,18 @@ on:
   issue_comment:
     types:
       - "created"
+permissions:
+  actions: "read"
+  contents: "read"
+  checks: "write"
+  pull-requests: "write"
 jobs:
   integrationrequest:
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
 
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v1"
+    secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/Register.yml
+++ b/.github/workflows/Register.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: "write"
     steps:
-      - uses: "julia-actions/RegisterAction@v1"
+      - uses: "julia-actions/RegisterAction@v0.3.2"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/Register.yml
+++ b/.github/workflows/Register.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: "write"
     steps:
-      - uses: "julia-actions/RegisterAction@latest"
+      - uses: "julia-actions/RegisterAction@v1"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   TagBot:
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@main"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
     with:
       subdirs: '["NDTensors"]'
     secrets: "inherit"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "julia-actions/setup-julia@latest"
+      - uses: "julia-actions/setup-julia@v3"
         with:
           version: "1"
       - name: "Install dependencies"

--- a/.github/workflows/main_test_itensors_base_macos_windows.yml
+++ b/.github/workflows/main_test_itensors_base_macos_windows.yml
@@ -38,6 +38,6 @@ jobs:
           Pkg.develop(path=".");
           Pkg.test("ITensors"; coverage=true, test_args=["base"]);
           
-      - uses: "julia-actions/julia-uploadcodecov@v1"
+      - uses: "julia-actions/julia-uploadcodecov@v0.1.0"
         env:
           CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/main_test_itensors_base_macos_windows.yml
+++ b/.github/workflows/main_test_itensors_base_macos_windows.yml
@@ -25,7 +25,7 @@ jobs:
             arch: "x86"
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "julia-actions/setup-julia@latest"
+      - uses: "julia-actions/setup-julia@v3"
         with:
           version: "${{ matrix.version }}"
           arch: "${{ matrix.arch }}"
@@ -38,6 +38,6 @@ jobs:
           Pkg.develop(path=".");
           Pkg.test("ITensors"; coverage=true, test_args=["base"]);
           
-      - uses: "julia-actions/julia-uploadcodecov@latest"
+      - uses: "julia-actions/julia-uploadcodecov@v1"
         env:
           CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/main_test_itensors_base_macos_windows.yml
+++ b/.github/workflows/main_test_itensors_base_macos_windows.yml
@@ -38,6 +38,6 @@ jobs:
           Pkg.develop(path=".");
           Pkg.test("ITensors"; coverage=true, test_args=["base"]);
           
-      - uses: "julia-actions/julia-uploadcodecov@v0.1.0"
-        env:
-          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+      - uses: "codecov/codecov-action@v5"
+        with:
+          token: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/test_itensors_base_ubuntu.yml
+++ b/.github/workflows/test_itensors_base_ubuntu.yml
@@ -39,6 +39,6 @@ jobs:
           Pkg.develop(path=".");
           Pkg.test("ITensors"; coverage=true, test_args=["base"]);
           
-      - uses: "julia-actions/julia-uploadcodecov@v0.1.0"
-        env:
-          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+      - uses: "codecov/codecov-action@v5"
+        with:
+          token: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/test_itensors_base_ubuntu.yml
+++ b/.github/workflows/test_itensors_base_ubuntu.yml
@@ -39,6 +39,6 @@ jobs:
           Pkg.develop(path=".");
           Pkg.test("ITensors"; coverage=true, test_args=["base"]);
           
-      - uses: "julia-actions/julia-uploadcodecov@v1"
+      - uses: "julia-actions/julia-uploadcodecov@v0.1.0"
         env:
           CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/test_itensors_base_ubuntu.yml
+++ b/.github/workflows/test_itensors_base_ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
             arch: "x86"
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "julia-actions/setup-julia@latest"
+      - uses: "julia-actions/setup-julia@v3"
         with:
           version: "${{ matrix.version }}"
           arch: "${{ matrix.arch }}"
@@ -39,6 +39,6 @@ jobs:
           Pkg.develop(path=".");
           Pkg.test("ITensors"; coverage=true, test_args=["base"]);
           
-      - uses: "julia-actions/julia-uploadcodecov@latest"
+      - uses: "julia-actions/julia-uploadcodecov@v1"
         env:
           CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/test_ndtensors.yml
+++ b/.github/workflows/test_ndtensors.yml
@@ -23,7 +23,7 @@ jobs:
           - "x64"
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "julia-actions/setup-julia@latest"
+      - uses: "julia-actions/setup-julia@v3"
         with:
           version: "${{ matrix.version }}"
           arch: "${{ matrix.arch }}"


### PR DESCRIPTION
## Summary
- switch reusable workflow references from the main branch ref to the v1 tag
- migrate IntegrationTest and Format Check from pull_request_target to pull_request
- update IntegrationTest caller to pass the downstream package list via `pkgs`
- add `.github/workflows/FormatCheckComment.yml` to use the workflow_run comment path
- add explicit permissions and secrets inheritance for Integration Test Request
- replace remaining action references pinned to latest with stable major tags

## Why
This aligns ITensors workflow security posture with the current org-wide hardened reusable workflow model while preserving existing required check contexts.

## Notes
- required check context `IntegrationTest / IntegrationTest` is already present in the active repository ruleset