### PR TITLE
VersionCheck: use additional-exclude-paths for NDTensors

### DIFF
--- a/.github/workflows/VersionCheck.yml
+++ b/.github/workflows/VersionCheck.yml
@@ -17,9 +17,5 @@ jobs:
     name: "VersionCheck"
     uses: "ITensor/ITensorActions/.github/workflows/VersionCheck.yml@v2"
     with:
-      exclude-paths: |
-        NDTensors
-        .github
-        .gitignore
-        .pre-commit-config.yaml
+      additional-exclude-paths: "NDTensors"
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"


### PR DESCRIPTION
## Summary

- Replace the explicit `exclude-paths` override with `additional-exclude-paths: NDTensors`. The previous list re-declared the reusable workflow's defaults (`.github`, `.gitignore`, `.pre-commit-config.yaml`) to keep `NDTensors` alongside them, which silently drifted as defaults evolved — the recent `jenkins` addition wasn't picked up, which is why VersionCheck has been failing on PRs that touch only `jenkins/` (e.g. #1754).
- Uses the new `additional-exclude-paths` input added in ITensor/ITensorActions#122 (released as `v2.4.0`).