### PR TITLE
[CI] Add explicit permissions blocks to custom workflows

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch: ~
+permissions:
+  contents: "write"
+  pull-requests: "write"
 jobs:
   CompatHelper:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - "main"
     tags: ["v*"]
+permissions:
+  contents: "read"
 jobs:
   build:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/main_test_itensors_base_macos_windows.yml
+++ b/.github/workflows/main_test_itensors_base_macos_windows.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - "main"
   pull_request: ~
+permissions:
+  contents: "read"
 jobs:
   test:
     name: "Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.threads }} thread(s)"

--- a/.github/workflows/test_itensors_base_ubuntu.yml
+++ b/.github/workflows/test_itensors_base_ubuntu.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - "main"
   pull_request: ~
+permissions:
+  contents: "read"
 jobs:
   test:
     name: "Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.threads }} thread(s)"

--- a/.github/workflows/test_ndtensors.yml
+++ b/.github/workflows/test_ndtensors.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - "main"
   pull_request: ~
+permissions:
+  contents: "read"
 jobs:
   test:
     name: "Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.threads }} thread(s)"


### PR DESCRIPTION
## Summary

The five custom workflows that PR #1739 didn't migrate to v2 reusable callers (`CompatHelper.yml`, `documentation.yml`, the three `test_*.yml` files) had no explicit `permissions:` blocks. They've been firing successfully under the org-default `read` ceiling since the 2026-05-04 flip — for the test workflows `read` is correct, and for `CompatHelper` / `documentation` the writes go via the `DOCUMENTER_KEY` SSH key which bypasses `GITHUB_TOKEN` scope. But explicit declaration is the ecosystem convention; rolling it out here makes the intent legible without having to reason about which token does what.

Per-workflow scope:

- `CompatHelper.yml`: `contents: write` + `pull-requests: write` (matches the standard template; CompatHelper.jl uses `GITHUB_TOKEN` for the GitHub API to open PRs).
- `documentation.yml`: `contents: read` (push to gh-pages goes via `DOCUMENTER_KEY` SSH; `GITHUB_TOKEN` doesn't need write).
- `main_test_itensors_base_macos_windows.yml`, `test_itensors_base_ubuntu.yml`, `test_ndtensors.yml`: `contents: read` (run tests + upload coverage, no writes).

Non-substantive (CI hygiene only); no version bump.