### PR TITLE
Add allocation-free pairwise contraction and cached contraction plan

### DIFF
--- a/NDTensors/src/abstractarray/tensoralgebra/contract.jl
+++ b/NDTensors/src/abstractarray/tensoralgebra/contract.jl
@@ -186,3 +186,60 @@ function _contract!(
 
     return CT
 end
+
+# --- Allocation-free contraction --------------------------------------------------------
+# Pre-allocated permute scratch reused across calls: `Ap`/`Bp` hold permuted A/B, `Cp` the GEMM
+# output before the C permute. Lazily sized on first use, then reused. Fields are untyped (Ap/Bp
+# can differ in ndims); dispatch cost is negligible next to the permute/GEMM kernels.
+mutable struct ContractScratch
+    Ap::Any
+    Bp::Any
+    Cp::Any
+end
+ContractScratch() = ContractScratch(nothing, nothing, nothing)
+
+_perm_size(T::AbstractArray, perm) = ntuple(i -> size(T, perm[i]), length(perm))
+
+# In-place, allocation-free variant of `_contract!` using pre-allocated `scr`. Only the
+# β == 0 case is supported for the permuteC path (the only case BP needs); it errors otherwise.
+function _contract_prealloc!(
+        scr::ContractScratch,
+        CT::AbstractArray{El, NC},
+        AT::AbstractArray{El, NA},
+        BT::AbstractArray{El, NB},
+        props::ContractionProperties,
+        α::Number = one(El),
+        β::Number = zero(El)
+    ) where {El, NC, NA, NB}
+    if props.permuteA
+        scr.Ap === nothing && (scr.Ap = similar(AT, _perm_size(AT, props.PA)))
+        permutedims!(expose(scr.Ap), expose(AT), props.PA)
+        AM = transpose(reshape(scr.Ap, (props.dmid, props.dleft)))
+    else
+        AM = Atrans(props) ? transpose(reshape(AT, (props.dmid, props.dleft))) :
+             reshape(AT, (props.dleft, props.dmid))
+    end
+
+    if props.permuteB
+        scr.Bp === nothing && (scr.Bp = similar(BT, _perm_size(BT, props.PB)))
+        permutedims!(expose(scr.Bp), expose(BT), props.PB)
+        BM = reshape(scr.Bp, (props.dmid, props.dright))
+    else
+        BM = Btrans(props) ? transpose(reshape(BT, (props.dright, props.dmid))) :
+             reshape(BT, (props.dmid, props.dright))
+    end
+
+    if props.permuteC
+        iszero(β) || error("_contract_prealloc! supports permuteC only for β == 0")
+        scr.Cp === nothing && (scr.Cp = similar(CT, (props.dleft * props.dright,)))
+        CM = reshape(scr.Cp, (props.dleft, props.dright))
+        CM = mul!!(CM, AM, BM, El(α), zero(El))
+        Cr = reshape(CM, props.newCrange)
+        permutedims!(expose(CT), expose(Cr), props.PC)
+    else
+        CM = Ctrans(props) ? transpose(reshape(CT, (props.dright, props.dleft))) :
+             reshape(CT, (props.dleft, props.dright))
+        CM = mul!!(CM, AM, BM, El(α), El(β))
+    end
+    return CT
+end

--- a/NDTensors/src/dense/tensoralgebra/contract.jl
+++ b/NDTensors/src/dense/tensoralgebra/contract.jl
@@ -215,6 +215,31 @@ function contract!(
     #end
 end
 
+# Allocation-free contraction into a pre-allocated R using permute scratch `scr`. Restricted to
+# the generic matmul path with matching eltypes (guaranteed by the caller). `props` may be
+# passed in to avoid recomputation.
+function contract_prealloc!(
+        scr::ContractScratch,
+        R::DenseTensor{ElR, NR},
+        labelsR,
+        T1::DenseTensor{El, N1},
+        labelsT1,
+        T2::DenseTensor{El, N2},
+        labelsT2,
+        props::ContractionProperties = _contract_props(R, labelsR, T1, labelsT1, T2, labelsT2),
+        α::Number = one(ElR),
+        β::Number = zero(ElR)
+    ) where {ElR, El, NR, N1, N2}
+    _contract_prealloc!(scr, array(R), array(T1), array(T2), props, α, β)
+    return R
+end
+
+function _contract_props(R, labelsR, T1, labelsT1, T2, labelsT2)
+    props = ContractionProperties(labelsT1, labelsT2, labelsR)
+    compute_contraction_properties!(props, T1, T2, R)
+    return props
+end
+
 function _contract!(
         CT::DenseTensor{El, NC},
         AT::DenseTensor{El, NA},

--- a/src/tensor_operations/tensor_algebra.jl
+++ b/src/tensor_operations/tensor_algebra.jl
@@ -185,6 +185,71 @@ function contract!(C::ITensor, A::ITensor, B::ITensor)::ITensor
     return settensor!(C, _contract!!(tensor(C), tensor(A), tensor(B)))
 end
 
+# Allocation-free pairwise contraction into C's existing storage using pre-allocated permute
+# scratch `scr`. C must already have the correct inds/storage; its identity/storage are kept.
+function contract_prealloc!(scr, C::ITensor, A::ITensor, B::ITensor)
+    labelsC, labelsA, labelsB = compute_contraction_labels(inds(C), inds(A), inds(B))
+    NDTensors.contract_prealloc!(
+        scr, tensor(C), _Tuple(labelsC), tensor(A), _Tuple(labelsA), tensor(B), _Tuple(labelsB)
+    )
+    return C
+end
+
+# --- Cached sequenced contraction plan (allocation-free replay) ----------------------------
+# Mirrors a binary contraction `sequence`. The first execution allocates the per-node
+# intermediate buffers; later executions reuse them via `contract_prealloc!` and are
+# device-allocation-free. The result is written into a caller-provided output buffer.
+abstract type _CPlan end
+struct _CLeaf <: _CPlan
+    idx::Int
+end
+mutable struct _CBranch <: _CPlan
+    a::_CPlan
+    b::_CPlan
+    out::Union{Nothing, ITensor}
+    scr::NDTensors.ContractScratch
+end
+
+_build_cplan(seq::Integer) = _CLeaf(seq)
+function _build_cplan(seq)
+    length(seq) == 2 ||
+        error("ContractionPlan supports binary sequences only (got arity $(length(seq)))")
+    return _CBranch(_build_cplan(seq[1]), _build_cplan(seq[2]), nothing, NDTensors.ContractScratch())
+end
+
+struct ContractionPlan
+    root::_CPlan
+end
+# Factory (a separate name, not a constructor overload, to avoid colliding with the
+# struct's auto-generated `ContractionPlan(::Any)` since `root` has an abstract type).
+contraction_plan(sequence) = ContractionPlan(_build_cplan(sequence))
+
+# Resolve an intermediate node to its (buffer) ITensor; allocate on first call, reuse after.
+_resolve!(n::_CLeaf, As) = As[n.idx]
+function _resolve!(n::_CBranch, As)
+    A = _resolve!(n.a, As)
+    B = _resolve!(n.b, As)
+    if n.out === nothing
+        n.out = A * B
+    else
+        contract_prealloc!(n.scr, n.out, A, B)
+    end
+    return n.out
+end
+
+# Contract `As` per `plan`, writing the final result into the caller-provided `C`.
+function contract!(C::ITensor, As::AbstractVector{ITensor}, plan::ContractionPlan)
+    root = plan.root
+    if root isa _CLeaf
+        C .= As[root.idx]
+        return C
+    end
+    A = _resolve!(root.a, As)
+    B = _resolve!(root.b, As)
+    contract_prealloc!(root.scr, C, A, B)
+    return C
+end
+
 """
     hadamard_product!(C::ITensor, A::ITensor, B::ITensor)
     hadamard_product(A::ITensor, B::ITensor)

--- a/test/base/test_contract.jl
+++ b/test/base/test_contract.jl
@@ -322,3 +322,41 @@ end
         @test array(permute(C, i, j)) ≈ kron(array(A), transpose(array(B)))
     end
 end
+
+using ITensors.NDTensors: ContractScratch
+@testset "Allocation-free contraction ($T)" for T in (Float64, ComplexF64)
+    i = Index(3, "i")
+    j = Index(4, "j")
+    k = Index(5, "k")
+    l = Index(2, "l")
+    A = random_itensor(T, i, j, k)
+    B = random_itensor(T, k, l)
+    D = random_itensor(T, l, j)
+    ref = A * B
+
+    @testset "contract_prealloc! matches * and reuses scratch" begin
+        C = ITensor(zero(T), (i, j, l))
+        scr = ContractScratch()
+        ITensors.contract_prealloc!(scr, C, A, B)
+        @test C ≈ ref
+        ITensors.contract_prealloc!(scr, C, A, B)   # reuse buffers
+        @test C ≈ ref
+    end
+
+    @testset "contract_prealloc! permuteC path" begin
+        C = ITensor(zero(T), (l, i, j))             # non-canonical order -> permuteC
+        ITensors.contract_prealloc!(ContractScratch(), C, A, B)
+        @test C ≈ ref
+    end
+
+    @testset "ContractionPlan replay" begin
+        As = ITensor[A, B, D]
+        expected = (A * B) * D
+        out = ITensor(zero(T), inds(expected))
+        plan = ITensors.contraction_plan([[1, 2], 3])
+        ITensors.contract!(out, As, plan)
+        @test out ≈ expected
+        ITensors.contract!(out, As, plan)           # allocation-free replay
+        @test out ≈ expected
+    end
+end


### PR DESCRIPTION
# Description

Adds an allocation-free path for repeated pairwise tensor contractions. The standard `A * B` / `contract!!` path allocates fresh permute and output buffers on every call. In hot loops that contract the same network shape many times (e.g. belief-propagation / iterative simulation), and especially on GPUs, these per-call device allocations dominate runtime.
This PR adds:
- `NDTensors.ContractScratch` plus `_contract_prealloc!` / `contract_prealloc!`, which contract into a pre-allocated output using cached permute scratch (`Ap`/`Bp`/`Cp`) that is lazily sized on first use and reused afterward.
- An ITensor-level `contract_prealloc!(scr, C, A, B)` that writes into `C`'s existing storage.
- `ContractionPlan` / `contraction_plan(sequence)` which mirrors a binary contraction sequence: the first run allocates the intermediate buffers, and later runs replay allocation-free via `contract!(C, As, plan)`.
The change is purely additive; no existing public interfaces are modified. The `permuteC` path is supported only for `β == 0` (it errors otherwise), which is the only case the plan needs. No new dependencies are required.

Fixes #(issue)

<details><summary>Minimal demonstration of previous behavior</summary><p>

```
julia
using ITensors
i, j, k, l = Index(3, "i"), Index(4, "j"), Index(5, "k"), Index(2, "l")
A = random_itensor(i, j, k)
B = random_itensor(k, l)
# Every contraction allocates fresh permute/output buffers, on every iteration:
for _ in 1:3
    C = A * B
    @show @allocated A * B   # > 0 on each call
end
```

</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>

```using ITensors
using ITensors.NDTensors: ContractScratch
i, j, k, l = Index(3, "i"), Index(4, "j"), Index(5, "k"), Index(2, "l")
A = random_itensor(i, j, k)
B = random_itensor(k, l)
C   = ITensor(0.0, (i, j, l))   # pre-allocated output
scr = ContractScratch()         # reused permute scratch
ITensors.contract_prealloc!(scr, C, A, B)   # first call sizes the buffers
@assert C ≈ A * B
# Subsequent calls reuse the buffers, no new allocations for the contraction:
for _ in 1:3
    @show @allocated ITensors.contract_prealloc!(scr, C, A, B)   # ~0
end
# Cached sequenced plan: first run allocates intermediates, later runs replay allocation-free.
D    = random_itensor(l, j)
As   = ITensor[A, B, D]
out  = ITensor(0.0, inds((A * B) * D))
plan = ITensors.contraction_plan([[1, 2], 3])
ITensors.contract!(out, As, plan)   # warms up (allocates intermediates)
ITensors.contract!(out, As, plan)   # allocation-free replay
@assert out ≈ (A * B) * D
```

</p></details>

# How Has This Been Tested?

Added a new @testset "Allocation-free contraction ($T)" (for T in (Float64, ComplexF64)) to test/base/test_contract.jl, which is auto-included by test/base/runtests.jl. All base contraction tests pass along with the new ones.

 contract_prealloc! produces the same result as A * B, and repeated calls reusing the same ContractScratch stay correct.
 contract_prealloc! is correct when the output index order forces the permuteC path.
 ContractionPlan matches sequential (A * B) * D, and a second replay into the same reused output buffer is still correct.

# Checklist:

- [ ] My code follows the style guidelines of this project. Please run the [ITensorFormatter](https://github.com/ITensor/ITensorFormatter.jl) in the base directory of the repository (`~/.julia/dev/ITensors`) to format your code according to our style guidelines.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
