### PR TITLE
[jenkins] updates for migration to new k8s-based system

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.3-devel-ubuntu22.04
+FROM docker.io/nvidia/cuda:12.6.3-devel-ubuntu22.04
 
 # julia
 RUN apt-get update && \

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,108 +1,85 @@
-pipeline {
-  agent none
-  options {
-    disableConcurrentBuilds(abortPrevious: true)
-    buildDiscarder(logRotator(numToKeepStr: '8', daysToKeepStr: '20'))
+properties([
+  disableConcurrentBuilds(abortPrevious: true),
+  buildDiscarder(logRotator(numToKeepStr: '8', daysToKeepStr: '20'))
+])
+
+buildImage(context: 'jenkins', buildArgs: '--build-arg JULIA=1.12')
+parallel cudaext: {
+  runPod(gpus: 1) {
+    stage('NDTensorsCUDAExt') {
+      timeout(time: 45, unit: 'MINUTES') {
+        withEnv([
+          "HOME=$WORKSPACE_TMP",
+          "OMP_NUM_THREADS=4",
+          "JULIA_NUM_THREADS=4"
+        ]) {
+          sh 'nvidia-smi'
+          sh '''
+            julia -e '
+              using Pkg: Pkg
+              Pkg.activate("./NDTensors/test")
+              Pkg.add(["CUDA", "Preferences", "CUDA_Driver_jll"])
+              using CUDA
+              CUDA.set_runtime_version!(v"12.6"; local_toolkit=false)
+              using CUDA_Driver_jll
+              using Preferences: set_preferences!
+              set_preferences!(CUDA_Driver_jll, "compat" => "false"; export_prefs=true)
+            '
+          '''
+          sh '''
+            julia -e 'using Pkg: Pkg; Pkg.activate(temp=true); Pkg.Registry.update(); Pkg.update(); Pkg.develop(path="./NDTensors"); Pkg.develop(path="."); Pkg.test("NDTensors"; test_args=["cuda"])'
+          '''
+        }
+      }
+    }
   }
-  stages {
-    stage('GPU Testing') {
-      parallel {
-        stage('NDTensorsCUDAExt') {
-          options {
-            timeout(time: 45, unit: 'MINUTES')
-          }
-          agent {
-            dockerfile {
-              label 'gpu&&v100'
-              filename 'Dockerfile'
-              dir 'jenkins'
-              additionalBuildArgs  '--build-arg JULIA=1.12'
-              args '--gpus "device=0"'
-            }
-          }
-          environment {
-            HOME = pwd(tmp:true)
-            OMP_NUM_THREADS = 4
-            JULIA_NUM_THREADS = 4
-          }
-          steps {
-            sh 'rm -rf "$HOME/.julia"'
-            sh 'nvidia-smi'
-            sh '''
-              julia -e '
-                using Pkg: Pkg
-                Pkg.activate("./NDTensors/test")
-                Pkg.add(["CUDA", "Preferences", "CUDA_Driver_jll"])
-                using CUDA
-                CUDA.set_runtime_version!(v"12.6"; local_toolkit=false)
-                using CUDA_Driver_jll
-                using Preferences: set_preferences!
-                set_preferences!(CUDA_Driver_jll, "compat" => "false"; export_prefs=true)
-              '
-            '''
-            sh '''
-              julia -e 'using Pkg: Pkg; Pkg.activate(temp=true); Pkg.Registry.update(); Pkg.update(); Pkg.develop(path="./NDTensors"); Pkg.develop(path="."); Pkg.test("NDTensors"; test_args=["cuda"])'
-            '''
-          }
+},
+tensorext: {
+  runPod(gpus: 1) {
+    stage('NDTensorscuTENSORExt') {
+      timeout(time: 45, unit: 'MINUTES') {
+        withEnv([
+          "HOME=$WORKSPACE_TMP",
+          "OMP_NUM_THREADS=4",
+          "JULIA_NUM_THREADS=4"
+        ]) {
+          sh 'nvidia-smi'
+          sh '''
+            julia -e '
+              using Pkg: Pkg
+              Pkg.activate("./NDTensors/test")
+              Pkg.add(["CUDA", "Preferences", "CUDA_Driver_jll"])
+              using CUDA
+              CUDA.set_runtime_version!(v"12.6"; local_toolkit=false)
+              using CUDA_Driver_jll
+              using Preferences: set_preferences!
+              set_preferences!(CUDA_Driver_jll, "compat" => "false"; export_prefs=true)
+            '
+          '''
+          sh '''
+            julia -e 'using Pkg: Pkg; Pkg.activate(temp=true); Pkg.Registry.update(); Pkg.update(); Pkg.develop(path="./NDTensors"); Pkg.develop(path="."); Pkg.test("NDTensors"; test_args=["cutensor"])'
+          '''
         }
-        stage('NDTensorscuTENSORExt') {
-          options {
-            timeout(time: 45, unit: 'MINUTES')
-          }
-          agent {
-            dockerfile {
-              label 'gpu&&v100'
-              filename 'Dockerfile'
-              dir 'jenkins'
-              additionalBuildArgs  '--build-arg JULIA=1.12'
-              args '--gpus "device=0"'
-            }
-          }
-          environment {
-            HOME = pwd(tmp:true)
-            OMP_NUM_THREADS = 4
-            JULIA_NUM_THREADS = 4
-          }
-          steps {
-            sh 'rm -rf "$HOME/.julia"'
-            sh 'nvidia-smi'
-            sh '''
-              julia -e '
-                using Pkg: Pkg
-                Pkg.activate("./NDTensors/test")
-                Pkg.add(["CUDA", "Preferences", "CUDA_Driver_jll"])
-                using CUDA
-                CUDA.set_runtime_version!(v"12.6"; local_toolkit=false)
-                using CUDA_Driver_jll
-                using Preferences: set_preferences!
-                set_preferences!(CUDA_Driver_jll, "compat" => "false"; export_prefs=true)
-              '
-            '''
-            sh '''
-              julia -e 'using Pkg: Pkg; Pkg.activate(temp=true); Pkg.Registry.update(); Pkg.update(); Pkg.develop(path="./NDTensors"); Pkg.develop(path="."); Pkg.test("NDTensors"; test_args=["cutensor"])'
-            '''
-          }
-        }
-        stage('NDTensorsMetalExt'){
-          options {
-            timeout(time: 45, unit: 'MINUTES')
-          }
-          agent {
-            label 'm1'
-          }
-          environment{
-            PATH="${env.HOME}/.juliaup/bin:${env.PATH}"
-            PLATFORM = 'macos'
-          }
-          steps{
-            sh '''
-              juliaup update
-              juliaup default release
-            '''
-            sh '''
-              julia -e 'using Pkg: Pkg; Pkg.activate(temp=true); Pkg.Registry.update(); Pkg.update(); Pkg.develop(path="./NDTensors"); Pkg.develop(path="."); Pkg.test("NDTensors"; test_args=["metal"])'
-            '''
-          }
+      }
+    }
+  }
+}, 
+metalext: {
+  node('m1') {
+    stage('NDTensorsMetalExt') {
+      timeout(time: 45, unit: 'MINUTES') {
+        withEnv([
+          "PATH=${env.HOME}/.juliaup/bin:${env.PATH}",
+          "PLATFORM=macos"
+        ]) {
+          checkout scm
+          sh '''
+            juliaup update
+            juliaup default release
+          '''
+          sh '''
+            julia -e 'using Pkg: Pkg; Pkg.activate(temp=true); Pkg.Registry.update(); Pkg.update(); Pkg.develop(path="./NDTensors"); Pkg.develop(path="."); Pkg.test("NDTensors"; test_args=["metal"])'
+          '''
         }
       }
     }


### PR DESCRIPTION
We are moving jenkins builds to a [new system](https://jenkins-new.flatironinstitute.org/job/CCQ/job/ITensor/job/ITensors.jl/) with more resources and flexibility. This commit will switch to allowing builds on the new system.

Once this is merged, I can remove the project on the old system.

(There's a couple other ITensor projects on the old system: `ITensor` and `ITensorGPU.jl`, but neither of these has been built in years, so I assume they're no longer needed.)