### PR TITLE
[NDTensors] Drop the unused InlineStrings dependency

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,6 +1,6 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
-version = "0.4.28"
+version = "0.4.29"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
 
 [workspace]
@@ -18,7 +18,6 @@ FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
-InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
@@ -74,7 +73,6 @@ Functors = "0.2, 0.3, 0.4, 0.5"
 GPUArraysCore = "0.1, 0.2"
 HDF5 = "0.14, 0.15, 0.16, 0.17"
 HalfIntegers = "1"
-InlineStrings = "1"
 JLArrays = "0.1, 0.2, 0.3"
 LinearAlgebra = "<0.0.1, 1.10"
 MacroTools = "0.5"

--- a/NDTensors/src/imports.jl
+++ b/NDTensors/src/imports.jl
@@ -9,7 +9,6 @@ using Base.Threads
 using Dictionaries
 using Folds
 using Functors
-using InlineStrings
 using LinearAlgebra
 using Random
 using SimpleTraits


### PR DESCRIPTION
## Summary

NDTensors declares `InlineStrings` and loads it in `imports.jl`, but no name from it is referenced anywhere in the package. The tag and string machinery is built on `BitIntegers` instead, so the dependency is dead weight. This supersedes https://github.com/ITensor/ITensors.jl/pull/1767, which widened the compat bound on it.