### PR TITLE
[CI] Migrate reusable callers to ITensorActions v2

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,4 +1,4 @@
-name: "Format Check"
+name: "FormatCheck"
 on:
   pull_request:
     types:
@@ -6,7 +6,9 @@ on:
       - "synchronize"
       - "reopened"
       - "ready_for_review"
+permissions:
+  contents: "read"
 jobs:
   format-check:
-    name: "Format Check"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v1"
+    name: "FormatCheck"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheck.yml@v2"

--- a/.github/workflows/FormatCheckComment.yml
+++ b/.github/workflows/FormatCheckComment.yml
@@ -1,16 +1,16 @@
-name: "Format Check Comment"
+name: "FormatCheckComment"
 on:
   workflow_run:
     workflows:
-      - "Format Check"
+      - "FormatCheck"
     types:
       - "completed"
+permissions:
+  pull-requests: "write"
+  actions: "read"
 jobs:
-  comment:
-    name: "Format Check Comment"
+  format-check-comment:
+    name: "FormatCheckComment"
     if: "github.event.workflow_run.event == 'pull_request'"
-    permissions:
-      pull-requests: "write"
-      actions: "read"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatCheckComment.yml@v2"
     secrets: "inherit"

--- a/.github/workflows/FormatPullRequest.yml
+++ b/.github/workflows/FormatPullRequest.yml
@@ -1,4 +1,4 @@
-name: "Format Pull Request"
+name: "FormatPullRequest"
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -11,6 +11,6 @@ permissions:
   pull-requests: "write"
 jobs:
   format-pull-request:
-    name: "Format Pull Request"
-    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v1"
+    name: "FormatPullRequest"
+    uses: "ITensor/ITensorActions/.github/workflows/FormatPullRequest.yml@v2"
     secrets: "inherit"

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -11,10 +11,13 @@ on:
       - "reopened"
       - "ready_for_review"
       - "converted_to_draft"
+permissions:
+  actions: "read"
+  contents: "read"
 jobs:
   integration-test:
     name: "IntegrationTest"
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
@@ -28,4 +31,3 @@ jobs:
           "ITensorVisualizationBase",
           "https://github.com/ITensor/Tennis.jl"
         ]
-          

--- a/.github/workflows/IntegrationTestRequest.yml
+++ b/.github/workflows/IntegrationTestRequest.yml
@@ -1,4 +1,4 @@
-name: "Integration Test Request"
+name: "IntegrationTestRequest"
 on:
   issue_comment:
     types:
@@ -9,12 +9,12 @@ permissions:
   checks: "write"
   pull-requests: "write"
 jobs:
-  integrationrequest:
+  integration-test-request:
+    name: "IntegrationTestRequest"
     if: |
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "COLLABORATOR", "MEMBER"]'), github.event.comment.author_association)
-
-    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/IntegrationTestRequest.yml@v2"
     secrets: "inherit"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,10 +6,14 @@ on:
   workflow_dispatch: ~
 env:
   REGISTRY_TAGBOT_ACTION: "JuliaRegistries/TagBot"
+permissions:
+  contents: "write"
+  issues: "read"
 jobs:
-  TagBot:
+  tagbot:
+    name: "TagBot"
     if: "github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'"
-    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v1"
+    uses: "ITensor/ITensorActions/.github/workflows/TagBot.yml@v2"
     with:
       subdirs: '["NDTensors"]'
     secrets: "inherit"

--- a/.github/workflows/main_test_itensors_base_macos_windows.yml
+++ b/.github/workflows/main_test_itensors_base_macos_windows.yml
@@ -3,32 +3,27 @@ on:
   push:
     branches:
       - "main"
+  pull_request: ~
 jobs:
   test:
-    name: "Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.threads }} thread(s)"
+    name: "Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.threads }} thread(s)"
     runs-on: "${{ matrix.os }}"
     env:
       JULIA_NUM_THREADS: "${{ matrix.threads }}"
     strategy:
+      fail-fast: false
       matrix:
