### PR TITLE
[NDTensors] Route JLArray svd and qr through the CPU

### DIFF
--- a/NDTensors/Project.toml
+++ b/NDTensors/Project.toml
@@ -1,6 +1,6 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
-version = "0.4.28"
+version = "0.4.29"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
 
 [workspace]

--- a/NDTensors/ext/NDTensorsJLArraysExt/linearalgebra.jl
+++ b/NDTensors/ext/NDTensorsJLArraysExt/linearalgebra.jl
@@ -1,20 +1,17 @@
 using Adapt: adapt
 using JLArrays: JLArray, JLMatrix
-using LinearAlgebra: LinearAlgebra, Hermitian, Symmetric, eigen, qr
+using LinearAlgebra: LinearAlgebra, Hermitian, Symmetric, eigen, qr, svd
 using NDTensors.Expose: Expose, expose, ql, ql_positive, qr, qr_positive
 using NDTensors.GPUArraysCoreExtensions: cpu
 using NDTensors: NDTensors
 using TypeParameterAccessors: unwrap_array_type
 
-## TODO this function exists because of the same issue below. when
-## that issue is resolved we can rely on the abstractarray version of
-## this operation.
+## TODO these should work using a JLArray but there is an error converting the Q from its packed QR form
+## back into a JLArray see https://github.com/JuliaGPU/GPUArrays.jl/issues/545. To fix call cpu for now
 function Expose.qr(A::Exposed{<:JLArray})
-    Q, L = qr(unexpose(A))
+    Q, L = qr(expose(cpu(A)))
     return adapt(unwrap_array_type(A), Matrix(Q)), adapt(unwrap_array_type(A), L)
 end
-## TODO this should work using a JLArray but there is an error converting the Q from its packed QR from
-## back into a JLArray see https://github.com/JuliaGPU/GPUArrays.jl/issues/545. To fix call cpu for now
 function Expose.qr_positive(A::Exposed{<:JLArray})
     Q, L = qr_positive(expose(cpu(A)))
     return adapt(unwrap_array_type(A), copy(Q)), adapt(unwrap_array_type(A), L)
@@ -37,4 +34,11 @@ end
 function LinearAlgebra.eigen(A::Exposed{<:JLMatrix, <:Hermitian})
     q, l = (eigen(expose(Hermitian(cpu(unexpose(A).data)))))
     return adapt.(JLArray, (q, l))
+end
+
+## Julia 1.13's `svd!` counts the singular values above a tolerance, which indexes them
+## one at a time and so is disallowed on a GPU array. To fix call cpu for now.
+function LinearAlgebra.svd(A::Exposed{<:JLMatrix}; kwargs...)
+    U, S, V = svd(expose(cpu(A)); kwargs...)
+    return adapt.(JLArray, (U, S, V))
 end


### PR DESCRIPTION
## Summary

Adds an `svd` method for `JLMatrix` and routes the existing `qr` through `cpu`, matching the Metal and AMDGPU extensions. Julia 1.13's `svd!` counts the singular values above a tolerance, which indexes them one at a time and so fails on a `JLArray`, and JLArrays 0.4 will disallow the pointer conversion that `qr` relied on.