-        version:
-          - "lts"
-          - "1"
+        version: ${{ github.event_name == 'pull_request' && fromJSON('["1"]') || fromJSON('["lts","1"]') }}
         os:
           - "macOS-latest"
+          - "windows-latest"
         threads:
           - "2"
-        arch:
-          - "x64"
-        exclude:
-          - os: "macOS-latest"
-            arch: "x86"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "julia-actions/setup-julia@v3"
         with:
           version: "${{ matrix.version }}"
-          arch: "${{ matrix.arch }}"
       - name: "Install Julia dependencies and run tests"
         shell: "julia {0}"
         run: |
@@ -37,7 +32,6 @@ jobs:
           Pkg.develop(path="./NDTensors");
           Pkg.develop(path=".");
           Pkg.test("ITensors"; coverage=true, test_args=["base"]);
-          
       - uses: "codecov/codecov-action@v5"
         with:
           token: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/test_itensors_base_ubuntu.yml
+++ b/.github/workflows/test_itensors_base_ubuntu.yml
@@ -21,9 +21,6 @@ jobs:
           - "2"
         arch:
           - "x64"
-        exclude:
-          - os: "macOS-latest"
-            arch: "x86"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "julia-actions/setup-julia@v3"


### PR DESCRIPTION
## Summary

Two related changes:

**1. Migrate the six reusable-caller workflows to ITensorActions v2.**

- Pin `FormatCheck`, `FormatCheckComment`, `FormatPullRequest`, `IntegrationTest`, `IntegrationTestRequest`, `TagBot` to `ITensor/ITensorActions` at the `v2` tag, matching the rest of the ecosystem after the v2 rollout.
- Apply the filename-derived naming convention: workflow `name:` and job display `name:` match the file basename; job keys in kebab-case.
- Add explicit workflow-level `permissions:` blocks where missing (`FormatCheck`, `IntegrationTest`, `TagBot`); promote `FormatCheckComment`'s job-level permissions to workflow-level.
- ITensors-specific inputs preserved: `IntegrationTest.yml` keeps `extra-dev-paths: NDTensors`, the custom `pkgs` list, and the `tags: "*"` push trigger; `TagBot.yml` keeps `subdirs: '["NDTensors"]'`.
- `CompatHelper.yml`, `documentation.yml`, `Register.yml`, and the custom `test_*.yml` workflows are not reusable callers and remain unchanged here.

**2. Fix the macOS+Windows test workflow.**

The custom `main_test_itensors_base_macos_windows.yml` had three accumulated issues: it triggered on `push: main` only (so macOS regressions only surfaced post-merge), it hardcoded `arch: x64` (which silently broke after `macOS-latest` flipped to Apple Silicon), and the matrix only included `macOS-latest` despite the filename promising Windows.

- Add `pull_request:` trigger so future regressions surface before merge.
- Add `windows-latest` to the matrix.
- Drop `arch:` dimension; `setup-julia` auto-detects the runner's native architecture (arm64 on macOS, x86_64 on Windows).
- Limit the PR matrix to `julia-version: 1` (full `lts + 1` matrix still runs on push to main) to keep PR compute reasonable.
- Add `fail-fast: false` so a Windows failure doesn't cancel macOS feedback.

Also remove a dead `exclude:` clause from `test_itensors_base_ubuntu.yml` (it referenced `os: macOS-latest` but the matrix only has Ubuntu).

The Ubuntu test workflows keep `arch: x64` in their matrix so the `main-branch-policy` ruleset's required-status-check contexts (which embed `x64`) continue to match without coordinated changes there.

This is a non-substantive change (CI-only); no version bump.

## Follow-up

The `main-branch-policy` ruleset's required context `Format Check / Check Formatting` will need renaming to `FormatCheck / FormatCheck` after this lands (the standard `run_ruleset_v2_rename.jl` rename map already covers this case).

A separate, larger followup project tracks consolidating ITensors.jl's remaining custom workflows (custom `CompatHelper.yml`, custom `documentation.yml`, three custom test workflows) onto the standard ITensorActions reusables once those grow subdir-aware inputs.